### PR TITLE
feat(calendar): add context cancellation and comprehensive tests

### DIFF
--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -50,7 +50,7 @@ func newCalendarCalendarsCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			resp, err := svc.CalendarList.List().Do()
+			resp, err := svc.CalendarList.List().Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -91,7 +91,7 @@ func newCalendarAclCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			resp, err := svc.Acl.List(calendarID).Do()
+			resp, err := svc.Acl.List(calendarID).Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -163,7 +163,7 @@ func newCalendarEventsCmd(flags *rootFlags) *cobra.Command {
 			if strings.TrimSpace(query) != "" {
 				call = call.Q(query)
 			}
-			resp, err := call.Do()
+			resp, err := call.Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -220,7 +220,7 @@ func newCalendarEventCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			e, err := svc.Events.Get(calendarID, eventID).Do()
+			e, err := svc.Events.Get(calendarID, eventID).Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -299,7 +299,7 @@ func newCalendarCreateCmd(flags *rootFlags) *cobra.Command {
 				Attendees:   buildAttendees(attendees),
 			}
 
-			created, err := svc.Events.Insert(calendarID, event).Do()
+			created, err := svc.Events.Insert(calendarID, event).Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -351,7 +351,7 @@ func newCalendarUpdateCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			existing, err := svc.Events.Get(calendarID, eventID).Do()
+			existing, err := svc.Events.Get(calendarID, eventID).Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -398,7 +398,7 @@ func newCalendarUpdateCmd(flags *rootFlags) *cobra.Command {
 				return errors.New("no updates provided")
 			}
 
-			updated, err := svc.Events.Update(calendarID, eventID, existing).Do()
+			updated, err := svc.Events.Update(calendarID, eventID, existing).Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}
@@ -442,7 +442,7 @@ func newCalendarDeleteCmd(flags *rootFlags) *cobra.Command {
 				return err
 			}
 
-			if err := svc.Events.Delete(calendarID, eventID).Do(); err != nil {
+			if err := svc.Events.Delete(calendarID, eventID).Context(cmd.Context()).Do(); err != nil {
 				return err
 			}
 			if outfmt.IsJSON(cmd.Context()) {
@@ -496,7 +496,7 @@ func newCalendarFreeBusyCmd(flags *rootFlags) *cobra.Command {
 				TimeMin: from,
 				TimeMax: to,
 				Items:   items,
-			}).Do()
+			}).Context(cmd.Context()).Do()
 			if err != nil {
 				return err
 			}

