### PR TITLE
Add --recurrence flag to calendar create command

### DIFF
--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -219,6 +219,7 @@ type CalendarCreateCmd struct {
 	Location    string `name:"location" help:"Location"`
 	Attendees   string `name:"attendees" help:"Comma-separated attendee emails"`
 	AllDay      bool   `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
+	Recurrence  string `name:"recurrence" help:"Recurrence rule (YEARLY, MONTHLY, WEEKLY, DAILY or full RRULE)"`
 }
 
 func (c *CalendarCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -248,6 +249,7 @@ func (c *CalendarCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		Start:       buildEventDateTime(c.From, c.AllDay),
 		End:         buildEventDateTime(c.To, c.AllDay),
 		Attendees:   buildAttendees(c.Attendees),
+		Recurrence:  buildRecurrence(c.Recurrence),
 	}
 
 	created, err := svc.Events.Insert(calendarID, event).Do()
@@ -590,6 +592,17 @@ func buildAttendees(csv string) []*calendar.EventAttendee {
 		out = append(out, &calendar.EventAttendee{Email: a})
 	}
 	return out
+}
+
+func buildRecurrence(rule string) []string {
+	rule = strings.TrimSpace(strings.ToUpper(rule))
+	if rule == "" {
+		return nil
+	}
+	if !strings.HasPrefix(rule, "RRULE:") {
+		rule = "RRULE:FREQ=" + rule
+	}
+	return []string{rule}
 }
 
 func splitCSV(s string) []string {


### PR DESCRIPTION
## Summary
- Adds `--recurrence` flag to `gog calendar create` command
- Supports shorthand values: `YEARLY`, `MONTHLY`, `WEEKLY`, `DAILY`
- Also accepts full RRULE syntax (e.g., `RRULE:FREQ=YEARLY;INTERVAL=2`)

## Usage
```bash
# Create a yearly recurring birthday
gog calendar create primary --summary="Birthday" --from="2026-09-25" --to="2026-09-26" --all-day --recurrence=YEARLY

# Using full RRULE syntax
gog calendar create primary --summary="Standup" --from="2026-01-06T09:00:00Z" --to="2026-01-06T09:30:00Z" --recurrence="RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR"
```

## Changes
- Added `Recurrence` field to `CalendarCreateCmd` struct
- Added `buildRecurrence()` helper function that converts shorthand to full RRULE format
- Sets `Recurrence` field on the event before insert

## Test plan
- [x] Built and tested locally
- [x] Verified recurring events appear correctly in Google Calendar