### PR TITLE
Fix keyring file backend fallback (set FileDir + password prompt)

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -26,6 +26,30 @@ func EnsureDir() (string, error) {
 	return dir, nil
 }
 
+// KeyringDir is where the keyring "file" backend stores encrypted entries.
+//
+// We keep this separate from the main config dir because the file backend creates
+// one file per key.
+func KeyringDir() (string, error) {
+	dir, err := Dir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "keyring"), nil
+}
+
+func EnsureKeyringDir() (string, error) {
+	dir, err := KeyringDir()
+	if err != nil {
+		return "", err
+	}
+	// keyring's file backend uses 0700 by default; match that.
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
 func ClientCredentialsPath() (string, error) {
 	dir, err := Dir()
 	if err != nil {

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -31,8 +31,18 @@ type Token struct {
 }
 
 func OpenDefault() (Store, error) {
+	// On Linux/WSL/containers, OS keychains (secret-service/kwallet) may be unavailable.
+	// In that case github.com/99designs/keyring falls back to the "file" backend,
+	// which *requires* both a directory and a password prompt function.
+	keyringDir, err := config.EnsureKeyringDir()
+	if err != nil {
+		return nil, err
+	}
+
 	ring, err := keyring.Open(keyring.Config{
-		ServiceName: config.AppName,
+		ServiceName:      config.AppName,
+		FileDir:          keyringDir,
+		FilePasswordFunc: keyring.TerminalPrompt,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes `No directory provided for file keyring` when OS keychain backends are unavailable and `github.com/99designs/keyring` falls back to the `file` backend.

Changes:
- Add `config.KeyringDir()` / `config.EnsureKeyringDir()` (`~/.config/gogcli/keyring`).
- Pass `FileDir` and `FilePasswordFunc` when opening the keyring in `secrets.OpenDefault()`.