### PR TITLE
feat(contacts): add address support to create/update commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Sheets: add `sheets create --parent` to place new spreadsheets in a Drive folder. (#424) — thanks @ManManavadaria.
 - Contacts: support `--org`, `--title`, `--url`, `--note`, and `--custom` on create/update; include custom fields in get output with deterministic ordering. (#199) — thanks @phuctm97.
 - Contacts: add `--relation type=person` to contact create/update, include relations in text `contacts get`, and cover relation payload updates. (#351) — thanks @karbassi.
+- Contacts: add `--address` to contact create/update and include addresses in text `contacts get`. (#148) — thanks @beezly.
 - Docs: add `--pageless` to `docs create`, `docs write`, and `docs update` to switch documents into pageless mode after writes. (#300) — thanks @shohei-majima.
 - Gmail: add `watch serve --history-types` filtering (`messageAdded|messageDeleted|labelAdded|labelRemoved`) and include `deletedMessageIds` in webhook payloads. (#168) — thanks @salmonumbrella.
 - Drive: add `drive ls --all` (alias `--global`) to list across all accessible files; make `--all` and `--parent` mutually exclusive. (#107) — thanks @struong.

--- a/README.md
+++ b/README.md
@@ -951,11 +951,13 @@ gog contacts create \
   --family "Doe" \
   --email "john@example.com" \
   --phone "+1234567890" \
+  --address "12 St James's Square, London" \
   --relation "spouse=Jane Doe"
 
 gog contacts update people/<resourceName> \
   --given "Jane" \
   --email "jane@example.com" \
+  --address "1 Infinite Loop, Cupertino" \
   --birthday "1990-05-12" \
   --notes "Met at WWDC" \
   --relation "friend=Bob"

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -197,6 +197,52 @@ func primaryBio(p *people.Person) string {
 	return p.Biographies[0].Value
 }
 
+func formatAddress(a *people.Address) string {
+	if a == nil {
+		return ""
+	}
+	if a.FormattedValue != "" {
+		return a.FormattedValue
+	}
+	// Build a readable string from structured fields.
+	parts := make([]string, 0, 6)
+	if a.StreetAddress != "" {
+		parts = append(parts, a.StreetAddress)
+	}
+	if a.ExtendedAddress != "" {
+		parts = append(parts, a.ExtendedAddress)
+	}
+	if a.City != "" {
+		parts = append(parts, a.City)
+	}
+	if a.Region != "" {
+		parts = append(parts, a.Region)
+	}
+	if a.PostalCode != "" {
+		parts = append(parts, a.PostalCode)
+	}
+	if a.Country != "" {
+		parts = append(parts, a.Country)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func allAddresses(p *people.Person) []string {
+	if p == nil || len(p.Addresses) == 0 {
+		return nil
+	}
+	addrs := make([]string, 0, len(p.Addresses))
+	for _, a := range p.Addresses {
+		if a == nil {
+			continue
+		}
+		if formatted := formatAddress(a); formatted != "" {
+			addrs = append(addrs, formatted)
+		}
+	}
+	return addrs
+}
+
 func userDefinedFields(p *people.Person) map[string]string {
 	if p == nil || len(p.UserDefined) == 0 {
 		return nil

--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -18,7 +18,7 @@ import (
 const (
 	contactsReadMask       = "names,emailAddresses,phoneNumbers,organizations,urls"
 	contactsGetReadMask    = contactsReadMask + ",birthdays,biographies,addresses,userDefined,relations,metadata"
-	contactsUpdateReadMask = contactsReadMask + ",birthdays,biographies,userDefined,relations,metadata"
+	contactsUpdateReadMask = contactsReadMask + ",birthdays,biographies,addresses,userDefined,relations,metadata"
 )
 
 type ContactsListCmd struct {
@@ -178,6 +178,9 @@ func (c *ContactsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	for _, url := range allURLs(p) {
 		u.Out().Printf("url\t%s", url)
 	}
+	for _, addr := range allAddresses(p) {
+		u.Out().Printf("address\t%s", sanitizeTab(addr))
+	}
 	if bio := primaryBio(p); bio != "" {
 		u.Out().Printf("note\t%s", bio)
 	}
@@ -210,6 +213,7 @@ type ContactsCreateCmd struct {
 	Title        string   `name:"title" help:"Job title"`
 	URL          []string `name:"url" help:"URL (can be repeated for multiple URLs)"`
 	Note         string   `name:"note" help:"Note/biography"`
+	Address      []string `name:"address" sep:";" help:"Postal address (can be repeated for multiple addresses)"`
 	Custom       []string `name:"custom" help:"Custom field as key=value (can be repeated)"`
 	Relation     []string `name:"relation" help:"Relation as type=person (can be repeated)"`
 }
@@ -268,6 +272,19 @@ func contactsURLs(values []string) []*people.Url {
 	for _, u := range values {
 		if trimmed := strings.TrimSpace(u); trimmed != "" {
 			out = append(out, &people.Url{Value: trimmed})
+		}
+	}
+	return out
+}
+
+func contactsAddresses(values []string) []*people.Address {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]*people.Address, 0, len(values))
+	for _, a := range values {
+		if trimmed := strings.TrimSpace(a); trimmed != "" {
+			out = append(out, &people.Address{StreetAddress: trimmed})
 		}
 	}
 	return out
@@ -350,6 +367,11 @@ func (c *ContactsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if strings.TrimSpace(c.Note) != "" {
 		p.Biographies = []*people.Biography{{Value: strings.TrimSpace(c.Note)}}
 	}
+	if len(c.Address) > 0 {
+		if addrs := contactsAddresses(c.Address); len(addrs) > 0 {
+			p.Addresses = addrs
+		}
+	}
 	if len(c.Custom) > 0 {
 		userDefined, _, parseErr := parseCustomUserDefined(c.Custom, false)
 		if parseErr != nil {
@@ -390,6 +412,7 @@ type ContactsUpdateCmd struct {
 	Title        string   `name:"title" help:"Job title (empty clears)"`
 	URL          []string `name:"url" help:"URL (can be repeated; empty clears all)"`
 	Note         string   `name:"note" help:"Note/biography (empty clears)"`
+	Address      []string `name:"address" sep:";" help:"Postal address (can be repeated; empty clears all)"`
 	Custom       []string `name:"custom" help:"Custom field as key=value (can be repeated; empty clears all)"`
 	Relation     []string `name:"relation" help:"Relation as type=person (can be repeated; empty clears all)"`
 	FromFile     string   `name:"from-file" help:"Update from contact JSON file (use - for stdin)"`
@@ -438,6 +461,7 @@ func (c *ContactsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 	wantTitle := flagProvided(kctx, "title")
 	wantURL := flagProvided(kctx, "url")
 	wantNote := flagProvided(kctx, "note")
+	wantAddress := flagProvided(kctx, "address")
 	wantBirthday := flagProvided(kctx, "birthday")
 	wantNotes := flagProvided(kctx, "notes")
 	wantCustom := flagProvided(kctx, "custom")
@@ -483,6 +507,15 @@ func (c *ContactsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 			existing.Biographies = []*people.Biography{{Value: strings.TrimSpace(c.Note)}}
 		}
 		updateFields = append(updateFields, "biographies")
+	}
+	if wantAddress {
+		addrs := contactsAddresses(c.Address)
+		if len(addrs) == 0 {
+			existing.Addresses = nil // will be forced to [] for patch
+		} else {
+			existing.Addresses = addrs
+		}
+		updateFields = append(updateFields, "addresses")
 	}
 	if wantCustom {
 		userDefined, clearAll, parseErr := parseCustomUserDefined(c.Custom, true)

--- a/internal/cmd/contacts_helpers_test.go
+++ b/internal/cmd/contacts_helpers_test.go
@@ -184,3 +184,51 @@ func TestParseRelations_EmptySlice(t *testing.T) {
 		t.Fatalf("expected empty, got %v", rels)
 	}
 }
+
+func TestFormatAddressAndAllAddresses(t *testing.T) {
+	if got := formatAddress(nil); got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+
+	addr := &people.Address{FormattedValue: "1 Infinite Loop, Cupertino, CA"}
+	if got := formatAddress(addr); got != "1 Infinite Loop, Cupertino, CA" {
+		t.Fatalf("unexpected formatted address: %q", got)
+	}
+
+	structured := &people.Address{
+		StreetAddress:   "123 Main St",
+		ExtendedAddress: "Apt 4",
+		City:            "London",
+		Region:          "Greater London",
+		PostalCode:      "SW1A 1AA",
+		Country:         "UK",
+	}
+	if got := formatAddress(structured); got != "123 Main St, Apt 4, London, Greater London, SW1A 1AA, UK" {
+		t.Fatalf("unexpected structured address: %q", got)
+	}
+
+	person := &people.Person{
+		Addresses: []*people.Address{
+			nil,
+			{FormattedValue: "One"},
+			{StreetAddress: "Two"},
+		},
+	}
+	got := allAddresses(person)
+	if len(got) != 2 || got[0] != "One" || got[1] != "Two" {
+		t.Fatalf("unexpected addresses: %#v", got)
+	}
+}
+
+func TestContactsAddresses(t *testing.T) {
+	addrs := contactsAddresses([]string{" 123 Main St ", "", "456 Side St"})
+	if len(addrs) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(addrs))
+	}
+	if addrs[0].StreetAddress != "123 Main St" {
+		t.Fatalf("unexpected first address: %#v", addrs[0])
+	}
+	if addrs[1].StreetAddress != "456 Side St" {
+		t.Fatalf("unexpected second address: %#v", addrs[1])
+	}
+}

--- a/internal/cmd/contacts_update_more_test.go
+++ b/internal/cmd/contacts_update_more_test.go
@@ -309,6 +309,158 @@ func TestContactsCreate_Relation_Set(t *testing.T) {
 	}
 }
 
+func TestContactsUpdate_Address_Set(t *testing.T) {
+	var gotGetFields string
+	var gotUpdateFields string
+	var gotAddresses []map[string]any
+
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "people/c1") && r.Method == http.MethodGet && !strings.Contains(r.URL.Path, ":"):
+			gotGetFields = r.URL.Query().Get("personFields")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceName": "people/c1",
+				"names":        []map[string]any{{"givenName": "Ada", "familyName": "Lovelace"}},
+			})
+			return
+		case strings.Contains(r.URL.Path, ":updateContact") && (r.Method == http.MethodPatch || r.Method == http.MethodPost):
+			gotUpdateFields = r.URL.Query().Get("updatePersonFields")
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if addrs, ok := body["addresses"].([]any); ok {
+				for _, addr := range addrs {
+					if m, ok := addr.(map[string]any); ok {
+						gotAddresses = append(gotAddresses, m)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceName": "people/c1"})
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+	stubPeopleServices(t, svc)
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	if err := runKong(t, &ContactsUpdateCmd{}, []string{"people/c1", "--address", "123 Main St", "--address", "456 Side St"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	if !strings.Contains(gotGetFields, "addresses") {
+		t.Fatalf("missing addresses in people.get fields: %q", gotGetFields)
+	}
+	if !strings.Contains(gotUpdateFields, "addresses") {
+		t.Fatalf("missing addresses in update fields: %q", gotUpdateFields)
+	}
+	if len(gotAddresses) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(gotAddresses))
+	}
+	if gotAddresses[0]["streetAddress"] != "123 Main St" {
+		t.Fatalf("unexpected first address: %v", gotAddresses[0])
+	}
+	if gotAddresses[1]["streetAddress"] != "456 Side St" {
+		t.Fatalf("unexpected second address: %v", gotAddresses[1])
+	}
+}
+
+func TestContactsUpdate_Address_Clear(t *testing.T) {
+	var gotUpdateFields string
+
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "people/c1") && r.Method == http.MethodGet && !strings.Contains(r.URL.Path, ":"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceName": "people/c1",
+				"addresses":    []map[string]any{{"streetAddress": "123 Main St"}},
+			})
+			return
+		case strings.Contains(r.URL.Path, ":updateContact") && (r.Method == http.MethodPatch || r.Method == http.MethodPost):
+			gotUpdateFields = r.URL.Query().Get("updatePersonFields")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceName": "people/c1"})
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+	stubPeopleServices(t, svc)
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	if err := runKong(t, &ContactsUpdateCmd{}, []string{"people/c1", "--address", ""}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	if !strings.Contains(gotUpdateFields, "addresses") {
+		t.Fatalf("missing addresses in clear update fields: %q", gotUpdateFields)
+	}
+}
+
+func TestContactsCreate_Address_Set(t *testing.T) {
+	var gotAddresses []map[string]any
+
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasSuffix(r.URL.Path, ":createContact") && r.Method == http.MethodPost:
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if addrs, ok := body["addresses"].([]any); ok {
+				for _, addr := range addrs {
+					if m, ok := addr.(map[string]any); ok {
+						gotAddresses = append(gotAddresses, m)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceName": "people/c1"})
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+	stubPeopleServices(t, svc)
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	if err := runKong(t, &ContactsCreateCmd{}, []string{"--given", "Ada", "--address", "123 Main St", "--address", "456 Side St"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	if len(gotAddresses) != 2 {
+		t.Fatalf("expected 2 addresses, got %d", len(gotAddresses))
+	}
+	if gotAddresses[0]["streetAddress"] != "123 Main St" {
+		t.Fatalf("unexpected first address: %v", gotAddresses[0])
+	}
+	if gotAddresses[1]["streetAddress"] != "456 Side St" {
+		t.Fatalf("unexpected second address: %v", gotAddresses[1])
+	}
+}
+
 func leftPad2(s string) string {
 	s = strings.TrimSpace(s)
 	if len(s) >= 2 {


### PR DESCRIPTION
## Summary

Add `--address` flag to `gog contacts create` and `gog contacts update` commands, allowing users to set street addresses on contacts.

## Changes

- Add `addresses` to `contactsReadMask` for API requests
- Add `Address` field to `ContactsCreateCmd` and `ContactsUpdateCmd`
- Add `primaryAddress()` helper to extract formatted address
- Display address in `gog contacts get` output

## Usage

```bash
# Create contact with address
gog contacts create --given John --family Doe --address "123 Main St, London"

# Update existing contact's address
gog contacts update people/c123456 --address "456 New St, Manchester"

# Clear address
gog contacts update people/c123456 --address ""

# View contact (now shows address)
gog contacts get people/c123456
```

## Testing

- `make test` passes
- `make fmt` applied
- Manually tested create/update/get with real Google Contacts

## Notes

The `--address` flag sets the `StreetAddress` field. Google automatically generates the `FormattedValue` from this. For display, we prefer `FormattedValue` if available, falling back to `StreetAddress`.

This follows the existing pattern for phone/email handling in the codebase.