### PR TITLE
fix(completion): include current token in fish completion

### DIFF
--- a/internal/cmd/completion_scripts.go
+++ b/internal/cmd/completion_scripts.go
@@ -46,10 +46,13 @@ func fishCompletionScript() string {
 	return `function __gog_complete
   set -l words (commandline -opc)
   set -l cur (commandline -ct)
-  set -l cword (count $words)
-  if test -n "$cur"
-    set cword (math $cword - 1)
-  end
+
+  # Include the current token (partial word being typed) to match bash behavior
+  set words $words $cur
+
+  # cword points to the last word (the one being completed)
+  set -l cword (math (count $words) - 1)
+
   gog __complete --cword $cword -- $words
 end
 


### PR DESCRIPTION
## Summary

The fish shell completion script was not passing the current partial word to `gog __complete`, causing partial command and flag completion to fail.

**Problem:**
- `commandline -opc` returns words before the cursor, *excluding* the current token being typed
- `commandline -ct` returns the current token
- The original script adjusted `cword` based on whether a partial word existed, but never actually passed the partial word to `gog __complete`

**Result:** Typing `gog cal<TAB>` would call `gog __complete --cword 0 -- gog` instead of `gog __complete --cword 1 -- gog cal`, so no matches were found.

**Fix:** Append the current token to the word list and set `cword` to point to it, matching bash completion behavior.

🤖 Generated with [Claude Code](https://claude.ai/code)