### PR TITLE
fix(gmail): encode UTF-8 display names in From header

### DIFF
--- a/internal/cmd/gmail_mime.go
+++ b/internal/cmd/gmail_mime.go
@@ -65,7 +65,7 @@ func buildRFC822(opts mailOptions, cfg *rfc822Config) ([]byte, error) {
 		}
 	}
 
-	writeHeader(&b, "From", opts.From)
+	writeHeader(&b, "From", encodeAddressHeader(opts.From))
 	if len(opts.To) > 0 {
 		writeHeader(&b, "To", strings.Join(opts.To, ", "))
 	}
@@ -294,6 +294,30 @@ func encodeHeaderIfNeeded(v string) string {
 		return v
 	}
 	return mime.QEncoding.Encode("utf-8", v)
+}
+
+// encodeAddressHeader encodes the display name portion of an email address
+// if it contains non-ASCII characters. The email address itself is not encoded.
+// Input: "Display Name <email@example.com>" or "email@example.com"
+// Output: "=?utf-8?q?Encoded_Name?= <email@example.com>" or unchanged if ASCII
+func encodeAddressHeader(addr string) string {
+	parsed, err := mail.ParseAddress(addr)
+	if err != nil {
+		// Can't parse, return as-is
+		return addr
+	}
+
+	if parsed.Name == "" || isASCII(parsed.Name) {
+		// No display name or ASCII-only, return as-is
+		return addr
+	}
+
+	// Encode the display name and reconstruct
+	encoded := &mail.Address{
+		Name:    mime.QEncoding.Encode("utf-8", parsed.Name),
+		Address: parsed.Address,
+	}
+	return encoded.String()
 }
 
 func isASCII(s string) bool {

--- a/internal/cmd/gmail_mime_test.go
+++ b/internal/cmd/gmail_mime_test.go
@@ -255,3 +255,57 @@ func TestRandomMessageID(t *testing.T) {
 		t.Fatalf("unexpected: %q", id)
 	}
 }
+
+func TestEncodeAddressHeader(t *testing.T) {
+	// Plain email without display name - unchanged
+	if got := encodeAddressHeader("test@example.com"); got != "test@example.com" {
+		t.Fatalf("plain email changed: %q", got)
+	}
+
+	// ASCII display name - unchanged
+	if got := encodeAddressHeader("John Doe <john@example.com>"); got != "John Doe <john@example.com>" {
+		t.Fatalf("ASCII name changed: %q", got)
+	}
+
+	// UTF-8 display name - should be encoded
+	got := encodeAddressHeader("Jørgen Østergaard <jorgen@example.com>")
+	if strings.Contains(got, "Jørgen") {
+		t.Fatalf("UTF-8 name not encoded: %q", got)
+	}
+	if !strings.Contains(got, "=?utf-8?q?") {
+		t.Fatalf("expected MIME encoding: %q", got)
+	}
+	if !strings.Contains(got, "<jorgen@example.com>") {
+		t.Fatalf("email address missing: %q", got)
+	}
+
+	// Invalid address - returned as-is
+	if got := encodeAddressHeader("not a valid address"); got != "not a valid address" {
+		t.Fatalf("invalid address changed: %q", got)
+	}
+}
+
+func TestBuildRFC822UTF8FromDisplayName(t *testing.T) {
+	raw, err := buildRFC822(mailOptions{
+		From:    "Jørgen Østergaard <jorgen@example.com>",
+		To:      []string{"recipient@example.com"},
+		Subject: "Test",
+		Body:    "Hello",
+	}, nil)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	s := string(raw)
+	// The display name should be MIME-encoded, not raw UTF-8
+	if strings.Contains(s, "From: Jørgen") {
+		t.Fatalf("From header contains unencoded UTF-8: %q", s)
+	}
+	// Should contain encoded-word format (may be quoted by mail.Address.String)
+	if !strings.Contains(s, "=?utf-8?q?") {
+		t.Fatalf("expected MIME-encoded From display name: %q", s)
+	}
+	// Should still contain the email address
+	if !strings.Contains(s, "<jorgen@example.com>") {
+		t.Fatalf("missing email address in From header: %q", s)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `encodeAddressHeader()` function to MIME Q-encode non-ASCII display names in the From header
- The From header was being passed raw while Subject was already encoded, causing UTF-8 characters like "ø" to get double-encoded/corrupted
- Added comprehensive tests for the new function and UTF-8 display name handling

## Root Cause
The `buildRFC822()` function encoded the Subject header with `encodeHeaderIfNeeded()` but passed the From header as-is. When the display name contained UTF-8 characters, they would get corrupted during transmission.

## Test Plan
- [x] Added `TestEncodeAddressHeader` covering: plain email, ASCII name, UTF-8 name, invalid address
- [x] Added `TestBuildRFC822UTF8FromDisplayName` verifying From header is properly encoded
- [x] All existing tests pass
- [x] Linting passes

Fixes #112

🤖 Generated with [Claude Code](https://claude.ai/code)