### PR TITLE
Expand Drive --convert-to to sheet|doc|slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,9 +777,15 @@ gog drive search "invoice" --max 20
 gog drive get <fileId>                # Get file metadata
 gog drive url <fileId>                # Print Drive web URL
 gog drive copy <fileId> "Copy Name"
+gog drive copy <fileId> "Sheet Copy" --convert-to sheet
+gog drive copy <fileId> "Doc Copy" --convert-to doc
+gog drive copy <fileId> "Slides Copy" --convert-to slides
 
 # Upload and download
 gog drive upload ./path/to/file --parent <folderId>
+gog drive upload ./file.xlsx --convert-to sheet
+gog drive upload ./file.docx --convert-to doc
+gog drive upload ./file.pptx --convert-to slides
 gog drive download <fileId> --out ./downloaded.bin
 gog drive download <fileId> --format pdf --out ./exported.pdf
 gog drive download <fileId> --format docx --out ./doc.docx

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -173,7 +173,8 @@ Flag aliases:
 - `gog drive search <text> [--max N] [--page TOKEN]`
 - `gog drive get <fileId>`
 - `gog drive download <fileId> [--out PATH]`
-- `gog drive upload <localPath> [--name N] [--parent ID]`
+- `gog drive copy <fileId> <name> [--parent ID] [--convert-to sheet|doc|slides]`
+- `gog drive upload <localPath> [--name N] [--parent ID] [--convert-to sheet|doc|slides]`
 - `gog drive mkdir <name> [--parent ID]`
 - `gog drive delete <fileId>`
 - `gog drive move <fileId> --parent ID`

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -174,7 +174,7 @@ func (c *DocsCopyCmd) Run(ctx context.Context, flags *RootFlags) error {
 		ArgName:      "docId",
 		ExpectedMime: "application/vnd.google-apps.document",
 		KindLabel:    "Google Doc",
-	}, c.DocID, c.Title, c.Parent)
+	}, c.DocID, c.Title, c.Parent, "")
 }
 
 type DocsCatCmd struct {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -311,21 +311,28 @@ func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type DriveCopyCmd struct {
-	FileID string `arg:"" name:"fileId" help:"File ID"`
-	Name   string `arg:"" name:"name" help:"New file name"`
-	Parent string `name:"parent" help:"Destination folder ID"`
+	FileID    string `arg:"" name:"fileId" help:"File ID"`
+	Name      string `arg:"" name:"name" help:"New file name"`
+	Parent    string `name:"parent" help:"Destination folder ID"`
+	ConvertTo string `name:"convert-to" help:"Convert copied file to: sheet|doc|slides"`
 }
 
 func (c *DriveCopyCmd) Run(ctx context.Context, flags *RootFlags) error {
+	targetMimeType, err := driveConvertToMimeType(c.ConvertTo)
+	if err != nil {
+		return err
+	}
+
 	return copyViaDrive(ctx, flags, copyViaDriveOptions{
 		ArgName: "fileId",
-	}, c.FileID, c.Name, c.Parent)
+	}, c.FileID, c.Name, c.Parent, targetMimeType)
 }
 
 type DriveUploadCmd struct {
 	LocalPath string `arg:"" name:"localPath" help:"Path to local file"`
 	Name      string `name:"name" help:"Override filename"`
 	Parent    string `name:"parent" help:"Destination folder ID"`
+	ConvertTo string `name:"convert-to" help:"Convert uploaded file to: sheet|doc|slides"`
 }
 
 func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -340,6 +347,11 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("empty localPath")
 	}
 	localPath, err = config.ExpandPath(localPath)
+	if err != nil {
+		return err
+	}
+
+	targetMimeType, err := driveConvertToMimeType(c.ConvertTo)
 	if err != nil {
 		return err
 	}
@@ -361,6 +373,9 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	meta := &drive.File{Name: fileName}
+	if targetMimeType != "" {
+		meta.MimeType = targetMimeType
+	}
 	parent := strings.TrimSpace(c.Parent)
 	if parent != "" {
 		meta.Parents = []string{parent}
@@ -957,6 +972,21 @@ func guessMimeType(path string) string {
 		return "text/markdown"
 	default:
 		return "application/octet-stream"
+	}
+}
+
+func driveConvertToMimeType(convertTo string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(convertTo)) {
+	case "":
+		return "", nil
+	case "sheet":
+		return driveMimeGoogleSheet, nil
+	case "doc":
+		return driveMimeGoogleDoc, nil
+	case "slides":
+		return driveMimeGoogleSlides, nil
+	default:
+		return "", usagef("invalid --convert-to %q (expected: sheet|doc|slides)", convertTo)
 	}
 }
 

