### PR TITLE
Add List-Unsubscribe extraction to Gmail details

### DIFF
--- a/internal/cmd/execute_gmail_get_test.go
+++ b/internal/cmd/execute_gmail_get_test.go
@@ -26,7 +26,7 @@ func TestExecute_GmailGet_Metadata_JSON(t *testing.T) {
 			t.Fatalf("format=%q", got)
 		}
 		gotHeaders := r.URL.Query()["metadataHeaders"]
-		if len(gotHeaders) != 2 || !containsAll(gotHeaders, []string{"Subject", "Date"}) {
+		if len(gotHeaders) != 3 || !containsAll(gotHeaders, []string{"Subject", "Date", "List-Unsubscribe"}) {
 			t.Fatalf("metadataHeaders=%#v", gotHeaders)
 		}
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/mail"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -123,6 +124,15 @@ func headerValue(p *gmail.MessagePart, name string) string {
 	return ""
 }
 
+func hasHeaderName(headers []string, name string) bool {
+	for _, h := range headers {
+		if strings.EqualFold(strings.TrimSpace(h), name) {
+			return true
+		}
+	}
+	return false
+}
+
 func formatGmailDate(raw string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
@@ -132,6 +142,73 @@ func formatGmailDate(raw string) string {
 		return t.Format("2006-01-02 15:04")
 	}
 	return raw
+}
+
+var listUnsubscribeLinkPattern = regexp.MustCompile(`<([^>]+)>`)
+
+func bestUnsubscribeLink(p *gmail.MessagePart) string {
+	links := parseListUnsubscribe(headerValue(p, "List-Unsubscribe"))
+	if len(links) == 0 {
+		return ""
+	}
+	for _, link := range links {
+		lower := strings.ToLower(link)
+		if strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://") {
+			return link
+		}
+	}
+	return links[0]
+}
+
+func parseListUnsubscribe(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	candidates := make([]string, 0)
+	matches := listUnsubscribeLinkPattern.FindAllStringSubmatch(raw, -1)
+	if len(matches) > 0 {
+		for _, match := range matches {
+			candidate := strings.TrimSpace(match[1])
+			if candidate == "" {
+				continue
+			}
+			candidates = append(candidates, candidate)
+		}
+	} else {
+		parts := strings.Split(raw, ",")
+		for _, part := range parts {
+			candidate := strings.TrimSpace(strings.Trim(part, "<>\""))
+			if candidate == "" {
+				continue
+			}
+			candidates = append(candidates, candidate)
+		}
+	}
+	filtered := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{})
+	for _, candidate := range candidates {
+		if !isUnsubscribeLink(candidate) {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		filtered = append(filtered, candidate)
+	}
+	return filtered
+}
+
+func isUnsubscribeLink(raw string) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	lower := strings.ToLower(raw)
+	return strings.HasPrefix(lower, "http://") ||
+		strings.HasPrefix(lower, "https://") ||
+		strings.HasPrefix(lower, "mailto:")
 }
 
 func mailParseDate(s string) (time.Time, error) {

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -55,6 +55,9 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if len(headerList) == 0 {
 			headerList = []string{"From", "To", "Subject", "Date"}
 		}
+		if !hasHeaderName(headerList, "List-Unsubscribe") {
+			headerList = append(headerList, "List-Unsubscribe")
+		}
 		call = call.MetadataHeaders(headerList...)
 	}
 
@@ -63,8 +66,13 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	unsubscribe := bestUnsubscribeLink(msg.Payload)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{"message": msg})
+		payload := map[string]any{"message": msg}
+		if unsubscribe != "" {
+			payload["unsubscribe"] = unsubscribe
+		}
+		return outfmt.WriteJSON(os.Stdout, payload)
 	}
 
 	u.Out().Printf("id\t%s", msg.Id)
@@ -89,6 +97,9 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		u.Out().Printf("to\t%s", headerValue(msg.Payload, "To"))
 		u.Out().Printf("subject\t%s", headerValue(msg.Payload, "Subject"))
 		u.Out().Printf("date\t%s", headerValue(msg.Payload, "Date"))
+		if unsubscribe != "" {
+			u.Out().Printf("unsubscribe\t%s", unsubscribe)
+		}
 		if format == gmailFormatFull {
 			body := bestBodyText(msg.Payload)
 			if body != "" {

--- a/internal/cmd/gmail_test.go
+++ b/internal/cmd/gmail_test.go
@@ -24,6 +24,29 @@ func TestHeaderValue(t *testing.T) {
 	}
 }
 
+func TestBestUnsubscribeLink(t *testing.T) {
+	p := &gmail.MessagePart{
+		Headers: []*gmail.MessagePartHeader{
+			{Name: "List-Unsubscribe", Value: "<mailto:unsubscribe@example.com>, <https://example.com/unsub?id=1>"},
+		},
+	}
+	if got := bestUnsubscribeLink(p); got != "https://example.com/unsub?id=1" {
+		t.Fatalf("unexpected: %q", got)
+	}
+	p.Headers[0].Value = "mailto:unsubscribe@example.com, https://example.com/unsub"
+	if got := bestUnsubscribeLink(p); got != "https://example.com/unsub" {
+		t.Fatalf("unexpected: %q", got)
+	}
+	p.Headers[0].Value = "<mailto:unsubscribe@example.com>"
+	if got := bestUnsubscribeLink(p); got != "mailto:unsubscribe@example.com" {
+		t.Fatalf("unexpected: %q", got)
+	}
+	p.Headers[0].Value = "not a link"
+	if got := bestUnsubscribeLink(p); got != "" {
+		t.Fatalf("unexpected: %q", got)
+	}
+}
+
 func TestSanitizeTab(t *testing.T) {
 	if got := sanitizeTab("a\tb"); got != "a b" {
 		t.Fatalf("unexpected: %q", got)

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -140,6 +140,10 @@ func (c *GmailThreadGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		u.Out().Printf("To: %s", headerValue(msg.Payload, "To"))
 		u.Out().Printf("Subject: %s", headerValue(msg.Payload, "Subject"))
 		u.Out().Printf("Date: %s", headerValue(msg.Payload, "Date"))
+		unsubscribe := bestUnsubscribeLink(msg.Payload)
+		if unsubscribe != "" {
+			u.Out().Printf("Unsubscribe: %s", unsubscribe)
+		}
 		u.Out().Println("")
 
 		body, isHTML := bestBodyForDisplay(msg.Payload)


### PR DESCRIPTION
Motivation:
  - I want to be able to tell my AI assistant to unsubscribe from certain email newsletters etc and do so with limited token usage.

Details:
  - Extract and surface List‑Unsubscribe links in gog gmail get output (text + JSON).
  - Include unsubscribe info in gog gmail thread get per-message details.
  - Ensure metadata requests always include List-Unsubscribe; add parsing tests and update metadata header expectations.

Codex assisted. Tested locally (redacting some details):

```
% bin/gog gmail get 19b8a0f7da40deb6 --account me@email.com
id      19b8a0f7da40deb6
thread_id       19b8a0f7da40deb6
label_ids       CATEGORY_PROMOTIONS,UNREAD,INBOX
from    Seamless <email@a.seamless.com>
to      me@email.com
subject Pssst, This Restaurant (Brooklyn) and more have something for you👀
date    Sun, 04 Jan 2026 17:30:28 +0000 (UTC)
unsubscribe     https://01.emailinboundprocessing.com/enc_user/list_unsubscribe?d=...&1=1
```