### PR TITLE
fix(security): redact webhook bearer token in watch status output

### DIFF
--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -93,10 +93,12 @@ func (c *GmailWatchStartCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 		return err
 	}
 
-	return writeWatchState(ctx, state)
+	return writeWatchState(ctx, state, false)
 }
 
-type GmailWatchStatusCmd struct{}
+type GmailWatchStatusCmd struct {
+	ShowSecrets bool `help:"Show secret values (e.g. hook token) in plaintext"`
+}
 
 func (c *GmailWatchStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	account, err := requireAccount(flags)
@@ -107,7 +109,7 @@ func (c *GmailWatchStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	return writeWatchState(ctx, store.Get())
+	return writeWatchState(ctx, store.Get(), c.ShowSecrets)
 }
 
 type GmailWatchRenewCmd struct {
@@ -156,7 +158,7 @@ func (c *GmailWatchRenewCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	return writeWatchState(ctx, updated)
+	return writeWatchState(ctx, updated, false)
 }
 
 type GmailWatchStopCmd struct{}
@@ -335,8 +337,15 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 	return listenAndServe(httpServer)
 }
 
-func writeWatchState(ctx context.Context, state gmailWatchState) error {
+func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets bool) error {
 	if outfmt.IsJSON(ctx) {
+		if !showSecrets && state.Hook != nil && state.Hook.Token != "" {
+			redacted := state
+			h := *state.Hook
+			h.Token = "[REDACTED]"
+			redacted.Hook = &h
+			return outfmt.WriteJSON(os.Stdout, map[string]any{"watch": redacted})
+		}
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"watch": state})
 	}
 	u := ui.FromContext(ctx)
@@ -367,7 +376,13 @@ func writeWatchState(ctx context.Context, state gmailWatchState) error {
 			u.Out().Printf("hook_max_bytes\t%d", state.Hook.MaxBytes)
 		}
 		if state.Hook.Token != "" {
-			u.Out().Printf("hook_token\t%s", state.Hook.Token)
+			if showSecrets {
+				u.Out().Printf("hook_token\t%s", state.Hook.Token)
+			} else if len(state.Hook.Token) > 4 {
+				u.Out().Printf("hook_token\t%s...(%d chars)", state.Hook.Token[:4], len(state.Hook.Token))
+			} else {
+				u.Out().Printf("hook_token\t[REDACTED]")
+			}
 		}
 	}
 	if state.LastDeliveryStatus != "" {

--- a/internal/cmd/gmail_watch_cmds_errors_test.go
+++ b/internal/cmd/gmail_watch_cmds_errors_test.go
@@ -484,7 +484,7 @@ func TestWriteWatchState_LastPushMessageID(t *testing.T) {
 		LastDeliveryStatusNote: "note",
 		LastPushMessageID:      "msg1",
 	}
-	if err := writeWatchState(ctx, state); err != nil {
+	if err := writeWatchState(ctx, state, false); err != nil {
 		t.Fatalf("writeWatchState: %v", err)
 	}
 	if !strings.Contains(out.String(), "last_push_message_id") {

--- a/internal/cmd/gmail_watch_helpers_test.go
+++ b/internal/cmd/gmail_watch_helpers_test.go
@@ -40,7 +40,7 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 			t.Fatalf("ui.New: %v", uiErr)
 		}
 		ctx := ui.WithUI(context.Background(), u)
-		if err := writeWatchState(ctx, state); err != nil {
+		if err := writeWatchState(ctx, state, false); err != nil {
 			t.Fatalf("writeWatchState: %v", err)
 		}
 	})
@@ -58,7 +58,7 @@ func TestWriteWatchState_TextAndJSON(t *testing.T) {
 		}
 		ctx := ui.WithUI(context.Background(), u)
 		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
-		if err := writeWatchState(ctx, state); err != nil {
+		if err := writeWatchState(ctx, state, false); err != nil {
 			t.Fatalf("writeWatchState json: %v", err)
 		}
 	})

