### PR TITLE
calendar: set timeZone for recurring creates; document no-offset usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,13 +685,18 @@ gog calendar update <calendarId> <eventId> \
   --send-updates externalOnly
 
 # Recurrence + reminders
+# Tip (recommended for recurring events): pass local times without an explicit offset,
+# so the event is anchored in the calendar's timezone.
 gog calendar create <calendarId> \
   --summary "Payment" \
-  --from 2025-02-11T09:00:00-03:00 \
-  --to 2025-02-11T09:15:00-03:00 \
+  --from 2025-02-11T09:00:00 \
+  --to 2025-02-11T09:15:00 \
   --rrule "RRULE:FREQ=MONTHLY;BYMONTHDAY=11" \
   --reminder "email:3d" \
   --reminder "popup:30m"
+
+# If you need a different timezone for the recurring event, set an IANA timezone name:
+# export GOG_TIMEZONE=Asia/Kolkata
 
 # Special event types via --event-type (focus-time/out-of-office/working-location)
 gog calendar create primary \

--- a/internal/cmd/calendar_build.go
+++ b/internal/cmd/calendar_build.go
@@ -13,12 +13,24 @@ import (
 const tzUTC = "UTC"
 
 func buildEventDateTime(value string, allDay bool) *calendar.EventDateTime {
+	return buildEventDateTimeWithTimezone(value, allDay, "")
+}
+
+// buildEventDateTimeWithTimezone builds an EventDateTime from an RFC3339 string.
+//
+// For recurring events, Google Calendar requires start/end.timeZone to be set to an
+// IANA timezone name (e.g. "Europe/Berlin").
+func buildEventDateTimeWithTimezone(value string, allDay bool, tzOverride string) *calendar.EventDateTime {
 	value = strings.TrimSpace(value)
 	if allDay {
 		return &calendar.EventDateTime{Date: value}
 	}
 
 	edt := &calendar.EventDateTime{DateTime: value}
+	if tz := strings.TrimSpace(tzOverride); tz != "" {
+		edt.TimeZone = tz
+		return edt
+	}
 	if tz := extractTimezone(value); tz != "" {
 		edt.TimeZone = tz
 	}
@@ -27,6 +39,14 @@ func buildEventDateTime(value string, allDay bool) *calendar.EventDateTime {
 
 // extractTimezone attempts to determine a timezone from an RFC3339 datetime string.
 // Returns an IANA timezone name if determinable, empty string otherwise.
+//
+// This function handles two unambiguous cases:
+//   - UTC (offset 0) returns "UTC"
+//   - Local timezone match returns time.Local's IANA name
+//
+// For other offsets, returns "" since offset-to-IANA mapping is inherently ambiguous
+// (multiple IANA zones can share the same offset). Callers should use GOG_TIMEZONE
+// or the calendar's timezone for recurring events.
 func extractTimezone(value string) string {
 	t, err := time.Parse(time.RFC3339, value)
 	if err != nil {
@@ -34,29 +54,25 @@ func extractTimezone(value string) string {
 	}
 
 	_, offset := t.Zone()
+
+	// UTC is unambiguous
 	if offset == 0 {
 		return tzUTC
 	}
 
-	// RFC3339 values have a fixed offset, but Google Calendar requires an IANA timezone
-	// name for recurring events. We guess by checking which common zones match the
-	// offset at this instant.
-	for _, candidate := range []string{
-		"America/New_York",
-		"America/Chicago",
-		"America/Denver",
-		"America/Phoenix",
-		"America/Los_Angeles",
-	} {
-		loc, err := time.LoadLocation(candidate)
-		if err != nil {
-			continue
-		}
-		_, candidateOffset := t.In(loc).Zone()
-		if candidateOffset == offset {
-			return candidate
+	// Check if offset matches local timezone at this moment
+	_, localOffset := t.In(time.Local).Zone()
+	if localOffset == offset {
+		localName := time.Local.String()
+		// time.Local.String() returns "Local" if IANA name isn't available;
+		// only return it if we have a real IANA name (contains "/")
+		if localName != "Local" && localName != "" {
+			return localName
 		}
 	}
+
+	// Cannot reliably determine IANA timezone from offset alone.
+	// Caller should use GOG_TIMEZONE or calendar timezone for recurring events.
 	return ""
 }
 

--- a/internal/cmd/calendar_build_test.go
+++ b/internal/cmd/calendar_build_test.go
@@ -1,34 +1,85 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestExtractTimezone(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{"2026-01-08T11:00:00-05:00", "America/New_York"},
-		{"2026-07-08T11:00:00-04:00", "America/New_York"},
-		{"2026-01-08T11:00:00-06:00", "America/Chicago"},
-		{"2026-07-08T11:00:00-05:00", "America/Chicago"},
-		{"2026-01-08T11:00:00-07:00", "America/Denver"},
-		{"2026-07-08T11:00:00-07:00", "America/Phoenix"},
-		{"2026-01-08T11:00:00-08:00", "America/Los_Angeles"},
-		{"2026-01-08T16:00:00Z", "UTC"},
-		{"2026-01-08T11:00:00+00:00", "UTC"},
-		{"invalid", ""},
-		{"2026-01-08T11:00:00-04:00", ""}, // not a common US offset on this date
-		{"2026-01-08T11:00:00+05:30", ""}, // India - not mapped
+	// Test UTC cases - always returns "UTC"
+	utcTests := []string{
+		"2026-01-08T16:00:00Z",
+		"2026-01-08T11:00:00+00:00",
+		"2026-07-15T09:30:00Z",
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.input, func(t *testing.T) {
-			got := extractTimezone(tc.input)
-			if got != tc.expected {
-				t.Errorf("extractTimezone(%q) = %q, want %q", tc.input, got, tc.expected)
+	for _, input := range utcTests {
+		t.Run("UTC_"+input, func(t *testing.T) {
+			got := extractTimezone(input)
+			if got != "UTC" {
+				t.Errorf("extractTimezone(%q) = %q, want %q", input, got, "UTC")
 			}
 		})
 	}
+
+	// Test local timezone - when offset matches local and IANA name is available
+	t.Run("local_timezone_match", func(t *testing.T) {
+		localName := time.Local.String()
+		// Skip if local timezone doesn't have a real IANA name
+		if localName == "Local" || localName == "" {
+			t.Skip("local timezone doesn't have IANA name available")
+		}
+
+		// Create a time in the local timezone and format it as RFC3339
+		now := time.Now()
+		localTime := now.Format(time.RFC3339)
+		got := extractTimezone(localTime)
+		if got != localName {
+			t.Errorf("extractTimezone(%q) = %q, want %q (local timezone)", localTime, got, localName)
+		}
+	})
+
+	// Test with explicit timezone to ensure non-UTC handling works
+	t.Run("explicit_timezone_europe_berlin", func(t *testing.T) {
+		loc, err := time.LoadLocation("Europe/Berlin")
+		if err != nil {
+			t.Skip("Europe/Berlin timezone not available")
+		}
+
+		// Temporarily set local timezone for this test
+		origLocal := time.Local
+		time.Local = loc
+		defer func() { time.Local = origLocal }()
+
+		// Winter time: +01:00
+		input := "2026-01-15T14:00:00+01:00"
+		got := extractTimezone(input)
+		if got != "Europe/Berlin" {
+			t.Errorf("extractTimezone(%q) = %q, want %q", input, got, "Europe/Berlin")
+		}
+	})
+
+	// Test invalid input
+	t.Run("invalid", func(t *testing.T) {
+		if got := extractTimezone("invalid"); got != "" {
+			t.Errorf("extractTimezone(invalid) = %q, want empty", got)
+		}
+	})
+
+	// Non-matching offsets return empty (caller uses calendar/configured timezone)
+	t.Run("non_matching_offset", func(t *testing.T) {
+		// Use +05:30 (India) which is unlikely to be the local timezone
+		input := "2026-01-08T11:00:00+05:30"
+		testTime, _ := time.Parse(time.RFC3339, input)
+		_, localOffset := testTime.In(time.Local).Zone()
+		_, inputOffset := testTime.Zone()
+		if localOffset == inputOffset {
+			t.Skip("local timezone matches test offset, skipping")
+		}
+		got := extractTimezone(input)
+		if got != "" {
+			t.Errorf("extractTimezone(%q) = %q, want empty for non-matching offset", input, got)
+		}
+	})
 }
 
 func TestBuildAttachments(t *testing.T) {

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -16,8 +16,8 @@ import (
 type CalendarCreateCmd struct {
 	CalendarID            string   `arg:"" name:"calendarId" help:"Calendar ID"`
 	Summary               string   `name:"summary" help:"Event summary/title"`
-	From                  string   `name:"from" help:"Start time (RFC3339)"`
-	To                    string   `name:"to" help:"End time (RFC3339)"`
+	From                  string   `name:"from" help:"Start time (RFC3339). For recurring events, timezone is inferred from GOG_TIMEZONE env var, config, or calendar settings."`
+	To                    string   `name:"to" help:"End time (RFC3339). For recurring events, timezone is inferred from GOG_TIMEZONE env var, config, or calendar settings."`
 	Description           string   `name:"description" help:"Description"`
 	Location              string   `name:"location" help:"Location"`
 	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails"`
@@ -107,14 +107,36 @@ func (c *CalendarCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	// For recurring events, Google Calendar requires start/end.timeZone to be set to an
+	// IANA timezone name (a fixed RFC3339 offset alone is not sufficient).
+	recurrence := buildRecurrence(c.Recurrence)
+	start := buildEventDateTime(c.From, allDay)
+	end := buildEventDateTime(c.To, allDay)
+	if !allDay && len(recurrence) > 0 {
+		tz := ""
+		if loc, err := getConfiguredTimezone(""); err == nil && loc != nil {
+			tz = loc.String()
+		}
+		if tz == "" {
+			calTZ, _, err := getCalendarLocation(ctx, svc, calendarID)
+			if err == nil {
+				tz = calTZ
+			}
+		}
+		if tz != "" {
+			start = buildEventDateTimeWithTimezone(c.From, allDay, tz)
+			end = buildEventDateTimeWithTimezone(c.To, allDay, tz)
+		}
+	}
+
 	event := &calendar.Event{
 		Summary:            summary,
 		Description:        strings.TrimSpace(c.Description),
 		Location:           strings.TrimSpace(c.Location),
-		Start:              buildEventDateTime(c.From, allDay),
-		End:                buildEventDateTime(c.To, allDay),
+		Start:              start,
+		End:                end,
 		Attendees:          buildAttendees(c.Attendees),
-		Recurrence:         buildRecurrence(c.Recurrence),
+		Recurrence:         recurrence,
 		Reminders:          reminders,
 		ColorId:            colorId,
 		Visibility:         visibility,
@@ -298,8 +320,8 @@ type CalendarUpdateCmd struct {
 	CalendarID            string   `arg:"" name:"calendarId" help:"Calendar ID"`
 	EventID               string   `arg:"" name:"eventId" help:"Event ID"`
 	Summary               string   `name:"summary" help:"New summary/title (set empty to clear)"`
-	From                  string   `name:"from" help:"New start time (RFC3339; set empty to clear)"`
-	To                    string   `name:"to" help:"New end time (RFC3339; set empty to clear)"`
+	From                  string   `name:"from" help:"New start time (RFC3339; set empty to clear). For recurring events, timezone uses GOG_TIMEZONE or calendar settings."`
+	To                    string   `name:"to" help:"New end time (RFC3339; set empty to clear). For recurring events, timezone uses GOG_TIMEZONE or calendar settings."`
 	Description           string   `name:"description" help:"New description (set empty to clear)"`
 	Location              string   `name:"location" help:"New location (set empty to clear)"`
 	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails (replaces all; set empty to clear)"`


### PR DESCRIPTION
Google Calendar requires start/end.timeZone (IANA) for recurring events; a fixed
RFC3339 offset alone can fail with “Missing time zone definition for start
time”.

When --rrule is set, derive the timezone from GOG_TIMEZONE/config or fall back
to the calendar’s timezone, and include it in the create payload.

Also update README to recommend passing local times without an explicit offset
for recurring events (anchored to calendar TZ), and using GOG_TIMEZONE to force
a different timezone.

## Problem
Creating a recurring event with `--rrule` can fail with:

> Google API error (400 required): Missing time zone definition for start time.

This happens when `--from/--to` are provided as RFC3339 datetimes but the Calendar API request does not include `event.start.timeZone` / `event.end.timeZone`.

Google Calendar requires an **IANA timezone name** (e.g. `Europe/Berlin`) for recurring events; a fixed offset alone is not sufficient.

## Recommended usage (recurring events)
**Best practice:** for recurring events, pass times **without** an explicit timezone/offset in the RFC3339 string, so the event is anchored in the calendar’s default timezone.

Example (uses the calendar timezone):

```bash
gog calendar create <calendarId> \
  --summary "Practice the piano" \
  --from "2026-02-03T17:00:00" \
  --to   "2026-02-03T17:15:00" \
  --rrule "RRULE:FREQ=WEEKLY;BYDAY=TU" \
  --json --no-input
```

If you **must** create a recurring event in a different timezone, set `GOG_TIMEZONE` (or config default timezone) to an IANA timezone name:

```bash
export GOG_TIMEZONE=Asia/Kolkata

gog calendar create <calendarId> \
  --summary "Practice the piano" \
  --from "2026-02-03T17:00:00" \
  --to   "2026-02-03T17:15:00" \
  --rrule "RRULE:FREQ=WEEKLY;BYDAY=TU" \
  --json --no-input
```

Note: when using a non-local timezone, the stored absolute time will be displayed in your calendar’s timezone accordingly.

## Repro (pre-fix)
(Example from Europe/Berlin)

```bash
gog calendar create <calendarId> \
  --summary "Practice the piano" \
  --from "2026-02-03T17:00:00+01:00" \
  --to   "2026-02-03T17:15:00+01:00" \
  --rrule "RRULE:FREQ=WEEKLY;BYDAY=TU" \
  --json --no-input
```

Expected: event is created.

Observed (before fix): 400 error above.

## Fix (implementation)
Ensure that recurring events include an IANA timezone:
- set `event.start.timeZone`
- set `event.end.timeZone`

Implementation detail:
- for recurring events, prefer `GOG_TIMEZONE`/config or the calendar’s timezone, instead of attempting to infer an IANA zone from a fixed offset.

Co-authored with codex 5.2 and Cursor composer-1