### PR TITLE
fix(gmail): prevent URL corruption in quoted-printable decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Fixed
 
+- Gmail: avoid false quoted-printable detection for already-decoded URLs with uppercase hex-like tokens while still decoding unambiguous markers (`=3D`, chained escapes, soft breaks). (#186) — thanks @100menotu001.
+
 - Secrets: set keyring item labels to `gogcli` so macOS security prompts show a clear item name. (#106) — thanks @maxceem.
 - Auth: improve remote/server-friendly manual OAuth flow (`auth add --remote`). (#187) — thanks @salmonumbrella.
 

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -158,7 +158,7 @@ func TestFindPartBody_PreservesURLsWhenAlreadyDecoded(t *testing.T) {
 	// Content-Transfer-Encoding header says quoted-printable.
 	// URLs with = should be preserved, not corrupted to U+FFFD.
 	// See: https://github.com/steipete/gogcli/issues/159
-	url := "https://example.com/auth?token_hash=abc123&type=magiclink"
+	url := "https://example.com/auth?token_hash=ABCD12&type=magiclink"
 	encoded := base64.RawURLEncoding.EncodeToString([]byte(url))
 	part := &gmail.MessagePart{
 		MimeType: "text/plain",
@@ -180,18 +180,21 @@ func TestLooksLikeQuotedPrintable(t *testing.T) {
 		input string
 		want  bool
 	}{
-		{"actual QP uppercase hex", "Price =E2=82=AC99", true},
+		{"actual QP uppercase chain", "Price =E2=82=AC99", true},
+		{"actual QP lowercase chain", "Price =e2=82=ac99", true},
 		{"soft line break CRLF", "line=\r\ncontinued", true},
 		{"soft line break LF", "line=\ncontinued", true},
 		{"plain URL lowercase", "https://example.com?foo=bar", false},
 		{"URL with multiple params", "https://example.com?a=b1&c=d2", false},
-		{"lowercase hex sequence", "test=ab", false}, // lowercase not matched
-		{"uppercase hex sequence", "test=AB", true},
-		{"mixed case hex", "test=Ab", false}, // requires both uppercase
+		{"URL with uppercase hex token", "https://example.com?token=ABCD12", false},
+		{"lowercase hex sequence", "test=ab", false},
+		{"uppercase hex sequence", "test=AB", false},
+		{"mixed case hex", "test=Ab", false},
 		{"plain text", "Hello World", false},
 		{"equals at end", "foo=", false},
 		{"short input", "=", false},
-		{"QP encoded equals", "foo=3Dbar", true}, // =3D is QP for =
+		{"QP encoded equals uppercase", "foo=3Dbar", true},
+		{"QP encoded equals lowercase", "foo=3dbar", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #159 — URLs with `=` characters were being corrupted to U+FFFD when emails had `Content-Transfer-Encoding: quoted-printable` but content was already decoded by Gmail API.

## Root Cause

Gmail API's `format=full` may return body.data with content already decoded from its original transfer encoding, but the CTE header still indicates `quoted-printable`. The existing code would attempt to QP-decode again, causing:
- Raw `=` characters (from URLs like `?foo=bar`) treated as invalid QP sequences
- Go's `quotedprintable.Reader` produces U+FFFD for invalid sequences

## Solution

Added `looksLikeQuotedPrintable()` check (similar to existing `looksLikeBase64()`) that detects actual QP markers before decoding:
- Soft line breaks (`=\r\n` or `=\n`)  
- Uppercase hex sequences (`=XX` where X is 0-9 or A-F)

Using uppercase-only hex detection avoids false positives from URLs containing lowercase letters after `=` (e.g., `?foo=bar`).

## Testing

Added unit tests covering:
- Original issue (URL preservation when already decoded)
- Various QP patterns (uppercase hex, soft breaks)
- False positive prevention (lowercase URL params)
- Edge cases (short input, mixed case)

---

*Contributed via OpenClaw agent — active gog CLI users contributing back.*