### PR TITLE
feat(calendar): add --send-updates flag to update command

### DIFF
--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -310,6 +310,7 @@ type CalendarUpdateCmd struct {
 	ColorId               string   `name:"event-color" help:"Event color ID (1-11, or empty to clear)"`
 	Visibility            string   `name:"visibility" help:"Event visibility: default, public, private, confidential"`
 	Transparency          string   `name:"transparency" help:"Show as busy (opaque) or free (transparent). Aliases: busy, free"`
+	SendUpdates           string   `name:"send-updates" help:"Notification mode: all, externalOnly, none (default: none)"`
 	GuestsCanInviteOthers *bool    `name:"guests-can-invite" help:"Allow guests to invite others"`
 	GuestsCanModify       *bool    `name:"guests-can-modify" help:"Allow guests to modify event"`
 	GuestsCanSeeOthers    *bool    `name:"guests-can-see-others" help:"Allow guests to see other guests"`
@@ -371,6 +372,12 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		}
 	}
 
+	// Validate sendUpdates parameter for attendee notifications.
+	sendUpdates, err := validateSendUpdates(c.SendUpdates)
+	if err != nil {
+		return err
+	}
+
 	// Cannot use both --attendees and --add-attendee at the same time.
 	if flagProvided(kctx, "attendees") && flagProvided(kctx, "add-attendee") {
 		return usage("cannot use both --attendees and --add-attendee; use --attendees to replace all, or --add-attendee to add")
@@ -414,7 +421,11 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		return err
 	}
 
-	updated, err := svc.Events.Patch(calendarID, targetEventID, patch).Do()
+	call := svc.Events.Patch(calendarID, targetEventID, patch)
+	if sendUpdates != "" {
+		call = call.SendUpdates(sendUpdates)
+	}
+	updated, err := call.Do()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
The `update` command was missing the `sendUpdates` parameter that exists in the Google Calendar API. This meant attendees wouldn't receive notification emails when events were rescheduled.

## Changes
- Adds `SendUpdates` field to `CalendarUpdateCmd` struct
- Validates the parameter using existing `validateSendUpdates()`
- Passes `sendUpdates` to `Events.Patch()` API call

## Usage
```bash
gog calendar update primary <eventId> --from "2026-02-03T15:30:00" --send-updates all
```

## Google Calendar API Reference
The [Events: update](https://developers.google.com/calendar/api/v3/reference/events/update) endpoint supports the `sendUpdates` query parameter with values: `all`, `externalOnly`, `none`.

Fixes #175