--- a/internal/cmd/gmail_watch_redact_test.go
+++ b/internal/cmd/gmail_watch_redact_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestWriteWatchState_TokenRedaction(t *testing.T) {
+	makeState := func(token string) gmailWatchState {
+		return gmailWatchState{
+			Account:   "a@b.com",
+			Topic:     "projects/p/topics/t",
+			HistoryID: "1",
+			Hook: &gmailWatchHook{
+				URL:   "http://example.com/hook",
+				Token: token,
+			},
+		}
+	}
+
+	run := func(t *testing.T, state gmailWatchState, showSecrets bool) string {
+		t.Helper()
+		return captureStdout(t, func() {
+			u, err := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+			if err != nil {
+				t.Fatalf("ui.New: %v", err)
+			}
+			ctx := ui.WithUI(context.Background(), u)
+			if err := writeWatchState(ctx, state, showSecrets); err != nil {
+				t.Fatalf("writeWatchState: %v", err)
+			}
+		})
+	}
+
+	t.Run("long token is redacted by default", func(t *testing.T) {
+		out := run(t, makeState("supersecrettoken123"), false)
+		if strings.Contains(out, "supersecrettoken123") {
+			t.Fatal("token should be redacted but was shown in full")
+		}
+		if !strings.Contains(out, "supe...(19 chars)") {
+			t.Fatalf("expected masked token, got: %s", out)
+		}
+	})
+
+	t.Run("short token is fully redacted", func(t *testing.T) {
+		out := run(t, makeState("ab"), false)
+		if strings.Contains(out, "hook_token\tab") {
+			t.Fatal("short token should be fully redacted")
+		}
+		if !strings.Contains(out, "[REDACTED]") {
+			t.Fatalf("expected [REDACTED], got: %s", out)
+		}
+	})
+
+	t.Run("4-char token is fully redacted", func(t *testing.T) {
+		out := run(t, makeState("abcd"), false)
+		if !strings.Contains(out, "[REDACTED]") {
+			t.Fatalf("expected [REDACTED] for 4-char token, got: %s", out)
+		}
+	})
+
+	t.Run("show-secrets reveals full token", func(t *testing.T) {
+		out := run(t, makeState("supersecrettoken123"), true)
+		if !strings.Contains(out, "hook_token\tsupersecrettoken123") {
+			t.Fatalf("expected full token with --show-secrets, got: %s", out)
+		}
+	})
+
+	t.Run("empty token not shown", func(t *testing.T) {
+		out := run(t, makeState(""), false)
+		if strings.Contains(out, "hook_token") {
+			t.Fatal("empty token should not appear in output")
+		}
+	})
+
+	t.Run("json output redacts token by default", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			u, err := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+			if err != nil {
+				t.Fatalf("ui.New: %v", err)
+			}
+			ctx := ui.WithUI(context.Background(), u)
+			ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+			if err := writeWatchState(ctx, makeState("supersecrettoken123"), false); err != nil {
+				t.Fatalf("writeWatchState json: %v", err)
+			}
+		})
+		if strings.Contains(out, "supersecrettoken123") {
+			t.Fatal("JSON output should not contain plaintext token")
+		}
+		var parsed map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+			t.Fatalf("json parse: %v", err)
+		}
+		if !strings.Contains(out, `"[REDACTED]"`) {
+			t.Fatalf("expected [REDACTED] in JSON, got: %s", out)
+		}
+	})
+
+	t.Run("json output shows token with show-secrets", func(t *testing.T) {
+		out := captureStdout(t, func() {
+			u, err := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+			if err != nil {
+				t.Fatalf("ui.New: %v", err)
+			}
+			ctx := ui.WithUI(context.Background(), u)
+			ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+			if err := writeWatchState(ctx, makeState("supersecrettoken123"), true); err != nil {
+				t.Fatalf("writeWatchState json: %v", err)
+			}
+		})
+		if !strings.Contains(out, "supersecrettoken123") {
+			t.Fatalf("JSON with --show-secrets should contain token, got: %s", out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Redact `hook_token` in `gmail watch status` output (text and JSON) to prevent accidental exposure of the webhook bearer token
- Add `--show-secrets` flag to explicitly reveal the full token when needed
- Add tests covering redaction for long tokens, short tokens, empty tokens, JSON output, and `--show-secrets` behavior

## Test plan
- [x] `go test ./internal/cmd/ -run TestWriteWatchState_TokenRedaction` passes (7 subtests)
- [x] `go vet ./internal/cmd/` passes
- [x] Existing tests (`TestWriteWatchState_TextAndJSON`, `TestWriteWatchState_LastPushMessageID`) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)