### PR TITLE
feat(gmail): Add thread message count to search results

### DIFF
--- a/internal/cmd/execute_gmail_test.go
+++ b/internal/cmd/execute_gmail_test.go
@@ -83,11 +83,12 @@ func TestExecute_GmailSearch_JSON(t *testing.T) {
 
 	var parsed struct {
 		Threads []struct {
-			ID      string   `json:"id"`
-			Date    string   `json:"date"`
-			From    string   `json:"from"`
-			Subject string   `json:"subject"`
-			Labels  []string `json:"labels"`
+			ID           string   `json:"id"`
+			Date         string   `json:"date"`
+			From         string   `json:"from"`
+			Subject      string   `json:"subject"`
+			Labels       []string `json:"labels"`
+			MessageCount int      `json:"messageCount"`
 		} `json:"threads"`
 		NextPageToken string `json:"nextPageToken"`
 	}
@@ -99,6 +100,9 @@ func TestExecute_GmailSearch_JSON(t *testing.T) {
 	}
 	if parsed.Threads[0].ID != "t1" || parsed.Threads[0].Subject != "Hello" {
 		t.Fatalf("unexpected thread: %#v", parsed.Threads[0])
+	}
+	if parsed.Threads[0].MessageCount != 1 {
+		t.Fatalf("unexpected messageCount: %d", parsed.Threads[0].MessageCount)
 	}
 	if parsed.Threads[0].Date != "2006-01-02 22:04" {
 		t.Fatalf("unexpected date: %q", parsed.Threads[0].Date)


### PR DESCRIPTION
Show message count in search output to help agents and users understand when an email is part of a multi-message conversation.

## Problem

When searching Gmail via `gog gmail search`, the results show thread IDs but not the number of messages in each thread. This makes it difficult for AI agents (and humans) to determine if a message is a standalone email or part of a conversation.

**Example scenario:**
- User asks agent: "Are there any new emails from Claire?"
- Agent runs `gog gmail search 'newer_than:1d'`
- Results show "Meilleurs vœux 2026" from Claire
- Agent reads the email and sees it's a New Year's greeting
- **Missing:** The agent doesn't see that there are 6 messages in this thread with a back-and-forth conversation

## Solution

This PR adds message count to the search output:

**Before:**
```
ID  DATE  FROM  SUBJECT  LABELS
19b97acb5adefd83  Jan 20  Claire  Meilleurs vœux 2026  CATEGORY_PERSONAL,INBOX
```

**After:**
```
ID  DATE  FROM  SUBJECT  LABELS  THREAD
19b97acb5adefd83  Jan 20  Claire  Meilleurs vœux 2026  CATEGORY_PERSONAL,INBOX  [6 msgs]
```

Single-message emails show `-`, multi-message threads show `[X msgs]`.
The `LABELS` column is preserved for backward compatibility.

## Changes

1. **Added `MessageCount` field** to `threadItem` struct (for JSON output)
2. **Populated message count** from `len(thread.Messages)` in `fetchThreadDetails`
3. **Added new THREAD column** showing `[X msgs]` for threads, `-` for single messages
4. **Preserved LABELS column** for backward compatibility
5. **JSON output** includes `messageCount` field for programmatic access

## Feedback Requested

- Should the THREAD column be moved closer to the beginning (e.g., right after SUBJECT instead of at the end)?
- Is the `[X msgs]` format clear, or should we just show the raw count (e.g., `6` instead of `[6 msgs]`)?
- Alternative approaches for making thread context visible?

## Additional Notes

I considered updating the gogcli skill documentation to reduce confusion around when to use `gog gmail get` vs `gog gmail thread get`. However, having thread message count visible in search results benefits all users, not just agents — similar to how Gmail's web UI shows conversation counts.

I was using MiniMax M2.1 for this session. It's unclear if a more capable model like Claude Opus would have been less confused by the lack of thread context, but making this information explicit removes the ambiguity entirely.

## Testing

- All existing Gmail tests pass
- Manual testing confirms:
  - Both LABELS and THREAD columns are displayed
  - Single messages show `-` in THREAD column
  - Multi-message threads show `[X msgs]` (e.g., `[6 msgs]`)
  - JSON output includes `messageCount` field