### PR TITLE
feat(gmail): add --with-history to include original body in replies

### DIFF
--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -299,7 +299,7 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 		}
 	}
 
-	info, err := fetchReplyInfo(ctx, svc, input.ReplyToMessageID, input.ReplyToThreadID)
+	info, err := fetchReplyInfo(ctx, svc, input.ReplyToMessageID, input.ReplyToThreadID, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -32,6 +32,7 @@ type GmailSendCmd struct {
 	From             string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
 	Track            bool     `name:"track" help:"Enable open tracking (requires tracking setup)"`
 	TrackSplit       bool     `name:"track-split" help:"Send tracked messages separately per recipient"`
+	WithHistory      bool     `name:"with-history" help:"Include original message body in reply (requires --reply-to-message-id or --thread-id)"`
 }
 
 type sendBatch struct {
@@ -97,6 +98,9 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.TrackSplit && !c.Track {
 		return usage("--track-split requires --track")
 	}
+	if c.WithHistory && replyToMessageID == "" && threadID == "" {
+		return usage("--with-history requires --reply-to-message-id or --thread-id")
+	}
 
 	svc, err := newGmailService(ctx, account)
 	if err != nil {
@@ -133,9 +137,28 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	// Fetch reply info (includes recipient headers for reply-all)
-	replyInfo, err := fetchReplyInfo(ctx, svc, replyToMessageID, threadID)
+	replyInfo, err := fetchReplyInfo(ctx, svc, replyToMessageID, threadID, c.WithHistory)
 	if err != nil {
 		return err
+	}
+
+	if c.WithHistory {
+		if replyInfo.OriginalBody != "" {
+			quoted := quoteBody(replyInfo.OriginalBody, replyInfo.FromAddr, replyInfo.Date)
+			if body != "" {
+				body = body + "\n\n" + quoted
+			} else {
+				body = quoted
+			}
+		}
+		if replyInfo.OriginalHTML != "" {
+			quotedHTML := quoteHTML(replyInfo.OriginalHTML, replyInfo.FromAddr, replyInfo.Date)
+			if c.BodyHTML != "" {
+				c.BodyHTML = c.BodyHTML + "<br><br>" + quotedHTML
+			} else {
+				c.BodyHTML = quotedHTML
+			}
+		}
 	}
 
 	// Determine recipients
@@ -444,34 +467,42 @@ func buildReplyAllRecipients(info *replyInfo, selfEmail string) (to, cc []string
 
 // replyInfo contains all information extracted from the original message for replying
 type replyInfo struct {
-	InReplyTo   string
-	References  string
-	ThreadID    string
-	FromAddr    string   // Original sender
-	ReplyToAddr string   // Original Reply-To header (per RFC 5322, use this instead of From if present)
-	ToAddrs     []string // Original To recipients
-	CcAddrs     []string // Original Cc recipients
+	InReplyTo    string
+	References   string
+	ThreadID     string
+	FromAddr     string   // Original sender
+	ReplyToAddr  string   // Original Reply-To header (per RFC 5322, use this instead of From if present)
+	ToAddrs      []string // Original To recipients
+	CcAddrs      []string // Original Cc recipients
+	Date         string   // Original date
+	OriginalBody string   // Original plain text body
+	OriginalHTML string   // Original HTML body
 }
 
 func replyHeaders(ctx context.Context, svc *gmail.Service, replyToMessageID string) (inReplyTo string, references string, threadID string, err error) {
-	info, err := fetchReplyInfo(ctx, svc, replyToMessageID, "")
+	info, err := fetchReplyInfo(ctx, svc, replyToMessageID, "", false)
 	if err != nil {
 		return "", "", "", err
 	}
 	return info.InReplyTo, info.References, info.ThreadID, nil
 }
 
-func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID string, threadID string) (*replyInfo, error) {
+func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID string, threadID string, full bool) (*replyInfo, error) {
 	replyToMessageID = strings.TrimSpace(replyToMessageID)
 	threadID = strings.TrimSpace(threadID)
 	if replyToMessageID == "" && threadID == "" {
 		return &replyInfo{}, nil
 	}
 
+	format := "metadata"
+	if full {
+		format = "full"
+	}
+
 	if replyToMessageID != "" {
 		msg, err := svc.Users.Messages.Get("me", replyToMessageID).
-			Format("metadata").
-			MetadataHeaders("Message-ID", "Message-Id", "References", "In-Reply-To", "From", "Reply-To", "To", "Cc").
+			Format(format).
+			MetadataHeaders("Message-ID", "Message-Id", "References", "In-Reply-To", "From", "Reply-To", "To", "Cc", "Date").
 			Context(ctx).
 			Do()
 		if err != nil {
@@ -481,8 +512,8 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 	}
 
 	thread, err := svc.Users.Threads.Get("me", threadID).
-		Format("metadata").
-		MetadataHeaders("Message-ID", "Message-Id", "References", "In-Reply-To", "From", "Reply-To", "To", "Cc").
+		Format(format).
+		MetadataHeaders("Message-ID", "Message-Id", "References", "In-Reply-To", "From", "Reply-To", "To", "Cc", "Date").
 		Context(ctx).
 		Do()
 	if err != nil {
@@ -513,6 +544,12 @@ func replyInfoFromMessage(msg *gmail.Message) *replyInfo {
 		ReplyToAddr: headerValue(msg.Payload, "Reply-To"),
 		ToAddrs:     parseEmailAddresses(headerValue(msg.Payload, "To")),
 		CcAddrs:     parseEmailAddresses(headerValue(msg.Payload, "Cc")),
+		Date:        headerValue(msg.Payload, "Date"),
+	}
+
+	if msg.Payload != nil {
+		info.OriginalBody = findPartBody(msg.Payload, "text/plain")
+		info.OriginalHTML = findPartBody(msg.Payload, "text/html")
 	}
 
 	// Prefer Message-ID and References from the original message.
@@ -625,4 +662,27 @@ func deduplicateAddresses(addresses []string) []string {
 		}
 	}
 	return result
+}
+
+func quoteBody(body, from, date string) string {
+	prefix := "On " + date + ", " + from + " wrote:\n"
+	lines := strings.Split(body, "\n")
+	for i, line := range lines {
+		lines[i] = "> " + line
+	}
+	return prefix + strings.Join(lines, "\n")
+}
+
+func quoteHTML(html, from, date string) string {
+	header := fmt.Sprintf("<div>On %s, %s wrote:</div>", htmlEscape(date), htmlEscape(from))
+	return header + "<blockquote style=\"margin:0 0 0 .8ex;border-left:1px #ccc solid;padding-left:1ex\">" + html + "</blockquote>"
+}
+
+func htmlEscape(s string) string {
+	s = strings.ReplaceAll(s, "&", "&amp;")
+	s = strings.ReplaceAll(s, "<", "&lt;")
+	s = strings.ReplaceAll(s, ">", "&gt;")
+	s = strings.ReplaceAll(s, "\"", "&quot;")
+	s = strings.ReplaceAll(s, "'", "&#39;")
+	return s
 }

--- a/internal/cmd/gmail_send_reply_test.go
+++ b/internal/cmd/gmail_send_reply_test.go
@@ -100,7 +100,7 @@ func TestFetchReplyInfoFromThread(t *testing.T) {
 	}
 	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
 
-	info, err := fetchReplyInfo(context.Background(), svc, "", "t1")
+	info, err := fetchReplyInfo(context.Background(), svc, "", "t1", false)
 	if err != nil {
 		t.Fatalf("fetchReplyInfo: %v", err)
 	}
@@ -132,5 +132,70 @@ func TestWriteSendResults_JSON(t *testing.T) {
 	}
 	if payload["messageId"] != "m1" || payload["threadId"] != "t1" || payload["tracking_id"] != "trk" {
 		t.Fatalf("unexpected json payload: %#v", payload)
+	}
+}
+
+func TestWithHistory(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		switch {
+		case r.Method == http.MethodGet && path == "/users/me/threads/t1":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "t1",
+				"messages": []map[string]any{
+					{
+						"id":           "m1",
+						"internalDate": "200",
+						"payload": map[string]any{
+							"mimeType": "text/plain",
+							"headers": []map[string]any{
+								{"name": "Message-ID", "value": "<m1>"},
+								{"name": "From", "value": "a@example.com"},
+								{"name": "Date", "value": "Wed, 28 Jan 2026 10:00:00 +0000"},
+							},
+							"body": map[string]any{
+								"data": "SGVsbG8gd29ybGQ=", // "Hello world"
+							},
+						},
+					},
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	info, err := fetchReplyInfo(context.Background(), svc, "", "t1", true)
+	if err != nil {
+		t.Fatalf("fetchReplyInfo: %v", err)
+	}
+
+	if info.OriginalBody != "Hello world" {
+		t.Fatalf("expected 'Hello world', got %q", info.OriginalBody)
+	}
+
+	quoted := quoteBody(info.OriginalBody, info.FromAddr, info.Date)
+	expectedPrefix := "On Wed, 28 Jan 2026 10:00:00 +0000, a@example.com wrote:"
+	if !strings.Contains(quoted, expectedPrefix) {
+		t.Fatalf("quoted body missing prefix: %q", quoted)
+	}
+	if !strings.Contains(quoted, "> Hello world") {
+		t.Fatalf("quoted body missing quoted text: %q", quoted)
 	}
 }

--- a/internal/cmd/gmail_send_test.go
+++ b/internal/cmd/gmail_send_test.go
@@ -179,7 +179,7 @@ func TestFetchReplyInfo_ThreadID(t *testing.T) {
 		t.Fatalf("NewService: %v", err)
 	}
 
-	info, err := fetchReplyInfo(context.Background(), svc, "", "t1")
+	info, err := fetchReplyInfo(context.Background(), svc, "", "t1", false)
 	if err != nil {
 		t.Fatalf("fetchReplyInfo: %v", err)
 	}
@@ -910,7 +910,7 @@ func TestFetchReplyInfo(t *testing.T) {
 	ctx := context.Background()
 
 	// Test m1: multiple recipients
-	info, err := fetchReplyInfo(ctx, svc, "m1", "")
+	info, err := fetchReplyInfo(ctx, svc, "m1", "", false)
 	if err != nil {
 		t.Fatalf("fetchReplyInfo(m1): %v", err)
 	}
@@ -930,7 +930,7 @@ func TestFetchReplyInfo(t *testing.T) {
 	}
 
 	// Test m2: sender with display name
-	info, err = fetchReplyInfo(ctx, svc, "m2", "")
+	info, err = fetchReplyInfo(ctx, svc, "m2", "", false)
 	if err != nil {
 		t.Fatalf("fetchReplyInfo(m2): %v", err)
 	}
@@ -939,7 +939,7 @@ func TestFetchReplyInfo(t *testing.T) {
 	}
 
 	// Test empty message ID
-	info, err = fetchReplyInfo(ctx, svc, "", "")
+	info, err = fetchReplyInfo(ctx, svc, "", "", false)
 	if err != nil {
 		t.Fatalf("fetchReplyInfo(''): %v", err)
 	}
@@ -948,7 +948,7 @@ func TestFetchReplyInfo(t *testing.T) {
 	}
 
 	// Test m3: message with Reply-To header
-	info, err = fetchReplyInfo(ctx, svc, "m3", "")
+	info, err = fetchReplyInfo(ctx, svc, "m3", "", false)
 	if err != nil {
 		t.Fatalf("fetchReplyInfo(m3): %v", err)
 	}


### PR DESCRIPTION
This PR adds a `--with-history` flag to `gog gmail send`. When used with `--thread-id` or `--reply-to-message-id`, it automatically fetches the parent message's body (plain text and/or HTML) and includes it as quoted text in the new reply.