### PR TITLE
fix: multiple improvements including Gmail label collision fix, docs tabs, and date parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Calendar: fix recurrence rules with BYDAY parameter (e.g., `BYDAY=MO,TU,WE,TH,FR`). (#120)
+
 ## 0.9.0 - 2026-01-22
 
 ### Highlights

--- a/README.md
+++ b/README.md
@@ -789,10 +789,18 @@ gog drive drives --max 100
 ```bash
 # Docs
 gog docs info <docId>
+gog docs info <docId> --tab <tabId>
 gog docs cat <docId> --max-bytes 10000
+gog docs cat <docId> --tab <tabId>
 gog docs create "My Doc"
 gog docs copy <docId> "My Doc Copy"
 gog docs export <docId> --format pdf --out ./doc.pdf
+gog docs insert <docId> --text "Hello" --index 1
+gog docs replace <docId> --match "foo" --replace "bar"
+gog docs tabs list <docId>
+gog docs tabs add <docId> "New Tab"
+gog docs tabs delete <docId> <tabId>
+gog docs update <docId> --requests-json '[{"insertText":{"text":"Hi","location":{"index":1}}}]'
 
 # Slides
 gog slides info <presentationId>

--- a/internal/cli/dates.go
+++ b/internal/cli/dates.go
@@ -1,11 +1,20 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+)
+
+// Sentinel errors for time parsing.
+var (
+	ErrEmptyTimeExpression = errors.New("empty time expression")
+	ErrInvalidTimeFormat   = errors.New("cannot parse time")
+	ErrInvalidDuration     = errors.New("invalid duration")
+	ErrInvalidDurationUnit = errors.New("invalid duration unit")
 )
 
 // Matches: "2h ago", "30m ago", "1d ago", "2w ago", "1mo ago"
@@ -19,7 +28,7 @@ var relativeFutureRegex = regexp.MustCompile(`^(\d+)(mo|w|d|h|m)$`)
 func ParseRelativeTime(s string, now time.Time) (time.Time, error) {
 	expr := strings.TrimSpace(s)
 	if expr == "" {
-		return time.Time{}, fmt.Errorf("empty time expression")
+		return time.Time{}, ErrEmptyTimeExpression
 	}
 
 	// Try RFC3339 first (before lowercasing).
@@ -37,6 +46,7 @@ func ParseRelativeTime(s string, now time.Time) (time.Time, error) {
 	if matches := relativeAgoRegex.FindStringSubmatch(exprLower); matches != nil {
 		return applyRelativeDuration(matches[1], matches[2], now, -1)
 	}
+
 	if matches := relativeFutureRegex.FindStringSubmatch(exprLower); matches != nil {
 		return applyRelativeDuration(matches[1], matches[2], now, 1)
 	}
@@ -46,15 +56,15 @@ func ParseRelativeTime(s string, now time.Time) (time.Time, error) {
 	case "now":
 		return now, nil
 	case "today":
-		return startOfDay(now), nil
+		return StartOfDay(now), nil
 	case "tomorrow":
-		return startOfDay(now.AddDate(0, 0, 1)), nil
+		return StartOfDay(now.AddDate(0, 0, 1)), nil
 	case "yesterday":
-		return startOfDay(now.AddDate(0, 0, -1)), nil
+		return StartOfDay(now.AddDate(0, 0, -1)), nil
 	}
 
 	// Try day of week (this week or next).
-	if t, ok := parseWeekday(exprLower, now); ok {
+	if t, ok := ParseWeekday(exprLower, now); ok {
 		return t, nil
 	}
 
@@ -72,21 +82,24 @@ func ParseRelativeTime(s string, now time.Time) (time.Time, error) {
 	if t, err := time.ParseInLocation("2006-01-02T15:04:05", expr, loc); err == nil {
 		return t, nil
 	}
+
 	if t, err := time.ParseInLocation("2006-01-02 15:04", expr, loc); err == nil {
 		return t, nil
 	}
 
-	return time.Time{}, fmt.Errorf("cannot parse %q as time", s)
+	return time.Time{}, fmt.Errorf("%w: %q", ErrInvalidTimeFormat, s)
 }
 
 func applyRelativeDuration(value string, unit string, now time.Time, direction int) (time.Time, error) {
 	n, err := strconv.Atoi(value)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("invalid duration %q", value)
+		return time.Time{}, fmt.Errorf("%w: %q", ErrInvalidDuration, value)
 	}
+
 	if n == 0 {
 		return now, nil
 	}
+
 	if direction < 0 {
 		n = -n
 	}
@@ -103,23 +116,19 @@ func applyRelativeDuration(value string, unit string, now time.Time, direction i
 	case "m":
 		return now.Add(time.Duration(n) * time.Minute), nil
 	default:
-		return time.Time{}, fmt.Errorf("invalid duration unit %q", unit)
+		return time.Time{}, fmt.Errorf("%w: %q", ErrInvalidDurationUnit, unit)
 	}
 }
 
-// startOfDay returns the start of the day (00:00:00) in the given time's location.
-func startOfDay(t time.Time) time.Time {
+// StartOfDay returns the start of the day (00:00:00) in the given time's location.
+func StartOfDay(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }
 
-// endOfDay returns the end of the day (23:59:59.999) in the given time's location.
-func endOfDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
-}
-
-// parseWeekday parses weekday expressions like "monday", "next tuesday".
-func parseWeekday(expr string, now time.Time) (time.Time, bool) {
+// ParseWeekday parses weekday expressions like "monday", "next tuesday".
+func ParseWeekday(expr string, now time.Time) (time.Time, bool) {
 	expr = strings.TrimSpace(expr)
+
 	next := false
 	if strings.HasPrefix(expr, "next ") {
 		next = true
@@ -149,13 +158,15 @@ func parseWeekday(expr string, now time.Time) (time.Time, bool) {
 	}
 
 	currentDay := now.Weekday()
+
 	daysUntil := int(targetDay) - int(currentDay)
 	if daysUntil < 0 || (daysUntil == 0 && next) {
 		daysUntil += 7
 	}
 
 	if daysUntil == 0 {
-		return startOfDay(now), true
+		return StartOfDay(now), true
 	}
-	return startOfDay(now.AddDate(0, 0, daysUntil)), true
+
+	return StartOfDay(now.AddDate(0, 0, daysUntil)), true
 }

--- a/internal/cli/dates.go
+++ b/internal/cli/dates.go
@@ -1,0 +1,161 @@
+package cli
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Matches: "2h ago", "30m ago", "1d ago", "2w ago", "1mo ago"
+var relativeAgoRegex = regexp.MustCompile(`^(\d+)(mo|w|d|h|m)\s*ago$`)
+
+// Matches: "30m", "2h", "1d" (future, for reminders)
+var relativeFutureRegex = regexp.MustCompile(`^(\d+)(mo|w|d|h|m)$`)
+
+// ParseRelativeTime parses human-friendly time expressions.
+// Supports: "2h ago", "yesterday", "monday", "next tue", "30m", RFC3339.
+func ParseRelativeTime(s string, now time.Time) (time.Time, error) {
+	expr := strings.TrimSpace(s)
+	if expr == "" {
+		return time.Time{}, fmt.Errorf("empty time expression")
+	}
+
+	// Try RFC3339 first (before lowercasing).
+	if t, err := time.Parse(time.RFC3339, expr); err == nil {
+		return t, nil
+	}
+
+	// Try ISO 8601 with numeric timezone without colon (e.g., -0800).
+	if t, err := time.Parse("2006-01-02T15:04:05-0700", expr); err == nil {
+		return t, nil
+	}
+
+	exprLower := strings.ToLower(expr)
+
+	if matches := relativeAgoRegex.FindStringSubmatch(exprLower); matches != nil {
+		return applyRelativeDuration(matches[1], matches[2], now, -1)
+	}
+	if matches := relativeFutureRegex.FindStringSubmatch(exprLower); matches != nil {
+		return applyRelativeDuration(matches[1], matches[2], now, 1)
+	}
+
+	// Try relative day expressions.
+	switch exprLower {
+	case "now":
+		return now, nil
+	case "today":
+		return startOfDay(now), nil
+	case "tomorrow":
+		return startOfDay(now.AddDate(0, 0, 1)), nil
+	case "yesterday":
+		return startOfDay(now.AddDate(0, 0, -1)), nil
+	}
+
+	// Try day of week (this week or next).
+	if t, ok := parseWeekday(exprLower, now); ok {
+		return t, nil
+	}
+
+	loc := now.Location()
+	if loc == nil {
+		loc = time.Local
+	}
+
+	// Try date only (YYYY-MM-DD).
+	if t, err := time.ParseInLocation("2006-01-02", expr, loc); err == nil {
+		return t, nil
+	}
+
+	// Try date with time but no timezone.
+	if t, err := time.ParseInLocation("2006-01-02T15:04:05", expr, loc); err == nil {
+		return t, nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02 15:04", expr, loc); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("cannot parse %q as time", s)
+}
+
+func applyRelativeDuration(value string, unit string, now time.Time, direction int) (time.Time, error) {
+	n, err := strconv.Atoi(value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("invalid duration %q", value)
+	}
+	if n == 0 {
+		return now, nil
+	}
+	if direction < 0 {
+		n = -n
+	}
+
+	switch unit {
+	case "mo":
+		return now.AddDate(0, n, 0), nil
+	case "w":
+		return now.AddDate(0, 0, n*7), nil
+	case "d":
+		return now.AddDate(0, 0, n), nil
+	case "h":
+		return now.Add(time.Duration(n) * time.Hour), nil
+	case "m":
+		return now.Add(time.Duration(n) * time.Minute), nil
+	default:
+		return time.Time{}, fmt.Errorf("invalid duration unit %q", unit)
+	}
+}
+
+// startOfDay returns the start of the day (00:00:00) in the given time's location.
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}
+
+// endOfDay returns the end of the day (23:59:59.999) in the given time's location.
+func endOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
+}
+
+// parseWeekday parses weekday expressions like "monday", "next tuesday".
+func parseWeekday(expr string, now time.Time) (time.Time, bool) {
+	expr = strings.TrimSpace(expr)
+	next := false
+	if strings.HasPrefix(expr, "next ") {
+		next = true
+		expr = strings.TrimPrefix(expr, "next ")
+	}
+
+	weekdays := map[string]time.Weekday{
+		"sunday":    time.Sunday,
+		"sun":       time.Sunday,
+		"monday":    time.Monday,
+		"mon":       time.Monday,
+		"tuesday":   time.Tuesday,
+		"tue":       time.Tuesday,
+		"wednesday": time.Wednesday,
+		"wed":       time.Wednesday,
+		"thursday":  time.Thursday,
+		"thu":       time.Thursday,
+		"friday":    time.Friday,
+		"fri":       time.Friday,
+		"saturday":  time.Saturday,
+		"sat":       time.Saturday,
+	}
+
+	targetDay, ok := weekdays[expr]
+	if !ok {
+		return time.Time{}, false
+	}
+
+	currentDay := now.Weekday()
+	daysUntil := int(targetDay) - int(currentDay)
+	if daysUntil < 0 || (daysUntil == 0 && next) {
+		daysUntil += 7
+	}
+
+	if daysUntil == 0 {
+		return startOfDay(now), true
+	}
+	return startOfDay(now.AddDate(0, 0, daysUntil)), true
+}

--- a/internal/cli/dates_test.go
+++ b/internal/cli/dates_test.go
@@ -12,6 +12,7 @@ func TestParseRelativeTimeRelativeDurations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime 2h ago: %v", err)
 	}
+
 	if !parsed.Equal(now.Add(-2 * time.Hour)) {
 		t.Fatalf("unexpected 2h ago: %v", parsed)
 	}
@@ -20,6 +21,7 @@ func TestParseRelativeTimeRelativeDurations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime 30m: %v", err)
 	}
+
 	if !parsed.Equal(now.Add(30 * time.Minute)) {
 		t.Fatalf("unexpected 30m: %v", parsed)
 	}
@@ -28,6 +30,7 @@ func TestParseRelativeTimeRelativeDurations(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime 1d ago: %v", err)
 	}
+
 	if !parsed.Equal(now.AddDate(0, 0, -1)) {
 		t.Fatalf("unexpected 1d ago: %v", parsed)
 	}
@@ -40,7 +43,8 @@ func TestParseRelativeTimeWeekday(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime monday: %v", err)
 	}
-	if parsed.Weekday() != time.Monday || !parsed.After(startOfDay(now)) {
+
+	if parsed.Weekday() != time.Monday || !parsed.After(StartOfDay(now)) {
 		t.Fatalf("unexpected monday: %v", parsed)
 	}
 
@@ -48,7 +52,8 @@ func TestParseRelativeTimeWeekday(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime next friday: %v", err)
 	}
-	if parsed.Weekday() != time.Friday || !parsed.After(startOfDay(now)) {
+
+	if parsed.Weekday() != time.Friday || !parsed.After(StartOfDay(now)) {
 		t.Fatalf("unexpected next friday: %v", parsed)
 	}
 }
@@ -61,6 +66,7 @@ func TestParseRelativeTimeDatesAndRFC3339(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime date: %v", err)
 	}
+
 	if parsed.Location() != loc || parsed.Hour() != 0 {
 		t.Fatalf("unexpected date parse: %v", parsed)
 	}
@@ -69,6 +75,7 @@ func TestParseRelativeTimeDatesAndRFC3339(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ParseRelativeTime rfc3339: %v", err)
 	}
+
 	if parsed.Location() != time.UTC || parsed.Hour() != 10 {
 		t.Fatalf("unexpected rfc3339 parse: %v", parsed)
 	}

--- a/internal/cli/dates_test.go
+++ b/internal/cli/dates_test.go
@@ -1,0 +1,75 @@
+package cli
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseRelativeTimeRelativeDurations(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+
+	parsed, err := ParseRelativeTime("2h ago", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime 2h ago: %v", err)
+	}
+	if !parsed.Equal(now.Add(-2 * time.Hour)) {
+		t.Fatalf("unexpected 2h ago: %v", parsed)
+	}
+
+	parsed, err = ParseRelativeTime("30m", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime 30m: %v", err)
+	}
+	if !parsed.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("unexpected 30m: %v", parsed)
+	}
+
+	parsed, err = ParseRelativeTime("1d ago", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime 1d ago: %v", err)
+	}
+	if !parsed.Equal(now.AddDate(0, 0, -1)) {
+		t.Fatalf("unexpected 1d ago: %v", parsed)
+	}
+}
+
+func TestParseRelativeTimeWeekday(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC) // Friday
+
+	parsed, err := ParseRelativeTime("monday", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime monday: %v", err)
+	}
+	if parsed.Weekday() != time.Monday || !parsed.After(startOfDay(now)) {
+		t.Fatalf("unexpected monday: %v", parsed)
+	}
+
+	parsed, err = ParseRelativeTime("next friday", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime next friday: %v", err)
+	}
+	if parsed.Weekday() != time.Friday || !parsed.After(startOfDay(now)) {
+		t.Fatalf("unexpected next friday: %v", parsed)
+	}
+}
+
+func TestParseRelativeTimeDatesAndRFC3339(t *testing.T) {
+	loc := time.FixedZone("Offset", -5*3600)
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, loc)
+
+	parsed, err := ParseRelativeTime("2025-01-27", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime date: %v", err)
+	}
+	if parsed.Location() != loc || parsed.Hour() != 0 {
+		t.Fatalf("unexpected date parse: %v", parsed)
+	}
+
+	parsed, err = ParseRelativeTime("2025-01-27T10:00:00Z", now)
+	if err != nil {
+		t.Fatalf("ParseRelativeTime rfc3339: %v", err)
+	}
+	if parsed.Location() != time.UTC || parsed.Hour() != 10 {
+		t.Fatalf("unexpected rfc3339 parse: %v", parsed)
+	}
+}

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -22,7 +22,7 @@ type CalendarCreateCmd struct {
 	Location              string   `name:"location" help:"Location"`
 	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
-	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated."`
+	Recurrence            []string `name:"rrule" sep:"none" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated."`
 	Reminders             []string `name:"reminder" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5)."`
 	ColorId               string   `name:"event-color" help:"Event color ID (1-11). Use 'gog calendar colors' to see available colors."`
 	Visibility            string   `name:"visibility" help:"Event visibility: default, public, private, confidential"`
@@ -305,7 +305,7 @@ type CalendarUpdateCmd struct {
 	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails (replaces all; set empty to clear)"`
 	AddAttendee           string   `name:"add-attendee" help:"Comma-separated attendee emails to add (preserves existing attendees)"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
-	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear."`
+	Recurrence            []string `name:"rrule" sep:"none" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear."`
 	Reminders             []string `name:"reminder" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to clear."`
 	ColorId               string   `name:"event-color" help:"Event color ID (1-11, or empty to clear)"`
 	Visibility            string   `name:"visibility" help:"Event visibility: default, public, private, confidential"`

--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -20,7 +20,7 @@ type CalendarFocusTimeCmd struct {
 	AutoDecline    string   `name:"auto-decline" help:"Auto-decline mode: none, all, new" default:"all"`
 	DeclineMessage string   `name:"decline-message" help:"Message for declined invitations"`
 	ChatStatus     string   `name:"chat-status" help:"Chat status: available, doNotDisturb" default:"doNotDisturb"`
-	Recurrence     []string `name:"rrule" help:"Recurrence rules. Can be repeated."`
+	Recurrence     []string `name:"rrule" sep:"none" help:"Recurrence rules (e.g., 'RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR'). Can be repeated."`
 }
 
 func (c *CalendarFocusTimeCmd) Run(ctx context.Context, flags *RootFlags) error {

--- a/internal/cmd/calendar_test.go
+++ b/internal/cmd/calendar_test.go
@@ -232,6 +232,33 @@ func TestBuildRecurrence(t *testing.T) {
 	if len(got) != 2 || got[0] != "RRULE:FREQ=DAILY" || got[1] != "EXDATE:20250101" {
 		t.Fatalf("unexpected: %#v", got)
 	}
+
+	// Test BYDAY parameter with commas (issue #120)
+	got = buildRecurrence([]string{"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"})
+	if len(got) != 1 || got[0] != "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" {
+		t.Fatalf("BYDAY rule corrupted: %#v", got)
+	}
+
+	// Test multiple rrule flags with BYDAY and EXDATE (issue #120)
+	got = buildRecurrence([]string{
+		"RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR",
+		"EXDATE:20260130T100000Z",
+	})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 rules, got %d: %#v", len(got), got)
+	}
+	if got[0] != "RRULE:FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR" {
+		t.Fatalf("first rule corrupted: %q", got[0])
+	}
+	if got[1] != "EXDATE:20260130T100000Z" {
+		t.Fatalf("second rule corrupted: %q", got[1])
+	}
+
+	// Test other comma-containing parameters (BYMONTH, BYMONTHDAY)
+	got = buildRecurrence([]string{"RRULE:FREQ=YEARLY;BYMONTH=1,2,3;BYMONTHDAY=1,15"})
+	if len(got) != 1 || got[0] != "RRULE:FREQ=YEARLY;BYMONTH=1,2,3;BYMONTHDAY=1,15" {
+		t.Fatalf("BYMONTH/BYMONTHDAY rule corrupted: %#v", got)
+	}
 }
 
 func TestParseDuration(t *testing.T) {

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -590,20 +590,22 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if strings.TrimSpace(c.RequiredRev) != "" || strings.TrimSpace(c.TargetRev) != "" {
 			return usage("use only one of --body-* or revision flags")
 		}
-		raw, err := readJSONInput(bodyJSON, bodyFile, "body")
+		var raw string
+		raw, err = readJSONInput(bodyJSON, bodyFile, "body")
 		if err != nil {
 			return err
 		}
-		if err := json.Unmarshal([]byte(raw), &req); err != nil {
+		if err = json.Unmarshal([]byte(raw), &req); err != nil {
 			return fmt.Errorf("invalid batchUpdate JSON: %w", err)
 		}
 	default:
-		raw, err := readJSONInput(reqJSON, reqFile, "requests")
+		var raw string
+		raw, err = readJSONInput(reqJSON, reqFile, "requests")
 		if err != nil {
 			return err
 		}
 		var requests []*docs.Request
-		if err := json.Unmarshal([]byte(raw), &requests); err != nil {
+		if err = json.Unmarshal([]byte(raw), &requests); err != nil {
 			return fmt.Errorf("invalid requests JSON: %w", err)
 		}
 		req.Requests = requests

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"google.golang.org/api/drive/v3"
 	gapi "google.golang.org/api/googleapi"
 
+	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
@@ -22,11 +24,15 @@ import (
 var newDocsService = googleapi.NewDocs
 
 type DocsCmd struct {
-	Export DocsExportCmd `cmd:"" name:"export" help:"Export a Google Doc (pdf|docx|txt)"`
-	Info   DocsInfoCmd   `cmd:"" name:"info" help:"Get Google Doc metadata"`
-	Create DocsCreateCmd `cmd:"" name:"create" help:"Create a Google Doc"`
-	Copy   DocsCopyCmd   `cmd:"" name:"copy" help:"Copy a Google Doc"`
-	Cat    DocsCatCmd    `cmd:"" name:"cat" help:"Print a Google Doc as plain text"`
+	Export  DocsExportCmd  `cmd:"" name:"export" help:"Export a Google Doc (pdf|docx|txt)"`
+	Info    DocsInfoCmd    `cmd:"" name:"info" help:"Get Google Doc metadata"`
+	Create  DocsCreateCmd  `cmd:"" name:"create" help:"Create a Google Doc"`
+	Copy    DocsCopyCmd    `cmd:"" name:"copy" help:"Copy a Google Doc"`
+	Cat     DocsCatCmd     `cmd:"" name:"cat" help:"Print a Google Doc as plain text"`
+	Insert  DocsInsertCmd  `cmd:"" name:"insert" help:"Insert text into a Google Doc"`
+	Replace DocsReplaceCmd `cmd:"" name:"replace" help:"Replace text in a Google Doc"`
+	Update  DocsUpdateCmd  `cmd:"" name:"update" help:"Batch update a Google Doc (Docs API)"`
+	Tabs    DocsTabsCmd    `cmd:"" name:"tabs" help:"Manage document tabs"`
 }
 
 type DocsExportCmd struct {
@@ -46,6 +52,7 @@ func (c *DocsExportCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 type DocsInfoCmd struct {
 	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	TabID string `name:"tab" help:"Tab ID (adds tab link/details)"`
 }
 
 func (c *DocsInfoCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -65,8 +72,13 @@ func (c *DocsInfoCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	tabID := strings.TrimSpace(c.TabID)
+	fields := "documentId,title,revisionId"
+	if tabID != "" {
+		fields = "documentId,title,revisionId,tabs"
+	}
 	doc, err := svc.Documents.Get(id).
-		Fields("documentId,title,revisionId").
+		Fields(gapi.Field(fields)).
 		Context(ctx).
 		Do()
 	if err != nil {
@@ -79,30 +91,57 @@ func (c *DocsInfoCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return errors.New("doc not found")
 	}
 
+	var tabProps *docs.TabProperties
+	if tabID != "" {
+		tab := findDocsTab(doc.Tabs, tabID)
+		if tab == nil || tab.TabProperties == nil {
+			return fmt.Errorf("tab not found (id=%s)", tabID)
+		}
+		tabProps = tab.TabProperties
+	}
+
 	file := map[string]any{
 		"id":       doc.DocumentId,
 		"name":     doc.Title,
 		"mimeType": driveMimeGoogleDoc,
 	}
-	if link := docsWebViewLink(doc.DocumentId); link != "" {
+	if link := docsWebViewLink(doc.DocumentId, tabID); link != "" {
 		file["webViewLink"] = link
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(os.Stdout, map[string]any{
+		payload := map[string]any{
 			strFile:    file,
 			"document": doc,
-		})
+		}
+		if tabProps != nil {
+			payload["tab"] = tabProps
+		}
+		return outfmt.WriteJSON(os.Stdout, payload)
 	}
 
 	u.Out().Printf("id\t%s", doc.DocumentId)
 	u.Out().Printf("name\t%s", doc.Title)
 	u.Out().Printf("mime\t%s", driveMimeGoogleDoc)
-	if link := docsWebViewLink(doc.DocumentId); link != "" {
+	if link := docsWebViewLink(doc.DocumentId, tabID); link != "" {
 		u.Out().Printf("link\t%s", link)
 	}
 	if doc.RevisionId != "" {
 		u.Out().Printf("revision\t%s", doc.RevisionId)
+	}
+	if tabProps != nil {
+		u.Out().Printf("tab\t%s", tabProps.TabId)
+		if tabProps.Title != "" {
+			u.Out().Printf("tab-title\t%s", tabProps.Title)
+		}
+		if tabProps.ParentTabId != "" {
+			u.Out().Printf("tab-parent\t%s", tabProps.ParentTabId)
+		}
+		if tabProps.IconEmoji != "" {
+			u.Out().Printf("tab-icon\t%s", tabProps.IconEmoji)
+		}
+		u.Out().Printf("tab-index\t%d", tabProps.Index)
+		u.Out().Printf("tab-level\t%d", tabProps.NestingLevel)
 	}
 	return nil
 }
@@ -180,6 +219,7 @@ func (c *DocsCopyCmd) Run(ctx context.Context, flags *RootFlags) error {
 type DocsCatCmd struct {
 	DocID    string `arg:"" name:"docId" help:"Doc ID"`
 	MaxBytes int64  `name:"max-bytes" help:"Max bytes to read (0 = unlimited)" default:"2000000"`
+	TabID    string `name:"tab" help:"Tab ID"`
 }
 
 func (c *DocsCatCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -192,15 +232,18 @@ func (c *DocsCatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if id == "" {
 		return usage("empty docId")
 	}
+	tabID := strings.TrimSpace(c.TabID)
 
 	svc, err := newDocsService(ctx, account)
 	if err != nil {
 		return err
 	}
 
-	doc, err := svc.Documents.Get(id).
-		Context(ctx).
-		Do()
+	call := svc.Documents.Get(id).Context(ctx)
+	if tabID != "" {
+		call = call.IncludeTabsContent(true)
+	}
+	doc, err := call.Do()
 	if err != nil {
 		if isDocsNotFound(err) {
 			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
@@ -211,7 +254,16 @@ func (c *DocsCatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return errors.New("doc not found")
 	}
 
-	text := docsPlainText(doc, c.MaxBytes)
+	var text string
+	if tabID != "" {
+		tab := findDocsTab(doc.Tabs, tabID)
+		if tab == nil || tab.DocumentTab == nil {
+			return fmt.Errorf("tab not found (id=%s)", tabID)
+		}
+		text = docsTabPlainText(tab.DocumentTab, c.MaxBytes)
+	} else {
+		text = docsPlainText(doc, c.MaxBytes)
+	}
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{"text": text})
@@ -220,21 +272,207 @@ func (c *DocsCatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return err
 }
 
-func docsWebViewLink(id string) string {
+type DocsInsertCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Text  string `name:"text" help:"Text to insert" required:""`
+	Index *int64 `name:"index" help:"Zero-based UTF-16 index"`
+	End   bool   `name:"end" help:"Insert at the end of the segment"`
+	TabID string `name:"tab" help:"Tab ID"`
+}
+
+func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	if c.End && c.Index != nil {
+		return usage("use only one of --index or --end")
+	}
+	if !c.End && c.Index == nil {
+		return usage("missing --index (or use --end)")
+	}
+
+	tabID := strings.TrimSpace(c.TabID)
+	insert := &docs.InsertTextRequest{
+		Text: c.Text,
+	}
+	if c.End {
+		insert.EndOfSegmentLocation = &docs.EndOfSegmentLocation{
+			TabId: tabID,
+		}
+	} else {
+		loc := &docs.Location{
+			Index: *c.Index,
+			TabId: tabID,
+		}
+		loc.ForceSendFields = append(loc.ForceSendFields, "Index")
+		insert.Location = loc
+	}
+
+	req := &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{
+			{
+				InsertText: insert,
+			},
+		},
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(id, req).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		out := map[string]any{
+			"documentId": resp.DocumentId,
+			"text":       c.Text,
+		}
+		if c.Index != nil {
+			out["index"] = *c.Index
+		}
+		if c.End {
+			out["end"] = true
+		}
+		if tabID != "" {
+			out["tabId"] = tabID
+		}
+		return outfmt.WriteJSON(os.Stdout, out)
+	}
+
+	u.Out().Printf("id\t%s", resp.DocumentId)
+	u.Out().Printf("inserted\t%d", len(c.Text))
+	if tabID != "" {
+		u.Out().Printf("tab\t%s", tabID)
+	}
+	if c.Index != nil {
+		u.Out().Printf("index\t%d", *c.Index)
+	}
+	if c.End {
+		u.Out().Printf("end\ttrue")
+	}
+	return nil
+}
+
+type DocsReplaceCmd struct {
+	DocID     string `arg:"" name:"docId" help:"Doc ID"`
+	Match     string `name:"match" help:"Text to match" required:""`
+	Replace   string `name:"replace" help:"Replacement text" required:""`
+	MatchCase bool   `name:"match-case" help:"Match case"`
+	TabID     string `name:"tab" help:"Tab ID"`
+}
+
+func (c *DocsReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	tabID := strings.TrimSpace(c.TabID)
+	req := &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{
+			{
+				ReplaceAllText: &docs.ReplaceAllTextRequest{
+					ContainsText: &docs.SubstringMatchCriteria{
+						Text:      c.Match,
+						MatchCase: c.MatchCase,
+					},
+					ReplaceText: c.Replace,
+					TabsCriteria: func() *docs.TabsCriteria {
+						if tabID == "" {
+							return nil
+						}
+						return &docs.TabsCriteria{TabIds: []string{tabID}}
+					}(),
+				},
+			},
+		},
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(id, req).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	var occurrences int64
+	if len(resp.Replies) > 0 && resp.Replies[0].ReplaceAllText != nil {
+		occurrences = resp.Replies[0].ReplaceAllText.OccurrencesChanged
+	}
+
+	if outfmt.IsJSON(ctx) {
+		out := map[string]any{
+			"documentId":         resp.DocumentId,
+			"occurrencesChanged": occurrences,
+		}
+		if tabID != "" {
+			out["tabId"] = tabID
+		}
+		return outfmt.WriteJSON(os.Stdout, out)
+	}
+
+	u.Out().Printf("id\t%s", resp.DocumentId)
+	u.Out().Printf("replaced\t%d", occurrences)
+	if tabID != "" {
+		u.Out().Printf("tab\t%s", tabID)
+	}
+	return nil
+}
+
+func docsWebViewLink(id, tabID string) string {
 	id = strings.TrimSpace(id)
 	if id == "" {
 		return ""
 	}
-	return "https://docs.google.com/document/d/" + id + "/edit"
+	link := "https://docs.google.com/document/d/" + id + "/edit"
+	tabID = strings.TrimSpace(tabID)
+	if tabID != "" {
+		link += "?tab=" + tabID
+	}
+	return link
 }
 
 func docsPlainText(doc *docs.Document, maxBytes int64) string {
-	if doc == nil || doc.Body == nil {
+	if doc == nil {
 		return ""
 	}
+	return docsBodyPlainText(doc.Body, maxBytes)
+}
 
+func docsTabPlainText(tab *docs.DocumentTab, maxBytes int64) string {
+	if tab == nil {
+		return ""
+	}
+	return docsBodyPlainText(tab.Body, maxBytes)
+}
+
+func docsBodyPlainText(body *docs.Body, maxBytes int64) string {
+	if body == nil {
+		return ""
+	}
 	var buf bytes.Buffer
-	for _, el := range doc.Body.Content {
+	for _, el := range body.Content {
 		if !appendDocsElementText(&buf, maxBytes, el) {
 			break
 		}
@@ -313,4 +551,484 @@ func isDocsNotFound(err error) bool {
 		return false
 	}
 	return apiErr.Code == http.StatusNotFound
+}
+
+type DocsUpdateCmd struct {
+	DocID        string `arg:"" name:"docId" help:"Doc ID"`
+	RequestsJSON string `name:"requests-json" help:"Batch update requests as JSON array"`
+	RequestsFile string `name:"requests-file" help:"Requests JSON file path ('-' for stdin)"`
+	BodyJSON     string `name:"body-json" help:"Full batchUpdate request JSON"`
+	BodyFile     string `name:"body-file" help:"BatchUpdate request JSON file path ('-' for stdin)"`
+	RequiredRev  string `name:"required-revision" help:"Require this revision ID"`
+	TargetRev    string `name:"target-revision" help:"Target this revision ID"`
+}
+
+func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	bodyJSON := strings.TrimSpace(c.BodyJSON)
+	bodyFile := strings.TrimSpace(c.BodyFile)
+	reqJSON := strings.TrimSpace(c.RequestsJSON)
+	reqFile := strings.TrimSpace(c.RequestsFile)
+
+	if (bodyJSON != "" || bodyFile != "") && (reqJSON != "" || reqFile != "") {
+		return usage("use either --body-json/--body-file or --requests-json/--requests-file")
+	}
+
+	var req docs.BatchUpdateDocumentRequest
+	switch {
+	case bodyJSON != "" || bodyFile != "":
+		if strings.TrimSpace(c.RequiredRev) != "" || strings.TrimSpace(c.TargetRev) != "" {
+			return usage("use only one of --body-* or revision flags")
+		}
+		raw, err := readJSONInput(bodyJSON, bodyFile, "body")
+		if err != nil {
+			return err
+		}
+		if err := json.Unmarshal([]byte(raw), &req); err != nil {
+			return fmt.Errorf("invalid batchUpdate JSON: %w", err)
+		}
+	default:
+		raw, err := readJSONInput(reqJSON, reqFile, "requests")
+		if err != nil {
+			return err
+		}
+		var requests []*docs.Request
+		if err := json.Unmarshal([]byte(raw), &requests); err != nil {
+			return fmt.Errorf("invalid requests JSON: %w", err)
+		}
+		req.Requests = requests
+		if strings.TrimSpace(c.RequiredRev) != "" || strings.TrimSpace(c.TargetRev) != "" {
+			req.WriteControl = &docs.WriteControl{
+				RequiredRevisionId: strings.TrimSpace(c.RequiredRev),
+				TargetRevisionId:   strings.TrimSpace(c.TargetRev),
+			}
+		}
+	}
+
+	if len(req.Requests) == 0 {
+		return fmt.Errorf("no requests provided")
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(id, &req).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"documentId":   resp.DocumentId,
+			"replies":      resp.Replies,
+			"writeControl": resp.WriteControl,
+		})
+	}
+
+	u.Out().Printf("id\t%s", resp.DocumentId)
+	u.Out().Printf("requests\t%d", len(req.Requests))
+	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
+		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
+type DocsTabsCmd struct {
+	List   DocsTabsListCmd   `cmd:"" name:"list" help:"List document tabs"`
+	Add    DocsTabsAddCmd    `cmd:"" name:"add" help:"Add a document tab"`
+	Update DocsTabsUpdateCmd `cmd:"" name:"update" help:"Update a document tab" aliases:"rename,move"`
+	Delete DocsTabsDeleteCmd `cmd:"" name:"delete" help:"Delete a document tab" aliases:"rm,del"`
+}
+
+type DocsTabsListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+}
+
+func (c *DocsTabsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	doc, err := svc.Documents.Get(id).
+		Fields("documentId,title,tabs").
+		Context(ctx).
+		Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return err
+	}
+	if doc == nil {
+		return errors.New("doc not found")
+	}
+
+	tabs := flattenDocsTabs(doc.Tabs)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"documentId": doc.DocumentId,
+			"tabs":       tabs,
+			"tabCount":   len(tabs),
+		})
+	}
+
+	if len(tabs) == 0 {
+		u.Err().Println("No tabs")
+		return nil
+	}
+
+	w, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(w, "ID\tTITLE\tPARENT\tINDEX\tLEVEL\tICON")
+	for _, tab := range tabs {
+		parent := tab.ParentID
+		if parent == "" {
+			parent = "-"
+		}
+		icon := tab.IconEmoji
+		if icon == "" {
+			icon = "-"
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%s\n", tab.ID, tab.Title, parent, tab.Index, tab.NestingLevel, icon)
+	}
+	return nil
+}
+
+type DocsTabsAddCmd struct {
+	DocID  string `arg:"" name:"docId" help:"Doc ID"`
+	Title  string `arg:"" name:"title" help:"Tab title"`
+	Parent string `name:"parent" help:"Parent tab ID"`
+	Index  *int64 `name:"index" help:"Zero-based tab index"`
+	Emoji  string `name:"emoji" help:"Tab emoji icon"`
+}
+
+func (c *DocsTabsAddCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+	title := strings.TrimSpace(c.Title)
+	if title == "" {
+		return usage("empty title")
+	}
+
+	props := &docs.TabProperties{
+		Title: title,
+	}
+	if parent := strings.TrimSpace(c.Parent); parent != "" {
+		props.ParentTabId = parent
+	}
+	if emoji := strings.TrimSpace(c.Emoji); emoji != "" {
+		props.IconEmoji = emoji
+	}
+	if c.Index != nil {
+		props.Index = *c.Index
+		props.ForceSendFields = append(props.ForceSendFields, "Index")
+	}
+
+	req := &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{
+			{
+				AddDocumentTab: &docs.AddDocumentTabRequest{
+					TabProperties: props,
+				},
+			},
+		},
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(id, req).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	var tabProps *docs.TabProperties
+	if len(resp.Replies) > 0 && resp.Replies[0].AddDocumentTab != nil {
+		tabProps = resp.Replies[0].AddDocumentTab.TabProperties
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"documentId": resp.DocumentId,
+			"tab":        tabProps,
+		})
+	}
+
+	if tabProps != nil {
+		u.Out().Printf("tab\t%s", tabProps.TabId)
+		u.Out().Printf("title\t%s", tabProps.Title)
+		if tabProps.ParentTabId != "" {
+			u.Out().Printf("parent\t%s", tabProps.ParentTabId)
+		}
+		u.Out().Printf("index\t%d", tabProps.Index)
+		if tabProps.IconEmoji != "" {
+			u.Out().Printf("icon\t%s", tabProps.IconEmoji)
+		}
+		return nil
+	}
+	u.Out().Printf("updated\ttrue")
+	return nil
+}
+
+type DocsTabsUpdateCmd struct {
+	DocID  string  `arg:"" name:"docId" help:"Doc ID"`
+	TabID  string  `arg:"" name:"tabId" help:"Tab ID"`
+	Title  *string `name:"title" help:"New tab title"`
+	Parent *string `name:"parent" help:"New parent tab ID (empty = root)"`
+	Index  *int64  `name:"index" help:"Zero-based tab index"`
+	Emoji  *string `name:"emoji" help:"New tab emoji icon"`
+}
+
+func (c *DocsTabsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+	tabID := strings.TrimSpace(c.TabID)
+	if tabID == "" {
+		return usage("empty tabId")
+	}
+
+	props := &docs.TabProperties{
+		TabId: tabID,
+	}
+	fields := make([]string, 0, 4)
+	if c.Title != nil {
+		props.Title = *c.Title
+		props.ForceSendFields = append(props.ForceSendFields, "Title")
+		fields = append(fields, "title")
+	}
+	if c.Parent != nil {
+		props.ParentTabId = *c.Parent
+		props.ForceSendFields = append(props.ForceSendFields, "ParentTabId")
+		fields = append(fields, "parentTabId")
+	}
+	if c.Index != nil {
+		props.Index = *c.Index
+		props.ForceSendFields = append(props.ForceSendFields, "Index")
+		fields = append(fields, "index")
+	}
+	if c.Emoji != nil {
+		props.IconEmoji = *c.Emoji
+		props.ForceSendFields = append(props.ForceSendFields, "IconEmoji")
+		fields = append(fields, "iconEmoji")
+	}
+	if len(fields) == 0 {
+		return usage("no fields to update (set at least one of: --title, --parent, --index, --emoji)")
+	}
+
+	req := &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{
+			{
+				UpdateDocumentTabProperties: &docs.UpdateDocumentTabPropertiesRequest{
+					TabProperties: props,
+					Fields:        strings.Join(fields, ","),
+				},
+			},
+		},
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(id, req).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"documentId": resp.DocumentId,
+			"tabId":      tabID,
+			"fields":     fields,
+		})
+	}
+
+	u.Out().Printf("tab\t%s", tabID)
+	u.Out().Printf("fields\t%s", strings.Join(fields, ","))
+	return nil
+}
+
+type DocsTabsDeleteCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	TabID string `arg:"" name:"tabId" help:"Tab ID"`
+}
+
+func (c *DocsTabsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+	tabID := strings.TrimSpace(c.TabID)
+	if tabID == "" {
+		return usage("empty tabId")
+	}
+
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete tab %s from doc %s", tabID, id)); confirmErr != nil {
+		return confirmErr
+	}
+
+	req := &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{
+			{
+				DeleteTab: &docs.DeleteTabRequest{
+					TabId: tabID,
+				},
+			},
+		},
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	if _, err := svc.Documents.BatchUpdate(id, req).Context(ctx).Do(); err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(os.Stdout, map[string]any{
+			"deleted":    true,
+			"documentId": id,
+			"tabId":      tabID,
+		})
+	}
+
+	u.Out().Printf("deleted\ttrue")
+	u.Out().Printf("tab\t%s", tabID)
+	return nil
+}
+
+type docsTabInfo struct {
+	ID           string `json:"id"`
+	Title        string `json:"title"`
+	ParentID     string `json:"parentId,omitempty"`
+	Index        int64  `json:"index"`
+	NestingLevel int64  `json:"nestingLevel"`
+	IconEmoji    string `json:"iconEmoji,omitempty"`
+}
+
+func flattenDocsTabs(tabs []*docs.Tab) []docsTabInfo {
+	var out []docsTabInfo
+	var walk func(items []*docs.Tab)
+	walk = func(items []*docs.Tab) {
+		for _, tab := range items {
+			if tab == nil || tab.TabProperties == nil {
+				continue
+			}
+			props := tab.TabProperties
+			out = append(out, docsTabInfo{
+				ID:           props.TabId,
+				Title:        props.Title,
+				ParentID:     props.ParentTabId,
+				Index:        props.Index,
+				NestingLevel: props.NestingLevel,
+				IconEmoji:    props.IconEmoji,
+			})
+			if len(tab.ChildTabs) > 0 {
+				walk(tab.ChildTabs)
+			}
+		}
+	}
+	walk(tabs)
+	return out
+}
+
+func findDocsTab(tabs []*docs.Tab, tabID string) *docs.Tab {
+	tabID = strings.TrimSpace(tabID)
+	if tabID == "" {
+		return nil
+	}
+	for _, tab := range tabs {
+		if tab == nil || tab.TabProperties == nil {
+			continue
+		}
+		if tab.TabProperties.TabId == tabID {
+			return tab
+		}
+		if found := findDocsTab(tab.ChildTabs, tabID); found != nil {
+			return found
+		}
+	}
+	return nil
+}
+
+func readJSONInput(raw, path, label string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	path = strings.TrimSpace(path)
+	if raw == "" && path == "" {
+		return "", usagef("provide %s via --%s-json or --%s-file", label, label, label)
+	}
+	if raw != "" && path != "" {
+		return "", usagef("use only one of --%s-json or --%s-file", label, label)
+	}
+	if path == "" {
+		return raw, nil
+	}
+
+	var (
+		b   []byte
+		err error
+	)
+	if path == "-" {
+		b, err = io.ReadAll(os.Stdin)
+	} else {
+		path, err = config.ExpandPath(path)
+		if err != nil {
+			return "", err
+		}
+		b, err = os.ReadFile(path) //nolint:gosec // user-provided path
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
 }

--- a/internal/cmd/docs_helpers_test.go
+++ b/internal/cmd/docs_helpers_test.go
@@ -9,12 +9,16 @@ import (
 )
 
 func TestDocsWebViewLink(t *testing.T) {
-	if docsWebViewLink("") != "" {
+	if docsWebViewLink("", "") != "" {
 		t.Fatalf("expected empty link")
 	}
-	link := docsWebViewLink("abc")
+	link := docsWebViewLink("abc", "")
 	if link != "https://docs.google.com/document/d/abc/edit" {
 		t.Fatalf("unexpected link: %q", link)
+	}
+	link = docsWebViewLink("abc", "tab1")
+	if link != "https://docs.google.com/document/d/abc/edit?tab=tab1" {
+		t.Fatalf("unexpected tab link: %q", link)
 	}
 }
 

--- a/internal/cmd/docs_tabs_test.go
+++ b/internal/cmd/docs_tabs_test.go
@@ -1,0 +1,538 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestDocsCat_Tab(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/documents/doc1") && r.Method == http.MethodGet {
+			if r.URL.Query().Get("includeTabsContent") != "true" {
+				t.Fatalf("expected includeTabsContent=true, got %q", r.URL.RawQuery)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"tabs": []any{
+					map[string]any{
+						"tabProperties": map[string]any{"tabId": "tab1", "title": "Tab 1"},
+						"documentTab": map[string]any{
+							"body": map[string]any{
+								"content": []any{
+									map[string]any{
+										"paragraph": map[string]any{
+											"elements": []any{
+												map[string]any{"textRun": map[string]any{"content": "Tab text"}},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	out := captureStdout(t, func() {
+		cmd := &DocsCatCmd{}
+		if err := runKong(t, cmd, []string{"doc1", "--tab", "tab1"}, ctx, flags); err != nil {
+			t.Fatalf("cat: %v", err)
+		}
+	})
+	if out != "Tab text" {
+		t.Fatalf("unexpected cat output: %q", out)
+	}
+}
+
+func TestDocsInfo_Tab(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/documents/doc1") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"title":      "Doc",
+				"revisionId": "r1",
+				"tabs": []any{
+					map[string]any{
+						"tabProperties": map[string]any{
+							"tabId":        "tab1",
+							"title":        "First",
+							"index":        0,
+							"nestingLevel": 0,
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	var outBuf strings.Builder
+	u, uiErr := ui.New(ui.Options{Stdout: &outBuf, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsInfoCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--tab", "tab1"}, ctx, flags); err != nil {
+		t.Fatalf("info: %v", err)
+	}
+	out := outBuf.String()
+	if !strings.Contains(out, "tab\ttab1") {
+		t.Fatalf("expected tab output, got %q", out)
+	}
+	if !strings.Contains(out, "link\thttps://docs.google.com/document/d/doc1/edit?tab=tab1") {
+		t.Fatalf("expected tab link, got %q", out)
+	}
+}
+
+func TestDocsTabsList_JSON(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasPrefix(r.URL.Path, "/v1/documents/doc1") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"title":      "Doc",
+				"tabs": []any{
+					map[string]any{
+						"tabProperties": map[string]any{
+							"tabId":        "t1",
+							"title":        "One",
+							"index":        0,
+							"nestingLevel": 0,
+						},
+						"childTabs": []any{
+							map[string]any{
+								"tabProperties": map[string]any{
+									"tabId":        "t1a",
+									"title":        "Child",
+									"index":        0,
+									"nestingLevel": 1,
+									"parentTabId":  "t1",
+								},
+							},
+						},
+					},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+
+	out := captureStdout(t, func() {
+		cmd := &DocsTabsListCmd{}
+		if err := runKong(t, cmd, []string{"doc1"}, ctx, flags); err != nil {
+			t.Fatalf("tabs list: %v", err)
+		}
+	})
+
+	var parsed struct {
+		TabCount int `json:"tabCount"`
+		Tabs     []struct {
+			ID string `json:"id"`
+		} `json:"tabs"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v", err)
+	}
+	if parsed.TabCount != 2 || len(parsed.Tabs) != 2 {
+		t.Fatalf("unexpected tab count: %#v", parsed)
+	}
+	if parsed.Tabs[0].ID != "t1" || parsed.Tabs[1].ID != "t1a" {
+		t.Fatalf("unexpected tabs: %#v", parsed.Tabs)
+	}
+}
+
+func TestDocsUpdate_RequestsJSON(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/documents/doc1:batchUpdate") && r.Method == http.MethodPost {
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].InsertText == nil {
+				t.Fatalf("expected insertText request, got %#v", req.Requests)
+			}
+			if req.WriteControl == nil || req.WriteControl.RequiredRevisionId != "r1" {
+				t.Fatalf("missing required revision: %#v", req.WriteControl)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsUpdateCmd{}
+	if err := runKong(t, cmd, []string{
+		"doc1",
+		"--requests-json", `[{"insertText":{"text":"Hello","location":{"index":1}}}]`,
+		"--required-revision", "r1",
+	}, ctx, flags); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+}
+
+func TestDocsTabsAdd(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/documents/doc1:batchUpdate") && r.Method == http.MethodPost {
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].AddDocumentTab == nil {
+				t.Fatalf("expected addDocumentTab request, got %#v", req.Requests)
+			}
+			props := req.Requests[0].AddDocumentTab.TabProperties
+			if props == nil || props.Title != "New Tab" || props.ParentTabId != "parent1" || props.Index != 0 {
+				t.Fatalf("unexpected tab properties: %#v", props)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies": []any{
+					map[string]any{"addDocumentTab": map[string]any{"tabProperties": map[string]any{"tabId": "tab123", "title": "New Tab"}}},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsTabsAddCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "New Tab", "--parent", "parent1", "--index", "0"}, ctx, flags); err != nil {
+		t.Fatalf("tabs add: %v", err)
+	}
+}
+
+func TestDocsTabsUpdate(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/documents/doc1:batchUpdate") && r.Method == http.MethodPost {
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].UpdateDocumentTabProperties == nil {
+				t.Fatalf("expected updateDocumentTabProperties request, got %#v", req.Requests)
+			}
+			update := req.Requests[0].UpdateDocumentTabProperties
+			if update.Fields != "title,index" {
+				t.Fatalf("unexpected fields: %q", update.Fields)
+			}
+			if update.TabProperties == nil || update.TabProperties.TabId != "tab1" || update.TabProperties.Title != "Renamed" || update.TabProperties.Index != 0 {
+				t.Fatalf("unexpected tab properties: %#v", update.TabProperties)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsTabsUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "tab1", "--title", "Renamed", "--index", "0"}, ctx, flags); err != nil {
+		t.Fatalf("tabs update: %v", err)
+	}
+}
+
+func TestDocsTabsDelete(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/documents/doc1:batchUpdate") && r.Method == http.MethodPost {
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].DeleteTab == nil || req.Requests[0].DeleteTab.TabId != "tab1" {
+				t.Fatalf("unexpected delete request: %#v", req.Requests)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com", Force: true}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsTabsDeleteCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "tab1"}, ctx, flags); err != nil {
+		t.Fatalf("tabs delete: %v", err)
+	}
+}
+
+func TestDocsInsert_Index(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/documents/doc1:batchUpdate") && r.Method == http.MethodPost {
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].InsertText == nil {
+				t.Fatalf("expected insertText request, got %#v", req.Requests)
+			}
+			insert := req.Requests[0].InsertText
+			if insert.Text != "Hello" {
+				t.Fatalf("unexpected text: %q", insert.Text)
+			}
+			if insert.Location == nil || insert.Location.Index != 0 || insert.Location.TabId != "tab1" {
+				t.Fatalf("unexpected location: %#v", insert.Location)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsInsertCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--text", "Hello", "--index", "0", "--tab", "tab1"}, ctx, flags); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+}
+
+func TestDocsReplace_Tab(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/v1/documents/doc1:batchUpdate") && r.Method == http.MethodPost {
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].ReplaceAllText == nil {
+				t.Fatalf("expected replaceAllText request, got %#v", req.Requests)
+			}
+			replace := req.Requests[0].ReplaceAllText
+			if replace.ContainsText == nil || replace.ContainsText.Text != "old" || replace.ReplaceText != "new" {
+				t.Fatalf("unexpected replace request: %#v", replace)
+			}
+			if replace.TabsCriteria == nil || len(replace.TabsCriteria.TabIds) != 1 || replace.TabsCriteria.TabIds[0] != "tab1" {
+				t.Fatalf("unexpected tabs criteria: %#v", replace.TabsCriteria)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies": []any{
+					map[string]any{"replaceAllText": map[string]any{"occurrencesChanged": 2}},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &DocsReplaceCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--match", "old", "--replace", "new", "--tab", "tab1"}, ctx, flags); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+}

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -140,6 +140,7 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u.Out().Printf("Message-ID: %s", msg.Id)
 	u.Out().Printf("To: %s", headerValue(msg.Payload, "To"))
 	u.Out().Printf("Cc: %s", headerValue(msg.Payload, "Cc"))
+	u.Out().Printf("Bcc: %s", headerValue(msg.Payload, "Bcc"))
 	u.Out().Printf("Subject: %s", headerValue(msg.Payload, "Subject"))
 	u.Out().Println("")
 

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -53,7 +53,7 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if format == gmailFormatMetadata {
 		headerList := splitCSV(c.Headers)
 		if len(headerList) == 0 {
-			headerList = []string{"From", "To", "Subject", "Date"}
+			headerList = []string{"From", "To", "Cc", "Bcc", "Subject", "Date"}
 		}
 		if !hasHeaderName(headerList, "List-Unsubscribe") {
 			headerList = append(headerList, "List-Unsubscribe")
@@ -119,6 +119,8 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	case gmailFormatMetadata, gmailFormatFull:
 		u.Out().Printf("from\t%s", headerValue(msg.Payload, "From"))
 		u.Out().Printf("to\t%s", headerValue(msg.Payload, "To"))
+		u.Out().Printf("cc\t%s", headerValue(msg.Payload, "Cc"))
+		u.Out().Printf("bcc\t%s", headerValue(msg.Payload, "Bcc"))
 		u.Out().Printf("subject\t%s", headerValue(msg.Payload, "Subject"))
 		u.Out().Printf("date\t%s", headerValue(msg.Payload, "Date"))
 		if unsubscribe != "" {

--- a/internal/cmd/gmail_get_cmd_test.go
+++ b/internal/cmd/gmail_get_cmd_test.go
@@ -39,6 +39,8 @@ func TestGmailGetCmd_JSON_Full(t *testing.T) {
 				"headers": []map[string]any{
 					{"name": "From", "value": "a@example.com"},
 					{"name": "To", "value": "b@example.com"},
+					{"name": "Cc", "value": "c@example.com"},
+					{"name": "Bcc", "value": "d@example.com"},
 					{"name": "Subject", "value": "S"},
 					{"name": "Date", "value": "Fri, 26 Dec 2025 10:00:00 +0000"},
 					{"name": "List-Unsubscribe", "value": "<mailto:unsubscribe@example.com>"},
@@ -84,6 +86,16 @@ func TestGmailGetCmd_JSON_Full(t *testing.T) {
 	}
 	if parsed["unsubscribe"] != "mailto:unsubscribe@example.com" {
 		t.Fatalf("unexpected unsubscribe: %v", parsed["unsubscribe"])
+	}
+	headers, ok := parsed["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected headers map, got: %T", parsed["headers"])
+	}
+	if headers["cc"] != "c@example.com" {
+		t.Fatalf("unexpected cc header: %v", headers["cc"])
+	}
+	if headers["bcc"] != "d@example.com" {
+		t.Fatalf("unexpected bcc header: %v", headers["bcc"])
 	}
 }
 
@@ -204,6 +216,8 @@ func TestGmailGetCmd_JSON_Metadata_WithAttachments(t *testing.T) {
 				"headers": []map[string]any{
 					{"name": "From", "value": "a@example.com"},
 					{"name": "To", "value": "b@example.com"},
+					{"name": "Cc", "value": "c@example.com"},
+					{"name": "Bcc", "value": "d@example.com"},
 					{"name": "Subject", "value": "Metadata attachments"},
 					{"name": "Date", "value": "Fri, 26 Dec 2025 10:00:00 +0000"},
 				},
@@ -256,6 +270,16 @@ func TestGmailGetCmd_JSON_Metadata_WithAttachments(t *testing.T) {
 	if _, ok := parsed["body"]; ok {
 		t.Fatalf("expected no body for metadata output")
 	}
+	headers, ok := parsed["headers"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected headers map, got: %T", parsed["headers"])
+	}
+	if headers["cc"] != "c@example.com" {
+		t.Fatalf("unexpected cc header: %v", headers["cc"])
+	}
+	if headers["bcc"] != "d@example.com" {
+		t.Fatalf("unexpected bcc header: %v", headers["bcc"])
+	}
 	attachments, ok := parsed["attachments"].([]any)
 	if !ok || len(attachments) != 1 {
 		t.Fatalf("expected 1 attachment, got: %v", parsed["attachments"])
@@ -298,6 +322,8 @@ func TestGmailGetCmd_Text_Full_WithAttachments(t *testing.T) {
 				"headers": []map[string]any{
 					{"name": "From", "value": "a@example.com"},
 					{"name": "To", "value": "b@example.com"},
+					{"name": "Cc", "value": "c@example.com"},
+					{"name": "Bcc", "value": "d@example.com"},
 					{"name": "Subject", "value": "Test"},
 					{"name": "Date", "value": "Fri, 26 Dec 2025 10:00:00 +0000"},
 				},
@@ -349,6 +375,12 @@ func TestGmailGetCmd_Text_Full_WithAttachments(t *testing.T) {
 	if !strings.Contains(out, "attachment\treport.pdf\t"+formatBytes(54321)+"\tapplication/pdf\tANGjdJ-xyz789") {
 		t.Fatalf("expected attachment line in output, got: %q", out)
 	}
+	if !strings.Contains(out, "cc\tc@example.com") {
+		t.Fatalf("expected cc header in output, got: %q", out)
+	}
+	if !strings.Contains(out, "bcc\td@example.com") {
+		t.Fatalf("expected bcc header in output, got: %q", out)
+	}
 }
 
 func TestGmailGetCmd_Text_Metadata_WithAttachments(t *testing.T) {
@@ -371,6 +403,8 @@ func TestGmailGetCmd_Text_Metadata_WithAttachments(t *testing.T) {
 				"headers": []map[string]any{
 					{"name": "From", "value": "a@example.com"},
 					{"name": "To", "value": "b@example.com"},
+					{"name": "Cc", "value": "c@example.com"},
+					{"name": "Bcc", "value": "d@example.com"},
 					{"name": "Subject", "value": "Metadata"},
 					{"name": "Date", "value": "Fri, 26 Dec 2025 10:00:00 +0000"},
 				},
@@ -424,6 +458,12 @@ func TestGmailGetCmd_Text_Metadata_WithAttachments(t *testing.T) {
 	}
 	if strings.Contains(out, "metadata body") {
 		t.Fatalf("unexpected body output for metadata: %q", out)
+	}
+	if !strings.Contains(out, "cc\tc@example.com") {
+		t.Fatalf("expected cc header in output, got: %q", out)
+	}
+	if !strings.Contains(out, "bcc\td@example.com") {
+		t.Fatalf("expected bcc header in output, got: %q", out)
 	}
 }
 

--- a/internal/cmd/gmail_labels_cmd_test.go
+++ b/internal/cmd/gmail_labels_cmd_test.go
@@ -487,6 +487,39 @@ func TestGmailLabelsCreateCmd_DuplicateName_Preflight(t *testing.T) {
 	}
 }
 
+func TestGmailLabelsCreateCmd_NameCheckIgnoresIDs(t *testing.T) {
+	var createCalled bool
+	srv := newLabelsServer(t, []map[string]any{
+		{"id": "gog/pr-review", "name": "gog-pr-review", "type": "user"},
+	}, func(w http.ResponseWriter, r *http.Request) {
+		createCalled = true
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "Label_42",
+			"name": "gog/pr-review",
+			"type": "user",
+		})
+	})
+	defer srv.Close()
+	stubGmailService(t, srv)
+
+	flags := &RootFlags{Account: "a@b.com"}
+
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &GmailLabelsCreateCmd{}
+	if err := runKong(t, cmd, []string{"gog/pr-review"}, ctx, flags); err != nil {
+		t.Fatalf("execute: %v", err)
+	}
+	if !createCalled {
+		t.Fatal("expected create call")
+	}
+}
+
 func TestGmailLabelsCreateCmd_DuplicateName_APIError(t *testing.T) {
 	srv := newLabelsServer(t, []map[string]any{}, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/gmail_labels_utils.go
+++ b/internal/cmd/gmail_labels_utils.go
@@ -31,11 +31,11 @@ func resolveLabelIDs(labels []string, nameToID map[string]string) []string {
 }
 
 func ensureLabelNameAvailable(svc *gmail.Service, name string) error {
-	idMap, err := fetchLabelNameToID(svc)
+	nameMap, err := fetchLabelNameSet(svc)
 	if err != nil {
 		return err
 	}
-	if _, ok := idMap[strings.ToLower(name)]; ok {
+	if _, ok := nameMap[strings.ToLower(name)]; ok {
 		return usagef("label already exists: %s", name)
 	}
 	return nil
@@ -93,4 +93,19 @@ func labelDuplicateReason(reason string) bool {
 	default:
 		return false
 	}
+}
+
+func fetchLabelNameSet(svc *gmail.Service) (map[string]struct{}, error) {
+	resp, err := svc.Users.Labels.List("me").Do()
+	if err != nil {
+		return nil, err
+	}
+	m := make(map[string]struct{}, len(resp.Labels))
+	for _, l := range resp.Labels {
+		if l.Name == "" {
+			continue
+		}
+		m[strings.ToLower(l.Name)] = struct{}{}
+	}
+	return m, nil
 }

--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -6,14 +6,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steipete/gogcli/internal/cli"
 	"google.golang.org/api/calendar/v3"
 )
 
 // TimeRangeFlags provides common time range options for calendar commands.
 // Embed this struct in commands that need time range support.
 type TimeRangeFlags struct {
-	From      string `name:"from" help:"Start time (RFC3339, date, or relative: today, tomorrow, monday)"`
-	To        string `name:"to" help:"End time (RFC3339, date, or relative)"`
+	From      string `name:"from" help:"Start time (RFC3339, date, or relative: today, monday, 2h ago, 30m)"`
+	To        string `name:"to" help:"End time (RFC3339, date, or relative: tomorrow, next fri, 2h ago, 30m)"`
 	Today     bool   `name:"today" help:"Today only"`
 	Tomorrow  bool   `name:"tomorrow" help:"Tomorrow only"`
 	Week      bool   `name:"week" help:"This week (uses --week-start, default Mon)"`
@@ -153,55 +154,18 @@ func ResolveTimeRangeWithDefaults(ctx context.Context, svc *calendar.Service, fl
 // - RFC3339: 2026-01-05T14:00:00-08:00
 // - ISO 8601 with numeric timezone: 2026-01-05T14:00:00-0800 (no colon)
 // - Date only: 2026-01-05 (interpreted as start of day in user's timezone)
-// - Relative: today, tomorrow, monday, next tuesday
+// - Relative: today, tomorrow, monday, next tuesday, 2h ago, 30m
 func parseTimeExpr(expr string, now time.Time, loc *time.Location) (time.Time, error) {
-	expr = strings.TrimSpace(expr)
-
-	// Try RFC3339 first (before lowercasing)
-	if t, err := time.Parse(time.RFC3339, expr); err == nil {
-		return t, nil
+	if loc != nil && now.Location() != loc {
+		now = now.In(loc)
 	}
 
-	// Try ISO 8601 with numeric timezone without colon (e.g., -0800)
-	// This is what macOS `date +%Y-%m-%dT%H:%M:%S%z` produces
-	if t, err := time.Parse("2006-01-02T15:04:05-0700", expr); err == nil {
-		return t, nil
+	parsed, err := cli.ParseRelativeTime(expr, now)
+	if err == nil {
+		return parsed, nil
 	}
 
-	// Now lowercase for relative expressions
-	exprLower := strings.ToLower(expr)
-
-	// Try relative expressions
-	switch exprLower {
-	case "now":
-		return now, nil
-	case "today":
-		return startOfDay(now), nil
-	case "tomorrow":
-		return startOfDay(now.AddDate(0, 0, 1)), nil
-	case "yesterday":
-		return startOfDay(now.AddDate(0, 0, -1)), nil
-	}
-
-	// Try day of week (this week or next)
-	if t, ok := parseWeekday(exprLower, now); ok {
-		return t, nil
-	}
-
-	// Try date only (YYYY-MM-DD)
-	if t, err := time.ParseInLocation("2006-01-02", expr, loc); err == nil {
-		return t, nil
-	}
-
-	// Try date with time but no timezone
-	if t, err := time.ParseInLocation("2006-01-02T15:04:05", expr, loc); err == nil {
-		return t, nil
-	}
-	if t, err := time.ParseInLocation("2006-01-02 15:04", expr, loc); err == nil {
-		return t, nil
-	}
-
-	return time.Time{}, fmt.Errorf("cannot parse %q as time (try: 2026-01-05, today, tomorrow, monday)", expr)
+	return time.Time{}, fmt.Errorf("cannot parse %q as time (try: 2026-01-05, today, tomorrow, monday, 2h ago, 30m)", expr)
 }
 
 // parseWeekday parses weekday expressions like "monday", "next tuesday"

--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/steipete/gogcli/internal/cli"
 	"google.golang.org/api/calendar/v3"
+
+	"github.com/steipete/gogcli/internal/cli"
 )
 
 // TimeRangeFlags provides common time range options for calendar commands.
@@ -107,17 +108,17 @@ func ResolveTimeRangeWithDefaults(ctx context.Context, svc *calendar.Service, fl
 	// Handle convenience flags first
 	switch {
 	case flags.Today:
-		from = startOfDay(now)
+		from = cli.StartOfDay(now)
 		to = endOfDay(now)
 	case flags.Tomorrow:
 		tomorrow := now.AddDate(0, 0, 1)
-		from = startOfDay(tomorrow)
+		from = cli.StartOfDay(tomorrow)
 		to = endOfDay(tomorrow)
 	case flags.Week:
 		from = startOfWeek(now, weekStart)
 		to = endOfWeek(now, weekStart)
 	case flags.Days > 0:
-		from = startOfDay(now)
+		from = cli.StartOfDay(now)
 		to = endOfDay(now.AddDate(0, 0, flags.Days-1))
 	default:
 		// Parse --from and --to, or use defaults
@@ -168,54 +169,6 @@ func parseTimeExpr(expr string, now time.Time, loc *time.Location) (time.Time, e
 	return time.Time{}, fmt.Errorf("cannot parse %q as time (try: 2026-01-05, today, tomorrow, monday, 2h ago, 30m)", expr)
 }
 
-// parseWeekday parses weekday expressions like "monday", "next tuesday"
-func parseWeekday(expr string, now time.Time) (time.Time, bool) {
-	expr = strings.TrimSpace(expr)
-	next := false
-	if strings.HasPrefix(expr, "next ") {
-		next = true
-		expr = strings.TrimPrefix(expr, "next ")
-	}
-
-	weekdays := map[string]time.Weekday{
-		"sunday":    time.Sunday,
-		"sun":       time.Sunday,
-		"monday":    time.Monday,
-		"mon":       time.Monday,
-		"tuesday":   time.Tuesday,
-		"tue":       time.Tuesday,
-		"wednesday": time.Wednesday,
-		"wed":       time.Wednesday,
-		"thursday":  time.Thursday,
-		"thu":       time.Thursday,
-		"friday":    time.Friday,
-		"fri":       time.Friday,
-		"saturday":  time.Saturday,
-		"sat":       time.Saturday,
-	}
-
-	targetDay, ok := weekdays[expr]
-	if !ok {
-		return time.Time{}, false
-	}
-
-	currentDay := now.Weekday()
-	daysUntil := int(targetDay) - int(currentDay)
-	if daysUntil < 0 || (daysUntil == 0 && next) {
-		daysUntil += 7 // Next week
-	}
-
-	if daysUntil == 0 {
-		return startOfDay(now), true
-	}
-	return startOfDay(now.AddDate(0, 0, daysUntil)), true
-}
-
-// startOfDay returns the start of the day (00:00:00) in the given time's location.
-func startOfDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
-}
-
 // endOfDay returns the end of the day (23:59:59.999) in the given time's location.
 func endOfDay(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
@@ -229,7 +182,7 @@ func startOfWeek(t time.Time, weekStart time.Weekday) time.Time {
 	if daysBack < 0 {
 		daysBack += 7
 	}
-	return startOfDay(t.AddDate(0, 0, -daysBack))
+	return cli.StartOfDay(t.AddDate(0, 0, -daysBack))
 }
 
 // endOfWeek returns the end of the week for the given time.

--- a/internal/cmd/time_helpers_test.go
+++ b/internal/cmd/time_helpers_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"testing"
 	"time"
+
+	"github.com/steipete/gogcli/internal/cli"
 )
 
 func TestParseTimeExpr(t *testing.T) {
@@ -13,7 +15,7 @@ func TestParseTimeExpr(t *testing.T) {
 		t.Fatalf("parseTimeExpr today: %v", err)
 	}
 
-	if !parsed.Equal(startOfDay(now)) {
+	if !parsed.Equal(cli.StartOfDay(now)) {
 		t.Fatalf("unexpected today: %v", parsed)
 	}
 
@@ -62,7 +64,7 @@ func TestParseTimeExprMore(t *testing.T) {
 		t.Fatalf("parseTimeExpr yesterday: %v", err)
 	}
 
-	if !parsed.Equal(startOfDay(now.In(loc).AddDate(0, 0, -1))) {
+	if !parsed.Equal(cli.StartOfDay(now.In(loc).AddDate(0, 0, -1))) {
 		t.Fatalf("unexpected yesterday: %v", parsed)
 	}
 
@@ -132,13 +134,13 @@ func TestParseTimeExprRelativeDurations(t *testing.T) {
 
 func TestParseWeekday(t *testing.T) {
 	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
-	parsed, ok := parseWeekday("monday", now)
+	parsed, ok := cli.ParseWeekday("monday", now)
 	if !ok || parsed.Weekday() != time.Monday {
 		t.Fatalf("unexpected weekday: %v ok=%v", parsed, ok)
 	}
 
-	next, ok := parseWeekday("next monday", now)
-	if !ok || next.Weekday() != time.Monday || !next.After(startOfDay(now)) {
+	next, ok := cli.ParseWeekday("next monday", now)
+	if !ok || next.Weekday() != time.Monday || !next.After(cli.StartOfDay(now)) {
 		t.Fatalf("unexpected next weekday: %v ok=%v", next, ok)
 	}
 }
@@ -186,7 +188,7 @@ func TestWeekBounds(t *testing.T) {
 
 func TestDayBounds(t *testing.T) {
 	now := time.Date(2025, 1, 8, 12, 34, 56, 0, time.UTC)
-	start := startOfDay(now)
+	start := cli.StartOfDay(now)
 	end := endOfDay(now)
 	if start.Hour() != 0 || start.Minute() != 0 || start.Second() != 0 {
 		t.Fatalf("unexpected startOfDay: %v", start)

--- a/internal/cmd/time_helpers_test.go
+++ b/internal/cmd/time_helpers_test.go
@@ -62,7 +62,7 @@ func TestParseTimeExprMore(t *testing.T) {
 		t.Fatalf("parseTimeExpr yesterday: %v", err)
 	}
 
-	if !parsed.Equal(startOfDay(now.AddDate(0, 0, -1))) {
+	if !parsed.Equal(startOfDay(now.In(loc).AddDate(0, 0, -1))) {
 		t.Fatalf("unexpected yesterday: %v", parsed)
 	}
 
@@ -91,6 +91,42 @@ func TestParseTimeExprMore(t *testing.T) {
 
 	if parsed.Location() != loc {
 		t.Fatalf("expected loc, got %v", parsed.Location())
+	}
+}
+
+func TestParseTimeExprRelativeDurations(t *testing.T) {
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+
+	parsed, err := parseTimeExpr("2h ago", now, time.UTC)
+	if err != nil {
+		t.Fatalf("parseTimeExpr 2h ago: %v", err)
+	}
+	if !parsed.Equal(now.Add(-2 * time.Hour)) {
+		t.Fatalf("unexpected 2h ago: %v", parsed)
+	}
+
+	parsed, err = parseTimeExpr("30m", now, time.UTC)
+	if err != nil {
+		t.Fatalf("parseTimeExpr 30m: %v", err)
+	}
+	if !parsed.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("unexpected 30m: %v", parsed)
+	}
+
+	parsed, err = parseTimeExpr("2w ago", now, time.UTC)
+	if err != nil {
+		t.Fatalf("parseTimeExpr 2w ago: %v", err)
+	}
+	if !parsed.Equal(now.AddDate(0, 0, -14)) {
+		t.Fatalf("unexpected 2w ago: %v", parsed)
+	}
+
+	parsed, err = parseTimeExpr("1mo", now, time.UTC)
+	if err != nil {
+		t.Fatalf("parseTimeExpr 1mo: %v", err)
+	}
+	if !parsed.Equal(now.AddDate(0, 1, 0)) {
+		t.Fatalf("unexpected 1mo: %v", parsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **fix(gmail)**: Avoid label ID collisions on create by adding preflight check and improved error handling
- **fix(calendar)**: Prevent Kong from splitting BYDAY recurrence rules
- **feat(docs)**: Add comprehensive tab management commands (list, add, update, delete) and batch edit support
- **feat(cli)**: Improve relative time parsing with support for weekdays, durations, and named days
- **refactor(cli)**: Consolidate date helpers and add sentinel errors for better error handling
- **fix(docs)**: Resolve variable shadowing lint errors
- **fix(gmail)**: Include cc/bcc headers in get output

## Closes

- Closes #137 (gmail labels create fails with nested labels)
- Closes #120 (cannot create recurring events with BYDAY parameter)
- Closes #125 (feature request: support google docs tabs)
- Closes #127 (cc flag doesn't send CC recipients)

## Test Plan

- [x] All existing tests pass (`go test ./...`)
- [x] New tests added for Gmail label collision detection
- [x] New tests added for docs tabs commands
- [x] New tests added for relative time parsing
- [x] Calendar recurrence rule tests verify BYDAY not split
- [x] Gmail get output includes cc/bcc headers

🤖 Generated with [Claude Code](https://claude.ai/code)