### PR TITLE
fix(sheets): preserve tabs for sheets get --plain

### DIFF
--- a/internal/cmd/execute_sheets_more_commands_test.go
+++ b/internal/cmd/execute_sheets_more_commands_test.go
@@ -99,6 +99,15 @@ func TestExecute_SheetsMoreCommands(t *testing.T) {
 			t.Fatalf("unexpected out=%q", out)
 		}
 
+		plainOut := captureStdout(t, func() {
+			if err := Execute([]string{"--plain", "sheets", "get", "id1", `Sheet1\\!A1:B1`}); err != nil {
+				t.Fatalf("get plain: %v", err)
+			}
+		})
+		if plainOut != "a\tb\n" {
+			t.Fatalf("unexpected plain out=%q", plainOut)
+		}
+
 		_ = captureStdout(t, func() {
 			if err := Execute([]string{"--json", "sheets", "update", "id1", "Sheet1!A1:B1", "a|b"}); err != nil {
 				t.Fatalf("update: %v", err)

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -118,15 +118,15 @@ func (c *SheetsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return nil
 	}
 
-	tw := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	w, flush := tableWriter(ctx)
+	defer flush()
 	for _, row := range resp.Values {
 		cells := make([]string, len(row))
 		for i, cell := range row {
 			cells[i] = fmt.Sprintf("%v", cell)
 		}
-		fmt.Fprintln(tw, strings.Join(cells, "\t"))
+		fmt.Fprintln(w, strings.Join(cells, "\t"))
 	}
-	_ = tw.Flush()
 	return nil
 }
 


### PR DESCRIPTION
Fixes #209.

- Use `tableWriter(ctx)` in `sheets get` so `--plain` outputs real TSV with `	` delimiters (no `tabwriter` conversion).
- Add a unit test asserting `--plain` output preserves tabs.

Testing: `make ci`