### PR TITLE
feat(gmail): add forward command with tests and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,6 +762,7 @@ gog drive copy <fileId> "Copy Name"
 
 # Upload and download
 gog drive upload ./path/to/file --parent <folderId>
+gog drive upload ./path/to/report.docx --convert
 gog drive download <fileId> --out ./downloaded.bin
 gog drive download <fileId> --format pdf --out ./exported.pdf
 gog drive download <fileId> --format docx --out ./doc.docx

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -169,7 +169,7 @@ Flag aliases:
 - `gog drive search <text> [--max N] [--page TOKEN]`
 - `gog drive get <fileId>`
 - `gog drive download <fileId> [--out PATH]`
-- `gog drive upload <localPath> [--name N] [--parent ID]`
+- `gog drive upload <localPath> [--name N] [--parent ID] [--convert]`
 - `gog drive mkdir <name> [--parent ID]`
 - `gog drive delete <fileId>`
 - `gog drive move <fileId> --parent ID`

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"strings"
 
+	"github.com/alecthomas/kong"
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/drive/v3"
 	gapi "google.golang.org/api/googleapi"
 
+	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
@@ -26,6 +28,8 @@ type DocsCmd struct {
 	Info   DocsInfoCmd   `cmd:"" name:"info" help:"Get Google Doc metadata"`
 	Create DocsCreateCmd `cmd:"" name:"create" help:"Create a Google Doc"`
 	Copy   DocsCopyCmd   `cmd:"" name:"copy" help:"Copy a Google Doc"`
+	Write  DocsWriteCmd  `cmd:"" name:"write" help:"Write content to a Google Doc"`
+	Update DocsUpdateCmd `cmd:"" name:"update" help:"Insert text into a Google Doc"`
 	Cat    DocsCatCmd    `cmd:"" name:"cat" help:"Print a Google Doc as plain text"`
 }
 
@@ -177,6 +181,213 @@ func (c *DocsCopyCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}, c.DocID, c.Title, c.Parent)
 }
 
+type DocsWriteCmd struct {
+	DocID  string `arg:"" name:"docId" help:"Doc ID"`
+	Text   string `name:"text" help:"Text to write"`
+	File   string `name:"file" help:"Text file path ('-' for stdin)"`
+	Append bool   `name:"append" help:"Append instead of replacing the document body"`
+}
+
+func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	text, provided, err := resolveTextInput(c.Text, c.File, kctx, "text", "file")
+	if err != nil {
+		return err
+	}
+	if !provided {
+		return usage("required: --text or --file")
+	}
+	if text == "" {
+		return usage("empty text")
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	doc, err := svc.Documents.Get(id).
+		Fields("documentId,body/content(startIndex,endIndex)").
+		Context(ctx).
+		Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return err
+	}
+	if doc == nil {
+		return errors.New("doc not found")
+	}
+
+	endIndex := docsDocumentEndIndex(doc)
+	insertIndex := int64(1)
+	if c.Append {
+		insertIndex = docsAppendIndex(endIndex)
+	}
+
+	reqs := []*docs.Request{}
+	if !c.Append {
+		deleteEnd := endIndex - 1
+		if deleteEnd > 1 {
+			reqs = append(reqs, &docs.Request{
+				DeleteContentRange: &docs.DeleteContentRangeRequest{
+					Range: &docs.Range{
+						StartIndex: 1,
+						EndIndex:   deleteEnd,
+					},
+				},
+			})
+		}
+	}
+
+	reqs = append(reqs, &docs.Request{
+		InsertText: &docs.InsertTextRequest{
+			Location: &docs.Location{Index: insertIndex},
+			Text:     text,
+		},
+	})
+
+	resp, err := svc.Documents.BatchUpdate(id, &docs.BatchUpdateDocumentRequest{Requests: reqs}).
+		Context(ctx).
+		Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": resp.DocumentId,
+			"requests":   len(reqs),
+			"append":     c.Append,
+			"index":      insertIndex,
+		}
+		if resp.WriteControl != nil {
+			payload["writeControl"] = resp.WriteControl
+		}
+		return outfmt.WriteJSON(os.Stdout, payload)
+	}
+
+	u.Out().Printf("id\t%s", resp.DocumentId)
+	u.Out().Printf("requests\t%d", len(reqs))
+	u.Out().Printf("append\t%t", c.Append)
+	u.Out().Printf("index\t%d", insertIndex)
+	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
+		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
+type DocsUpdateCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Text  string `name:"text" help:"Text to insert"`
+	File  string `name:"file" help:"Text file path ('-' for stdin)"`
+	Index int64  `name:"index" help:"Insert index (default: end of document)"`
+}
+
+func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	text, provided, err := resolveTextInput(c.Text, c.File, kctx, "text", "file")
+	if err != nil {
+		return err
+	}
+	if !provided {
+		return usage("required: --text or --file")
+	}
+	if text == "" {
+		return usage("empty text")
+	}
+
+	if flagProvided(kctx, "index") && c.Index <= 0 {
+		return usage("invalid --index (must be >= 1)")
+	}
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	insertIndex := c.Index
+	if insertIndex <= 0 {
+		doc, err := svc.Documents.Get(id).
+			Fields("documentId,body/content(startIndex,endIndex)").
+			Context(ctx).
+			Do()
+		if err != nil {
+			if isDocsNotFound(err) {
+				return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+			}
+			return err
+		}
+		if doc == nil {
+			return errors.New("doc not found")
+		}
+		insertIndex = docsAppendIndex(docsDocumentEndIndex(doc))
+	}
+
+	reqs := []*docs.Request{
+		{
+			InsertText: &docs.InsertTextRequest{
+				Location: &docs.Location{Index: insertIndex},
+				Text:     text,
+			},
+		},
+	}
+
+	resp, err := svc.Documents.BatchUpdate(id, &docs.BatchUpdateDocumentRequest{Requests: reqs}).
+		Context(ctx).
+		Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": resp.DocumentId,
+			"requests":   len(reqs),
+			"index":      insertIndex,
+		}
+		if resp.WriteControl != nil {
+			payload["writeControl"] = resp.WriteControl
+		}
+		return outfmt.WriteJSON(os.Stdout, payload)
+	}
+
+	u.Out().Printf("id\t%s", resp.DocumentId)
+	u.Out().Printf("requests\t%d", len(reqs))
+	u.Out().Printf("index\t%d", insertIndex)
+	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
+		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
 type DocsCatCmd struct {
 	DocID    string `arg:"" name:"docId" help:"Doc ID"`
 	MaxBytes int64  `name:"max-bytes" help:"Max bytes to read (0 = unlimited)" default:"2000000"`
@@ -305,6 +516,60 @@ func appendLimited(buf *bytes.Buffer, maxBytes int64, s string) bool {
 	}
 	_, _ = buf.WriteString(s)
 	return true
+}
+
+func resolveTextInput(text, file string, kctx *kong.Context, textFlag, fileFlag string) (string, bool, error) {
+	file = strings.TrimSpace(file)
+	textProvided := text != "" || flagProvided(kctx, textFlag)
+	fileProvided := file != "" || flagProvided(kctx, fileFlag)
+	if textProvided && fileProvided {
+		return "", true, usage(fmt.Sprintf("use only one of --%s or --%s", textFlag, fileFlag))
+	}
+	if fileProvided {
+		b, err := readTextInput(file)
+		if err != nil {
+			return "", true, err
+		}
+		return string(b), true, nil
+	}
+	if textProvided {
+		return text, true, nil
+	}
+	return text, false, nil
+}
+
+func readTextInput(path string) ([]byte, error) {
+	if path == "-" {
+		return io.ReadAll(os.Stdin)
+	}
+	expanded, err := config.ExpandPath(path)
+	if err != nil {
+		return nil, err
+	}
+	return os.ReadFile(expanded) //nolint:gosec // user-provided path
+}
+
+func docsDocumentEndIndex(doc *docs.Document) int64 {
+	if doc == nil || doc.Body == nil {
+		return 1
+	}
+	end := int64(1)
+	for _, el := range doc.Body.Content {
+		if el == nil {
+			continue
+		}
+		if el.EndIndex > end {
+			end = el.EndIndex
+		}
+	}
+	return end
+}
+
+func docsAppendIndex(endIndex int64) int64 {
+	if endIndex > 1 {
+		return endIndex - 1
+	}
+	return 1
 }
 
 func isDocsNotFound(err error) bool {

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -332,7 +332,8 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 
 	insertIndex := c.Index
 	if insertIndex <= 0 {
-		doc, err := svc.Documents.Get(id).
+		var doc *docs.Document
+		doc, err = svc.Documents.Get(id).
 			Fields("documentId,body/content(startIndex,endIndex)").
 			Context(ctx).
 			Do()

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -29,7 +29,7 @@ type DocsCmd struct {
 	Create DocsCreateCmd `cmd:"" name:"create" help:"Create a Google Doc"`
 	Copy   DocsCopyCmd   `cmd:"" name:"copy" help:"Copy a Google Doc"`
 	Write  DocsWriteCmd  `cmd:"" name:"write" help:"Write content to a Google Doc"`
-	Update DocsUpdateCmd `cmd:"" name:"update" help:"Insert text into a Google Doc"`
+	Update DocsUpdateCmd `cmd:"" name:"update" help:"Insert text at a specific index in a Google Doc"`
 	Cat    DocsCatCmd    `cmd:"" name:"cat" help:"Print a Google Doc as plain text"`
 }
 

--- a/internal/cmd/docs_validation_more_test.go
+++ b/internal/cmd/docs_validation_more_test.go
@@ -9,12 +9,27 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/alecthomas/kong"
 	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/option"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
+
+func parseDocsKong(t *testing.T, cmd any, args []string) *kong.Context {
+	t.Helper()
+
+	parser, err := kong.New(cmd)
+	if err != nil {
+		t.Fatalf("kong new: %v", err)
+	}
+	kctx, err := parser.Parse(args)
+	if err != nil {
+		t.Fatalf("kong parse: %v", err)
+	}
+	return kctx
+}
 
 func TestDocsInfo_ValidationAndText(t *testing.T) {
 	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
@@ -149,5 +164,36 @@ func TestDocsCat_JSON_EmptyDoc(t *testing.T) {
 	})
 	if !strings.Contains(out, "\"text\"") {
 		t.Fatalf("unexpected json: %q", out)
+	}
+}
+
+func TestDocsUpdate_InvalidIndex(t *testing.T) {
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"zero index", []string{"doc1", "--text", "hello", "--index", "0"}},
+		{"negative index", []string{"doc1", "--text", "hello", "--index=-1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &DocsUpdateCmd{}
+			kctx := parseDocsKong(t, cmd, tt.args)
+			err := cmd.Run(ctx, kctx, flags)
+			if err == nil {
+				t.Fatalf("expected invalid --index error for %s", tt.name)
+			}
+			if !strings.Contains(err.Error(), "invalid --index") {
+				t.Fatalf("expected 'invalid --index' error, got: %v", err)
+			}
+		})
 	}
 }

