### PR TITLE
fix: handle historyId sync after server restarts

### DIFF
--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -109,16 +109,40 @@ func (s *gmailWatchStore) Save() error {
 func (s *gmailWatchStore) StartHistoryID(pushHistory string) (uint64, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	if s.state.HistoryID == "" {
-		if pushHistory == "" {
-			return 0, nil
+
+	// Parse push historyId if provided
+	var pushID uint64
+	if pushHistory != "" {
+		var err error
+		pushID, err = parseHistoryID(pushHistory)
+		if err != nil {
+			return 0, err
 		}
-		s.state.HistoryID = pushHistory
-		s.state.UpdatedAtMs = time.Now().UnixMilli()
-		_ = s.Save()
+	}
+
+	// If no stored state, use push historyId
+	if s.state.HistoryID == "" {
+		if pushHistory != "" {
+			s.state.HistoryID = pushHistory
+			s.state.UpdatedAtMs = time.Now().UnixMilli()
+			_ = s.Save()
+			return pushID, nil // Return parsed ID, not 0
+		}
 		return 0, nil
 	}
-	return parseHistoryID(s.state.HistoryID)
+
+	storedID, err := parseHistoryID(s.state.HistoryID)
+	if err != nil {
+		return 0, err
+	}
+
+	// If push historyId is lower than stored, use push
+	// This catches messages that arrived before our stored checkpoint
+	if pushID > 0 && pushID < storedID {
+		return pushID, nil
+	}
+
+	return storedID, nil
 }
 
 func parseHistoryID(raw string) (uint64, error) {


### PR DESCRIPTION
## Problem

When using `gmail watch serve` with webhooks, the Gmail API sometimes returns "no history" even when new emails have arrived. This happens because the stored `historyId` can become >= the push notification's `historyId`, causing `history.list` to return empty results.

### Reproduction scenario:
1. Start `gmail watch serve`
2. Receive some emails, historyId advances and is stored
3. Restart the server (gateway restart, deployment, etc.)
4. Receive a push notification with a historyId that's lower than stored
5. API returns "no history" because startHistoryId >= push historyId

This is particularly common in development environments with frequent restarts and low email volume.

## Solution

Modify `StartHistoryID()` in `gmail_watch_state.go` to:

1. **Return parsed pushHistory when state is empty** - Previously returned 0
2. **Use the lower of stored vs push historyId** - Ensures we don't miss messages after restarts

## Testing

- ✅ All existing tests pass
- ✅ Tested with Clawdis gateway integration over multiple days
- ✅ Verified webhooks work reliably after gateway restarts
- ✅ Confirmed no duplicate processing (historyId still advances correctly)

---

## 🤖 AI Disclosure

This PR was created with AI assistance (Claude/Jib via Clawdis).

- **Testing level:** Fully tested in production environment (Clawdis gateway)
- **Human review:** Code reviewed and approved by @joargp
- **Understanding:** The fix addresses historyId comparison logic - when push ID is lower than stored ID, use push ID to avoid missing messages that arrived during downtime