### PR TITLE
feat(cmd): add --disable-commands flag for command denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ gog keep get <noteId> --account you@yourdomain.com
 - `GOG_COLOR` - Color mode: `auto` (default), `always`, or `never`
 - `GOG_TIMEZONE` - Default output timezone for Calendar/Gmail (IANA name, `UTC`, or `local`)
 - `GOG_ENABLE_COMMANDS` - Comma-separated allowlist of top-level commands (e.g., `calendar,tasks`)
+- `GOG_DISABLE_COMMANDS` - Comma-separated denylist using dot-notation (e.g., `gmail.send`)
 
 ### Config File (JSON5)
 
@@ -435,7 +436,7 @@ gog auth alias unset work
 
 Aliases work anywhere you pass `--account` or `GOG_ACCOUNT` (reserved: `auto`, `default`).
 
-### Command Allowlist (Sandboxing)
+### Command Allowlist/Denylist (Sandboxing)
 
 ```bash
 # Only allow calendar + tasks commands for an agent
@@ -444,6 +445,18 @@ gog --enable-commands calendar,tasks calendar events --today
 # Same via env
 export GOG_ENABLE_COMMANDS=calendar,tasks
 gog tasks list <tasklistId>
+
+# Block specific subcommands using dot-notation
+gog --disable-commands gmail.send gmail search 'from:boss'  # allowed
+gog --disable-commands gmail.send gmail send --to a@b.com   # blocked
+
+# Block all subcommands of a command
+gog --disable-commands gmail gmail search 'from:boss'       # blocked
+
+# Same via env
+export GOG_DISABLE_COMMANDS=gmail.send,calendar.delete
+gog gmail search 'from:boss'  # allowed
+gog gmail send --to a@b.com   # blocked
 ```
  
 ## Security
@@ -1235,6 +1248,7 @@ All commands support these flags:
 
 - `--account <email|alias|auto>` - Account to use (overrides GOG_ACCOUNT)
 - `--enable-commands <csv>` - Allowlist top-level commands (e.g., `calendar,tasks`)
+- `--disable-commands <csv>` - Denylist commands using dot-notation (e.g., `gmail.send`)
 - `--json` - Output JSON to stdout (best for scripting)
 - `--plain` - Output stable, parseable text to stdout (TSV; no colors)
 - `--color <mode>` - Color mode: `auto`, `always`, or `never` (default: auto)

--- a/internal/cmd/enabled_commands.go
+++ b/internal/cmd/enabled_commands.go
@@ -40,3 +40,35 @@ func parseEnabledCommands(value string) map[string]bool {
 	}
 	return out
 }
+
+func enforceDisabledCommands(kctx *kong.Context, disabled string) error {
+	return enforceDisabledCommandsForCommand(kctx.Command(), disabled)
+}
+
+func enforceDisabledCommandsForCommand(command, disabled string) error {
+	disabled = strings.TrimSpace(disabled)
+	if disabled == "" {
+		return nil
+	}
+
+	denyList := parseEnabledCommands(disabled)
+	if len(denyList) == 0 {
+		return nil
+	}
+
+	cmdParts := strings.Fields(command)
+	if len(cmdParts) == 0 {
+		return nil
+	}
+
+	// Check if any prefix of the command path is disabled
+	// e.g., ["gmail", "send"] checks "gmail.send", then "gmail"
+	for i := len(cmdParts); i >= 1; i-- {
+		prefix := strings.ToLower(strings.Join(cmdParts[:i], "."))
+		if denyList[prefix] {
+			return usagef("command %q is disabled (blocked by --disable-commands)", strings.Join(cmdParts[:i], " "))
+		}
+	}
+
+	return nil
+}

--- a/internal/cmd/enabled_commands_test.go
+++ b/internal/cmd/enabled_commands_test.go
@@ -1,10 +1,121 @@
 package cmd
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestParseEnabledCommands(t *testing.T) {
 	allow := parseEnabledCommands("calendar, tasks ,Gmail")
 	if !allow["calendar"] || !allow["tasks"] || !allow["gmail"] {
 		t.Fatalf("unexpected allow map: %#v", allow)
+	}
+}
+
+func TestEnforceDisabledCommands(t *testing.T) {
+	tests := []struct {
+		name     string
+		disabled string
+		command  string
+		wantErr  bool
+	}{
+		{
+			name:     "empty disabled allows all",
+			disabled: "",
+			command:  "gmail send",
+			wantErr:  false,
+		},
+		{
+			name:     "whitespace-only disabled allows all",
+			disabled: "   ",
+			command:  "gmail send",
+			wantErr:  false,
+		},
+		{
+			name:     "exact match blocks command",
+			disabled: "gmail.send",
+			command:  "gmail send",
+			wantErr:  true,
+		},
+		{
+			name:     "parent blocks all children",
+			disabled: "gmail",
+			command:  "gmail send",
+			wantErr:  true,
+		},
+		{
+			name:     "parent blocks nested children",
+			disabled: "gmail",
+			command:  "gmail messages list",
+			wantErr:  true,
+		},
+		{
+			name:     "specific subcommand does not block sibling",
+			disabled: "gmail.send",
+			command:  "gmail search",
+			wantErr:  false,
+		},
+		{
+			name:     "specific subcommand does not block different parent",
+			disabled: "gmail.messages",
+			command:  "gmail send",
+			wantErr:  false,
+		},
+		{
+			name:     "case insensitive matching",
+			disabled: "Gmail.SEND",
+			command:  "gmail send",
+			wantErr:  true,
+		},
+		{
+			name:     "multiple disabled commands",
+			disabled: "gmail.send,calendar.delete",
+			command:  "gmail send",
+			wantErr:  true,
+		},
+		{
+			name:     "multiple disabled commands - second match",
+			disabled: "gmail.send,calendar.delete",
+			command:  "calendar delete",
+			wantErr:  true,
+		},
+		{
+			name:     "multiple disabled commands - no match",
+			disabled: "gmail.send,calendar.delete",
+			command:  "gmail search",
+			wantErr:  false,
+		},
+		{
+			name:     "empty command allowed",
+			disabled: "gmail.send",
+			command:  "",
+			wantErr:  false,
+		},
+		{
+			name:     "three-level command blocked by middle",
+			disabled: "gmail.messages",
+			command:  "gmail messages list",
+			wantErr:  true,
+		},
+		{
+			name:     "three-level command blocked by exact match",
+			disabled: "gmail.messages.list",
+			command:  "gmail messages list",
+			wantErr:  true,
+		},
+		{
+			name:     "three-level command - sibling allowed",
+			disabled: "gmail.messages.list",
+			command:  "gmail messages get",
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := enforceDisabledCommandsForCommand(tt.command, tt.disabled)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("enforceDisabledCommandsForCommand() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Add support for blocking specific commands using dot-notation (e.g., gmail.send, calendar.delete).
- Add GOG_DISABLE_COMMANDS env var
- Block commands by exact match or parent prefix
- Case-insensitive matching