### PR TITLE
feat: Add a hasMore field to list calendar events if actual_event_count > max 

### DIFF
--- a/internal/cmd/calendar_search.go
+++ b/internal/cmd/calendar_search.go
@@ -59,8 +59,10 @@ func (c *CalendarSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(os.Stdout, map[string]any{
-			"events": wrapEventsWithDays(resp.Items),
-			"query":  query,
+			"events":        wrapEventsWithDays(resp.Items),
+			"query":         query,
+			"nextPageToken": resp.NextPageToken,
+			"hasMore":       resp.NextPageToken != "",
 		})
 	}
 


### PR DESCRIPTION
In my openclaw journey I found that if my claw decides to search for a large range(say 3 months) and I have a weekly recurring event, then some events may get truncated but LLM has no way of knowing there is more events. The hasMore param can hint at LLM to fetch mroe