### PR TITLE
feat(gmail): add gmail.settings.basic scope for filter operations

### DIFF
--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -37,7 +37,10 @@ func AllServices() []Service {
 func Scopes(service Service) ([]string, error) {
 	switch service {
 	case ServiceGmail:
-		return []string{"https://mail.google.com/"}, nil
+		return []string{
+			"https://mail.google.com/",
+			"https://www.googleapis.com/auth/gmail.settings.basic",
+		}, nil
 	case ServiceCalendar:
 		return []string{"https://www.googleapis.com/auth/calendar"}, nil
 	case ServiceDrive:


### PR DESCRIPTION
## Problem

The Gmail filters API requires the `gmail.settings.basic` scope to create, update, or delete filters. Without this scope, filter operations fail with `insufficientPermissions` error even when the full `mail.google.com` scope is granted.

## Solution

Add `https://www.googleapis.com/auth/gmail.settings.basic` alongside the existing full Gmail scope in the `Scopes()` function for `ServiceGmail`.

## Testing

After this change:
1. Re-auth with `gog auth add email@gmail.com --services gmail --force-consent`
2. `gog gmail filters create` works correctly

Without this change, `gog gmail filters create` returns:
```
Google API error (403 insufficientPermissions): Request had insufficient authentication scopes.
```