### PR TITLE
feat(tasks): manage tasks + create tasklists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Gmail: HTML bodies for `gmail send` and `gmail drafts create` via `--body-html` (multipart/alternative when combined with `--body`, PR #16 — thanks @shanelindsay).
 - Gmail: `--reply-to-address` (sets `Reply-To` header, PR #16 — thanks @shanelindsay).
+- Tasks: manage tasklists and tasks (`lists`, `list`, `add`, `update`, `done`, `undo`, `delete`, `clear`, PR #10 — thanks @shanelindsay).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Minimal Google CLI in Go for:
 - Calendar
 - Drive
 - Contacts (People API)
+- Tasks
 - People (profile / `people/me`)
 
 ## Install / Build
@@ -32,6 +33,7 @@ Before adding an account you need OAuth2 credentials from Google Cloud Console:
    - Google Calendar API: https://console.cloud.google.com/apis/api/calendar-json.googleapis.com
    - Google Drive API: https://console.cloud.google.com/apis/api/drive.googleapis.com
    - People API (Contacts): https://console.cloud.google.com/apis/api/people.googleapis.com
+   - Google Tasks API: https://console.cloud.google.com/apis/api/tasks.googleapis.com
 3. Set app name / branding (OAuth consent screen): https://console.cloud.google.com/auth/branding
 4. If your app is in “Testing”, add test users (all Google accounts you’ll use with `gog`): https://console.cloud.google.com/auth/audience
 5. Create an OAuth client: https://console.cloud.google.com/auth/clients
@@ -49,7 +51,7 @@ Then:
 Notes:
 
 - If no OS keychain backend is available (e.g. Linux/WSL/container), keyring can fall back to an encrypted on-disk store and may prompt for a password; for non-interactive runs set `GOG_KEYRING_PASSWORD`.
-- Default is `--services all` (gmail, calendar, drive, contacts).
+- Default is `--services all` (gmail, calendar, drive, contacts, tasks).
 - To request fewer scopes: `gog auth add you@gmail.com --services drive,calendar`.
 - If you add services later and Google doesn’t return a refresh token, re-run with `--force-consent`.
 - `gog auth add ...` overwrites the stored token for that email.
@@ -111,6 +113,18 @@ Contacts:
 - `gog contacts search "Ada" --max 50`
 - `gog contacts get people/...`
 - `gog contacts other list --max 50`
+
+Tasks:
+
+- `gog tasks lists --max 50`
+- `gog tasks lists create <title>`
+- `gog tasks list <tasklistId> --max 50`
+- `gog tasks add <tasklistId> --title "Task title"`
+- `gog tasks update <tasklistId> <taskId> --title "New title"`
+- `gog tasks done <tasklistId> <taskId>`
+- `gog tasks undo <tasklistId> <taskId>`
+- `gog tasks delete <tasklistId> <taskId>`
+- `gog tasks clear <tasklistId>`
 
 Workspace directory (requires Google Workspace account; `@gmail.com` won’t work):
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -120,7 +120,7 @@ Environment:
 ### Implemented
 
 - `gog auth credentials <credentials.json>`
-- `gog auth add <email> [--services all|gmail,calendar,drive,contacts] [--manual] [--force-consent]`
+- `gog auth add <email> [--services all|gmail,calendar,drive,contacts,tasks] [--manual] [--force-consent]`
 - `gog auth list`
 - `gog auth remove <email>`
 - `gog auth tokens list`
@@ -160,6 +160,15 @@ Environment:
 - `gog gmail drafts create --to a@b.com --subject S [--body B] [--body-html H] [--cc ...] [--bcc ...] [--reply-to <messageId>] [--reply-to-address addr] [--attach <file>...]`
 - `gog gmail drafts send <draftId>`
 - `gog gmail drafts delete <draftId>`
+- `gog tasks lists [--max N] [--page TOKEN]`
+- `gog tasks lists create <title>`
+- `gog tasks list <tasklistId> [--max N] [--page TOKEN]`
+- `gog tasks add <tasklistId> --title T [--notes N] [--due RFC3339] [--parent ID] [--previous ID]`
+- `gog tasks update <tasklistId> <taskId> [--title T] [--notes N] [--due RFC3339] [--status needsAction|completed]`
+- `gog tasks done <tasklistId> <taskId>`
+- `gog tasks undo <tasklistId> <taskId>`
+- `gog tasks delete <tasklistId> <taskId>`
+- `gog tasks clear <tasklistId>`
 - `gog contacts search <query> [--max N]`
 - `gog contacts list [--max N] [--page TOKEN]`
 - `gog contacts get <people/...|email>`
@@ -180,6 +189,7 @@ Environment:
 - `gog calendar …`
 - `gog drive …`
 - `gog contacts …`
+- `gog tasks …`
 - `gog people …`
 
 Planned service identifiers (canonical):
@@ -188,6 +198,7 @@ Planned service identifiers (canonical):
 - `calendar`
 - `drive`
 - `contacts`
+- `tasks`
 - `people`
 
 ## Google API dependencies (planned)
@@ -199,6 +210,7 @@ Planned service identifiers (canonical):
 - `google.golang.org/api/calendar/v3`
 - `google.golang.org/api/drive/v3`
 - `google.golang.org/api/people/v1`
+- `google.golang.org/api/tasks/v1`
 
 ## Scopes (planned)
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -378,7 +378,7 @@ func newAuthAddCmd() *cobra.Command {
 
 	cmd.Flags().BoolVar(&manual, "manual", false, "Browserless auth flow (paste redirect URL)")
 	cmd.Flags().BoolVar(&forceConsent, "force-consent", false, "Force consent screen to obtain a refresh token")
-	cmd.Flags().StringVar(&servicesCSV, "services", "all", "Services to authorize: all or comma-separated gmail,calendar,drive,contacts")
+	cmd.Flags().StringVar(&servicesCSV, "services", "all", "Services to authorize: all or comma-separated gmail,calendar,drive,contacts,tasks")
 	return cmd
 }
 

--- a/internal/cmd/execute_tasks_test.go
+++ b/internal/cmd/execute_tasks_test.go
@@ -1,0 +1,498 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/tasks/v1"
+)
+
+func TestExecute_TasksLists_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/users/@me/lists" && r.Method == http.MethodGet) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": "l1", "title": "One"},
+				{"id": "l2", "title": "Two"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "lists", "--max", "10"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Tasklists []struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"tasklists"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if len(parsed.Tasklists) != 2 || parsed.Tasklists[0].ID != "l1" || parsed.Tasklists[1].ID != "l2" {
+		t.Fatalf("unexpected tasklists: %#v", parsed.Tasklists)
+	}
+}
+
+func TestExecute_TasksListsCreate_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/users/@me/lists" && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body["title"] != "Teaching" {
+			http.Error(w, "expected title Teaching", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":    "l3",
+			"title": "Teaching",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "lists", "create", "Teaching"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Tasklist struct {
+			ID    string `json:"id"`
+			Title string `json:"title"`
+		} `json:"tasklist"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Tasklist.ID != "l3" || parsed.Tasklist.Title != "Teaching" {
+		t.Fatalf("unexpected tasklist: %#v", parsed.Tasklist)
+	}
+}
+
+func TestExecute_TasksList_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.HasPrefix(r.URL.Path, "/tasks/v1/lists/") && strings.HasSuffix(r.URL.Path, "/tasks") && r.Method == http.MethodGet) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{"id": "t1", "title": "Task One", "status": "needsAction"},
+				{"id": "t2", "title": "Task Two", "status": "completed"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "list", "l1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Tasks []struct {
+			ID     string `json:"id"`
+			Title  string `json:"title"`
+			Status string `json:"status"`
+		} `json:"tasks"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if len(parsed.Tasks) != 2 || parsed.Tasks[0].ID != "t1" || parsed.Tasks[1].ID != "t2" {
+		t.Fatalf("unexpected tasks: %#v", parsed.Tasks)
+	}
+}
+
+func TestExecute_TasksAdd_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/lists/l1/tasks" && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body["title"] != "Hello" {
+			http.Error(w, "expected title Hello", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     "t1",
+			"title":  "Hello",
+			"status": "needsAction",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "add", "l1", "--title", "Hello"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Task struct {
+			ID     string `json:"id"`
+			Title  string `json:"title"`
+			Status string `json:"status"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Task.ID != "t1" || parsed.Task.Title != "Hello" || parsed.Task.Status != "needsAction" {
+		t.Fatalf("unexpected task: %#v", parsed.Task)
+	}
+}
+
+func TestExecute_TasksDone_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/lists/l1/tasks/t1" && r.Method == http.MethodPatch) {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body["status"] != "completed" {
+			http.Error(w, "expected status completed", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     "t1",
+			"title":  "Hello",
+			"status": "completed",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "done", "l1", "t1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Task struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Task.ID != "t1" || parsed.Task.Status != "completed" {
+		t.Fatalf("unexpected task: %#v", parsed.Task)
+	}
+}
+
+func TestExecute_TasksDelete_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/lists/l1/tasks/t1" && r.Method == http.MethodDelete) {
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "delete", "l1", "t1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Deleted bool   `json:"deleted"`
+		ID      string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if !parsed.Deleted || parsed.ID != "t1" {
+		t.Fatalf("unexpected response: %#v", parsed)
+	}
+}
+
+func TestExecute_TasksUpdate_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/lists/l1/tasks/t1" && r.Method == http.MethodPatch) {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body["title"] != "New title" {
+			http.Error(w, "expected title New title", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     "t1",
+			"title":  "New title",
+			"status": "needsAction",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "update", "l1", "t1", "--title", "New title"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Task struct {
+			ID     string `json:"id"`
+			Title  string `json:"title"`
+			Status string `json:"status"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Task.ID != "t1" || parsed.Task.Title != "New title" || parsed.Task.Status != "needsAction" {
+		t.Fatalf("unexpected task: %#v", parsed.Task)
+	}
+}
+
+func TestExecute_TasksUndo_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/lists/l1/tasks/t1" && r.Method == http.MethodPatch) {
+			http.NotFound(w, r)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if body["status"] != "needsAction" {
+			http.Error(w, "expected status needsAction", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":     "t1",
+			"status": "needsAction",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "undo", "l1", "t1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Task struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"task"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Task.ID != "t1" || parsed.Task.Status != "needsAction" {
+		t.Fatalf("unexpected task: %#v", parsed.Task)
+	}
+}
+
+func TestExecute_TasksClear_JSON(t *testing.T) {
+	origNew := newTasksService
+	t.Cleanup(func() { newTasksService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.URL.Path == "/tasks/v1/lists/l1/clear" && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{})
+	}))
+	defer srv.Close()
+
+	svc, err := tasks.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newTasksService = func(context.Context, string) (*tasks.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--output", "json", "--account", "a@b.com", "tasks", "clear", "l1"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Cleared    bool   `json:"cleared"`
+		TasklistID string `json:"tasklistId"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if !parsed.Cleared || parsed.TasklistID != "l1" {
+		t.Fatalf("unexpected response: %#v", parsed)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,7 +23,7 @@ func Execute(args []string) error {
 
 	root := &cobra.Command{
 		Use:           "gog",
-		Short:         "Google CLI for Gmail/Calendar/Drive/Contacts/People",
+		Short:         "Google CLI for Gmail/Calendar/Drive/Contacts/Tasks/People",
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		CompletionOptions: cobra.CompletionOptions{
@@ -53,6 +53,10 @@ func Execute(args []string) error {
   gog contacts list --max 50
   gog contacts search "Ada" --max 50
   gog contacts other list --max 50
+
+  # Tasks
+  gog tasks lists --max 50
+  gog tasks list <tasklistId> --max 50
 
   # People
   gog people me
@@ -87,7 +91,7 @@ func Execute(args []string) error {
 
 	root.SetArgs(args)
 	root.PersistentFlags().StringVar(&flags.Color, "color", flags.Color, "Color output: auto|always|never")
-	root.PersistentFlags().StringVar(&flags.Account, "account", "", "Account email for API commands (gmail/calendar/drive/contacts/people)")
+	root.PersistentFlags().StringVar(&flags.Account, "account", "", "Account email for API commands (gmail/calendar/drive/contacts/tasks/people)")
 	root.PersistentFlags().StringVar(&flags.Output, "output", flags.Output, "Output format: text|json")
 
 	root.AddCommand(newAuthCmd())
@@ -95,6 +99,7 @@ func Execute(args []string) error {
 	root.AddCommand(newCalendarCmd(&flags))
 	root.AddCommand(newGmailCmd(&flags))
 	root.AddCommand(newContactsCmd(&flags))
+	root.AddCommand(newTasksCmd(&flags))
 	root.AddCommand(newPeopleCmd(&flags))
 
 	err := root.Execute()

--- a/internal/cmd/tasks.go
+++ b/internal/cmd/tasks.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/steipete/gogcli/internal/googleapi"
+)
+
+var newTasksService = googleapi.NewTasks
+
+func newTasksCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tasks",
+		Short: "Google Tasks",
+	}
+	cmd.AddCommand(newTasksListsCmd(flags))
+	cmd.AddCommand(newTasksListCmd(flags))
+	cmd.AddCommand(newTasksAddCmd(flags))
+	cmd.AddCommand(newTasksUpdateCmd(flags))
+	cmd.AddCommand(newTasksDoneCmd(flags))
+	cmd.AddCommand(newTasksUndoCmd(flags))
+	cmd.AddCommand(newTasksDeleteCmd(flags))
+	cmd.AddCommand(newTasksClearCmd(flags))
+	return cmd
+}

--- a/internal/cmd/tasks_items.go
+++ b/internal/cmd/tasks_items.go
@@ -1,0 +1,444 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+	"google.golang.org/api/tasks/v1"
+)
+
+func newTasksListCmd(flags *rootFlags) *cobra.Command {
+	var max int64
+	var page string
+	var showCompleted bool
+	var showDeleted bool
+	var showHidden bool
+	var showAssigned bool
+	var dueMin string
+	var dueMax string
+	var completedMin string
+	var completedMax string
+	var updatedMin string
+
+	cmd := &cobra.Command{
+		Use:   "list <tasklistId>",
+		Short: "List tasks in a task list",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			call := svc.Tasks.List(tasklistID).
+				MaxResults(max).
+				PageToken(page).
+				ShowCompleted(showCompleted).
+				ShowDeleted(showDeleted).
+				ShowHidden(showHidden).
+				ShowAssigned(showAssigned)
+			if strings.TrimSpace(dueMin) != "" {
+				call = call.DueMin(strings.TrimSpace(dueMin))
+			}
+			if strings.TrimSpace(dueMax) != "" {
+				call = call.DueMax(strings.TrimSpace(dueMax))
+			}
+			if strings.TrimSpace(completedMin) != "" {
+				call = call.CompletedMin(strings.TrimSpace(completedMin))
+			}
+			if strings.TrimSpace(completedMax) != "" {
+				call = call.CompletedMax(strings.TrimSpace(completedMax))
+			}
+			if strings.TrimSpace(updatedMin) != "" {
+				call = call.UpdatedMin(strings.TrimSpace(updatedMin))
+			}
+
+			resp, err := call.Do()
+			if err != nil {
+				return err
+			}
+
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{
+					"tasks":         resp.Items,
+					"nextPageToken": resp.NextPageToken,
+				})
+			}
+
+			if len(resp.Items) == 0 {
+				u.Err().Println("No tasks")
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "ID\tTITLE\tSTATUS\tDUE\tUPDATED")
+			for _, t := range resp.Items {
+				status := strings.TrimSpace(t.Status)
+				if status == "" {
+					status = "needsAction"
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", t.Id, t.Title, status, strings.TrimSpace(t.Due), strings.TrimSpace(t.Updated))
+			}
+			_ = tw.Flush()
+
+			if resp.NextPageToken != "" {
+				u.Err().Printf("# Next page: --page %s", resp.NextPageToken)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64Var(&max, "max", 20, "Max results (max allowed: 100)")
+	cmd.Flags().StringVar(&page, "page", "", "Page token")
+
+	cmd.Flags().BoolVar(&showCompleted, "show-completed", true, "Include completed tasks (requires --show-hidden for some clients)")
+	cmd.Flags().BoolVar(&showDeleted, "show-deleted", false, "Include deleted tasks")
+	cmd.Flags().BoolVar(&showHidden, "show-hidden", false, "Include hidden tasks")
+	cmd.Flags().BoolVar(&showAssigned, "show-assigned", false, "Include tasks assigned to current user")
+
+	cmd.Flags().StringVar(&dueMin, "due-min", "", "Lower bound for due date filter (RFC3339)")
+	cmd.Flags().StringVar(&dueMax, "due-max", "", "Upper bound for due date filter (RFC3339)")
+	cmd.Flags().StringVar(&completedMin, "completed-min", "", "Lower bound for completion date filter (RFC3339)")
+	cmd.Flags().StringVar(&completedMax, "completed-max", "", "Upper bound for completion date filter (RFC3339)")
+	cmd.Flags().StringVar(&updatedMin, "updated-min", "", "Lower bound for updated time filter (RFC3339)")
+	return cmd
+}
+
+func newTasksAddCmd(flags *rootFlags) *cobra.Command {
+	var title string
+	var notes string
+	var due string
+	var parent string
+	var previous string
+
+	cmd := &cobra.Command{
+		Use:     "add <tasklistId>",
+		Short:   "Create a task in a task list",
+		Aliases: []string{"create"},
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+			if strings.TrimSpace(title) == "" {
+				return errors.New("required: --title")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			task := &tasks.Task{
+				Title: strings.TrimSpace(title),
+				Notes: strings.TrimSpace(notes),
+				Due:   strings.TrimSpace(due),
+			}
+			call := svc.Tasks.Insert(tasklistID, task)
+			if strings.TrimSpace(parent) != "" {
+				call = call.Parent(strings.TrimSpace(parent))
+			}
+			if strings.TrimSpace(previous) != "" {
+				call = call.Previous(strings.TrimSpace(previous))
+			}
+
+			created, err := call.Do()
+			if err != nil {
+				return err
+			}
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{"task": created})
+			}
+			u.Out().Printf("id\t%s", created.Id)
+			u.Out().Printf("title\t%s", created.Title)
+			if strings.TrimSpace(created.Status) != "" {
+				u.Out().Printf("status\t%s", created.Status)
+			}
+			if strings.TrimSpace(created.Due) != "" {
+				u.Out().Printf("due\t%s", created.Due)
+			}
+			if strings.TrimSpace(created.WebViewLink) != "" {
+				u.Out().Printf("link\t%s", created.WebViewLink)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "Task title (required)")
+	cmd.Flags().StringVar(&notes, "notes", "", "Task notes/description")
+	cmd.Flags().StringVar(&due, "due", "", "Due date/time (RFC3339)")
+	cmd.Flags().StringVar(&parent, "parent", "", "Parent task ID (create as subtask)")
+	cmd.Flags().StringVar(&previous, "previous", "", "Previous sibling task ID (controls ordering)")
+	return cmd
+}
+
+func newTasksUpdateCmd(flags *rootFlags) *cobra.Command {
+	var title string
+	var notes string
+	var due string
+	var status string
+
+	cmd := &cobra.Command{
+		Use:   "update <tasklistId> <taskId>",
+		Short: "Update a task",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			taskID := strings.TrimSpace(args[1])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+			if taskID == "" {
+				return errors.New("empty taskId")
+			}
+
+			patch := &tasks.Task{}
+			changed := false
+			if cmd.Flags().Changed("title") {
+				patch.Title = strings.TrimSpace(title)
+				changed = true
+			}
+			if cmd.Flags().Changed("notes") {
+				patch.Notes = strings.TrimSpace(notes)
+				changed = true
+			}
+			if cmd.Flags().Changed("due") {
+				patch.Due = strings.TrimSpace(due)
+				changed = true
+			}
+			if cmd.Flags().Changed("status") {
+				patch.Status = strings.TrimSpace(status)
+				changed = true
+			}
+			if !changed {
+				return errors.New("no fields to update (set at least one of: --title, --notes, --due, --status)")
+			}
+
+			if cmd.Flags().Changed("status") && patch.Status != "" && patch.Status != "needsAction" && patch.Status != "completed" {
+				return errors.New("invalid --status (expected needsAction or completed)")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			updated, err := svc.Tasks.Patch(tasklistID, taskID, patch).Do()
+			if err != nil {
+				return err
+			}
+
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+			}
+			u.Out().Printf("id\t%s", updated.Id)
+			u.Out().Printf("title\t%s", updated.Title)
+			if strings.TrimSpace(updated.Status) != "" {
+				u.Out().Printf("status\t%s", updated.Status)
+			}
+			if strings.TrimSpace(updated.Due) != "" {
+				u.Out().Printf("due\t%s", updated.Due)
+			}
+			if strings.TrimSpace(updated.WebViewLink) != "" {
+				u.Out().Printf("link\t%s", updated.WebViewLink)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&title, "title", "", "New title (set empty to clear)")
+	cmd.Flags().StringVar(&notes, "notes", "", "New notes (set empty to clear)")
+	cmd.Flags().StringVar(&due, "due", "", "New due date/time (RFC3339; set empty to clear)")
+	cmd.Flags().StringVar(&status, "status", "", "New status: needsAction|completed (set empty to clear)")
+	return cmd
+}
+
+func newTasksDoneCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "done <tasklistId> <taskId>",
+		Short:   "Mark a task as completed",
+		Aliases: []string{"complete"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			taskID := strings.TrimSpace(args[1])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+			if taskID == "" {
+				return errors.New("empty taskId")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			updated, err := svc.Tasks.Patch(tasklistID, taskID, &tasks.Task{Status: "completed"}).Do()
+			if err != nil {
+				return err
+			}
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+			}
+			u.Out().Printf("id\t%s", updated.Id)
+			u.Out().Printf("status\t%s", strings.TrimSpace(updated.Status))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTasksUndoCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "undo <tasklistId> <taskId>",
+		Short:   "Mark a task as not completed",
+		Aliases: []string{"uncomplete", "undone"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			taskID := strings.TrimSpace(args[1])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+			if taskID == "" {
+				return errors.New("empty taskId")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			updated, err := svc.Tasks.Patch(tasklistID, taskID, &tasks.Task{Status: "needsAction"}).Do()
+			if err != nil {
+				return err
+			}
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{"task": updated})
+			}
+			u.Out().Printf("id\t%s", updated.Id)
+			u.Out().Printf("status\t%s", strings.TrimSpace(updated.Status))
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTasksDeleteCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "delete <tasklistId> <taskId>",
+		Short:   "Delete a task",
+		Aliases: []string{"rm", "del"},
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			taskID := strings.TrimSpace(args[1])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+			if taskID == "" {
+				return errors.New("empty taskId")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			if err := svc.Tasks.Delete(tasklistID, taskID).Do(); err != nil {
+				return err
+			}
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{
+					"deleted": true,
+					"id":      taskID,
+				})
+			}
+			u.Out().Printf("deleted\ttrue")
+			u.Out().Printf("id\t%s", taskID)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newTasksClearCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "clear <tasklistId>",
+		Short: "Clear completed tasks from a task list",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			tasklistID := strings.TrimSpace(args[0])
+			if tasklistID == "" {
+				return errors.New("empty tasklistId")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			if err := svc.Tasks.Clear(tasklistID).Do(); err != nil {
+				return err
+			}
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{
+					"cleared":    true,
+					"tasklistId": tasklistID,
+				})
+			}
+			u.Out().Printf("cleared\ttrue")
+			u.Out().Printf("tasklistId\t%s", tasklistID)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cmd/tasks_lists.go
+++ b/internal/cmd/tasks_lists.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+	"google.golang.org/api/tasks/v1"
+)
+
+func newTasksListsCmd(flags *rootFlags) *cobra.Command {
+	var max int64
+	var page string
+
+	cmd := &cobra.Command{
+		Use:   "lists",
+		Short: "List task lists",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			call := svc.Tasklists.List().MaxResults(max).PageToken(page)
+			resp, err := call.Do()
+			if err != nil {
+				return err
+			}
+
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{
+					"tasklists":     resp.Items,
+					"nextPageToken": resp.NextPageToken,
+				})
+			}
+
+			if len(resp.Items) == 0 {
+				u.Err().Println("No task lists")
+				return nil
+			}
+
+			tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+			fmt.Fprintln(tw, "ID\tTITLE")
+			for _, tl := range resp.Items {
+				fmt.Fprintf(tw, "%s\t%s\n", tl.Id, tl.Title)
+			}
+			_ = tw.Flush()
+			if resp.NextPageToken != "" {
+				u.Err().Printf("# Next page: --page %s", resp.NextPageToken)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().Int64Var(&max, "max", 100, "Max results (max allowed: 1000)")
+	cmd.Flags().StringVar(&page, "page", "", "Page token")
+	cmd.AddCommand(newTasksListsCreateCmd(flags))
+	return cmd
+}
+
+func newTasksListsCreateCmd(flags *rootFlags) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "create <title>",
+		Short:   "Create a task list",
+		Aliases: []string{"add", "new"},
+		Args:    cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			u := ui.FromContext(cmd.Context())
+			account, err := requireAccount(flags)
+			if err != nil {
+				return err
+			}
+			title := strings.TrimSpace(strings.Join(args, " "))
+			if title == "" {
+				return errors.New("empty title")
+			}
+
+			svc, err := newTasksService(cmd.Context(), account)
+			if err != nil {
+				return err
+			}
+
+			created, err := svc.Tasklists.Insert(&tasks.TaskList{Title: title}).Do()
+			if err != nil {
+				return err
+			}
+
+			if outfmt.IsJSON(cmd.Context()) {
+				return outfmt.WriteJSON(os.Stdout, map[string]any{"tasklist": created})
+			}
+			u.Out().Printf("id\t%s", created.Id)
+			u.Out().Printf("title\t%s", created.Title)
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -44,6 +44,9 @@ func TestNewServices_HappyPath(t *testing.T) {
 	if svc, err := NewPeopleDirectory(ctx, "a@b.com"); err != nil || svc == nil {
 		t.Fatalf("NewPeopleDirectory: %v", err)
 	}
+	if svc, err := NewTasks(ctx, "a@b.com"); err != nil || svc == nil {
+		t.Fatalf("NewTasks: %v", err)
+	}
 }
 
 func TestNewServices_AuthRequired(t *testing.T) {

--- a/internal/googleapi/tasks.go
+++ b/internal/googleapi/tasks.go
@@ -1,0 +1,16 @@
+package googleapi
+
+import (
+	"context"
+
+	"github.com/steipete/gogcli/internal/googleauth"
+	"google.golang.org/api/tasks/v1"
+)
+
+func NewTasks(ctx context.Context, email string) (*tasks.Service, error) {
+	opts, err := optionsForAccount(ctx, googleauth.ServiceTasks, email)
+	if err != nil {
+		return nil, err
+	}
+	return tasks.NewService(ctx, opts...)
+}

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -14,19 +14,20 @@ const (
 	ServiceCalendar Service = "calendar"
 	ServiceDrive    Service = "drive"
 	ServiceContacts Service = "contacts"
+	ServiceTasks    Service = "tasks"
 )
 
 func ParseService(s string) (Service, error) {
 	switch Service(strings.ToLower(strings.TrimSpace(s))) {
-	case ServiceGmail, ServiceCalendar, ServiceDrive, ServiceContacts:
+	case ServiceGmail, ServiceCalendar, ServiceDrive, ServiceContacts, ServiceTasks:
 		return Service(strings.ToLower(strings.TrimSpace(s))), nil
 	default:
-		return "", fmt.Errorf("unknown service %q (expected gmail|calendar|drive|contacts)", s)
+		return "", fmt.Errorf("unknown service %q (expected gmail|calendar|drive|contacts|tasks)", s)
 	}
 }
 
 func AllServices() []Service {
-	return []Service{ServiceGmail, ServiceCalendar, ServiceDrive, ServiceContacts}
+	return []Service{ServiceGmail, ServiceCalendar, ServiceDrive, ServiceContacts, ServiceTasks}
 }
 
 func Scopes(service Service) ([]string, error) {
@@ -43,6 +44,8 @@ func Scopes(service Service) ([]string, error) {
 			"https://www.googleapis.com/auth/contacts.other.readonly",
 			"https://www.googleapis.com/auth/directory.readonly",
 		}, nil
+	case ServiceTasks:
+		return []string{"https://www.googleapis.com/auth/tasks"}, nil
 	default:
 		return nil, errors.New("unknown service")
 	}

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -12,6 +12,7 @@ func TestParseService(t *testing.T) {
 		{"calendar", ServiceCalendar},
 		{"drive", ServiceDrive},
 		{"contacts", ServiceContacts},
+		{"tasks", ServiceTasks},
 	}
 	for _, tt := range tests {
 		got, err := ParseService(tt.in)
@@ -51,14 +52,14 @@ func TestExtractCodeAndState_Errors(t *testing.T) {
 
 func TestAllServices(t *testing.T) {
 	svcs := AllServices()
-	if len(svcs) != 4 {
+	if len(svcs) != 5 {
 		t.Fatalf("unexpected: %v", svcs)
 	}
 	seen := make(map[Service]bool)
 	for _, s := range svcs {
 		seen[s] = true
 	}
-	for _, want := range []Service{ServiceGmail, ServiceCalendar, ServiceDrive, ServiceContacts} {
+	for _, want := range []Service{ServiceGmail, ServiceCalendar, ServiceDrive, ServiceContacts, ServiceTasks} {
 		if !seen[want] {
 			t.Fatalf("missing %q", want)
 		}
@@ -66,7 +67,7 @@ func TestAllServices(t *testing.T) {
 }
 
 func TestScopesForServices_UnionSorted(t *testing.T) {
-	scopes, err := ScopesForServices([]Service{ServiceContacts, ServiceGmail, ServiceContacts})
+	scopes, err := ScopesForServices([]Service{ServiceContacts, ServiceGmail, ServiceTasks, ServiceContacts})
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -85,6 +86,7 @@ func TestScopesForServices_UnionSorted(t *testing.T) {
 		"https://www.googleapis.com/auth/contacts",
 		"https://www.googleapis.com/auth/contacts.other.readonly",
 		"https://www.googleapis.com/auth/directory.readonly",
+		"https://www.googleapis.com/auth/tasks",
 	}
 	for _, w := range want {
 		found := false


### PR DESCRIPTION
Adds fuller Google Tasks support:

- `gog tasks add|update|done|undo|delete|clear` for task management
- `gog tasks lists create <title>` for creating tasklists
- JSON-mode tests covering new endpoints

Tested:
- `go test ./...`
- Manual: `gog tasks lists create projects` (created list successfully)
