### PR TITLE
fix: cleanup headless Chrome processes after OAuth flow

### DIFF
--- a/internal/googleauth/oauth_flow.go
+++ b/internal/googleauth/oauth_flow.go
@@ -84,6 +84,9 @@ func Authorize(ctx context.Context, opts AuthorizeOptions) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, opts.Timeout)
 	defer cancel()
 
+	// Cleanup any spawned Chrome process on all exit paths
+	defer CleanupChrome()
+
 	if opts.Manual {
 		redirectURI := "http://localhost:1"
 		cfg := oauth2.Config{

--- a/internal/googleauth/open_browser.go
+++ b/internal/googleauth/open_browser.go
@@ -1,26 +1,122 @@
 package googleauth
 
 import (
+	"os"
 	"os/exec"
+	"regexp"
 	"runtime"
+	"strconv"
+	"sync"
+	"time"
 )
 
 var startCommand = func(name string, args ...string) error {
 	return exec.Command(name, args...).Start()
 }
 
+// chromeCleanup tracks the headless Chrome process for cleanup
+var (
+	chromeMu   sync.Mutex
+	chromePid  int
+	debugPort  = "9222"
+	debugPortRe = regexp.MustCompile(`--remote-debugging-port=(\d+)`)
+)
+
 func openBrowser(u string) error {
+	// In headless environments (no display), use Chrome directly for cleanup control
+	if isHeadless() {
+		return startHeadlessChrome(u)
+	}
+
 	name, args := openBrowserCommand(u, runtime.GOOS)
 	return startCommand(name, args...)
 }
 
-func openBrowserCommand(u string, goos string) (name string, args []string) {
-	switch goos {
-	case "darwin":
-		return "open", []string{u}
-	case "windows":
-		return "rundll32", []string{"url.dll,FileProtocolHandler", u}
-	default:
-		return "xdg-open", []string{u}
+func isHeadless() bool {
+	// Check common headless indicators
+	if runtime.GOOS == "linux" {
+		if os.Getenv("DISPLAY") == "" && os.Getenv("WAYLAND_DISPLAY") == "" {
+			return true
+		}
 	}
+	return false
+}
+
+func startHeadlessChrome(url string) error {
+	// Kill any existing Chrome on our debug port to avoid conflicts
+	cleanupChrome()
+
+	// Find Chrome binary
+	chromePath := findChromePath()
+	if chromePath == "" {
+		// Fall back to xdg-open if Chrome not found
+		name, args := openBrowserCommand(url, runtime.GOOS)
+		return startCommand(name, args...)
+	}
+
+	// Start Chrome in headless mode with debug port
+	cmd := exec.Command(chromePath,
+		"--headless",
+		"--no-first-run",
+		"--no-sandbox",
+		"--disable-dev-shm-usage",
+		"--remote-debugging-port="+debugPort,
+		url,
+	)
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	chromeMu.Lock()
+	chromePid = cmd.Process.Pid
+	chromeMu.Unlock()
+
+	return nil
+}
+
+func findChromePath() string {
+	// Common Chrome binary locations
+	paths := []string{
+		"google-chrome",
+		"google-chrome-stable",
+		"chromium",
+		"chromium-browser",
+		"/usr/bin/google-chrome",
+		"/usr/bin/chromium",
+		"/usr/bin/chromium-browser",
+	}
+
+	for _, p := range paths {
+		cmd := exec.Command("which", p)
+		if err := cmd.Run(); err == nil {
+			return p
+		}
+	}
+
+	return ""
+}
+
+// CleanupChrome kills any headless Chrome process we spawned
+func CleanupChrome() {
+	cleanupChrome()
+}
+
+func cleanupChrome() {
+	chromeMu.Lock()
+	pid := chromePid
+	chromePid = 0
+	chromeMu.Unlock()
+
+	if pid > 0 {
+		// First try SIGTERM for graceful shutdown
+		exec.Command("kill", "-TERM", "-"+strconv.Itoa(pid)).Run()
+		time.Sleep(500 * time.Millisecond)
+
+		// Then force kill if still running
+		exec.Command("kill", "-9", "-"+strconv.Itoa(pid)).Run()
+	}
+
+	// Also clean up any stale Chrome on our debug port
+	exec.Command("pkill", "-f", "chrome.*--remote-debugging-port="+debugPort).Run()
 }


### PR DESCRIPTION
## Problem

In headless environments (like remote servers), gog spawns headless Chrome for OAuth but doesn't track or clean it up. This causes zombie Chrome processes that accumulate over time and consume memory.

## Solution

1. **Detect headless environments** - Check for missing DISPLAY/WAYLAND_DISPLAY on Linux
2. **Use Chrome directly with debug port** - Spawn Chrome with `--remote-debugging-port=9222` for process control
3. **Track spawned Chrome PID** - Store PID in a package-level variable with mutex protection
4. **Cleanup on all exit paths** - Call `CleanupChrome()` via defer in `Authorize()` to handle success, error, and timeout cases
5. **Cleanup stale processes** - Also kill any existing Chrome on our debug port to avoid conflicts

## Files Changed

- `internal/googleauth/open_browser.go` - Added headless Chrome spawning with cleanup
- `internal/googleauth/oauth_flow.go` - Added defer cleanup on all exit paths

## Testing

This fix was developed in response to a real-world issue where a gog authentication session spawned Chrome on Jan 11 that ran for 13+ days, consuming 800MB+ memory and causing system load to spike from ~3 to 13.

The cron-based workaround for this issue was:
```
0 */6 * * * pkill -f 'chrome.*headless'
```

This PR provides a proper fix at the source.
