### PR TITLE
feat(sheets): add format command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Auth: Workspace service accounts (domain-wide delegation) for all services via `gog auth service-account ...` (preferred when configured). (#54) — thanks @pvieito.
+- Sheets: `gog sheets format` applies cell formatting via `--format-json` + `--format-fields`.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -605,6 +605,7 @@ gog slides export <presentationId> --format pdf --out ./deck.pdf
 # Sheets
 gog sheets copy <spreadsheetId> "My Sheet Copy"
 gog sheets export <spreadsheetId> --format pdf --out ./sheet.pdf
+gog sheets format <spreadsheetId> 'Sheet1!A1:B2' --format-json '{"textFormat":{"bold":true}}' --format-fields 'userEnteredFormat.textFormat.bold'
 ```
 
 ### Contacts
@@ -673,6 +674,9 @@ gog sheets update <spreadsheetId> 'Sheet1!A1:C1' 'new|row|data' --copy-validatio
 gog sheets append <spreadsheetId> 'Sheet1!A:C' 'new|row|data'
 gog sheets append <spreadsheetId> 'Sheet1!A:C' 'new|row|data' --copy-validation-from 'Sheet1!A2:C2'
 gog sheets clear <spreadsheetId> 'Sheet1!A1:B10'
+
+# Format
+gog sheets format <spreadsheetId> 'Sheet1!A1:B2' --format-json '{"textFormat":{"bold":true}}' --format-fields 'userEnteredFormat.textFormat.bold'
 
 # Create
 gog sheets create "My New Spreadsheet" --sheets "Sheet1,Sheet2"

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -28,6 +28,7 @@ type SheetsCmd struct {
 	Update   SheetsUpdateCmd   `cmd:"" name:"update" help:"Update values in a range"`
 	Append   SheetsAppendCmd   `cmd:"" name:"append" help:"Append values to a range"`
 	Clear    SheetsClearCmd    `cmd:"" name:"clear" help:"Clear values in a range"`
+	Format   SheetsFormatCmd   `cmd:"" name:"format" help:"Apply cell formatting to a range"`
 	Metadata SheetsMetadataCmd `cmd:"" name:"metadata" help:"Get spreadsheet metadata"`
 	Create   SheetsCreateCmd   `cmd:"" name:"create" help:"Create a new spreadsheet"`
 	Copy     SheetsCopyCmd     `cmd:"" name:"copy" help:"Copy a Google Sheet"`

--- a/internal/cmd/sheets_format.go
+++ b/internal/cmd/sheets_format.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type SheetsFormatCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	Range         string `arg:"" name:"range" help:"Range (eg. Sheet1!A1:B2)"`
+	FormatJSON    string `name:"format-json" help:"Cell format as JSON (Sheets API CellFormat)"`
+	FormatFields  string `name:"format-fields" help:"Format field mask (eg. userEnteredFormat.textFormat.bold)"`
+}
+
+func (c *SheetsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	spreadsheetID := strings.TrimSpace(c.SpreadsheetID)
+	rangeSpec := cleanRange(c.Range)
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+	if strings.TrimSpace(rangeSpec) == "" {
+		return usage("empty range")
+	}
+	if strings.TrimSpace(c.FormatJSON) == "" {
+		return fmt.Errorf("provide format JSON via --format-json")
+	}
+	formatFields := strings.TrimSpace(c.FormatFields)
+	if formatFields == "" {
+		return fmt.Errorf("provide format fields via --format-fields")
+	}
+
+	var format sheets.CellFormat
+	if err := json.Unmarshal([]byte(c.FormatJSON), &format); err != nil {
+		return fmt.Errorf("invalid format JSON: %w", err)
+	}
+
+	rangeInfo, err := parseA1Range(rangeSpec)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(rangeInfo.SheetName) == "" {
+		return fmt.Errorf("format range must include a sheet name")
+	}
+
+	svc, err := newSheetsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	sheetIDs, err := fetchSheetIDMap(ctx, svc, spreadsheetID)
+	if err != nil {
+		return err
+	}
+	sheetID, ok := sheetIDs[rangeInfo.SheetName]
+	if !ok {
+		return fmt.Errorf("unknown sheet %q in format range", rangeInfo.SheetName)
+	}
+
+	req := &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: []*sheets.Request{
+			{
+				RepeatCell: &sheets.RepeatCellRequest{
+					Range: toGridRange(rangeInfo, sheetID),
+					Cell: &sheets.CellData{
+						UserEnteredFormat: &format,
+					},
+					Fields: formatFields,
+				},
+			},
+		},
+	}
+
+	if _, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, req).Do(); err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"range":  rangeSpec,
+			"fields": formatFields,
+		})
+	}
+
+	u.Out().Printf("Formatted %s", rangeSpec)
+	return nil
+}

--- a/internal/cmd/sheets_format_test.go
+++ b/internal/cmd/sheets_format_test.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestSheetsFormatCmd(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	var gotRepeat *sheets.RepeatCellRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/sheets/v4")
+		path = strings.TrimPrefix(path, "/v4")
+		switch {
+		case strings.HasPrefix(path, "/spreadsheets/s1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "s1",
+				"sheets": []map[string]any{
+					{"properties": map[string]any{"sheetId": 42, "title": "Sheet1"}},
+				},
+			})
+			return
+		case strings.Contains(path, "/spreadsheets/s1:batchUpdate") && r.Method == http.MethodPost:
+			var req sheets.BatchUpdateSpreadsheetRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].RepeatCell == nil {
+				t.Fatalf("expected repeatCell request, got %#v", req.Requests)
+			}
+			gotRepeat = req.Requests[0].RepeatCell
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	cmd := &SheetsFormatCmd{}
+	if err := runKong(t, cmd, []string{
+		"s1",
+		"Sheet1!B2:C3",
+		"--format-json", `{"textFormat":{"bold":true}}`,
+		"--format-fields", "userEnteredFormat.textFormat.bold",
+	}, ctx, flags); err != nil {
+		t.Fatalf("format: %v", err)
+	}
+
+	if gotRepeat == nil {
+		t.Fatal("expected repeatCell request")
+	}
+	if gotRepeat.Fields != "userEnteredFormat.textFormat.bold" {
+		t.Fatalf("unexpected fields: %s", gotRepeat.Fields)
+	}
+	if gotRepeat.Range == nil {
+		t.Fatalf("missing range")
+	}
+	if gotRepeat.Range.SheetId != 42 {
+		t.Fatalf("unexpected sheet id: %d", gotRepeat.Range.SheetId)
+	}
+	if gotRepeat.Range.StartRowIndex != 1 || gotRepeat.Range.EndRowIndex != 3 {
+		t.Fatalf("unexpected row range: %#v", gotRepeat.Range)
+	}
+	if gotRepeat.Range.StartColumnIndex != 1 || gotRepeat.Range.EndColumnIndex != 3 {
+		t.Fatalf("unexpected column range: %#v", gotRepeat.Range)
+	}
+	if gotRepeat.Cell == nil || gotRepeat.Cell.UserEnteredFormat == nil || gotRepeat.Cell.UserEnteredFormat.TextFormat == nil {
+		t.Fatalf("missing format data: %#v", gotRepeat.Cell)
+	}
+	if !gotRepeat.Cell.UserEnteredFormat.TextFormat.Bold {
+		t.Fatalf("expected bold text format, got %#v", gotRepeat.Cell.UserEnteredFormat.TextFormat)
+	}
+}

--- a/internal/cmd/sheets_validation_more_test.go
+++ b/internal/cmd/sheets_validation_more_test.go
@@ -201,3 +201,31 @@ func TestSheetsClearMetadataCreate_ValidationErrors(t *testing.T) {
 		t.Fatalf("expected create missing title error")
 	}
 }
+
+func TestSheetsFormat_ValidationErrors(t *testing.T) {
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	if err := (&SheetsFormatCmd{}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected format missing spreadsheetId error")
+	}
+	if err := (&SheetsFormatCmd{SpreadsheetID: "s1"}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected format missing range error")
+	}
+	if err := (&SheetsFormatCmd{SpreadsheetID: "s1", Range: "Sheet1!A1"}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected format missing format-json error")
+	}
+	if err := (&SheetsFormatCmd{SpreadsheetID: "s1", Range: "Sheet1!A1", FormatJSON: "{\"textFormat\":{\"bold\":true}}"}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected format missing format-fields error")
+	}
+	if err := (&SheetsFormatCmd{SpreadsheetID: "s1", Range: "Sheet1!A1", FormatJSON: "nope", FormatFields: "userEnteredFormat.textFormat.bold"}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected format invalid json error")
+	}
+	if err := (&SheetsFormatCmd{SpreadsheetID: "s1", Range: "A1:B2", FormatJSON: "{\"textFormat\":{\"bold\":true}}", FormatFields: "userEnteredFormat.textFormat.bold"}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected format missing sheet name error")
+	}
+}


### PR DESCRIPTION
## Description
Hi @steipete,

love the cli and i am a heavy user. One thing i was missing to format stuff so the sheets look customer ready :D 

I hope contributions are welcome, tested the cases with AI and manually. If you need something let me know. 

Add `gog sheets format` to apply cell formatting via Sheets BatchUpdate (RepeatCell + CellFormat). Includes validation, tests, docs, and changelog updates.

## Use Case
Scriptable formatting for automation pipelines (bold headers, number/currency formats, colors, alignment) without UI.

## Prompt History (verbatim-ish)
- "allow also formatting for google sheets, investigate the cli and come up with a plan"
- "copy format i dont think i need, but format-json and format makes sense"
- "what is more consistent for the existing api" → chose `--format-json` + `--format-fields`
- "i want you to implement, we only need the format sub command plus the tests"
- "run the tests and the readme changelog needs update"
- "test it in this sheet" → manual run against sample sheet
- "add a few numbers nice formatted"
- "create a pr... explain the use case, explain what my prompt history was and which commands we enable"

## Commands Enabled
- `gog sheets format <spreadsheetId> <range> --format-json '{...}' --format-fields 'userEnteredFormat.*'`

## How has this been tested?
- `go test ./internal/cmd -run SheetsFormat`
- Manual: `gog sheets format` on sample sheet (bold header, background color, number/currency formats)

<img width="869" height="612" alt="image" src="https://github.com/user-attachments/assets/acf18231-effd-4c40-8a19-6de5861aadc3" />
