### PR TITLE
feat(calendar): add respond, search, colors, time, conflicts commands

### DIFF
--- a/internal/cmd/calendar_test.go
+++ b/internal/cmd/calendar_test.go
@@ -35,3 +35,45 @@ func TestIsAllDayEvent(t *testing.T) {
 		t.Fatalf("expected true")
 	}
 }
+
+func TestParseEventTimes(t *testing.T) {
+	// Test timed event
+	timedEvent := &calendar.Event{
+		Start: &calendar.EventDateTime{DateTime: "2025-01-15T10:00:00Z"},
+		End:   &calendar.EventDateTime{DateTime: "2025-01-15T11:00:00Z"},
+	}
+	start, end := parseEventTimes(timedEvent)
+	if start.IsZero() || end.IsZero() {
+		t.Fatalf("expected non-zero times for timed event")
+	}
+	if start.Hour() != 10 || end.Hour() != 11 {
+		t.Fatalf("unexpected hours: start=%d, end=%d", start.Hour(), end.Hour())
+	}
+
+	// Test all-day event
+	allDayEvent := &calendar.Event{
+		Start: &calendar.EventDateTime{Date: "2025-01-15"},
+		End:   &calendar.EventDateTime{Date: "2025-01-16"},
+	}
+	start2, end2 := parseEventTimes(allDayEvent)
+	if start2.IsZero() || end2.IsZero() {
+		t.Fatalf("expected non-zero times for all-day event")
+	}
+	if start2.Day() != 15 || end2.Day() != 16 {
+		t.Fatalf("unexpected days: start=%d, end=%d", start2.Day(), end2.Day())
+	}
+
+	// Test nil event
+	start3, end3 := parseEventTimes(nil)
+	if !start3.IsZero() || !end3.IsZero() {
+		t.Fatalf("expected zero times for nil event")
+	}
+
+	// Test event with nil Start/End
+	partialEvent := &calendar.Event{}
+	start4, end4 := parseEventTimes(partialEvent)
+	if !start4.IsZero() || !end4.IsZero() {
+		t.Fatalf("expected zero times for event with nil Start/End")
+	}
+}
+


### PR DESCRIPTION
## Summary

Adds comprehensive calendar enhancements inspired by [nspady/google-calendar-mcp](https://github.com/nspady/google-calendar-mcp):

### New Commands
- **`calendar respond`**: RSVP to calendar events with accepted/declined/tentative status
- **`calendar search`**: Full-text search across all calendars with optional date range filtering
- **`calendar colors`**: List all available event and calendar colors (useful for `--color` flag)
- **`calendar time`**: Show event times converted to any timezone (e.g., `--timezone America/New_York`)
- **`calendar conflicts`**: Detect scheduling overlaps using the FreeBusy API

### Enhanced Existing Commands
- **`calendar events`**: Multi-calendar support via `--all` flag (aggregates all calendars) or comma-separated calendar IDs (e.g., `--calendar "primary,work@example.com"`)
- **`calendar create`**: New `--organizer` flag to set event organizer email, `--color` flag to set event color ID

### Example Usage

```bash
# RSVP to an event
gogcli calendar respond --event abc123 --status accepted

# Search for events
gogcli calendar search "team meeting" --from 2025-01-01

# Check for conflicts
gogcli calendar conflicts --from 2025-01-15T09:00:00Z --to 2025-01-15T17:00:00Z

# View events from all calendars
gogcli calendar events --all --max 20

# Show event time in different timezone
gogcli calendar time --event abc123 --timezone Europe/Berlin

# Create event as specific organizer with color
gogcli calendar create "Standup" --start 2025-01-20T10:00:00Z --end 2025-01-20T10:30:00Z \
  --organizer team-calendar@company.com --color 11
```

## Test plan

- [x] All existing tests pass (`go test ./internal/cmd/...`)
- [x] Added `TestParseEventTimes` to test the new helper function with edge cases (nil event, nil Start/End, timed events, all-day events)
- [ ] Manual testing of new commands with real Google Calendar API

🤖 Generated with [Claude Code](https://claude.com/claude-code)