### PR TITLE
feat: support GOG_CLIENT_ID and GOG_CLIENT_SECRET env vars

### DIFF
--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -88,6 +88,13 @@ func ReadClientCredentials() (ClientCredentials, error) {
 }
 
 func ReadClientCredentialsFor(client string) (ClientCredentials, error) {
+	// Check env vars first (for multi-tenant deployments like Puffin)
+	if id := os.Getenv("GOG_CLIENT_ID"); id != "" {
+		if secret := os.Getenv("GOG_CLIENT_SECRET"); secret != "" {
+			return ClientCredentials{ClientID: id, ClientSecret: secret}, nil
+		}
+	}
+
 	path, err := ClientCredentialsPathFor(client)
 	if err != nil {
 		return ClientCredentials{}, fmt.Errorf("resolve credentials path: %w", err)

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -77,6 +77,72 @@ func TestClientCredentials_Roundtrip(t *testing.T) {
 	}
 }
 
+func TestReadClientCredentials_EnvVars(t *testing.T) {
+	t.Run("env vars take precedence", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+		// Write file credentials first
+		fileIn := ClientCredentials{ClientID: "file-id", ClientSecret: "file-secret"}
+		if err := WriteClientCredentials(fileIn); err != nil {
+			t.Fatalf("WriteClientCredentials: %v", err)
+		}
+
+		// Set env vars
+		t.Setenv("GOG_CLIENT_ID", "env-id")
+		t.Setenv("GOG_CLIENT_SECRET", "env-secret")
+
+		// Env vars should win
+		out, err := ReadClientCredentials()
+		if err != nil {
+			t.Fatalf("ReadClientCredentials: %v", err)
+		}
+
+		if out.ClientID != "env-id" || out.ClientSecret != "env-secret" {
+			t.Fatalf("expected env vars to take precedence, got: %#v", out)
+		}
+	})
+
+	t.Run("env vars only (no file)", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+		t.Setenv("GOG_CLIENT_ID", "env-only-id")
+		t.Setenv("GOG_CLIENT_SECRET", "env-only-secret")
+
+		out, err := ReadClientCredentials()
+		if err != nil {
+			t.Fatalf("ReadClientCredentials: %v", err)
+		}
+
+		if out.ClientID != "env-only-id" || out.ClientSecret != "env-only-secret" {
+			t.Fatalf("unexpected: %#v", out)
+		}
+	})
+
+	t.Run("partial env vars fall through to file", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+		// Only set one env var
+		t.Setenv("GOG_CLIENT_ID", "env-id")
+		// GOG_CLIENT_SECRET not set
+
+		// Should fall through to file (and fail since no file exists)
+		_, err := ReadClientCredentials()
+		if err == nil {
+			t.Fatalf("expected error when partial env and no file")
+		}
+
+		var missingErr *CredentialsMissingError
+		if !errors.As(err, &missingErr) {
+			t.Fatalf("expected CredentialsMissingError, got %T: %v", err, err)
+		}
+	})
+}
+
 func TestReadClientCredentials_Errors(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

Allows multi-tenant deployments to configure OAuth client credentials via environment variables instead of requiring a `credentials.json` file per deployment.

This is useful for hosted services where:
- Multiple users share a single OAuth client (owned by the service operator)
- Each user authenticates their own Gmail account
- Credentials are managed via environment variables rather than files

## Changes

- `ReadClientCredentialsFor()` now checks `GOG_CLIENT_ID` and `GOG_CLIENT_SECRET` env vars first
- If both env vars are set, uses them directly (no file read)
- If only one is set, falls through to file-based lookup (existing behavior)
- Added comprehensive tests for env var behavior

## Test plan

- [x] Added unit tests for env var credentials
- [x] Tests for env vars taking precedence over file
- [x] Tests for partial env var falling through to file
- [x] All existing tests pass