### PR TITLE
fix(calendar): add timezone to EventDateTime for recurring events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - DX: `make gogcli -- ...` passes args to the CLI; add `make gogcli-help` convenience target.
 - Calendar: `gog calendar update --add-attendee ...` adds attendees without replacing existing RSVP state (#24) — thanks @salmonumbrella.
 - Calendar: add `gog calendar create|update --rrule/--reminder` for recurrence rules and custom reminders (#34) — thanks @salmonumbrella.
+- Calendar: infer IANA `timeZone` from `--from/--to` offsets for recurring events (#53) — thanks @visionik.
 - Calendar: add Groups/team calendar commands + search time window flags (#41) — thanks @salmonumbrella.
 - Calendar: add `--week-start`, expand search window defaults, and improve team dedupe/nested group handling.
 - Gmail: `gog gmail thread attachments` list/download attachments (#27) — thanks @salmonumbrella.

--- a/internal/cmd/calendar_build_test.go
+++ b/internal/cmd/calendar_build_test.go
@@ -10,11 +10,14 @@ func TestExtractTimezone(t *testing.T) {
 		{"2026-01-08T11:00:00-05:00", "America/New_York"},
 		{"2026-07-08T11:00:00-04:00", "America/New_York"},
 		{"2026-01-08T11:00:00-06:00", "America/Chicago"},
+		{"2026-07-08T11:00:00-05:00", "America/Chicago"},
 		{"2026-01-08T11:00:00-07:00", "America/Denver"},
+		{"2026-07-08T11:00:00-07:00", "America/Phoenix"},
 		{"2026-01-08T11:00:00-08:00", "America/Los_Angeles"},
 		{"2026-01-08T16:00:00Z", "UTC"},
 		{"2026-01-08T11:00:00+00:00", "UTC"},
 		{"invalid", ""},
+		{"2026-01-08T11:00:00-04:00", ""}, // not a common US offset on this date
 		{"2026-01-08T11:00:00+05:30", ""}, // India - not mapped
 	}
 


### PR DESCRIPTION
## Problem

When creating a recurring event via `gog calendar create` with `--rrule`, the Google Calendar API returns:

```
Google API error (400 required): Missing time zone definition for start time.
```

This happens because Google requires an explicit `TimeZone` field on the `EventDateTime` struct for recurring events.

## Solution

Extract the timezone from the RFC3339 offset in the `--from`/`--to` values and map common offsets to IANA timezone names.

## Example

This now works:

```bash
gog calendar create primary \
  --summary 'Publix Pharmacy App Order' \
  --from '2026-01-08T11:00:00-05:00' \
  --to '2026-01-08T11:30:00-05:00' \
  --rrule 'RRULE:FREQ=DAILY;INTERVAL=28' \
  --account user@example.com
```

## Notes

- Maps common US timezone offsets (-8 to -4) to IANA names
- UTC (Z suffix or +00:00) is handled
- Unknown offsets gracefully degrade (no timezone set, non-recurring events still work)
- Added unit tests for `extractTimezone()`