### PR TITLE
feat(gmail): add --attach flag to send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Added
+
+- Gmail: add `--attach` flag to `send` command for file attachments (repeatable).
+
 ## 0.9.0 - 2026-01-22
 
 ### Highlights


### PR DESCRIPTION
 Adds support for attaching files when sending emails via `gog gmail send`.
     
     - Added `--attach` flag (can be used multiple times for multiple files)
     - Builds MIME multipart messages with attachments encoded in base64
     - Returns clear error if file doesn't exist or can't be read
     - Updated help text and CHANGELOG.md
     
     Tested with `make ci`.