--- a/internal/cmd/calendar_more_test.go
+++ b/internal/cmd/calendar_more_test.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
 )
 
 func TestBuildAttendees(t *testing.T) {
@@ -49,5 +55,320 @@ func TestOrEmpty(t *testing.T) {
 	}
 	if got := orEmpty("y", "x"); got != "y" {
 		t.Fatalf("unexpected: %q", got)
+	}
+}
+
+func TestCalendarCreate_AllDayEvent(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	var receivedEvent *calendar.Event
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/calendars/primary/events") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "expected POST", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var event calendar.Event
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		receivedEvent = &event
+
+		event.Id = "event123"
+		event.HtmlLink = "https://calendar.google.com/event?eid=event123"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(event)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{
+				"--output", "json",
+				"--account", "test@example.com",
+				"calendar", "create", "primary",
+				"--summary", "Team Meeting",
+				"--start", "2025-12-15",
+				"--end", "2025-12-16",
+				"--all-day",
+			})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if receivedEvent == nil {
+		t.Fatal("no event received by server")
+	}
+	if receivedEvent.Summary != "Team Meeting" {
+		t.Fatalf("unexpected summary: %q", receivedEvent.Summary)
+	}
+	if receivedEvent.Start == nil || receivedEvent.Start.Date != "2025-12-15" {
+		t.Fatalf("unexpected start: %#v", receivedEvent.Start)
+	}
+
+	var parsed struct {
+		Event struct {
+			ID string `json:"id"`
+		} `json:"event"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Event.ID != "event123" {
+		t.Fatalf("unexpected event ID: %q", parsed.Event.ID)
+	}
+}
+
+func TestCalendarCreate_WithAttendees(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	var receivedEvent *calendar.Event
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/calendars/primary/events") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			http.Error(w, "expected POST", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var event calendar.Event
+		if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		receivedEvent = &event
+
+		event.Id = "event456"
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(event)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{
+				"--output", "json",
+				"--account", "test@example.com",
+				"calendar", "create", "primary",
+				"--summary", "Project Sync",
+				"--start", "2025-12-15T10:00:00Z",
+				"--end", "2025-12-15T11:00:00Z",
+				"--attendees", "alice@example.com, bob@example.com",
+			})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if receivedEvent == nil {
+		t.Fatal("no event received by server")
+	}
+	if len(receivedEvent.Attendees) != 2 {
+		t.Fatalf("expected 2 attendees, got %d", len(receivedEvent.Attendees))
+	}
+	if receivedEvent.Attendees[0].Email != "alice@example.com" {
+		t.Fatalf("unexpected first attendee: %q", receivedEvent.Attendees[0].Email)
+	}
+}
+
+func TestCalendarCreate_MissingRequiredFields(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	svc, err := calendar.NewService(context.Background(), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "missing summary",
+			args: []string{
+				"--account", "test@example.com",
+				"calendar", "create", "primary",
+				"--start", "2025-12-15T10:00:00Z",
+				"--end", "2025-12-15T11:00:00Z",
+			},
+		},
+		{
+			name: "missing start",
+			args: []string{
+				"--account", "test@example.com",
+				"calendar", "create", "primary",
+				"--summary", "Meeting",
+				"--end", "2025-12-15T11:00:00Z",
+			},
+		},
+		{
+			name: "missing end",
+			args: []string{
+				"--account", "test@example.com",
+				"calendar", "create", "primary",
+				"--summary", "Meeting",
+				"--start", "2025-12-15T10:00:00Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Execute(tt.args)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "required: --summary, --start, --end") {
+				t.Fatalf("expected required fields error, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestCalendarUpdate_Success(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	existingEvent := &calendar.Event{
+		Id:      "event789",
+		Summary: "Old Title",
+		Start:   &calendar.EventDateTime{DateTime: "2025-12-15T10:00:00Z"},
+		End:     &calendar.EventDateTime{DateTime: "2025-12-15T11:00:00Z"},
+	}
+
+	var updatedEvent *calendar.Event
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/primary/events/event789") {
+			if r.Method == http.MethodGet {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(existingEvent)
+				return
+			}
+			if r.Method == http.MethodPut {
+				var event calendar.Event
+				if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				updatedEvent = &event
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(event)
+				return
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{
+				"--output", "json",
+				"--account", "test@example.com",
+				"calendar", "update", "primary", "event789",
+				"--summary", "New Title",
+			})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if updatedEvent == nil {
+		t.Fatal("no updated event received by server")
+	}
+	if updatedEvent.Summary != "New Title" {
+		t.Fatalf("expected 'New Title', got %q", updatedEvent.Summary)
+	}
+}
+
+func TestCalendarUpdate_NoChangesProvided(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	existingEvent := &calendar.Event{
+		Id:      "event789",
+		Summary: "Meeting",
+		Start:   &calendar.EventDateTime{DateTime: "2025-12-15T10:00:00Z"},
+		End:     &calendar.EventDateTime{DateTime: "2025-12-15T11:00:00Z"},
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/primary/events/event789") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(existingEvent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	err = Execute([]string{
+		"--output", "json",
+		"--account", "test@example.com",
+		"calendar", "update", "primary", "event789",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "no updates provided") {
+		t.Fatalf("expected 'no updates provided' error, got: %v", err)
 	}
 }

--- a/internal/cmd/calendar_test.go
+++ b/internal/cmd/calendar_test.go
@@ -1,9 +1,15 @@
 package cmd
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
 )
 
 func TestSplitCSV(t *testing.T) {
@@ -33,5 +39,498 @@ func TestIsAllDayEvent(t *testing.T) {
 	}
 	if !isAllDayEvent(&calendar.Event{Start: &calendar.EventDateTime{Date: "2025-01-01"}}) {
 		t.Fatalf("expected true")
+	}
+}
+
+func TestCalendarDelete_Success(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/cal1/events/evt1") && r.Method == http.MethodDelete {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "delete", "cal1", "evt1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Deleted    bool   `json:"deleted"`
+		CalendarID string `json:"calendarId"`
+		EventID    string `json:"eventId"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if !parsed.Deleted || parsed.CalendarID != "cal1" || parsed.EventID != "evt1" {
+		t.Fatalf("unexpected result: %#v", parsed)
+	}
+}
+
+func TestCalendarDelete_NotFound(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/cal1/events/nonexistent") && r.Method == http.MethodDelete {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusNotFound)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    404,
+					"message": "Not Found",
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	err = Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "delete", "cal1", "nonexistent"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "404") && !strings.Contains(err.Error(), "Not Found") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCalendarDelete_APIError(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/cal1/events/evt1") && r.Method == http.MethodDelete {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{
+					"code":    500,
+					"message": "Internal Server Error",
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	err = Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "delete", "cal1", "evt1"})
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "500") && !strings.Contains(err.Error(), "Internal Server Error") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCalendarEvents_Success(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/cal1/events") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{
+						"id":      "evt1",
+						"summary": "Meeting 1",
+						"start":   map[string]any{"dateTime": "2025-12-13T10:00:00Z"},
+						"end":     map[string]any{"dateTime": "2025-12-13T11:00:00Z"},
+					},
+					{
+						"id":      "evt2",
+						"summary": "Meeting 2",
+						"start":   map[string]any{"dateTime": "2025-12-14T14:00:00Z"},
+						"end":     map[string]any{"dateTime": "2025-12-14T15:00:00Z"},
+					},
+				},
+				"nextPageToken": "",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "events", "cal1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Events []struct {
+			ID      string `json:"id"`
+			Summary string `json:"summary"`
+		} `json:"events"`
+		NextPageToken string `json:"nextPageToken"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if len(parsed.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(parsed.Events))
+	}
+	if parsed.Events[0].ID != "evt1" || parsed.Events[0].Summary != "Meeting 1" {
+		t.Fatalf("unexpected first event: %#v", parsed.Events[0])
+	}
+}
+
+func TestCalendarEvents_EmptyList(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/cal1/events") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items":         []map[string]any{},
+				"nextPageToken": "",
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "events", "cal1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Events        []any  `json:"events"`
+		NextPageToken string `json:"nextPageToken"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if len(parsed.Events) != 0 {
+		t.Fatalf("expected empty events list, got %d events", len(parsed.Events))
+	}
+}
+
+func TestCalendarACL_ListRoles(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/calendars/primary/acl") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "user:owner@example.com",
+					"role": "owner",
+					"scope": map[string]any{
+						"type":  "user",
+						"value": "owner@example.com",
+					},
+				},
+				{
+					"id":   "user:reader@example.com",
+					"role": "reader",
+					"scope": map[string]any{
+						"type":  "user",
+						"value": "reader@example.com",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "text", "--account", "a@b.com", "calendar", "acl", "primary"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(out, "SCOPE_TYPE") || !strings.Contains(out, "ROLE") {
+		t.Fatalf("unexpected output headers: %q", out)
+	}
+	if !strings.Contains(out, "owner@example.com") {
+		t.Fatalf("missing ACL entries: %q", out)
+	}
+}
+
+func TestCalendarACL_JSONOutput(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/calendars/test@example.com/acl") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id":   "user:owner@example.com",
+					"role": "owner",
+					"scope": map[string]any{
+						"type":  "user",
+						"value": "owner@example.com",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "acl", "test@example.com"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Rules []struct {
+			ID   string `json:"id"`
+			Role string `json:"role"`
+		} `json:"rules"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if len(parsed.Rules) != 1 || parsed.Rules[0].Role != "owner" {
+		t.Fatalf("unexpected rules: %#v", parsed.Rules)
+	}
+}
+
+func TestCalendarFreeBusy_Success(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/freeBusy") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"calendars": map[string]any{
+				"primary": map[string]any{
+					"busy": []map[string]any{
+						{
+							"start": "2025-01-01T09:00:00Z",
+							"end":   "2025-01-01T10:00:00Z",
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "text", "--account", "a@b.com", "calendar", "freebusy", "primary", "--from", "2025-01-01T00:00:00Z", "--to", "2025-01-01T23:59:59Z"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(out, "CALENDAR") || !strings.Contains(out, "START") {
+		t.Fatalf("unexpected output headers: %q", out)
+	}
+	if !strings.Contains(out, "primary") {
+		t.Fatalf("missing calendar ID: %q", out)
+	}
+}
+
+func TestCalendarFreeBusy_InvalidTimeRange(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	svc, err := calendar.NewService(context.Background(), option.WithoutAuthentication())
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	// Test missing --from
+	err = Execute([]string{"--output", "text", "--account", "a@b.com", "calendar", "freebusy", "primary", "--to", "2025-01-01T23:59:59Z"})
+	if err == nil {
+		t.Fatalf("expected error for missing --from")
+	}
+	if !strings.Contains(err.Error(), "required: --from and --to") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Test missing --to
+	err = Execute([]string{"--output", "text", "--account", "a@b.com", "calendar", "freebusy", "primary", "--from", "2025-01-01T00:00:00Z"})
+	if err == nil {
+		t.Fatalf("expected error for missing --to")
+	}
+
+	// Test empty calendar IDs
+	err = Execute([]string{"--output", "text", "--account", "a@b.com", "calendar", "freebusy", "  ,  ,  ", "--from", "2025-01-01T00:00:00Z", "--to", "2025-01-01T23:59:59Z"})
+	if err == nil {
+		t.Fatalf("expected error for empty calendar IDs")
+	}
+	if !strings.Contains(err.Error(), "no calendar IDs provided") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCalendarFreeBusy_JSONOutput(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/freeBusy") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"calendars": map[string]any{
+				"work@example.com": map[string]any{
+					"busy": []map[string]any{
+						{"start": "2025-01-01T09:00:00Z", "end": "2025-01-01T10:00:00Z"},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "calendar", "freebusy", "work@example.com", "--from", "2025-01-01T00:00:00Z", "--to", "2025-01-01T23:59:59Z"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Calendars map[string]struct {
+			Busy []struct {
+				Start string `json:"start"`
+				End   string `json:"end"`
+			} `json:"busy"`
+		} `json:"calendars"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if _, ok := parsed.Calendars["work@example.com"]; !ok {
+		t.Fatalf("missing calendar in response")
 	}
 }


### PR DESCRIPTION
## Summary

- Add context cancellation support to all Calendar API calls for proper timeout and cancellation handling
- Fix `go.mod` to use valid Go version (1.24 instead of invalid 1.25)
- Add comprehensive test coverage for calendar commands (~800 lines of new tests)

## Changes

### Context Cancellation
All Calendar API calls now properly propagate context for timeout/cancellation support:
- `CalendarList.List()`
- `Acl.List()`
- `Events.List()`, `Events.Get()`, `Events.Insert()`, `Events.Update()`, `Events.Delete()`
- `Freebusy.Query()`

### New Tests
- Event delete: success, not-found, API error cases
- Event list: success, empty list
- ACL list: text and JSON output
- FreeBusy query: success, invalid time range, JSON output  
- Event create: all-day events, with attendees, validation
- Event update: success, no-changes validation

## Test plan
- [x] All existing tests pass
- [x] New calendar tests pass
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)