### PR TITLE
fix(auth): correct gmail search example in success template

### DIFF
--- a/internal/googleauth/templates/success.html
+++ b/internal/googleauth/templates/success.html
@@ -628,7 +628,6 @@
                     <span class="terminal-cmd">gog</span>
                     <span class="terminal-arg">gmail</span>
                     <span class="terminal-arg">search</span>
-                    <span class="terminal-flag">--query</span>
                     <span class="terminal-cmd">"is:unread"</span>
                 </div>
                 <div class="terminal-output success">Found 12 messages</div>


### PR DESCRIPTION
Remove incorrect `--query` flag from the gmail search example in the auth success template.

The `gog gmail search` command accepts the query as a positional argument:

```bash
# Correct
gog gmail search "is:unread"

# Incorrect (was shown in template)
gog gmail search --query "is:unread"
```