--- a/internal/cmd/docs_validation_more_test.go
+++ b/internal/cmd/docs_validation_more_test.go
@@ -86,6 +86,28 @@ func TestDocsCreateCat_ValidationErrors(t *testing.T) {
 	}
 }
 
+func TestDocsWriteUpdate_ValidationErrors(t *testing.T) {
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	if err := (&DocsWriteCmd{}).Run(ctx, nil, flags); err == nil {
+		t.Fatalf("expected missing docId error")
+	}
+	if err := (&DocsWriteCmd{DocID: "doc1"}).Run(ctx, nil, flags); err == nil {
+		t.Fatalf("expected missing text error")
+	}
+	if err := (&DocsUpdateCmd{}).Run(ctx, nil, flags); err == nil {
+		t.Fatalf("expected missing docId error")
+	}
+	if err := (&DocsUpdateCmd{DocID: "doc1"}).Run(ctx, nil, flags); err == nil {
+		t.Fatalf("expected missing text error")
+	}
+}
+
 func TestDocsCat_JSON_EmptyDoc(t *testing.T) {
 	origNew := newDocsService
 	t.Cleanup(func() { newDocsService = origNew })

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -303,8 +303,8 @@ func TestDocsWriteUpdate_FileInputErrors(t *testing.T) {
 	// Test with empty file
 	tmpDir := t.TempDir()
 	emptyFile := filepath.Join(tmpDir, "empty.txt")
-	if err := os.WriteFile(emptyFile, []byte(""), 0o600); err != nil {
-		t.Fatalf("write empty temp file: %v", err)
+	if writeErr := os.WriteFile(emptyFile, []byte(""), 0o600); writeErr != nil {
+		t.Fatalf("write empty temp file: %v", writeErr)
 	}
 	err = runKong(t, &DocsWriteCmd{}, []string{"doc1", "--file", emptyFile}, ctx, flags)
 	if err == nil {
@@ -316,8 +316,8 @@ func TestDocsWriteUpdate_FileInputErrors(t *testing.T) {
 
 	// Test that --text and --file are mutually exclusive
 	testFile := filepath.Join(tmpDir, "test.txt")
-	if err := os.WriteFile(testFile, []byte("content"), 0o600); err != nil {
-		t.Fatalf("write test temp file: %v", err)
+	if writeErr := os.WriteFile(testFile, []byte("content"), 0o600); writeErr != nil {
+		t.Fatalf("write test temp file: %v", writeErr)
 	}
 	err = runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--file", testFile}, ctx, flags)
 	if err == nil {

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestDocsWriteUpdate_JSON(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var batchRequests [][]*docs.Request
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			batchRequests = append(batchRequests, req.Requests)
+			id := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/documents/"), ":batchUpdate")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": id})
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/v1/documents/"):
+			id := strings.TrimPrefix(path, "/v1/documents/")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": id,
+				"body": map[string]any{
+					"content": []any{
+						map[string]any{"startIndex": 1, "endIndex": 12},
+					},
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello"}, ctx, flags); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if len(batchRequests) != 1 {
+		t.Fatalf("expected 1 batch request, got %d", len(batchRequests))
+	}
+	if got := batchRequests[0]; len(got) != 2 || got[0].DeleteContentRange == nil || got[1].InsertText == nil {
+		t.Fatalf("unexpected write requests: %#v", got)
+	}
+	if got := batchRequests[0][0].DeleteContentRange.Range; got.StartIndex != 1 || got.EndIndex != 11 {
+		t.Fatalf("unexpected delete range: %#v", got)
+	}
+	if got := batchRequests[0][1].InsertText; got.Location.Index != 1 || got.Text != "hello" {
+		t.Fatalf("unexpected insert: %#v", got)
+	}
+
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "world", "--append"}, ctx, flags); err != nil {
+		t.Fatalf("write append: %v", err)
+	}
+	if len(batchRequests) != 2 {
+		t.Fatalf("expected 2 batch requests, got %d", len(batchRequests))
+	}
+	if got := batchRequests[1]; len(got) != 1 || got[0].InsertText == nil {
+		t.Fatalf("unexpected append requests: %#v", got)
+	}
+	if got := batchRequests[1][0].InsertText; got.Location.Index != 11 || got.Text != "world" {
+		t.Fatalf("unexpected append insert: %#v", got)
+	}
+
+	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "!"}, ctx, flags); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if len(batchRequests) != 3 {
+		t.Fatalf("expected 3 batch requests, got %d", len(batchRequests))
+	}
+	if got := batchRequests[2]; len(got) != 1 || got[0].InsertText == nil {
+		t.Fatalf("unexpected update requests: %#v", got)
+	}
+	if got := batchRequests[2][0].InsertText; got.Location.Index != 11 || got.Text != "!" {
+		t.Fatalf("unexpected update insert: %#v", got)
+	}
+
+	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "?", "--index", "5"}, ctx, flags); err != nil {
+		t.Fatalf("update index: %v", err)
+	}
+	if len(batchRequests) != 4 {
+		t.Fatalf("expected 4 batch requests, got %d", len(batchRequests))
+	}
+	if got := batchRequests[3]; len(got) != 1 || got[0].InsertText == nil {
+		t.Fatalf("unexpected update index requests: %#v", got)
+	}
+	if got := batchRequests[3][0].InsertText; got.Location.Index != 5 || got.Text != "?" {
+		t.Fatalf("unexpected update index insert: %#v", got)
+	}
+}

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -124,5 +126,204 @@ func TestDocsWriteUpdate_JSON(t *testing.T) {
 	}
 	if got := batchRequests[3][0].InsertText; got.Location.Index != 5 || got.Text != "?" {
 		t.Fatalf("unexpected update index insert: %#v", got)
+	}
+}
+
+func TestDocsWriteUpdate_FileInput(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var batchRequests [][]*docs.Request
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			batchRequests = append(batchRequests, req.Requests)
+			id := strings.TrimSuffix(strings.TrimPrefix(path, "/v1/documents/"), ":batchUpdate")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": id})
+			return
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/v1/documents/"):
+			id := strings.TrimPrefix(path, "/v1/documents/")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": id,
+				"body": map[string]any{
+					"content": []any{
+						map[string]any{"startIndex": 1, "endIndex": 12},
+					},
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+
+	// Create a temp file for testing --file input
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "test-input.txt")
+	if err := os.WriteFile(tmpFile, []byte("file content"), 0o600); err != nil {
+		t.Fatalf("write temp file: %v", err)
+	}
+
+	// Test DocsWriteCmd with --file
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--file", tmpFile}, ctx, flags); err != nil {
+		t.Fatalf("write with file: %v", err)
+	}
+	if len(batchRequests) != 1 {
+		t.Fatalf("expected 1 batch request, got %d", len(batchRequests))
+	}
+	if got := batchRequests[0]; len(got) != 2 || got[0].DeleteContentRange == nil || got[1].InsertText == nil {
+		t.Fatalf("unexpected write requests: %#v", got)
+	}
+	if got := batchRequests[0][1].InsertText; got.Location.Index != 1 || got.Text != "file content" {
+		t.Fatalf("unexpected insert from file: got Text=%q, want %q", got.Text, "file content")
+	}
+
+	// Create another temp file for update test
+	updateFile := filepath.Join(tmpDir, "update-input.txt")
+	if err := os.WriteFile(updateFile, []byte("updated text"), 0o600); err != nil {
+		t.Fatalf("write update temp file: %v", err)
+	}
+
+	// Test DocsUpdateCmd with --file
+	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--file", updateFile}, ctx, flags); err != nil {
+		t.Fatalf("update with file: %v", err)
+	}
+	if len(batchRequests) != 2 {
+		t.Fatalf("expected 2 batch requests, got %d", len(batchRequests))
+	}
+	if got := batchRequests[1]; len(got) != 1 || got[0].InsertText == nil {
+		t.Fatalf("unexpected update requests: %#v", got)
+	}
+	if got := batchRequests[1][0].InsertText; got.Location.Index != 11 || got.Text != "updated text" {
+		t.Fatalf("unexpected update insert from file: got Text=%q at index %d, want %q at index 11",
+			got.Text, got.Location.Index, "updated text")
+	}
+
+	// Test DocsWriteCmd with --file and --append
+	appendFile := filepath.Join(tmpDir, "append-input.txt")
+	if err := os.WriteFile(appendFile, []byte("appended"), 0o600); err != nil {
+		t.Fatalf("write append temp file: %v", err)
+	}
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--file", appendFile, "--append"}, ctx, flags); err != nil {
+		t.Fatalf("write append with file: %v", err)
+	}
+	if len(batchRequests) != 3 {
+		t.Fatalf("expected 3 batch requests, got %d", len(batchRequests))
+	}
+	if got := batchRequests[2]; len(got) != 1 || got[0].InsertText == nil {
+		t.Fatalf("unexpected append requests: %#v", got)
+	}
+	if got := batchRequests[2][0].InsertText; got.Location.Index != 11 || got.Text != "appended" {
+		t.Fatalf("unexpected append insert from file: got Text=%q at index %d, want %q at index 11",
+			got.Text, got.Location.Index, "appended")
+	}
+
+	// Test DocsUpdateCmd with --file and --index
+	indexFile := filepath.Join(tmpDir, "index-input.txt")
+	if err := os.WriteFile(indexFile, []byte("at index 5"), 0o600); err != nil {
+		t.Fatalf("write index temp file: %v", err)
+	}
+	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--file", indexFile, "--index", "5"}, ctx, flags); err != nil {
+		t.Fatalf("update with file and index: %v", err)
+	}
+	if len(batchRequests) != 4 {
+		t.Fatalf("expected 4 batch requests, got %d", len(batchRequests))
+	}
+	if got := batchRequests[3]; len(got) != 1 || got[0].InsertText == nil {
+		t.Fatalf("unexpected update index requests: %#v", got)
+	}
+	if got := batchRequests[3][0].InsertText; got.Location.Index != 5 || got.Text != "at index 5" {
+		t.Fatalf("unexpected update index insert from file: got Text=%q at index %d, want %q at index 5",
+			got.Text, got.Location.Index, "at index 5")
+	}
+}
+
+func TestDocsWriteUpdate_FileInputErrors(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+
+	// Test with non-existent file
+	err = runKong(t, &DocsWriteCmd{}, []string{"doc1", "--file", "/nonexistent/path/file.txt"}, ctx, flags)
+	if err == nil {
+		t.Fatal("expected error for non-existent file, got nil")
+	}
+	if !strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("expected 'no such file' error, got: %v", err)
+	}
+
+	// Test with empty file
+	tmpDir := t.TempDir()
+	emptyFile := filepath.Join(tmpDir, "empty.txt")
+	if err := os.WriteFile(emptyFile, []byte(""), 0o600); err != nil {
+		t.Fatalf("write empty temp file: %v", err)
+	}
+	err = runKong(t, &DocsWriteCmd{}, []string{"doc1", "--file", emptyFile}, ctx, flags)
+	if err == nil {
+		t.Fatal("expected error for empty file, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty text") {
+		t.Fatalf("expected 'empty text' error, got: %v", err)
+	}
+
+	// Test that --text and --file are mutually exclusive
+	testFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("content"), 0o600); err != nil {
+		t.Fatalf("write test temp file: %v", err)
+	}
+	err = runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--file", testFile}, ctx, flags)
+	if err == nil {
+		t.Fatal("expected error for both --text and --file, got nil")
+	}
+	if !strings.Contains(err.Error(), "use only one of --text or --file") {
+		t.Fatalf("expected mutual exclusion error, got: %v", err)
 	}
 }

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -40,6 +40,7 @@ const (
 	extPptx                = ".pptx"
 	extPNG                 = ".png"
 	extTXT                 = ".txt"
+	formatAuto             = "auto"
 )
 
 type DriveCmd struct {
@@ -902,7 +903,7 @@ func guessMimeType(path string) string {
 func downloadDriveFile(ctx context.Context, svc *drive.Service, meta *drive.File, destPath string, format string) (string, int64, error) {
 	isGoogleDoc := strings.HasPrefix(meta.MimeType, "application/vnd.google-apps.")
 	normalizedFormat := strings.ToLower(strings.TrimSpace(format))
-	if normalizedFormat == "auto" {
+	if normalizedFormat == formatAuto {
 		normalizedFormat = ""
 	}
 
@@ -986,7 +987,7 @@ func driveExportMimeType(googleMimeType string) string {
 
 func driveExportMimeTypeForFormat(googleMimeType string, format string) (string, error) {
 	format = strings.ToLower(strings.TrimSpace(format))
-	if format == "" || format == "auto" {
+	if format == "" || format == formatAuto {
 		return driveExportMimeType(googleMimeType), nil
 	}
 

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -901,6 +901,14 @@ func guessMimeType(path string) string {
 
 func downloadDriveFile(ctx context.Context, svc *drive.Service, meta *drive.File, destPath string, format string) (string, int64, error) {
 	isGoogleDoc := strings.HasPrefix(meta.MimeType, "application/vnd.google-apps.")
+	normalizedFormat := strings.ToLower(strings.TrimSpace(format))
+	if normalizedFormat == "auto" {
+		normalizedFormat = ""
+	}
+
+	if !isGoogleDoc && normalizedFormat != "" {
+		return "", 0, fmt.Errorf("--format %q not supported for non-Google Workspace files (mimeType=%q); file can only be downloaded as-is", format, meta.MimeType)
+	}
 
 	var (
 		resp    *http.Response
@@ -910,11 +918,11 @@ func downloadDriveFile(ctx context.Context, svc *drive.Service, meta *drive.File
 
 	if isGoogleDoc {
 		var exportMimeType string
-		if strings.TrimSpace(format) == "" {
+		if normalizedFormat == "" {
 			exportMimeType = driveExportMimeType(meta.MimeType)
 		} else {
 			var mimeErr error
-			exportMimeType, mimeErr = driveExportMimeTypeForFormat(meta.MimeType, format)
+			exportMimeType, mimeErr = driveExportMimeTypeForFormat(meta.MimeType, normalizedFormat)
 			if mimeErr != nil {
 				return "", 0, mimeErr
 			}
@@ -978,7 +986,7 @@ func driveExportMimeType(googleMimeType string) string {
 
 func driveExportMimeTypeForFormat(googleMimeType string, format string) (string, error) {
 	format = strings.ToLower(strings.TrimSpace(format))
-	if format == "" {
+	if format == "" || format == "auto" {
 		return driveExportMimeType(googleMimeType), nil
 	}
 

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -93,6 +93,7 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		PageSize(c.Max).
 		PageToken(c.Page).
 		OrderBy("modifiedTime desc").
+		Corpora("allDrives").
 		SupportsAllDrives(true).
 		IncludeItemsFromAllDrives(true).
 		Fields("nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink)").

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -364,9 +364,9 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		meta.Parents = []string{parent}
 	}
 	if c.Convert {
-		convertMimeType, err := driveUploadConvertMimeType(localPath)
-		if err != nil {
-			return err
+		convertMimeType, convertErr := driveUploadConvertMimeType(localPath)
+		if convertErr != nil {
+			return convertErr
 		}
 		meta.MimeType = convertMimeType
 	}

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -159,6 +159,7 @@ func (c *DriveSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 		PageSize(c.Max).
 		PageToken(c.Page).
 		OrderBy("modifiedTime desc").
+		Corpora("allDrives").
 		SupportsAllDrives(true).
 		IncludeItemsFromAllDrives(true).
 		Fields("nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink)").

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -88,6 +88,7 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	q := buildDriveListQuery(folderID, c.Query)
 
+	// Include files from shared drives, not just personal "My Drive"
 	resp, err := svc.Files.List().
 		Q(q).
 		PageSize(c.Max).

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -323,6 +323,7 @@ type DriveUploadCmd struct {
 	LocalPath string `arg:"" name:"localPath" help:"Path to local file"`
 	Name      string `name:"name" help:"Override filename"`
 	Parent    string `name:"parent" help:"Destination folder ID"`
+	Convert   bool   `name:"convert" help:"Convert supported uploads to Google Workspace formats"`
 }
 
 func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -361,6 +362,13 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	parent := strings.TrimSpace(c.Parent)
 	if parent != "" {
 		meta.Parents = []string{parent}
+	}
+	if c.Convert {
+		convertMimeType, err := driveUploadConvertMimeType(localPath)
+		if err != nil {
+			return err
+		}
+		meta.MimeType = convertMimeType
 	}
 
 	mimeType := guessMimeType(localPath)
@@ -900,6 +908,24 @@ func guessMimeType(path string) string {
 		return "text/markdown"
 	default:
 		return "application/octet-stream"
+	}
+}
+
+func driveUploadConvertMimeType(path string) (string, error) {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".doc", extDocx:
+		return driveMimeGoogleDoc, nil
+	case ".xls", extXlsx, extCSV:
+		return driveMimeGoogleSheet, nil
+	case ".ppt", extPptx:
+		return driveMimeGoogleSlides, nil
+	default:
+		supported := "supported: .doc, .docx, .xls, .xlsx, .csv, .ppt, .pptx"
+		if ext == "" {
+			return "", fmt.Errorf("unsupported --convert for files without extension (%s)", supported)
+		}
+		return "", fmt.Errorf("unsupported --convert for %q (%s)", ext, supported)
 	}
 }
 

--- a/internal/cmd/drive_commands_more_test.go
+++ b/internal/cmd/drive_commands_more_test.go
@@ -26,6 +26,11 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 		switch {
 		case r.Method == http.MethodGet && path == "/files":
 			q := r.URL.Query().Get("q")
+			if strings.Contains(q, "fullText contains") {
+				if got := r.URL.Query().Get("corpora"); got != "allDrives" {
+					t.Fatalf("expected corpora=allDrives, got: %q", r.URL.RawQuery)
+				}
+			}
 			if strings.Contains(q, "empty") {
 				_ = json.NewEncoder(w).Encode(map[string]any{
 					"files": []map[string]any{},

--- a/internal/cmd/drive_export_format_test.go
+++ b/internal/cmd/drive_export_format_test.go
@@ -29,6 +29,12 @@ func TestDriveExportMimeTypeForFormat(t *testing.T) {
 			wantMime:   "application/pdf",
 		},
 		{
+			name:       "doc_auto",
+			googleMime: "application/vnd.google-apps.document",
+			format:     "auto",
+			wantMime:   "application/pdf",
+		},
+		{
 			name:       "doc_pdf",
 			googleMime: "application/vnd.google-apps.document",
 			format:     "pdf",
@@ -57,6 +63,12 @@ func TestDriveExportMimeTypeForFormat(t *testing.T) {
 			name:       "sheet_default",
 			googleMime: "application/vnd.google-apps.spreadsheet",
 			format:     "",
+			wantMime:   "text/csv",
+		},
+		{
+			name:       "sheet_auto",
+			googleMime: "application/vnd.google-apps.spreadsheet",
+			format:     "auto",
 			wantMime:   "text/csv",
 		},
 		{

--- a/internal/cmd/drive_helpers_test.go
+++ b/internal/cmd/drive_helpers_test.go
@@ -96,3 +96,32 @@ func TestGuessMimeTypeMore(t *testing.T) {
 		}
 	}
 }
+
+func TestDriveUploadConvertMimeType(t *testing.T) {
+	tests := map[string]string{
+		"file.doc":  driveMimeGoogleDoc,
+		"file.docx": driveMimeGoogleDoc,
+		"file.xls":  driveMimeGoogleSheet,
+		"file.xlsx": driveMimeGoogleSheet,
+		"file.csv":  driveMimeGoogleSheet,
+		"file.ppt":  driveMimeGoogleSlides,
+		"file.pptx": driveMimeGoogleSlides,
+	}
+
+	for name, expected := range tests {
+		got, err := driveUploadConvertMimeType(name)
+		if err != nil {
+			t.Fatalf("driveUploadConvertMimeType(%q) error: %v", name, err)
+		}
+		if got != expected {
+			t.Fatalf("driveUploadConvertMimeType(%q) = %q, want %q", name, got, expected)
+		}
+	}
+
+	if _, err := driveUploadConvertMimeType("file.pdf"); err == nil {
+		t.Fatalf("expected error for unsupported extension")
+	}
+	if _, err := driveUploadConvertMimeType("file"); err == nil {
+		t.Fatalf("expected error for missing extension")
+	}
+}

--- a/internal/cmd/drive_ls_cmd_test.go
+++ b/internal/cmd/drive_ls_cmd_test.go
@@ -24,6 +24,10 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == http.MethodGet && (r.URL.Path == "/drive/v3/files" || r.URL.Path == "/files"):
+			if errMsg := driveAllDrivesQueryError(r); errMsg != "" {
+				http.Error(w, errMsg, http.StatusBadRequest)
+				return
+			}
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"files": []map[string]any{

--- a/internal/cmd/drive_upload_convert_test.go
+++ b/internal/cmd/drive_upload_convert_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestDriveUploadConvertMetadata(t *testing.T) {
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+
+	var (
+		mu        sync.Mutex
+		gotMime   string
+		gotParsed bool
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.Contains(r.URL.Path, "/upload/drive/v3/files") {
+			http.NotFound(w, r)
+			return
+		}
+
+		mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		if err != nil {
+			t.Fatalf("parse content-type: %v", err)
+		}
+		if !strings.HasPrefix(mediaType, "multipart/") {
+			t.Fatalf("expected multipart upload, got %q", mediaType)
+		}
+		boundary := params["boundary"]
+		if boundary == "" {
+			t.Fatalf("missing multipart boundary")
+		}
+
+		reader := multipart.NewReader(r.Body, boundary)
+		found := false
+		for {
+			part, err := reader.NextPart()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				t.Fatalf("read multipart: %v", err)
+			}
+			if strings.Contains(part.Header.Get("Content-Type"), "application/json") {
+				var meta drive.File
+				if err := json.NewDecoder(part).Decode(&meta); err != nil {
+					t.Fatalf("decode metadata: %v", err)
+				}
+				mu.Lock()
+				gotMime = meta.MimeType
+				gotParsed = true
+				mu.Unlock()
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("metadata part not found")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "up1",
+			"name":     "upload.docx",
+			"mimeType": driveMimeGoogleDoc,
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	tmpFile := filepath.Join(t.TempDir(), "upload.docx")
+	if err := os.WriteFile(tmpFile, []byte("data"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	cmd := &DriveUploadCmd{LocalPath: tmpFile, Convert: true}
+	if err := cmd.Run(ctx, flags); err != nil {
+		t.Fatalf("upload: %v", err)
+	}
+
+	mu.Lock()
+	got := gotMime
+	parsed := gotParsed
+	mu.Unlock()
+
+	if !parsed {
+		t.Fatalf("expected metadata to be parsed")
+	}
+	if got != driveMimeGoogleDoc {
+		t.Fatalf("mimeType = %q, want %q", got, driveMimeGoogleDoc)
+	}
+}

--- a/internal/cmd/execute_drive_download_test.go
+++ b/internal/cmd/execute_drive_download_test.go
@@ -159,3 +159,69 @@ func TestExecute_DriveDownload_WithOutDir_JSON(t *testing.T) {
 		t.Fatalf("expected file at %s: %v", wantPath, statErr)
 	}
 }
+
+func TestExecute_DriveDownload_FormatRejected_NonGoogle(t *testing.T) {
+	origNew := newDriveService
+	origDownload := driveDownload
+	t.Cleanup(func() {
+		newDriveService = origNew
+		driveDownload = origDownload
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "/files/id1") && r.Method == http.MethodGet) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "id1",
+			"name":     "Doc",
+			"mimeType": "text/plain",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	called := false
+	driveDownload = func(context.Context, *drive.Service, string) (*http.Response, error) {
+		called = true
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("abc")),
+		}, nil
+	}
+
+	outPath := filepath.Join(t.TempDir(), "out.html")
+	var execErr error
+	_ = captureStderr(t, func() {
+		execErr = Execute([]string{
+			"--account", "a@b.com",
+			"drive", "download", "id1",
+			"--format", "html",
+			"--out", outPath,
+		})
+	})
+	if execErr == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(execErr.Error(), "non-Google Workspace") {
+		t.Fatalf("unexpected error: %v", execErr)
+	}
+	if called {
+		t.Fatalf("download should not be called on format error")
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no file written, stat=%v", statErr)
+	}
+}

--- a/internal/cmd/execute_gmail_forward_test.go
+++ b/internal/cmd/execute_gmail_forward_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+func TestExecute_GmailForward_DefaultSubjectAndAttachments(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	bodyText := "Original body"
+	bodyEncoded := base64.RawURLEncoding.EncodeToString([]byte(bodyText))
+	attData := []byte("hello")
+	attEncoded := base64.RawURLEncoding.EncodeToString(attData)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1/attachments/a1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": attEncoded})
+			return
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m1",
+				"threadId": "t1",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "Sender <sender@example.com>"},
+						{"name": "To", "value": "you@example.com"},
+						{"name": "Subject", "value": "Hello"},
+						{"name": "Date", "value": "Wed, 17 Dec 2025 14:00:00 -0800"},
+					},
+					"parts": []map[string]any{
+						{
+							"mimeType": "text/plain",
+							"body":     map[string]any{"data": bodyEncoded},
+						},
+						{
+							"filename": "a.txt",
+							"mimeType": "text/plain",
+							"body":     map[string]any{"attachmentId": "a1", "size": len(attData)},
+						},
+					},
+				},
+			})
+			return
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/send"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			var msg gmail.Message
+			if err := json.Unmarshal(body, &msg); err != nil {
+				t.Fatalf("unmarshal: %v body=%q", err, string(body))
+			}
+			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+			if err != nil {
+				t.Fatalf("decode raw: %v", err)
+			}
+			s := string(raw)
+			if !strings.Contains(s, "Subject: Fwd: Hello\r\n") {
+				t.Fatalf("missing forward subject in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "-------- Forwarded message --------") {
+				t.Fatalf("missing forwarded header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "Subject: Hello") {
+				t.Fatalf("missing original subject in forwarded header:\n%s", s)
+			}
+			if !strings.Contains(s, "From: Sender <sender@example.com>") {
+				t.Fatalf("missing original From in forwarded header:\n%s", s)
+			}
+			if !strings.Contains(s, "Forwarding note.") {
+				t.Fatalf("missing preface body in raw:\n%s", s)
+			}
+			prefaceIndex := strings.Index(s, "Forwarding note.")
+			forwardIndex := strings.Index(s, "-------- Forwarded message --------")
+			if prefaceIndex == -1 || forwardIndex == -1 || prefaceIndex > forwardIndex {
+				t.Fatalf("expected preface before forwarded header:\n%s", s)
+			}
+			if !strings.Contains(s, bodyText) {
+				t.Fatalf("missing original body in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "Content-Disposition: attachment; filename=\"a.txt\"") {
+				t.Fatalf("missing attachment filename in raw:\n%s", s)
+			}
+			if !strings.Contains(s, base64.StdEncoding.EncodeToString(attData)) {
+				t.Fatalf("missing attachment data in raw:\n%s", s)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "s1", "threadId": "t1"})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"gmail", "forward", "m1", "to@example.com",
+				"--body", "Forwarding note.",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}

--- a/internal/cmd/execute_gmail_forward_test.go
+++ b/internal/cmd/execute_gmail_forward_test.go
@@ -61,8 +61,8 @@ func TestExecute_GmailForward_DefaultSubjectAndAttachments(t *testing.T) {
 				t.Fatalf("ReadAll: %v", err)
 			}
 			var msg gmail.Message
-			if err := json.Unmarshal(body, &msg); err != nil {
-				t.Fatalf("unmarshal: %v body=%q", err, string(body))
+			if unmarshalErr := json.Unmarshal(body, &msg); unmarshalErr != nil {
+				t.Fatalf("unmarshal: %v body=%q", unmarshalErr, string(body))
 			}
 			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
 			if err != nil {
@@ -125,6 +125,282 @@ func TestExecute_GmailForward_DefaultSubjectAndAttachments(t *testing.T) {
 				"--account", "a@b.com",
 				"gmail", "forward", "m1", "to@example.com",
 				"--body", "Forwarding note.",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}
+
+func TestExecute_GmailForward_HTMLOnlyMessage(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	htmlBody := "<p>HTML <strong>body</strong></p>"
+	htmlEncoded := base64.RawURLEncoding.EncodeToString([]byte(htmlBody))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m2"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m2",
+				"threadId": "t2",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "sender@example.com"},
+						{"name": "To", "value": "you@example.com"},
+						{"name": "Subject", "value": "HTML Email"},
+						{"name": "Date", "value": "Wed, 17 Dec 2025 15:00:00 -0800"},
+					},
+					"parts": []map[string]any{
+						{
+							"mimeType": "text/html",
+							"body":     map[string]any{"data": htmlEncoded},
+						},
+					},
+				},
+			})
+			return
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/send"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			var msg gmail.Message
+			if unmarshalErr := json.Unmarshal(body, &msg); unmarshalErr != nil {
+				t.Fatalf("unmarshal: %v body=%q", unmarshalErr, string(body))
+			}
+			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+			if err != nil {
+				t.Fatalf("decode raw: %v", err)
+			}
+			s := string(raw)
+			if !strings.Contains(s, "Subject: Fwd: HTML Email\r\n") {
+				t.Fatalf("missing forward subject in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "-------- Forwarded message --------") {
+				t.Fatalf("missing forwarded header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "HTML body") {
+				t.Fatalf("missing stripped HTML content in plain part:\n%s", s)
+			}
+			if !strings.Contains(s, htmlBody) {
+				t.Fatalf("missing original HTML in HTML part:\n%s", s)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "s2", "threadId": "t2"})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"gmail", "forward", "m2", "to@example.com",
+				"--body", "Check this out.",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}
+
+func TestExecute_GmailForward_CustomSubject(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	bodyText := "Original body"
+	bodyEncoded := base64.RawURLEncoding.EncodeToString([]byte(bodyText))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m3"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m3",
+				"threadId": "t3",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "sender@example.com"},
+						{"name": "To", "value": "you@example.com"},
+						{"name": "Subject", "value": "Original Subject"},
+						{"name": "Date", "value": "Wed, 17 Dec 2025 16:00:00 -0800"},
+					},
+					"parts": []map[string]any{
+						{
+							"mimeType": "text/plain",
+							"body":     map[string]any{"data": bodyEncoded},
+						},
+					},
+				},
+			})
+			return
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/send"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			var msg gmail.Message
+			if unmarshalErr := json.Unmarshal(body, &msg); unmarshalErr != nil {
+				t.Fatalf("unmarshal: %v body=%q", unmarshalErr, string(body))
+			}
+			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+			if err != nil {
+				t.Fatalf("decode raw: %v", err)
+			}
+			s := string(raw)
+			if !strings.Contains(s, "Subject: Custom Forward Subject\r\n") {
+				t.Fatalf("missing custom subject in raw:\n%s", s)
+			}
+			if strings.Contains(s, "Subject: Fwd: Original Subject\r\n") {
+				t.Fatalf("should not contain default Fwd: subject:\n%s", s)
+			}
+			if !strings.Contains(s, "-------- Forwarded message --------") {
+				t.Fatalf("missing forwarded header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, bodyText) {
+				t.Fatalf("missing original body in raw:\n%s", s)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "s3", "threadId": "t3"})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"gmail", "forward", "m3", "to@example.com",
+				"--subject", "Custom Forward Subject",
+				"--body", "FYI.",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}
+
+func TestExecute_GmailForward_CcAndBcc(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	bodyText := "Original body"
+	bodyEncoded := base64.RawURLEncoding.EncodeToString([]byte(bodyText))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m4"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m4",
+				"threadId": "t4",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "From", "value": "sender@example.com"},
+						{"name": "To", "value": "you@example.com"},
+						{"name": "Subject", "value": "Test Message"},
+						{"name": "Date", "value": "Wed, 17 Dec 2025 17:00:00 -0800"},
+					},
+					"parts": []map[string]any{
+						{
+							"mimeType": "text/plain",
+							"body":     map[string]any{"data": bodyEncoded},
+						},
+					},
+				},
+			})
+			return
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/send"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("ReadAll: %v", err)
+			}
+			var msg gmail.Message
+			if unmarshalErr := json.Unmarshal(body, &msg); unmarshalErr != nil {
+				t.Fatalf("unmarshal: %v body=%q", unmarshalErr, string(body))
+			}
+			raw, err := base64.RawURLEncoding.DecodeString(msg.Raw)
+			if err != nil {
+				t.Fatalf("decode raw: %v", err)
+			}
+			s := string(raw)
+			if !strings.Contains(s, "To: to@example.com\r\n") {
+				t.Fatalf("missing To header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "Cc: cc1@example.com, cc2@example.com\r\n") {
+				t.Fatalf("missing Cc header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "Bcc: bcc@example.com\r\n") {
+				t.Fatalf("missing Bcc header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, "-------- Forwarded message --------") {
+				t.Fatalf("missing forwarded header in raw:\n%s", s)
+			}
+			if !strings.Contains(s, bodyText) {
+				t.Fatalf("missing original body in raw:\n%s", s)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "s4", "threadId": "t4"})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"gmail", "forward", "m4", "to@example.com",
+				"--cc", "cc1@example.com,cc2@example.com",
+				"--bcc", "bcc@example.com",
+				"--body", "Important message.",
 			}); err != nil {
 				t.Fatalf("Execute: %v", err)
 			}

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -30,9 +30,10 @@ type GmailCmd struct {
 	Labels GmailLabelsCmd `cmd:"" name:"labels" group:"Organize" help:"Label operations"`
 	Batch  GmailBatchCmd  `cmd:"" name:"batch" group:"Organize" help:"Batch operations"`
 
-	Send   GmailSendCmd   `cmd:"" name:"send" group:"Write" help:"Send an email"`
-	Track  GmailTrackCmd  `cmd:"" name:"track" group:"Write" help:"Email open tracking"`
-	Drafts GmailDraftsCmd `cmd:"" name:"drafts" group:"Write" help:"Draft operations"`
+	Send    GmailSendCmd    `cmd:"" name:"send" group:"Write" help:"Send an email"`
+	Forward GmailForwardCmd `cmd:"" name:"forward" group:"Write" help:"Forward a message"`
+	Track   GmailTrackCmd   `cmd:"" name:"track" group:"Write" help:"Email open tracking"`
+	Drafts  GmailDraftsCmd  `cmd:"" name:"drafts" group:"Write" help:"Draft operations"`
 
 	Settings GmailSettingsCmd `cmd:"" name:"settings" group:"Admin" help:"Settings and admin"`
 

--- a/internal/cmd/gmail_attachments.go
+++ b/internal/cmd/gmail_attachments.go
@@ -181,7 +181,7 @@ func collectAttachments(p *gmail.MessagePart) []attachmentInfo {
 	if p.Body != nil && p.Body.AttachmentId != "" {
 		filename := p.Filename
 		if strings.TrimSpace(filename) == "" {
-			filename = "attachment"
+			filename = defaultAttachmentFilename
 		}
 		out = append(out, attachmentInfo{
 			Filename:     filename,

--- a/internal/cmd/gmail_forward.go
+++ b/internal/cmd/gmail_forward.go
@@ -1,0 +1,289 @@
+package cmd
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"html"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type GmailForwardCmd struct {
+	MessageID string `arg:"" name:"messageId" help:"Message ID to forward"`
+	To        string `arg:"" name:"to" help:"Recipients (comma-separated)"`
+	Cc        string `name:"cc" help:"CC recipients (comma-separated)"`
+	Bcc       string `name:"bcc" help:"BCC recipients (comma-separated)"`
+	Subject   string `name:"subject" help:"Override subject (default: Fwd: <original subject>)"`
+	Body      string `name:"body" help:"Body preface (plain text)"`
+	BodyFile  string `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
+	BodyHTML  string `name:"body-html" help:"Body preface (HTML)"`
+	From      string `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
+}
+
+func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	messageID := strings.TrimSpace(c.MessageID)
+	toArg := strings.TrimSpace(c.To)
+	if messageID == "" || toArg == "" {
+		return usage("messageId/to required")
+	}
+
+	prefacePlain, err := resolveBodyInput(c.Body, c.BodyFile)
+	if err != nil {
+		return err
+	}
+
+	svc, err := newGmailService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	msg, err := svc.Users.Messages.Get("me", messageID).Format("full").Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	if msg == nil || msg.Payload == nil {
+		return fmt.Errorf("message %s has no payload", messageID)
+	}
+
+	fromAddr, err := resolveForwardFrom(ctx, svc, account, c.From)
+	if err != nil {
+		return err
+	}
+
+	subject := strings.TrimSpace(c.Subject)
+	if subject == "" {
+		subject = forwardSubject(headerValue(msg.Payload, "Subject"))
+	}
+	if subject == "" {
+		subject = "Fwd: (no subject)"
+	}
+
+	plainBody, htmlBody := buildForwardBodies(msg.Payload, prefacePlain, c.BodyHTML)
+
+	attachments, err := collectForwardAttachments(ctx, svc, messageID, msg.Payload)
+	if err != nil {
+		return err
+	}
+
+	toRecipients := splitCSV(toArg)
+	ccRecipients := splitCSV(c.Cc)
+	bccRecipients := splitCSV(c.Bcc)
+	if len(toRecipients) == 0 {
+		return usage("missing recipients")
+	}
+
+	raw, err := buildRFC822(mailOptions{
+		From:        fromAddr,
+		To:          toRecipients,
+		Cc:          ccRecipients,
+		Bcc:         bccRecipients,
+		Subject:     subject,
+		Body:        plainBody,
+		BodyHTML:    htmlBody,
+		Attachments: attachments,
+	}, nil)
+	if err != nil {
+		return err
+	}
+
+	sent, err := svc.Users.Messages.Send("me", &gmail.Message{
+		Raw: base64.RawURLEncoding.EncodeToString(raw),
+	}).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	results := []sendResult{{
+		To:        strings.TrimSpace(firstRecipient(toRecipients, ccRecipients, bccRecipients)),
+		MessageID: sent.Id,
+		ThreadID:  sent.ThreadId,
+	}}
+	return writeSendResults(ctx, u, fromAddr, results)
+}
+
+func resolveForwardFrom(ctx context.Context, svc *gmail.Service, account, from string) (string, error) {
+	fromAddr := account
+	from = strings.TrimSpace(from)
+	if from != "" {
+		sa, err := svc.Users.Settings.SendAs.Get("me", from).Context(ctx).Do()
+		if err != nil {
+			return "", fmt.Errorf("invalid --from address %q: %w", from, err)
+		}
+		if sa.VerificationStatus != gmailVerificationAccepted {
+			return "", fmt.Errorf("--from address %q is not verified (status: %s)", from, sa.VerificationStatus)
+		}
+		fromAddr = from
+		if sa.DisplayName != "" {
+			fromAddr = sa.DisplayName + " <" + from + ">"
+		}
+		return fromAddr, nil
+	}
+
+	// No --from specified: look up the primary account's send-as settings
+	// to get the display name
+	sa, saErr := svc.Users.Settings.SendAs.Get("me", account).Context(ctx).Do()
+	if saErr == nil && sa.DisplayName != "" {
+		fromAddr = sa.DisplayName + " <" + account + ">"
+	}
+	return fromAddr, nil
+}
+
+func forwardSubject(original string) string {
+	subject := strings.TrimSpace(original)
+	if subject == "" {
+		return "Fwd: (no subject)"
+	}
+	lower := strings.ToLower(subject)
+	if strings.HasPrefix(lower, "fwd:") || strings.HasPrefix(lower, "fw:") {
+		return subject
+	}
+	return "Fwd: " + subject
+}
+
+type forwardHeaderField struct {
+	Label string
+	Value string
+}
+
+func forwardHeaderFields(p *gmail.MessagePart) []forwardHeaderField {
+	fields := []string{"From", "Date", "Subject", "To", "Cc"}
+	out := make([]forwardHeaderField, 0, len(fields))
+	for _, name := range fields {
+		value := strings.TrimSpace(headerValue(p, name))
+		if value != "" {
+			out = append(out, forwardHeaderField{Label: name, Value: value})
+		}
+	}
+	return out
+}
+
+func forwardHeaderPlain(p *gmail.MessagePart) string {
+	lines := []string{"-------- Forwarded message --------"}
+	for _, field := range forwardHeaderFields(p) {
+		lines = append(lines, fmt.Sprintf("%s: %s", field.Label, field.Value))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func forwardHeaderHTML(p *gmail.MessagePart) string {
+	lines := []string{html.EscapeString("-------- Forwarded message --------")}
+	for _, field := range forwardHeaderFields(p) {
+		lines = append(lines, fmt.Sprintf("%s: %s", html.EscapeString(field.Label), html.EscapeString(field.Value)))
+	}
+	return strings.Join(lines, "<br>")
+}
+
+func joinSections(sep string, parts ...string) string {
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			continue
+		}
+		out = append(out, part)
+	}
+	if len(out) == 0 {
+		return ""
+	}
+	return strings.Join(out, sep)
+}
+
+func buildForwardBodies(payload *gmail.MessagePart, prefacePlain, prefaceHTML string) (string, string) {
+	plainOriginal := findPartBody(payload, "text/plain")
+	htmlOriginal := findPartBody(payload, "text/html")
+	if plainOriginal == "" && htmlOriginal != "" {
+		plainOriginal = stripHTMLTags(htmlOriginal)
+	}
+
+	plainHeader := forwardHeaderPlain(payload)
+	plainBody := joinSections("\n\n", prefacePlain, plainHeader, plainOriginal)
+
+	useHTML := strings.TrimSpace(htmlOriginal) != "" || strings.TrimSpace(prefaceHTML) != ""
+	if !useHTML {
+		return plainBody, ""
+	}
+
+	if strings.TrimSpace(prefaceHTML) == "" && strings.TrimSpace(prefacePlain) != "" {
+		prefaceHTML = plainToHTML(prefacePlain)
+	}
+	if strings.TrimSpace(htmlOriginal) == "" && strings.TrimSpace(plainOriginal) != "" {
+		htmlOriginal = plainToHTML(plainOriginal)
+	}
+
+	htmlHeader := forwardHeaderHTML(payload)
+	htmlBody := joinSections("<br><br>", prefaceHTML, htmlHeader, htmlOriginal)
+	return plainBody, htmlBody
+}
+
+func plainToHTML(value string) string {
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	value = strings.ReplaceAll(value, "\r", "\n")
+	escaped := html.EscapeString(value)
+	return strings.ReplaceAll(escaped, "\n", "<br>")
+}
+
+func collectForwardAttachments(ctx context.Context, svc *gmail.Service, messageID string, part *gmail.MessagePart) ([]mailAttachment, error) {
+	if part == nil {
+		return nil, nil
+	}
+	attachments := []mailAttachment{}
+	var walk func(p *gmail.MessagePart) error
+	walk = func(p *gmail.MessagePart) error {
+		if p == nil {
+			return nil
+		}
+		if p.Body != nil {
+			filename := strings.TrimSpace(p.Filename)
+			hasAttachmentID := strings.TrimSpace(p.Body.AttachmentId) != ""
+			hasInlineData := strings.TrimSpace(p.Body.Data) != "" && filename != ""
+			if hasAttachmentID || hasInlineData {
+				if filename == "" {
+					filename = "attachment"
+				}
+				att := mailAttachment{Filename: filename, MIMEType: p.MimeType}
+				var data []byte
+				if strings.TrimSpace(p.Body.Data) != "" {
+					decoded, err := decodeBase64URLBytes(p.Body.Data)
+					if err != nil {
+						return err
+					}
+					data = decoded
+				} else {
+					body, err := svc.Users.Messages.Attachments.Get("me", messageID, p.Body.AttachmentId).Context(ctx).Do()
+					if err != nil {
+						return err
+					}
+					if body == nil || body.Data == "" {
+						return fmt.Errorf("empty attachment data for %s", filename)
+					}
+					decoded, err := decodeBase64URLBytes(body.Data)
+					if err != nil {
+						return err
+					}
+					data = decoded
+				}
+				att.Data = data
+				attachments = append(attachments, att)
+			}
+		}
+		for _, child := range p.Parts {
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(part); err != nil {
+		return nil, err
+	}
+	return attachments, nil
+}

--- a/internal/cmd/gmail_forward.go
+++ b/internal/cmd/gmail_forward.go
@@ -55,7 +55,7 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return fmt.Errorf("message %s has no payload", messageID)
 	}
 
-	fromAddr, err := resolveForwardFrom(ctx, svc, account, c.From)
+	fromAddr, err := resolveSendFrom(ctx, svc, account, c.From)
 	if err != nil {
 		return err
 	}
@@ -63,9 +63,6 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 	subject := strings.TrimSpace(c.Subject)
 	if subject == "" {
 		subject = forwardSubject(headerValue(msg.Payload, "Subject"))
-	}
-	if subject == "" {
-		subject = "Fwd: (no subject)"
 	}
 
 	plainBody, htmlBody := buildForwardBodies(msg.Payload, prefacePlain, c.BodyHTML)
@@ -111,33 +108,6 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return writeSendResults(ctx, u, fromAddr, results)
 }
 
-func resolveForwardFrom(ctx context.Context, svc *gmail.Service, account, from string) (string, error) {
-	fromAddr := account
-	from = strings.TrimSpace(from)
-	if from != "" {
-		sa, err := svc.Users.Settings.SendAs.Get("me", from).Context(ctx).Do()
-		if err != nil {
-			return "", fmt.Errorf("invalid --from address %q: %w", from, err)
-		}
-		if sa.VerificationStatus != gmailVerificationAccepted {
-			return "", fmt.Errorf("--from address %q is not verified (status: %s)", from, sa.VerificationStatus)
-		}
-		fromAddr = from
-		if sa.DisplayName != "" {
-			fromAddr = sa.DisplayName + " <" + from + ">"
-		}
-		return fromAddr, nil
-	}
-
-	// No --from specified: look up the primary account's send-as settings
-	// to get the display name
-	sa, saErr := svc.Users.Settings.SendAs.Get("me", account).Context(ctx).Do()
-	if saErr == nil && sa.DisplayName != "" {
-		fromAddr = sa.DisplayName + " <" + account + ">"
-	}
-	return fromAddr, nil
-}
-
 func forwardSubject(original string) string {
 	subject := strings.TrimSpace(original)
 	if subject == "" {
@@ -168,7 +138,8 @@ func forwardHeaderFields(p *gmail.MessagePart) []forwardHeaderField {
 }
 
 func forwardHeaderPlain(p *gmail.MessagePart) string {
-	lines := []string{"-------- Forwarded message --------"}
+	lines := make([]string, 0, 6)
+	lines = append(lines, "-------- Forwarded message --------")
 	for _, field := range forwardHeaderFields(p) {
 		lines = append(lines, fmt.Sprintf("%s: %s", field.Label, field.Value))
 	}
@@ -176,7 +147,8 @@ func forwardHeaderPlain(p *gmail.MessagePart) string {
 }
 
 func forwardHeaderHTML(p *gmail.MessagePart) string {
-	lines := []string{html.EscapeString("-------- Forwarded message --------")}
+	lines := make([]string, 0, 6)
+	lines = append(lines, html.EscapeString("-------- Forwarded message --------"))
 	for _, field := range forwardHeaderFields(p) {
 		lines = append(lines, fmt.Sprintf("%s: %s", html.EscapeString(field.Label), html.EscapeString(field.Value)))
 	}
@@ -247,7 +219,7 @@ func collectForwardAttachments(ctx context.Context, svc *gmail.Service, messageI
 			hasInlineData := strings.TrimSpace(p.Body.Data) != "" && filename != ""
 			if hasAttachmentID || hasInlineData {
 				if filename == "" {
-					filename = "attachment"
+					filename = defaultAttachmentFilename
 				}
 				att := mailAttachment{Filename: filename, MIMEType: p.MimeType}
 				var data []byte

--- a/internal/cmd/gmail_helpers.go
+++ b/internal/cmd/gmail_helpers.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/gmail/v1"
+)
+
+// defaultAttachmentFilename is used when an attachment has no filename.
+const defaultAttachmentFilename = "attachment"
+
+// resolveSendFrom determines the From address to use when sending/forwarding.
+// If from is specified, validates it as a verified send-as alias and formats with display name.
+// If from is empty, uses the account and looks up its display name from send-as settings.
+// Returns the formatted "From" address (e.g., "Display Name <email@example.com>" or "email@example.com").
+func resolveSendFrom(ctx context.Context, svc *gmail.Service, account, from string) (string, error) {
+	fromAddr := account
+	from = strings.TrimSpace(from)
+	if from != "" {
+		sa, err := svc.Users.Settings.SendAs.Get("me", from).Context(ctx).Do()
+		if err != nil {
+			return "", fmt.Errorf("invalid --from address %q: %w", from, err)
+		}
+		if sa.VerificationStatus != gmailVerificationAccepted {
+			return "", fmt.Errorf("--from address %q is not verified (status: %s)", from, sa.VerificationStatus)
+		}
+		fromAddr = from
+		if sa.DisplayName != "" {
+			fromAddr = sa.DisplayName + " <" + from + ">"
+		}
+		return fromAddr, nil
+	}
+
+	// No --from specified: look up the primary account's send-as settings
+	// to get the display name
+	sa, saErr := svc.Users.Settings.SendAs.Get("me", account).Context(ctx).Do()
+	if saErr == nil && sa.DisplayName != "" {
+		fromAddr = sa.DisplayName + " <" + account + ">"
+	}
+	return fromAddr, nil
+}

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -104,32 +104,14 @@ func (c *GmailSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	// Determine the From address
-	fromAddr := account
-	sendingEmail := account // The email we're sending from (without display name)
+	fromAddr, err := resolveSendFrom(ctx, svc, account, c.From)
+	if err != nil {
+		return err
+	}
+	// The email we're sending from (without display name)
+	sendingEmail := account
 	if strings.TrimSpace(c.From) != "" {
-		// Validate that this is a configured send-as alias
-		var sa *gmail.SendAs
-		sa, err = svc.Users.Settings.SendAs.Get("me", c.From).Context(ctx).Do()
-		if err != nil {
-			return fmt.Errorf("invalid --from address %q: %w", c.From, err)
-		}
-		if sa.VerificationStatus != gmailVerificationAccepted {
-			return fmt.Errorf("--from address %q is not verified (status: %s)", c.From, sa.VerificationStatus)
-		}
 		sendingEmail = c.From
-		fromAddr = c.From
-		// Include display name if set
-		if sa.DisplayName != "" {
-			fromAddr = sa.DisplayName + " <" + c.From + ">"
-		}
-	} else {
-		// No --from specified: look up the primary account's send-as settings
-		// to get the display name
-		sa, saErr := svc.Users.Settings.SendAs.Get("me", account).Context(ctx).Do()
-		if saErr == nil && sa.DisplayName != "" {
-			fromAddr = sa.DisplayName + " <" + account + ">"
-		}
-		// If lookup fails, we just use the plain email address (no error)
 	}
 
 	// Fetch reply info (includes recipient headers for reply-all)

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"golang.org/x/net/html/charset"
 	"google.golang.org/api/gmail/v1"
@@ -442,12 +443,18 @@ func decodePartBody(p *gmail.MessagePart) (string, error) {
 		return "", err
 	}
 
+	contentType := strings.TrimSpace(headerValue(p, "Content-Type"))
+	charsetLabel := contentTypeCharset(contentType)
+
 	decoded := raw
 	if cte := strings.TrimSpace(headerValue(p, "Content-Transfer-Encoding")); cte != "" {
 		decoded = decodeTransferEncoding(decoded, cte)
+		if isQuotedPrintableEncoding(cte) && shouldSkipQuotedPrintable(raw, decoded, charsetLabel) {
+			decoded = raw
+		}
 	}
 
-	if contentType := strings.TrimSpace(headerValue(p, "Content-Type")); contentType != "" {
+	if contentType != "" {
 		decoded = decodeBodyCharset(decoded, contentType)
 	}
 
@@ -472,11 +479,7 @@ func decodeTransferEncoding(data []byte, encoding string) []byte {
 }
 
 func decodeBodyCharset(data []byte, contentType string) []byte {
-	_, params, err := mime.ParseMediaType(contentType)
-	if err != nil {
-		return data
-	}
-	charsetLabel := strings.TrimSpace(params["charset"])
+	charsetLabel := contentTypeCharset(contentType)
 	if charsetLabel == "" || strings.EqualFold(charsetLabel, "utf-8") {
 		return data
 	}
@@ -489,6 +492,43 @@ func decodeBodyCharset(data []byte, contentType string) []byte {
 		return data
 	}
 	return decoded
+}
+
+func contentTypeCharset(contentType string) string {
+	if contentType == "" {
+		return ""
+	}
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(params["charset"])
+}
+
+func isQuotedPrintableEncoding(value string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+	if idx := strings.Index(value, ";"); idx != -1 {
+		value = value[:idx]
+	}
+	return strings.EqualFold(strings.TrimSpace(value), "quoted-printable")
+}
+
+func shouldSkipQuotedPrintable(raw, decoded []byte, charsetLabel string) bool {
+	if !isUTF8Charset(charsetLabel) {
+		return false
+	}
+	if !utf8.Valid(raw) {
+		return false
+	}
+	return !utf8.Valid(decoded)
+}
+
+func isUTF8Charset(label string) bool {
+	label = strings.ToLower(strings.TrimSpace(label))
+	return label == "" || label == "utf-8" || label == "us-ascii"
 }
 
 func looksLikeBase64(data []byte) bool {

--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -510,12 +510,18 @@ func isQuotedPrintableEncoding(value string) bool {
 	if value == "" {
 		return false
 	}
+	// Handle potential parameters defensively, though RFC 2045 doesn't define them.
 	if idx := strings.Index(value, ";"); idx != -1 {
 		value = value[:idx]
 	}
 	return strings.EqualFold(strings.TrimSpace(value), "quoted-printable")
 }
 
+// shouldSkipQuotedPrintable returns true when QP decoding should be skipped.
+// This handles emails where Content-Transfer-Encoding is declared as quoted-printable
+// but the body is already decoded. Applying QP decoding to such content corrupts
+// '=' characters (e.g., in URLs). We detect this by checking if raw is valid UTF-8
+// but decoded becomes invalid (indicating the decoder treated literal '=' as escapes).
 func shouldSkipQuotedPrintable(raw, decoded []byte, charsetLabel string) bool {
 	if !isUTF8Charset(charsetLabel) {
 		return false

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -254,3 +254,44 @@ func TestDownloadAttachment_Cached(t *testing.T) {
 		t.Fatalf("expected cached path %q, got %q cached=%v", outPath, gotPath, cached)
 	}
 }
+
+func TestIsQuotedPrintableEncoding(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"quoted-printable", true},
+		{"QUOTED-PRINTABLE", true},
+		{"Quoted-Printable", true},
+		{"  quoted-printable  ", true},
+		{"base64", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := isQuotedPrintableEncoding(tc.input)
+		if got != tc.want {
+			t.Fatalf("isQuotedPrintableEncoding(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestIsUTF8Charset(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"", true},
+		{"utf-8", true},
+		{"UTF-8", true},
+		{"us-ascii", true},
+		{"US-ASCII", true},
+		{"iso-8859-1", false},
+		{"windows-1252", false},
+	}
+	for _, tc := range tests {
+		got := isUTF8Charset(tc.input)
+		if got != tc.want {
+			t.Fatalf("isUTF8Charset(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -153,6 +153,23 @@ func TestFindPartBody_DecodesQuotedPrintable(t *testing.T) {
 	}
 }
 
+func TestFindPartBody_SkipsQuotedPrintableWhenAlreadyDecoded(t *testing.T) {
+	body := "https://example.com/auth?token_hash=abc123&type=magiclink"
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(body))
+	part := &gmail.MessagePart{
+		MimeType: "text/plain",
+		Headers: []*gmail.MessagePartHeader{
+			{Name: "Content-Transfer-Encoding", Value: "quoted-printable"},
+			{Name: "Content-Type", Value: "text/plain; charset=utf-8"},
+		},
+		Body: &gmail.MessagePartBody{Data: encoded},
+	}
+	got := findPartBody(part, "text/plain")
+	if got != body {
+		t.Fatalf("unexpected decoded body: %q", got)
+	}
+}
+
 func TestFindPartBody_DecodesBase64Transfer(t *testing.T) {
 	inner := base64.StdEncoding.EncodeToString([]byte("plain body"))
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(inner))

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -170,6 +170,24 @@ func TestFindPartBody_SkipsQuotedPrintableWhenAlreadyDecoded(t *testing.T) {
 	}
 }
 
+func TestFindPartBody_DecodesQuotedPrintableEquals(t *testing.T) {
+	// In QP encoding, = is encoded as =3D, so "a=b" becomes "a=3Db"
+	qp := "a=3Db"
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(qp))
+	part := &gmail.MessagePart{
+		MimeType: "text/plain",
+		Headers: []*gmail.MessagePartHeader{
+			{Name: "Content-Transfer-Encoding", Value: "quoted-printable"},
+			{Name: "Content-Type", Value: "text/plain; charset=utf-8"},
+		},
+		Body: &gmail.MessagePartBody{Data: encoded},
+	}
+	got := findPartBody(part, "text/plain")
+	if got != "a=b" {
+		t.Fatalf("unexpected decoded body: %q, want %q", got, "a=b")
+	}
+}
+
 func TestFindPartBody_DecodesBase64Transfer(t *testing.T) {
 	inner := base64.StdEncoding.EncodeToString([]byte("plain body"))
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(inner))

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -21,6 +21,8 @@ import (
 const (
 	colorAuto  = "auto"
 	colorNever = "never"
+	boolTrue   = "true"
+	boolFalse  = "false"
 )
 
 type RootFlags struct {
@@ -163,9 +165,9 @@ func envOr(key, fallback string) string {
 
 func boolString(v bool) string {
 	if v {
-		return "true"
+		return boolTrue
 	}
-	return "false"
+	return boolFalse
 }
 
 func newParser(description string) (*kong.Kong, *CLI, error) {

--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -131,9 +131,13 @@ func ResolveTimeRangeWithDefaults(ctx context.Context, svc *calendar.Service, fl
 
 		switch {
 		case flags.To != "":
+			toIsDayExpr := isDayExpr(flags.To, now, loc)
 			to, err = parseTimeExpr(flags.To, now, loc)
 			if err != nil {
 				return nil, fmt.Errorf("invalid --to: %w", err)
+			}
+			if toIsDayExpr {
+				to = endOfDay(to)
 			}
 		case flags.From != "" && defaults.ToFromOffset != 0:
 			to = from.Add(defaults.ToFromOffset)
@@ -147,6 +151,27 @@ func ResolveTimeRangeWithDefaults(ctx context.Context, svc *calendar.Service, fl
 		To:       to,
 		Location: loc,
 	}, nil
+}
+
+func isDayExpr(expr string, now time.Time, loc *time.Location) bool {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return false
+	}
+	exprLower := strings.ToLower(expr)
+	switch exprLower {
+	case "today", "tomorrow", "yesterday":
+		return true
+	case "now":
+		return false
+	}
+	if _, ok := parseWeekday(exprLower, now); ok {
+		return true
+	}
+	if _, err := time.ParseInLocation("2006-01-02", expr, loc); err == nil {
+		return true
+	}
+	return false
 }
 
 // parseTimeExpr parses a time expression which can be:

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -161,3 +161,80 @@ func TestGetUserTimezoneInvalid(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestIsDayExpr(t *testing.T) {
+	loc := time.UTC
+	// Use a fixed reference time: Wednesday, January 15, 2025
+	now := time.Date(2025, 1, 15, 10, 30, 0, 0, loc)
+
+	tests := []struct {
+		name string
+		expr string
+		want bool
+	}{
+		// Relative day keywords -> true
+		{"today", "today", true},
+		{"tomorrow", "tomorrow", true},
+		{"yesterday", "yesterday", true},
+		{"today uppercase", "TODAY", true},
+		{"today mixed case", "ToDay", true},
+
+		// "now" is a precise moment -> false
+		{"now", "now", false},
+		{"now uppercase", "NOW", false},
+
+		// Weekday names -> true
+		{"monday", "monday", true},
+		{"tuesday", "tuesday", true},
+		{"wednesday", "wednesday", true},
+		{"thursday", "thursday", true},
+		{"friday", "friday", true},
+		{"saturday", "saturday", true},
+		{"sunday", "sunday", true},
+		{"mon abbreviation", "mon", true},
+		{"tue abbreviation", "tue", true},
+		{"wed abbreviation", "wed", true},
+		{"thu abbreviation", "thu", true},
+		{"fri abbreviation", "fri", true},
+		{"sat abbreviation", "sat", true},
+		{"sun abbreviation", "sun", true},
+		{"Monday uppercase", "MONDAY", true},
+		{"next monday", "next monday", true},
+		{"next tuesday", "next tuesday", true},
+
+		// ISO date (YYYY-MM-DD) -> true
+		{"iso date", "2025-01-05", true},
+		{"iso date future", "2026-12-31", true},
+		{"iso date past", "2020-01-01", true},
+
+		// RFC3339 timestamps -> false (precise moment, not a day)
+		{"rfc3339 utc", "2025-01-05T10:00:00Z", false},
+		{"rfc3339 offset", "2025-01-05T10:00:00-08:00", false},
+		{"rfc3339 positive offset", "2025-01-05T10:00:00+05:30", false},
+
+		// ISO 8601 with numeric timezone (no colon) -> false
+		{"iso8601 no colon", "2025-01-05T10:00:00-0800", false},
+
+		// Date with time but no timezone -> false (has time component)
+		{"datetime no tz", "2025-01-05T15:04:05", false},
+		{"datetime space separator", "2025-01-05 15:04", false},
+
+		// Empty string -> false
+		{"empty string", "", false},
+		{"whitespace only", "   ", false},
+
+		// Invalid expressions -> false
+		{"invalid word", "notaday", false},
+		{"invalid format", "01-05-2025", false},
+		{"partial date", "2025-01", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isDayExpr(tt.expr, now, loc)
+			if got != tt.want {
+				t.Errorf("isDayExpr(%q) = %v, want %v", tt.expr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -162,6 +162,65 @@ func TestGetUserTimezoneInvalid(t *testing.T) {
 	}
 }
 
+func TestResolveTimeRangeWithDefaultsToTomorrowEndOfDay(t *testing.T) {
+	svc := newCalendarServiceWithTimezone(t, "UTC")
+	flags := TimeRangeFlags{
+		From: "2025-01-05T10:00:00Z",
+		To:   "tomorrow",
+	}
+
+	// Capture now BEFORE calling the function to avoid midnight boundary flakiness
+	now := time.Now().In(time.UTC)
+
+	tr, err := ResolveTimeRangeWithDefaults(context.Background(), svc, flags, TimeRangeDefaults{})
+	if err != nil {
+		t.Fatalf("ResolveTimeRangeWithDefaults: %v", err)
+	}
+
+	expectedFrom := time.Date(2025, 1, 5, 10, 0, 0, 0, time.UTC)
+	if !tr.From.Equal(expectedFrom) {
+		t.Fatalf("unexpected from: %v", tr.From)
+	}
+
+	// "tomorrow" is relative to now, so we calculate expected tomorrow
+	expectedTomorrow := now.AddDate(0, 0, 1)
+	expectedTo := time.Date(expectedTomorrow.Year(), expectedTomorrow.Month(), expectedTomorrow.Day(), 23, 59, 59, 999999999, time.UTC)
+
+	if !tr.To.Equal(expectedTo) {
+		t.Fatalf("expected --to tomorrow to expand to end-of-day %v, got %v", expectedTo, tr.To)
+	}
+}
+
+func TestResolveTimeRangeWithDefaultsToNowNoExpansion(t *testing.T) {
+	svc := newCalendarServiceWithTimezone(t, "UTC")
+	flags := TimeRangeFlags{
+		From: "2025-01-05T10:00:00Z",
+		To:   "now",
+	}
+
+	before := time.Now().In(time.UTC)
+	tr, err := ResolveTimeRangeWithDefaults(context.Background(), svc, flags, TimeRangeDefaults{})
+	if err != nil {
+		t.Fatalf("ResolveTimeRangeWithDefaults: %v", err)
+	}
+	after := time.Now().In(time.UTC)
+
+	expectedFrom := time.Date(2025, 1, 5, 10, 0, 0, 0, time.UTC)
+	if !tr.From.Equal(expectedFrom) {
+		t.Fatalf("unexpected from: %v", tr.From)
+	}
+
+	// "now" should NOT be expanded to end-of-day; it should be the current time
+	if tr.To.Before(before) || tr.To.After(after) {
+		t.Fatalf("expected --to now to be current time (between %v and %v), got %v", before, after, tr.To)
+	}
+
+	// Verify it's NOT end-of-day (23:59:59.999999999)
+	if tr.To.Hour() == 23 && tr.To.Minute() == 59 && tr.To.Second() == 59 && tr.To.Nanosecond() == 999999999 {
+		t.Fatalf("expected --to now NOT to expand to end-of-day, but got %v", tr.To)
+	}
+}
+
 func TestIsDayExpr(t *testing.T) {
 	loc := time.UTC
 	// Use a fixed reference time: Wednesday, January 15, 2025

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -86,6 +86,27 @@ func TestResolveTimeRangeWithDefaultsFromTo(t *testing.T) {
 	}
 }
 
+func TestResolveTimeRangeWithDefaultsToDateOnlyEndOfDay(t *testing.T) {
+	svc := newCalendarServiceWithTimezone(t, "UTC")
+	flags := TimeRangeFlags{
+		From: "2025-01-05T10:00:00Z",
+		To:   "2025-01-05",
+	}
+	tr, err := ResolveTimeRangeWithDefaults(context.Background(), svc, flags, TimeRangeDefaults{})
+	if err != nil {
+		t.Fatalf("ResolveTimeRangeWithDefaults: %v", err)
+	}
+
+	expectedFrom := time.Date(2025, 1, 5, 10, 0, 0, 0, time.UTC)
+	expectedTo := time.Date(2025, 1, 5, 23, 59, 59, 999999999, time.UTC)
+	if !tr.From.Equal(expectedFrom) {
+		t.Fatalf("unexpected from: %v", tr.From)
+	}
+	if !tr.To.Equal(expectedTo) {
+		t.Fatalf("unexpected to: %v", tr.To)
+	}
+}
+
 func TestResolveTimeRangeWithDefaultsFromOffset(t *testing.T) {
 	svc := newCalendarServiceWithTimezone(t, "UTC")
 	flags := TimeRangeFlags{From: "2025-01-05T10:00:00Z"}

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -221,6 +221,41 @@ func TestResolveTimeRangeWithDefaultsToNowNoExpansion(t *testing.T) {
 	}
 }
 
+func TestResolveTimeRangeWithDefaultsToMondayEndOfDay(t *testing.T) {
+	svc := newCalendarServiceWithTimezone(t, "UTC")
+	flags := TimeRangeFlags{
+		From: "2025-01-05T10:00:00Z",
+		To:   "monday",
+	}
+
+	// Capture now BEFORE calling the function to avoid midnight boundary flakiness
+	now := time.Now().In(time.UTC)
+
+	tr, err := ResolveTimeRangeWithDefaults(context.Background(), svc, flags, TimeRangeDefaults{})
+	if err != nil {
+		t.Fatalf("ResolveTimeRangeWithDefaults: %v", err)
+	}
+
+	expectedFrom := time.Date(2025, 1, 5, 10, 0, 0, 0, time.UTC)
+	if !tr.From.Equal(expectedFrom) {
+		t.Fatalf("unexpected from: %v", tr.From)
+	}
+
+	// "monday" is relative to now, so we calculate expected Monday
+	// parseWeekday returns the upcoming Monday (or today if already Monday)
+	currentDay := now.Weekday()
+	daysUntil := int(time.Monday) - int(currentDay)
+	if daysUntil < 0 {
+		daysUntil += 7
+	}
+	expectedMonday := now.AddDate(0, 0, daysUntil)
+	expectedTo := time.Date(expectedMonday.Year(), expectedMonday.Month(), expectedMonday.Day(), 23, 59, 59, 999999999, time.UTC)
+
+	if !tr.To.Equal(expectedTo) {
+		t.Fatalf("expected --to monday to expand to end-of-day %v, got %v", expectedTo, tr.To)
+	}
+}
+
 func TestIsDayExpr(t *testing.T) {
 	loc := time.UTC
 	// Use a fixed reference time: Wednesday, January 15, 2025


### PR DESCRIPTION
Closes #166

## Summary
- Add `gmail forward` command to forward emails to specified recipients
- Extract shared `resolveSendFrom()` helper to reduce code duplication between send/forward
- Add comprehensive test coverage for forward edge cases (HTML-only, custom subject, CC/BCC)
- Fix lint issues (shadow declaration, slice preallocation, goconst)

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] golangci-lint passes with 0 issues
- [x] New forward tests cover: default subject, attachments, HTML-only messages, custom subject override, CC/BCC recipients

🤖 Generated with [Claude Code](https://claude.com/claude-code)