### PR TITLE
fix(googleauth): add missing keep readonly scope

### DIFF
--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -383,6 +383,10 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 	case ServiceGroups:
 		return Scopes(service)
 	case ServiceKeep:
+		if opts.Readonly {
+			return []string{"https://www.googleapis.com/auth/keep.readonly"}, nil
+		}
+
 		return Scopes(service)
 	default:
 		return nil, errUnknownService

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -211,7 +211,7 @@ func TestScopesForServices_UnionSorted(t *testing.T) {
 }
 
 func TestScopesForManageWithOptions_Readonly(t *testing.T) {
-	scopes, err := ScopesForManageWithOptions([]Service{ServiceGmail, ServiceDrive, ServiceCalendar, ServiceContacts, ServiceTasks, ServiceSheets, ServiceDocs, ServicePeople}, ScopeOptions{
+	scopes, err := ScopesForManageWithOptions([]Service{ServiceGmail, ServiceDrive, ServiceCalendar, ServiceContacts, ServiceTasks, ServiceSheets, ServiceDocs, ServicePeople, ServiceKeep}, ScopeOptions{
 		Readonly:   true,
 		DriveScope: DriveScopeFull,
 	})
@@ -230,6 +230,7 @@ func TestScopesForManageWithOptions_Readonly(t *testing.T) {
 		"https://www.googleapis.com/auth/tasks.readonly",
 		"https://www.googleapis.com/auth/spreadsheets.readonly",
 		"https://www.googleapis.com/auth/documents.readonly",
+		"https://www.googleapis.com/auth/keep.readonly",
 		"profile",
 	}
 	for _, w := range want {
@@ -247,6 +248,7 @@ func TestScopesForManageWithOptions_Readonly(t *testing.T) {
 		"https://www.googleapis.com/auth/tasks",
 		"https://www.googleapis.com/auth/spreadsheets",
 		"https://www.googleapis.com/auth/documents",
+		"https://www.googleapis.com/auth/keep",
 	}
 	for _, nw := range notWant {
 		if containsScope(scopes, nw) {


### PR DESCRIPTION
This PR adds the missing readonly scope support for the Google Keep service. Verified with tests.