### PR TITLE
feat(gmail): show attachment info in get command output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.7.0 - Unreleased
 
+### Added
+
+- Gmail: show attachment info (incl. humanized sizes) for `gmail get` full/metadata output, with JSON `sizeHuman`. (#83) — thanks @jeanregisser.
+
 ### Fixed
 
 - Gmail: include `gmail.settings.sharing` scope for filter operations to avoid 403 insufficientPermissions. (#69) — thanks @ryanh-ai.

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -27,6 +27,7 @@ const (
 type attachmentOutput struct {
 	Filename     string `json:"filename"`
 	Size         int64  `json:"size"`
+	SizeHuman    string `json:"sizeHuman"`
 	MimeType     string `json:"mimeType"`
 	AttachmentID string `json:"attachmentId"`
 }
@@ -97,6 +98,8 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 			if body := bestBodyText(msg.Payload); body != "" {
 				payload["body"] = body
 			}
+		}
+		if format == gmailFormatFull || format == gmailFormatMetadata {
 			attachments := collectAttachments(msg.Payload)
 			if len(attachments) > 0 {
 				out := make([]attachmentOutput, len(attachments))
@@ -104,6 +107,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 					out[i] = attachmentOutput{
 						Filename:     a.Filename,
 						Size:         a.Size,
+						SizeHuman:    formatBytes(a.Size),
 						MimeType:     a.MimeType,
 						AttachmentID: a.AttachmentID,
 					}
@@ -139,14 +143,14 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if unsubscribe != "" {
 			u.Out().Printf("unsubscribe\t%s", unsubscribe)
 		}
-		if format == gmailFormatFull {
-			attachments := collectAttachments(msg.Payload)
-			if len(attachments) > 0 {
-				u.Out().Println("")
-				for _, a := range attachments {
-					u.Out().Printf("attachment\t%s\t%d\t%s\t%s", a.Filename, a.Size, a.MimeType, a.AttachmentID)
-				}
+		attachments := collectAttachments(msg.Payload)
+		if len(attachments) > 0 {
+			u.Out().Println("")
+			for _, a := range attachments {
+				u.Out().Printf("attachment\t%s\t%s\t%s\t%s", a.Filename, formatBytes(a.Size), a.MimeType, a.AttachmentID)
 			}
+		}
+		if format == gmailFormatFull {
 			body := bestBodyText(msg.Payload)
 			if body != "" {
 				u.Out().Println("")

--- a/internal/cmd/gmail_get_cmd_test.go
+++ b/internal/cmd/gmail_get_cmd_test.go
@@ -171,10 +171,109 @@ func TestGmailGetCmd_JSON_Full_WithAttachments(t *testing.T) {
 	if att["filename"] != "document.pdf" {
 		t.Fatalf("unexpected attachment filename: %v", att["filename"])
 	}
+	if att["size"] != float64(12345) {
+		t.Fatalf("unexpected attachment size: %v", att["size"])
+	}
+	if att["sizeHuman"] != formatBytes(12345) {
+		t.Fatalf("unexpected attachment sizeHuman: %v", att["sizeHuman"])
+	}
 	if att["mimeType"] != "application/pdf" {
 		t.Fatalf("unexpected attachment mime type: %v", att["mimeType"])
 	}
 	if att["attachmentId"] != "ANGjdJ-abc123" {
+		t.Fatalf("unexpected attachment id: %v", att["attachmentId"])
+	}
+}
+
+func TestGmailGetCmd_JSON_Metadata_WithAttachments(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m1",
+			"threadId": "t1",
+			"labelIds": []string{"INBOX"},
+			"payload": map[string]any{
+				"mimeType": "multipart/mixed",
+				"headers": []map[string]any{
+					{"name": "From", "value": "a@example.com"},
+					{"name": "To", "value": "b@example.com"},
+					{"name": "Subject", "value": "Metadata attachments"},
+					{"name": "Date", "value": "Fri, 26 Dec 2025 10:00:00 +0000"},
+				},
+				"parts": []map[string]any{
+					{
+						"mimeType": "application/pdf",
+						"filename": "metadata.pdf",
+						"body": map[string]any{
+							"attachmentId": "ANGjdJ-meta123",
+							"size":         4096,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+			if uiErr != nil {
+				t.Fatalf("ui.New: %v", uiErr)
+			}
+			ctx := ui.WithUI(context.Background(), u)
+			ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+
+			cmd := &GmailGetCmd{}
+			if err := runKong(t, cmd, []string{"m1", "--format", "metadata"}, ctx, flags); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+		})
+	})
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v", err)
+	}
+	if _, ok := parsed["body"]; ok {
+		t.Fatalf("expected no body for metadata output")
+	}
+	attachments, ok := parsed["attachments"].([]any)
+	if !ok || len(attachments) != 1 {
+		t.Fatalf("expected 1 attachment, got: %v", parsed["attachments"])
+	}
+	att := attachments[0].(map[string]any)
+	if att["filename"] != "metadata.pdf" {
+		t.Fatalf("unexpected attachment filename: %v", att["filename"])
+	}
+	if att["size"] != float64(4096) {
+		t.Fatalf("unexpected attachment size: %v", att["size"])
+	}
+	if att["sizeHuman"] != formatBytes(4096) {
+		t.Fatalf("unexpected attachment sizeHuman: %v", att["sizeHuman"])
+	}
+	if att["mimeType"] != "application/pdf" {
+		t.Fatalf("unexpected attachment mime type: %v", att["mimeType"])
+	}
+	if att["attachmentId"] != "ANGjdJ-meta123" {
 		t.Fatalf("unexpected attachment id: %v", att["attachmentId"])
 	}
 }
@@ -247,8 +346,84 @@ func TestGmailGetCmd_Text_Full_WithAttachments(t *testing.T) {
 		})
 	})
 
-	if !strings.Contains(out, "attachment\treport.pdf\t54321\tapplication/pdf\tANGjdJ-xyz789") {
+	if !strings.Contains(out, "attachment\treport.pdf\t"+formatBytes(54321)+"\tapplication/pdf\tANGjdJ-xyz789") {
 		t.Fatalf("expected attachment line in output, got: %q", out)
+	}
+}
+
+func TestGmailGetCmd_Text_Metadata_WithAttachments(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	bodyData := base64.RawURLEncoding.EncodeToString([]byte("metadata body"))
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m1",
+			"threadId": "t1",
+			"labelIds": []string{"INBOX"},
+			"payload": map[string]any{
+				"mimeType": "multipart/mixed",
+				"headers": []map[string]any{
+					{"name": "From", "value": "a@example.com"},
+					{"name": "To", "value": "b@example.com"},
+					{"name": "Subject", "value": "Metadata"},
+					{"name": "Date", "value": "Fri, 26 Dec 2025 10:00:00 +0000"},
+				},
+				"parts": []map[string]any{
+					{
+						"mimeType": "text/plain",
+						"body":     map[string]any{"data": bodyData},
+					},
+					{
+						"mimeType": "application/pdf",
+						"filename": "report.pdf",
+						"body": map[string]any{
+							"attachmentId": "ANGjdJ-xyz789",
+							"size":         54321,
+						},
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+			if uiErr != nil {
+				t.Fatalf("ui.New: %v", uiErr)
+			}
+			ctx := ui.WithUI(context.Background(), u)
+
+			cmd := &GmailGetCmd{}
+			if err := runKong(t, cmd, []string{"m1", "--format", "metadata"}, ctx, flags); err != nil {
+				t.Fatalf("execute: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(out, "attachment\treport.pdf\t"+formatBytes(54321)+"\tapplication/pdf\tANGjdJ-xyz789") {
+		t.Fatalf("expected attachment line in output, got: %q", out)
+	}
+	if strings.Contains(out, "metadata body") {
+		t.Fatalf("unexpected body output for metadata: %q", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Display attachment filename, size, MIME type, and attachment_id in both plain text and JSON output for the `gmail get` command with `--format=full`.

This makes it easier to identify and download attachments without needing to manually parse the message payload structure.

## Problem

When using `gog gmail get <messageId>`, there's no indication of attachments in the output. Users need to use `--format=full --json` and then manually parse the nested `message.payload.parts` structure to find attachment IDs before they can use `gog gmail attachment` to download them.

## Solution

Reuse the existing `collectAttachments()` function from `gmail_thread.go` to extract and display attachment info in both output formats.

### Example plain text output (new section before body):
```
from	a@example.com
to	b@example.com
subject	Email with attachment
date	Fri, 26 Dec 2025 10:00:00 +0000

attachment	CV-Document.pdf	192123	application/pdf	ANGjdJ...

hello with attachment
```

### Example JSON output (new field):
```json
{
  "attachments": [
    {"filename": "CV-Document.pdf", "size": 192123, "mimeType": "application/pdf", "attachmentId": "ANGjdJ..."}
  ]
}
```

## AI-Assisted Development

This PR was created with AI assistance. The prompts used:

**Initial prompt:**
> I wonder if the gog cli email output should be improved to include info about attachments?

**Follow-up prompt:**
> Yes it's a repo from steipete, I think we could propose a PR directly with a proposed solution given the problem we had. Can you take care of it? Give a link to the PR once done. Include the prompts used in the PR too I think it's helpful for the maintainer

**Context:** The user was trying to download an email attachment and struggled because `gog gmail get` didn't show attachment info. They had to:
1. Use `gog gmail get <id> --format=full --json`
2. Parse the JSON to find `.message.payload.parts[].body.attachmentId`
3. Then use `gog gmail attachment <messageId> <attachmentId>`

With this change, the attachment ID is visible directly in the standard output.
