### PR TITLE
fix(calendar): interpret date-only --to values as end of day

### DIFF
--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -158,12 +158,50 @@ func parseTimeExprEndOfDay(expr string, now time.Time, loc *time.Location) (time
 	if err != nil {
 		return t, err
 	}
-	// If the result is exactly midnight (start of day), it was likely a date-only
-	// or relative day expression — adjust to end of day.
-	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+	// Only adjust to end-of-day for date-only or relative day expressions.
+	// If the input is a full timestamp (contains "T" or "t" indicating time
+	// components), respect the exact time the user specified — even midnight.
+	if isDateOnlyOrRelative(expr) {
 		return endOfDay(t), nil
 	}
 	return t, nil
+}
+
+// isDateOnlyOrRelative returns true if the expression is a date-only string
+// (YYYY-MM-DD) or a relative day keyword (today, tomorrow, yesterday, weekday
+// names). These should be adjusted to end-of-day when used as an upper bound.
+// Full timestamps (RFC3339, datetime with T separator) return false.
+func isDateOnlyOrRelative(expr string) bool {
+	trimmed := strings.TrimSpace(expr)
+	lower := strings.ToLower(trimmed)
+
+	// Relative day keywords
+	switch lower {
+	case "today", "tomorrow", "yesterday", "now":
+		return true
+	}
+
+	// Weekday names: "monday", "next tuesday", etc.
+	candidate := lower
+	if strings.HasPrefix(candidate, "next ") {
+		candidate = strings.TrimPrefix(candidate, "next ")
+	}
+	weekdays := []string{"sunday", "sun", "monday", "mon", "tuesday", "tue",
+		"wednesday", "wed", "thursday", "thu", "friday", "fri", "saturday", "sat"}
+	for _, wd := range weekdays {
+		if candidate == wd {
+			return true
+		}
+	}
+
+	// Date-only: YYYY-MM-DD (exactly 10 chars, no time component)
+	if len(trimmed) == 10 {
+		if _, err := time.Parse("2006-01-02", trimmed); err == nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 // parseTimeExpr parses a time expression which can be:

--- a/internal/cmd/time_helpers_test.go
+++ b/internal/cmd/time_helpers_test.go
@@ -195,13 +195,49 @@ func TestParseTimeExprEndOfDay(t *testing.T) {
 		t.Fatalf("expected hour 14, got %v", parsed.Hour())
 	}
 
-	// Explicit midnight RFC3339 IS adjusted (acceptable trade-off)
+	// Explicit midnight RFC3339 should NOT be adjusted — user intentionally specified midnight
 	parsed, err = parseTimeExprEndOfDay("2025-01-05T00:00:00Z", now, loc)
 	if err != nil {
 		t.Fatalf("parseTimeExprEndOfDay midnight rfc3339: %v", err)
 	}
-	if parsed.Hour() != 23 {
-		t.Fatalf("explicit midnight gets adjusted to end of day (known behavior), got hour %v", parsed.Hour())
+	if parsed.Hour() != 0 || parsed.Minute() != 0 || parsed.Second() != 0 {
+		t.Fatalf("explicit midnight RFC3339 should be preserved, got %v", parsed)
+	}
+
+	// ISO 8601 with numeric timezone should NOT be adjusted
+	parsed, err = parseTimeExprEndOfDay("2025-01-05T00:00:00-0800", now, loc)
+	if err != nil {
+		t.Fatalf("parseTimeExprEndOfDay iso8601: %v", err)
+	}
+	if parsed.Hour() != 0 || parsed.Minute() != 0 || parsed.Second() != 0 {
+		t.Fatalf("explicit midnight ISO8601 should be preserved, got %v", parsed)
+	}
+
+	// Local datetime without timezone should NOT be adjusted
+	parsed, err = parseTimeExprEndOfDay("2025-01-05T10:30:00", now, loc)
+	if err != nil {
+		t.Fatalf("parseTimeExprEndOfDay local datetime: %v", err)
+	}
+	if parsed.Hour() != 10 || parsed.Minute() != 30 {
+		t.Fatalf("local datetime should be preserved, got %v", parsed)
+	}
+
+	// Weekday expression should resolve to end of day
+	parsed, err = parseTimeExprEndOfDay("monday", now, time.UTC)
+	if err != nil {
+		t.Fatalf("parseTimeExprEndOfDay monday: %v", err)
+	}
+	if parsed.Hour() != 23 || parsed.Minute() != 59 || parsed.Second() != 59 {
+		t.Fatalf("expected end of day for monday, got %v", parsed)
+	}
+
+	// "tomorrow" should resolve to end of day
+	parsed, err = parseTimeExprEndOfDay("tomorrow", now, time.UTC)
+	if err != nil {
+		t.Fatalf("parseTimeExprEndOfDay tomorrow: %v", err)
+	}
+	if parsed.Hour() != 23 || parsed.Minute() != 59 || parsed.Second() != 59 {
+		t.Fatalf("expected end of day for tomorrow, got %v", parsed)
 	}
 }
 


### PR DESCRIPTION
## Summary

When `--to` is given a date-only value like `2026-02-02` or a relative expression like `tomorrow`, it was parsed as start of day (00:00:00), creating a zero-length query window when paired with the same `--from` date. This meant `--from 2026-02-02 --to 2026-02-02` returned no events.

## Fix

Added `parseTimeExprEndOfDay()` which wraps `parseTimeExpr()` and adjusts date-only/relative results to end of day (23:59:59.999). The `--to` flag now uses this function.

This matches the behavior of `--today`/`--tomorrow` convenience flags which already used `endOfDay()` correctly.

## What's preserved
- Full RFC3339 timestamps with explicit times are unchanged
- `--from` still resolves to start of day (correct for range starts)
- All existing tests pass, new tests added for the EndOfDay variant

Fixes #155