--- a/internal/cmd/drive_commands_more_test.go
+++ b/internal/cmd/drive_commands_more_test.go
@@ -3,6 +3,10 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,6 +21,21 @@ import (
 func TestDriveCommands_MoreCoverage(t *testing.T) {
 	origNew := newDriveService
 	t.Cleanup(func() { newDriveService = origNew })
+
+	convertTargets := []struct {
+		name string
+		mime string
+	}{
+		{name: "sheet", mime: driveMimeGoogleSheet},
+		{name: "doc", mime: driveMimeGoogleDoc},
+		{name: "slides", mime: driveMimeGoogleSlides},
+	}
+	convertTargetByMime := make(map[string]string, len(convertTargets))
+	sawCopyConvert := make(map[string]bool, len(convertTargets))
+	sawUploadConvert := make(map[string]bool, len(convertTargets))
+	for _, target := range convertTargets {
+		convertTargetByMime[target.mime] = target.name
+	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/drive/v3")
@@ -81,12 +100,34 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 			})
 			return
 		case r.Method == http.MethodPost && strings.HasSuffix(path, "/copy"):
+			var req map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				http.Error(w, "bad json", http.StatusBadRequest)
+				return
+			}
+			if mt, _ := req["mimeType"].(string); mt != "" {
+				if name, ok := convertTargetByMime[mt]; ok {
+					sawCopyConvert[name] = true
+				}
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":   "copy1",
 				"name": "Copy",
 			})
 			return
 		case r.Method == http.MethodPost && path == "/files":
+			if strings.HasPrefix(r.URL.Path, "/upload/drive/v3") {
+				meta, err := parseDriveUploadMetadata(r)
+				if err != nil {
+					http.Error(w, "bad upload metadata", http.StatusBadRequest)
+					return
+				}
+				if mt, _ := meta["mimeType"].(string); mt != "" {
+					if name, ok := convertTargetByMime[mt]; ok {
+						sawUploadConvert[name] = true
+					}
+				}
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":          "new1",
 				"name":        "New",
@@ -216,6 +257,12 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 	if !strings.Contains(out, "\"file\"") {
 		t.Fatalf("unexpected copy json: %q", out)
 	}
+	for _, target := range convertTargets {
+		out = run("--json", "--account", "a@b.com", "drive", "copy", "file1", "Copy as "+target.name, "--convert-to", target.name)
+		if !strings.Contains(out, "\"file\"") {
+			t.Fatalf("unexpected copy(convert=%s) json: %q", target.name, out)
+		}
+	}
 
 	tmp := filepath.Join(t.TempDir(), "upload.txt")
 	if err := os.WriteFile(tmp, []byte("data"), 0o600); err != nil {
@@ -224,6 +271,12 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 	out = run("--json", "--account", "a@b.com", "drive", "upload", tmp)
 	if !strings.Contains(out, "\"file\"") {
 		t.Fatalf("unexpected upload json: %q", out)
+	}
+	for _, target := range convertTargets {
+		out = run("--json", "--account", "a@b.com", "drive", "upload", tmp, "--convert-to", target.name)
+		if !strings.Contains(out, "\"file\"") {
+			t.Fatalf("unexpected upload(convert=%s) json: %q", target.name, out)
+		}
 	}
 
 	out = run("--account", "a@b.com", "drive", "mkdir", "Folder")
@@ -272,4 +325,50 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 	if !strings.Contains(out, "\"deleted\"") {
 		t.Fatalf("unexpected delete json: %q", out)
 	}
+	for _, target := range convertTargets {
+		if !sawCopyConvert[target.name] {
+			t.Fatalf("expected copy --convert-to %s to set mimeType=%q", target.name, target.mime)
+		}
+		if !sawUploadConvert[target.name] {
+			t.Fatalf("expected upload --convert-to %s to set mimeType=%q", target.name, target.mime)
+		}
+	}
+}
+
+func parseDriveUploadMetadata(r *http.Request) (map[string]any, error) {
+	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		return nil, errors.New("expected multipart upload content type")
+	}
+	boundary := strings.TrimSpace(params["boundary"])
+	if boundary == "" {
+		return nil, errors.New("missing multipart boundary")
+	}
+
+	reader := multipart.NewReader(r.Body, boundary)
+	for {
+		part, err := reader.NextPart()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		body, err := io.ReadAll(part)
+		_ = part.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err == nil {
+			return payload, nil
+		}
+	}
+
+	return nil, errors.New("upload metadata part not found")
 }

--- a/internal/cmd/drive_copy.go
+++ b/internal/cmd/drive_copy.go
@@ -19,7 +19,15 @@ type copyViaDriveOptions struct {
 	KindLabel    string
 }
 
