### PR TITLE
feat(docs): added install instruction for AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Fast, script-friendly CLI for Gmail, Calendar, Chat, Classroom, Drive, Docs, Sli
 ```bash
 brew install steipete/tap/gogcli
 ```
+### Arch User Repository
+
+```bash
+yay -S gogcli
+```
 
 ### Build from Source
 


### PR DESCRIPTION
I noticed gogcli wasn't available on the AUR, so I've created and am now maintaining a package for it. I've added this section to the README so other Arch users know it's available and how to install it easily.

https://aur.archlinux.org/packages/gogcli