### PR TITLE
feat(gmail): add --exclude-labels to watch serve

### DIFF
--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -191,20 +191,21 @@ func (c *GmailWatchStopCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type GmailWatchServeCmd struct {
-	Bind         string `name:"bind" help:"Bind address" default:"127.0.0.1"`
-	Port         int    `name:"port" help:"Listen port" default:"8788"`
-	Path         string `name:"path" help:"Push handler path" default:"/gmail-pubsub"`
-	Timezone     string `name:"timezone" short:"z" help:"Output timezone (IANA name, e.g. America/New_York, UTC). Default: local"`
-	Local        bool   `name:"local" help:"Use local timezone (default behavior, useful to override --timezone)"`
-	VerifyOIDC   bool   `name:"verify-oidc" help:"Verify Pub/Sub OIDC tokens"`
-	OIDCEmail    string `name:"oidc-email" help:"Expected service account email"`
-	OIDCAudience string `name:"oidc-audience" help:"Expected OIDC audience"`
-	SharedToken  string `name:"token" help:"Shared token for x-gog-token or ?token="`
-	HookURL      string `name:"hook-url" help:"Webhook URL to forward messages"`
-	HookToken    string `name:"hook-token" help:"Webhook bearer token"`
-	IncludeBody  bool   `name:"include-body" help:"Include text/plain body in hook payload"`
-	MaxBytes     int    `name:"max-bytes" help:"Max bytes of body to include" default:"20000"`
-	SaveHook     bool   `name:"save-hook" help:"Persist hook settings to watch state"`
+	Bind          string `name:"bind" help:"Bind address" default:"127.0.0.1"`
+	Port          int    `name:"port" help:"Listen port" default:"8788"`
+	Path          string `name:"path" help:"Push handler path" default:"/gmail-pubsub"`
+	Timezone      string `name:"timezone" short:"z" help:"Output timezone (IANA name, e.g. America/New_York, UTC). Default: local"`
+	Local         bool   `name:"local" help:"Use local timezone (default behavior, useful to override --timezone)"`
+	VerifyOIDC    bool   `name:"verify-oidc" help:"Verify Pub/Sub OIDC tokens"`
+	OIDCEmail     string `name:"oidc-email" help:"Expected service account email"`
+	OIDCAudience  string `name:"oidc-audience" help:"Expected OIDC audience"`
+	SharedToken   string `name:"token" help:"Shared token for x-gog-token or ?token="`
+	HookURL       string `name:"hook-url" help:"Webhook URL to forward messages"`
+	HookToken     string `name:"hook-token" help:"Webhook bearer token"`
+	IncludeBody   bool   `name:"include-body" help:"Include text/plain body in hook payload"`
+	MaxBytes      int    `name:"max-bytes" help:"Max bytes of body to include" default:"20000"`
+	ExcludeLabels string `name:"exclude-labels" help:"Comma-separated list of Gmail label IDs to exclude from hook payload (e.g. SPAM,TRASH). Set to empty string to disable." default:"SPAM,TRASH"`
+	SaveHook      bool   `name:"save-hook" help:"Persist hook settings to watch state"`
 }
 
 func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -286,21 +287,23 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 	}
 
 	cfg := gmailWatchServeConfig{
-		Account:      account,
-		Bind:         c.Bind,
-		Port:         c.Port,
-		Path:         c.Path,
-		VerifyOIDC:   c.VerifyOIDC,
-		OIDCEmail:    c.OIDCEmail,
-		OIDCAudience: c.OIDCAudience,
-		SharedToken:  c.SharedToken,
-		HookTimeout:  defaultHookRequestTimeoutSec * time.Second,
-		HistoryMax:   defaultHistoryMaxResults,
-		ResyncMax:    defaultHistoryResyncMax,
-		AllowNoHook:  hook == nil,
-		IncludeBody:  includeBody,
-		MaxBodyBytes: maxBytes,
-		DateLocation: loc,
+		Account:       account,
+		Bind:          c.Bind,
+		Port:          c.Port,
+		Path:          c.Path,
+		VerifyOIDC:    c.VerifyOIDC,
+		OIDCEmail:     c.OIDCEmail,
+		OIDCAudience:  c.OIDCAudience,
+		SharedToken:   c.SharedToken,
+		HookTimeout:   defaultHookRequestTimeoutSec * time.Second,
+		HistoryMax:    defaultHistoryMaxResults,
+		ResyncMax:     defaultHistoryResyncMax,
+		AllowNoHook:   hook == nil,
+		IncludeBody:   includeBody,
+		MaxBodyBytes:  maxBytes,
+		DateLocation:  loc,
+		ExcludeLabels: splitCommaList(c.ExcludeLabels),
+		VerboseOutput: flags.Verbose,
 	}
 	if hook != nil {
 		cfg.HookURL = hook.URL
@@ -315,13 +318,14 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 
 	hookClient := &http.Client{Timeout: cfg.HookTimeout}
 	server := &gmailWatchServer{
-		cfg:        cfg,
-		store:      store,
-		validator:  validator,
-		newService: newGmailService,
-		hookClient: hookClient,
-		logf:       u.Err().Printf,
-		warnf:      u.Err().Printf,
+		cfg:             cfg,
+		store:           store,
+		validator:       validator,
+		newService:      newGmailService,
+		hookClient:      hookClient,
+		excludeLabelIDs: lowerStringSet(cfg.ExcludeLabels),
+		logf:            u.Err().Printf,
+		warnf:           u.Err().Printf,
 	}
 
 	addr := net.JoinHostPort(c.Bind, strconv.Itoa(c.Port))

--- a/internal/cmd/gmail_watch_server.go
+++ b/internal/cmd/gmail_watch_server.go
@@ -26,13 +26,14 @@ const (
 )
 
 type gmailWatchServer struct {
-	cfg        gmailWatchServeConfig
-	store      *gmailWatchStore
-	validator  *idtoken.Validator
-	newService func(context.Context, string) (*gmail.Service, error)
-	hookClient *http.Client
-	logf       func(string, ...any)
-	warnf      func(string, ...any)
+	cfg             gmailWatchServeConfig
+	store           *gmailWatchStore
+	validator       *idtoken.Validator
+	newService      func(context.Context, string) (*gmail.Service, error)
+	hookClient      *http.Client
+	excludeLabelIDs map[string]struct{}
+	logf            func(string, ...any)
+	warnf           func(string, ...any)
 }
 
 func (s *gmailWatchServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -188,7 +189,7 @@ func (s *gmailWatchServer) handlePush(ctx context.Context, payload gmailPushPayl
 	}
 
 	messageIDs := collectHistoryMessageIDs(historyResp)
-	msgs, err := s.fetchMessages(ctx, svc, messageIDs)
+	msgs, excluded, err := s.fetchMessages(ctx, svc, messageIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -214,6 +215,13 @@ func (s *gmailWatchServer) handlePush(ctx context.Context, payload gmailPushPayl
 		s.warnf("watch: failed to update state: %v", err)
 	}
 
+	if excluded > 0 && len(msgs) == 0 {
+		if s.cfg.VerboseOutput {
+			s.logf("watch: skipping hook; all messages excluded")
+		}
+		return nil, errNoNewMessages
+	}
+
 	return &gmailHookPayload{
 		Source:    "gmail",
 		Account:   s.cfg.Account,
@@ -233,7 +241,7 @@ func (s *gmailWatchServer) resyncHistory(ctx context.Context, svc *gmail.Service
 			ids = append(ids, m.Id)
 		}
 	}
-	msgs, err := s.fetchMessages(ctx, svc, ids)
+	msgs, excluded, err := s.fetchMessages(ctx, svc, ids)
 	if err != nil {
 		return nil, err
 	}
@@ -255,6 +263,13 @@ func (s *gmailWatchServer) resyncHistory(ctx context.Context, svc *gmail.Service
 		s.warnf("watch: failed to update state after resync: %v", err)
 	}
 
+	if excluded > 0 && len(msgs) == 0 {
+		if s.cfg.VerboseOutput {
+			s.logf("watch: skipping hook; all messages excluded")
+		}
+		return nil, errNoNewMessages
+	}
+
 	return &gmailHookPayload{
 		Source:    "gmail",
 		Account:   s.cfg.Account,
@@ -263,8 +278,9 @@ func (s *gmailWatchServer) resyncHistory(ctx context.Context, svc *gmail.Service
 	}, nil
 }
 
-func (s *gmailWatchServer) fetchMessages(ctx context.Context, svc *gmail.Service, ids []string) ([]gmailHookMessage, error) {
+func (s *gmailWatchServer) fetchMessages(ctx context.Context, svc *gmail.Service, ids []string) ([]gmailHookMessage, int, error) {
 	messages := make([]gmailHookMessage, 0, len(ids))
+	excluded := 0
 	format := gmailWatchFormatMetadata
 	if s.cfg.IncludeBody {
 		format = "full"
@@ -282,9 +298,16 @@ func (s *gmailWatchServer) fetchMessages(ctx context.Context, svc *gmail.Service
 			if isNotFoundAPIError(err) {
 				continue
 			}
-			return nil, err
+			return nil, excluded, err
 		}
 		if msg == nil {
+			continue
+		}
+		if s.isExcludedLabel(msg.LabelIds) {
+			excluded++
+			if s.cfg.VerboseOutput {
+				s.logf("watch: excluded message %s labels=%v", msg.Id, msg.LabelIds)
+			}
 			continue
 		}
 		item := gmailHookMessage{
@@ -303,7 +326,23 @@ func (s *gmailWatchServer) fetchMessages(ctx context.Context, svc *gmail.Service
 		}
 		messages = append(messages, item)
 	}
-	return messages, nil
+	return messages, excluded, nil
+}
+
+func (s *gmailWatchServer) isExcludedLabel(labelIDs []string) bool {
+	if len(labelIDs) == 0 || len(s.excludeLabelIDs) == 0 {
+		return false
+	}
+	for _, id := range labelIDs {
+		trimmed := strings.TrimSpace(id)
+		if trimmed == "" {
+			continue
+		}
+		if _, ok := s.excludeLabelIDs[strings.ToLower(trimmed)]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *gmailWatchServer) sendHook(ctx context.Context, payload *gmailHookPayload) error {

--- a/internal/cmd/gmail_watch_server_exclude_labels_test.go
+++ b/internal/cmd/gmail_watch_server_exclude_labels_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+func TestGmailWatchServer_ServeHTTP_ExcludeLabels_SkipsHook(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store, err := newGmailWatchStore("a@b.com")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	// Seed state so StartHistoryID returns non-zero.
+	if updateErr := store.Update(func(s *gmailWatchState) error {
+		s.Account = "a@b.com"
+		s.HistoryID = "100"
+		return nil
+	}); updateErr != nil {
+		t.Fatalf("seed: %v", updateErr)
+	}
+
+	var hookCalls int
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hookCalls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer hookSrv.Close()
+
+	gmailSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/history"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"historyId": "200",
+				"history": []map[string]any{
+					{"messagesAdded": []map[string]any{{"message": map[string]any{"id": "m1"}}}},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "m1",
+				"threadId": "t1",
+				"snippet":  "spam",
+				"labelIds": []string{"SPAM"},
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Subject", "value": "S"},
+					},
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer gmailSrv.Close()
+
+	gsvc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(gmailSrv.Client()),
+		option.WithEndpoint(gmailSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	s := &gmailWatchServer{
+		cfg: gmailWatchServeConfig{
+			Account:     "a@b.com",
+			Path:        "/gmail-pubsub",
+			SharedToken: "tok",
+			HookURL:     hookSrv.URL,
+			HistoryMax:  100,
+			ResyncMax:   10,
+		},
+		store:           store,
+		newService:      func(context.Context, string) (*gmail.Service, error) { return gsvc, nil },
+		hookClient:      hookSrv.Client(),
+		excludeLabelIDs: map[string]struct{}{"spam": {}},
+		logf:            func(string, ...any) {},
+		warnf:           func(string, ...any) {},
+	}
+
+	push := pubsubPushEnvelope{}
+	push.Message.Data = base64.StdEncoding.EncodeToString([]byte(`{"emailAddress":"a@b.com","historyId":"200"}`))
+	body, _ := json.Marshal(push)
+
+	req := httptest.NewRequest(http.MethodPost, "/gmail-pubsub?token=tok", bytes.NewReader(body))
+	rr := httptest.NewRecorder()
+	s.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status: %d body=%q", rr.Code, rr.Body.String())
+	}
+	if hookCalls != 0 {
+		t.Fatalf("expected no hook calls, got %d", hookCalls)
+	}
+
+	st := store.Get()
+	if st.HistoryID != "200" {
+		t.Fatalf("expected history updated, got %q", st.HistoryID)
+	}
+}

--- a/internal/cmd/gmail_watch_types.go
+++ b/internal/cmd/gmail_watch_types.go
@@ -52,6 +52,7 @@ type gmailWatchServeConfig struct {
 	HookToken     string
 	IncludeBody   bool
 	MaxBodyBytes  int
+	ExcludeLabels []string
 	HistoryMax    int64
 	ResyncMax     int64
 	HookTimeout   time.Duration

--- a/internal/cmd/gmail_watch_utils.go
+++ b/internal/cmd/gmail_watch_utils.go
@@ -69,3 +69,21 @@ func resolveLabelIDsWithService(svc *gmail.Service, labels []string) ([]string, 
 	}
 	return out, nil
 }
+
+func lowerStringSet(items []string) map[string]struct{} {
+	if len(items) == 0 {
+		return nil
+	}
+	out := make(map[string]struct{}, len(items))
+	for _, item := range items {
+		v := strings.TrimSpace(item)
+		if v == "" {
+			continue
+		}
+		out[strings.ToLower(v)] = struct{}{}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}


### PR DESCRIPTION
Fixes #178

Adds `--exclude-labels` to `gog gmail watch serve` (default: `SPAM,TRASH`). Messages whose `labelIds` intersect the exclude list are skipped (no hook call when all new messages are excluded).

Examples:
- `gog gmail watch serve --exclude-labels SPAM,TRASH --hook-url ...`
- disable filtering: `gog gmail watch serve --exclude-labels="" ...`

Tests:
- `make ci`