-func copyViaDrive(ctx context.Context, flags *RootFlags, opts copyViaDriveOptions, id string, name string, parent string) error {
+func copyViaDrive(
+	ctx context.Context,
+	flags *RootFlags,
+	opts copyViaDriveOptions,
+	id string,
+	name string,
+	parent string,
+	targetMimeType string,
+) error {
 	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
 	if err != nil {
@@ -65,6 +73,10 @@ func copyViaDrive(ctx context.Context, flags *RootFlags, opts copyViaDriveOption
 
 	parent = strings.TrimSpace(parent)
 	req := &drive.File{Name: name}
+	targetMimeType = strings.TrimSpace(targetMimeType)
+	if targetMimeType != "" {
+		req.MimeType = targetMimeType
+	}
 	if parent != "" {
 		req.Parents = []string{parent}
 	}

--- a/internal/cmd/drive_helpers_test.go
+++ b/internal/cmd/drive_helpers_test.go
@@ -96,3 +96,39 @@ func TestGuessMimeTypeMore(t *testing.T) {
 		}
 	}
 }
+
+func TestDriveConvertToMimeType(t *testing.T) {
+	tests := map[string]string{
+		"":       "",
+		"sheet":  driveMimeGoogleSheet,
+		"SHEET":  driveMimeGoogleSheet,
+		"doc":    driveMimeGoogleDoc,
+		"DOC":    driveMimeGoogleDoc,
+		"slides": driveMimeGoogleSlides,
+		"SLIDES": driveMimeGoogleSlides,
+	}
+
+	for in, want := range tests {
+		got, err := driveConvertToMimeType(in)
+		if err != nil {
+			t.Fatalf("driveConvertToMimeType(%q): %v", in, err)
+		}
+		if got != want {
+			t.Fatalf("driveConvertToMimeType(%q)=%q want %q", in, got, want)
+		}
+	}
+
+	_, err := driveConvertToMimeType("nope")
+	if err == nil {
+		t.Fatalf("expected invalid convert-to error")
+	}
+	if ExitCode(err) != 2 {
+		t.Fatalf("expected exit code 2, got %d (err=%v)", ExitCode(err), err)
+	}
+	if !strings.Contains(err.Error(), "invalid --convert-to") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "sheet|doc|slides") {
+		t.Fatalf("unexpected error details: %v", err)
+	}
+}

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -62,7 +62,7 @@ func (c *SheetsCopyCmd) Run(ctx context.Context, flags *RootFlags) error {
 		ArgName:      "spreadsheetId",
 		ExpectedMime: "application/vnd.google-apps.spreadsheet",
 		KindLabel:    "Google Sheet",
-	}, c.SpreadsheetID, c.Title, c.Parent)
+	}, c.SpreadsheetID, c.Title, c.Parent, "")
 }
 
 type SheetsGetCmd struct {

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -113,5 +113,5 @@ func (c *SlidesCopyCmd) Run(ctx context.Context, flags *RootFlags) error {
 		ArgName:      "presentationId",
 		ExpectedMime: "application/vnd.google-apps.presentation",
 		KindLabel:    "Google Slides presentation",
-	}, c.PresentationID, c.Title, c.Parent)
+	}, c.PresentationID, c.Title, c.Parent, "")
 }


### PR DESCRIPTION
## Ticket
N/A

## Summary
Expand Drive conversion support to allow `--convert-to sheet|doc|slides` for both upload and copy flows, with stronger request-level test coverage and updated docs.

## Changes
- extend `gog drive copy` `--convert-to` to support `sheet`, `doc`, and `slides`
- extend `gog drive upload` `--convert-to` to support `sheet`, `doc`, and `slides`
- map each convert target to Google Workspace metadata MIME type:
  - `sheet` -> `application/vnd.google-apps.spreadsheet`
  - `doc` -> `application/vnd.google-apps.document`
  - `slides` -> `application/vnd.google-apps.presentation`
- improve validation messaging to show the full allowed set (`sheet|doc|slides`)
- expand command tests to cover all three targets for both copy and upload
- harden upload conversion tests by parsing multipart metadata JSON (instead of brittle substring matching)
- update docs:
  - README Drive examples
  - `docs/spec.md` command signatures

## Testing
- [x] `go test ./internal/cmd/...`
- [x] Manual live tests with generated sample files:
  - DOCX raw upload + conversion to Google Docs via copy and upload
  - PPTX raw upload + conversion to Google Slides via copy and upload
  - XLSX conversion to Google Sheets regression check
- [x] Invalid value handling:
  - `--convert-to nope` returns usage error with allowed values

## Checklist
- [x] Code follows project conventions
- [x] Documentation updated
- [x] No breaking changes
