### PR TITLE
fix: decode base64url attachments

### DIFF
--- a/internal/cmd/gmail_thread_test.go
+++ b/internal/cmd/gmail_thread_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/base64"
 	"testing"
 
@@ -57,7 +58,44 @@ func TestDecodeBase64URL(t *testing.T) {
 	if got != "ok" {
 		t.Fatalf("unexpected: %q", got)
 	}
+	got, err = decodeBase64URL(base64.URLEncoding.EncodeToString([]byte("ok")))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if got != "ok" {
+		t.Fatalf("unexpected: %q", got)
+	}
 	if _, err := decodeBase64URL("!!!"); err == nil {
 		t.Fatalf("expected error")
+	}
+}
+
+func TestDecodeBase64URLBytes(t *testing.T) {
+	want := []byte{0xff, 0xff}
+
+	got, err := decodeBase64URLBytes(base64.RawURLEncoding.EncodeToString(want))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("unexpected: %#v", got)
+	}
+
+	got, err = decodeBase64URLBytes(base64.URLEncoding.EncodeToString(want))
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("unexpected: %#v", got)
+	}
+
+	enc := base64.RawURLEncoding.EncodeToString(want[:1])
+	enc = enc[:1] + "\n" + enc[1:]
+	got, err = decodeBase64URLBytes(enc)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !bytes.Equal(got, want[:1]) {
+		t.Fatalf("unexpected: %#v", got)
 	}
 }


### PR DESCRIPTION
## Summary\n- decode Gmail attachment parts that are base64url-encoded before saving\n- add test coverage for base64url case and keep existing behaviour for base64\n\n## Testing\n- go test ./...