### PR TITLE
fix(secrets): allow empty GOG_KEYRING_PASSWORD to skip prompt

### DIFF
--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -126,7 +126,18 @@ func fileKeyringPasswordFuncFrom(password string, isTTY bool) keyring.PromptFunc
 }
 
 func fileKeyringPasswordFunc() keyring.PromptFunc {
-	return fileKeyringPasswordFuncFrom(os.Getenv(keyringPasswordEnv), term.IsTerminal(int(os.Stdin.Fd())))
+	password, isSet := os.LookupEnv(keyringPasswordEnv)
+	if isSet {
+		return keyring.FixedStringPrompt(password)
+	}
+
+	if term.IsTerminal(int(os.Stdin.Fd())) {
+		return keyring.TerminalPrompt
+	}
+
+	return func(_ string) (string, error) {
+		return "", fmt.Errorf("%w; set %s", errNoTTY, keyringPasswordEnv)
+	}
 }
 
 func normalizeKeyringBackend(value string) string {


### PR DESCRIPTION
## Summary
- Use `os.LookupEnv` instead of `os.Getenv` to detect when `GOG_KEYRING_PASSWORD` is explicitly set to an empty string
- This allows users to skip the interactive passphrase prompt by setting `GOG_KEYRING_PASSWORD=""`

## Problem
Previously, setting `GOG_KEYRING_PASSWORD=""` would still trigger the interactive password prompt because `os.Getenv` returns an empty string for both "not set" and "set to empty".

## Solution
Use `os.LookupEnv` which returns `(value, isSet)`, allowing us to distinguish between:
- Env var not set → use terminal prompt (existing behavior)
- Env var set to any value (including empty) → use that value as password

## Test plan
- [ ] Set `GOG_KEYRING_PASSWORD=""` and verify no prompt appears
- [ ] Unset `GOG_KEYRING_PASSWORD` and verify prompt still appears
- [ ] Set `GOG_KEYRING_PASSWORD="somepass"` and verify no prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)