### PR TITLE
feat(gmail): show last message date in thread search

### DIFF
--- a/internal/cmd/gmail_concurrent_test.go
+++ b/internal/cmd/gmail_concurrent_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestFetchThreadDetails_Empty(t *testing.T) {
-	items, err := fetchThreadDetails(context.Background(), nil, nil, nil)
+	items, err := fetchThreadDetails(context.Background(), nil, nil, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestFetchThreadDetails_Concurrent(t *testing.T) {
 		"INBOX": "Inbox",
 	}
 
-	items, err := fetchThreadDetails(context.Background(), svc, threads, idToName)
+	items, err := fetchThreadDetails(context.Background(), svc, threads, idToName, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestFetchThreadDetails_SkipsEmptyIDs(t *testing.T) {
 		{Id: ""},        // Should be skipped
 	}
 
-	items, err := fetchThreadDetails(context.Background(), svc, threads, nil)
+	items, err := fetchThreadDetails(context.Background(), svc, threads, nil, false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -176,7 +176,7 @@ func TestFetchThreadDetails_ContextCanceled(t *testing.T) {
 
 	threads := []*gmail.Thread{{Id: "thread1"}}
 
-	_, err := fetchThreadDetails(ctx, svc, threads, nil)
+	_, err := fetchThreadDetails(ctx, svc, threads, nil, false)
 	// Context was canceled, we may or may not get an error depending on timing.
 	// Either nil or context.Canceled is acceptable.
 	_ = err


### PR DESCRIPTION
## Summary
- Default behavior now shows the date of the last (newest) message in thread
- This aligns with Gmail API sort order (threads sorted by last message)
- Add `--oldest` flag to show first message date instead

## Test plan
- [x] `go test ./...` passes
- [x] `gog gmail search 'newer_than:7d'` shows last message date
- [x] `gog gmail search 'newer_than:7d' --oldest` shows first message date

🤖 Generated with [Claude Code](https://claude.com/claude-code)