### PR TITLE
Add thread modify command for batch label operations

### DIFF
--- a/internal/cmd/execute_gmail_more_commands_test.go
+++ b/internal/cmd/execute_gmail_more_commands_test.go
@@ -135,7 +135,7 @@ func TestExecute_GmailThreadDraftsSend_JSON(t *testing.T) {
 
 	_ = captureStderr(t, func() {
 		out := captureStdout(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "thread", "t1", "--download"}); err != nil {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "gmail", "thread", "get", "t1", "--download"}); err != nil {
 				t.Fatalf("thread: %v", err)
 			}
 		})

--- a/internal/cmd/execute_gmail_text_test.go
+++ b/internal/cmd/execute_gmail_text_test.go
@@ -86,7 +86,7 @@ func TestExecute_GmailThread_Text_Download(t *testing.T) {
 
 	out := captureStdout(t, func() {
 		_ = captureStderr(t, func() {
-			if execErr := Execute([]string{"--account", "a@b.com", "gmail", "thread", "t-thread-1", "--download"}); execErr != nil {
+			if execErr := Execute([]string{"--account", "a@b.com", "gmail", "thread", "get", "t-thread-1", "--download"}); execErr != nil {
 				t.Fatalf("Execute: %v", execErr)
 			}
 		})
@@ -238,7 +238,7 @@ func TestExecute_GmailThread_OutDir_CreatesParents_JSON(t *testing.T) {
 				if execErr := Execute([]string{
 					"--json",
 					"--account", "a@b.com",
-					"gmail", "thread", "t-thread-1",
+					"gmail", "thread", "get", "t-thread-1",
 					"--download",
 					"--out-dir", outDir,
 				}); execErr != nil {


### PR DESCRIPTION
## Summary
- Adds `gmail thread modify` subcommand that uses Gmail API's `Threads.Modify` endpoint
- Applies label changes to all messages in a thread at once
- Resolves label names to IDs automatically (existing `fetchLabelNameToID` helper)

## Usage
```bash
gog gmail thread modify <threadId> --add "Label1,Label2" --remove "Label3"
gog gmail thread modify abc123 --add STARRED --json
```

## Breaking Change
The `gmail thread` command is now a parent command with subcommands:
- **Before:** `gog gmail thread <id>`
- **After:** `gog gmail thread get <id>`

This follows the pattern established by other commands like `gmail drafts` which have subcommands (`list`, `get`, `create`, `send`, `delete`).

## Test plan
- [x] All existing tests pass (updated test files to use new API)
- [x] Manually tested `thread modify --add STARRED` and `thread get` commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)