### PR TITLE
contacts: support --birthday and --notes in contacts update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Contacts: support `contacts update --birthday` and `--notes`; unify shared date parsing and docs. (#233) — thanks @rosssivertsen.
 - Gmail: add `--exclude-labels` to `watch serve` (defaults: `SPAM,TRASH`). (#194) — thanks @salmonumbrella.
 - Drive: share files with an entire Workspace domain via `drive share --to domain`. (#192) — thanks @Danielkweber.
 

--- a/README.md
+++ b/README.md
@@ -839,14 +839,16 @@ gog contacts other search "John" --max 50
 
 # Create and update
 gog contacts create \
-  --given-name "John" \
-  --family-name "Doe" \
+  --given "John" \
+  --family "Doe" \
   --email "john@example.com" \
   --phone "+1234567890"
 
 gog contacts update people/<resourceName> \
-  --given-name "Jane" \
-  --email "jane@example.com"
+  --given "Jane" \
+  --email "jane@example.com" \
+  --birthday "1990-05-12" \
+  --notes "Met at WWDC"
 
 gog contacts delete people/<resourceName>
 
@@ -875,6 +877,7 @@ gog tasks delete <tasklistId> <taskId>
 gog tasks clear <tasklistId>
 
 # Note: Google Tasks treats due dates as date-only; time components may be ignored.
+# See docs/dates.md for all supported date/time input formats across commands.
 ```
 
 ### Sheets

--- a/docs/dates.md
+++ b/docs/dates.md
@@ -1,0 +1,38 @@
+# Date and Time Input Formats
+
+Use one parsing contract across commands.
+
+## Canonical choices
+
+- Prefer `RFC3339` in automation: `2026-02-13T15:04:05Z`
+- Use `YYYY-MM-DD` for date-only fields (birthdays, date-only due values)
+- Keep timezone explicit when time matters
+
+## Accepted input formats
+
+- Date-only: `YYYY-MM-DD`
+- Datetime: `RFC3339` / `RFC3339Nano`
+- ISO offset without colon: `YYYY-MM-DDTHH:MM:SS-0800`
+- Local datetime (no timezone):
+  - `YYYY-MM-DDTHH:MM[:SS]`
+  - `YYYY-MM-DD HH:MM[:SS]`
+
+## Relative forms
+
+Calendar range flags (`--from` / `--to`) also accept:
+
+- `now`, `today`, `tomorrow`, `yesterday`
+- Weekday names: `monday`, `next friday`
+
+## Duration forms
+
+Tracking `--since` also accepts `time.ParseDuration` values such as:
+
+- `24h`
+- `15m`
+
+## Agent guidance
+
+- Generate RFC3339 for all datetime fields by default.
+- Use date-only for fields explicitly documented as dates.
+- For local scheduling, pass an explicit offset (or timezone-aware RFC3339) to avoid ambiguity.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -295,7 +295,7 @@ Flag aliases:
 - `gog contacts list [--max N] [--page TOKEN]`
 - `gog contacts get <people/...|email>`
 - `gog contacts create --given NAME [--family NAME] [--email addr] [--phone num]`
-- `gog contacts update <people/...> [--given NAME] [--family NAME] [--email addr] [--phone num]`
+- `gog contacts update <people/...> [--given NAME] [--family NAME] [--email addr] [--phone num] [--birthday YYYY-MM-DD] [--notes TEXT]`
 - `gog contacts delete <people/...>`
 - `gog contacts directory list [--max N] [--page TOKEN]`
 - `gog contacts directory search <query> [--max N] [--page TOKEN]`
@@ -305,6 +305,14 @@ Flag aliases:
 - `gog people get <people/...|userId>`
 - `gog people search <query> [--max N] [--page TOKEN]`
 - `gog people relations [<people/...|userId>] [--type TYPE]`
+
+Date/time input conventions (shared parser):
+
+- Date-only: `YYYY-MM-DD`
+- Datetime: `RFC3339` / `RFC3339Nano` / `YYYY-MM-DDTHH:MM[:SS]` / `YYYY-MM-DD HH:MM[:SS]`
+- Numeric timezone offset accepted: `YYYY-MM-DDTHH:MM:SS-0800`
+- Calendar range flags also accept relatives: `now`, `today`, `tomorrow`, `yesterday`, weekday names (`monday`, `next friday`)
+- Tracking `--since` also accepts durations like `24h`
 
 ### Planned high-level command tree
 

--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/people/v1"
 
 	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/timeparse"
 	"github.com/steipete/gogcli/internal/ui"
 )
 
@@ -285,8 +285,8 @@ func (c *ContactsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		if strings.TrimSpace(c.Birthday) == "" {
 			existing.Birthdays = nil
 		} else {
-			d, err := parseYYYYMMDD(strings.TrimSpace(c.Birthday))
-			if err != nil {
+			d, parseErr := parseYYYYMMDD(strings.TrimSpace(c.Birthday))
+			if parseErr != nil {
 				return usage("invalid --birthday (expected YYYY-MM-DD)")
 			}
 			existing.Birthdays = []*people.Birthday{{
@@ -332,7 +332,7 @@ type ContactsDeleteCmd struct {
 }
 
 func parseYYYYMMDD(s string) (*people.Date, error) {
-	t, err := time.Parse("2006-01-02", s)
+	t, err := timeparse.ParseDate(s)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/contacts_update_more_test.go
+++ b/internal/cmd/contacts_update_more_test.go
@@ -1,0 +1,169 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestContactsUpdate_BirthdayAndNotes_Set(t *testing.T) {
+	var gotGetFields string
+	var gotUpdateFields string
+	var gotBirthday string
+	var gotNotes string
+
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "people/c1") && r.Method == http.MethodGet && !strings.Contains(r.URL.Path, ":"):
+			gotGetFields = r.URL.Query().Get("personFields")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceName": "people/c1",
+				"names":        []map[string]any{{"givenName": "Ada", "familyName": "Lovelace"}},
+			})
+			return
+		case strings.Contains(r.URL.Path, ":updateContact") && (r.Method == http.MethodPatch || r.Method == http.MethodPost):
+			gotUpdateFields = r.URL.Query().Get("updatePersonFields")
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			if birthdays, ok := body["birthdays"].([]any); ok && len(birthdays) > 0 {
+				if first, ok := birthdays[0].(map[string]any); ok {
+					if date, ok := first["date"].(map[string]any); ok {
+						gotBirthday = strings.TrimSpace(primaryValue(date, "year") + "-" + leftPad2(primaryValue(date, "month")) + "-" + leftPad2(primaryValue(date, "day")))
+					}
+				}
+			}
+			if bios, ok := body["biographies"].([]any); ok && len(bios) > 0 {
+				if first, ok := bios[0].(map[string]any); ok {
+					gotNotes = strings.TrimSpace(primaryValue(first, "value"))
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceName": "people/c1"})
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+	stubPeopleServices(t, svc)
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	if err := runKong(t, &ContactsUpdateCmd{}, []string{"people/c1", "--birthday", "2026-02-13", "--notes", "note text"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	if !strings.Contains(gotGetFields, "birthdays") || !strings.Contains(gotGetFields, "biographies") {
+		t.Fatalf("missing people.get fields: %q", gotGetFields)
+	}
+	if !strings.Contains(gotUpdateFields, "birthdays") || !strings.Contains(gotUpdateFields, "biographies") {
+		t.Fatalf("missing update fields: %q", gotUpdateFields)
+	}
+	if gotBirthday != "2026-02-13" {
+		t.Fatalf("unexpected birthday payload: %q", gotBirthday)
+	}
+	if gotNotes != "note text" {
+		t.Fatalf("unexpected notes payload: %q", gotNotes)
+	}
+}
+
+func TestContactsUpdate_BirthdayAndNotes_Clear(t *testing.T) {
+	var gotUpdateFields string
+
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "people/c1") && r.Method == http.MethodGet && !strings.Contains(r.URL.Path, ":"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resourceName": "people/c1",
+				"birthdays":    []map[string]any{{"date": map[string]any{"year": 2026, "month": 2, "day": 13}}},
+				"biographies":  []map[string]any{{"value": "existing"}},
+			})
+			return
+		case strings.Contains(r.URL.Path, ":updateContact") && (r.Method == http.MethodPatch || r.Method == http.MethodPost):
+			gotUpdateFields = r.URL.Query().Get("updatePersonFields")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceName": "people/c1"})
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+	stubPeopleServices(t, svc)
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	if err := runKong(t, &ContactsUpdateCmd{}, []string{"people/c1", "--birthday", "", "--notes", ""}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	if !strings.Contains(gotUpdateFields, "birthdays") || !strings.Contains(gotUpdateFields, "biographies") {
+		t.Fatalf("missing clear update fields: %q", gotUpdateFields)
+	}
+}
+
+func TestContactsUpdate_InvalidBirthday(t *testing.T) {
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "people/c1") && r.Method == http.MethodGet && !strings.Contains(r.URL.Path, ":"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"resourceName": "people/c1"})
+			return
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(closeSrv)
+	stubPeopleServices(t, svc)
+
+	err := runKong(t, &ContactsUpdateCmd{}, []string{"people/c1", "--birthday", "2026/02/13"}, context.Background(), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "invalid --birthday") {
+		t.Fatalf("expected invalid --birthday error, got %v", err)
+	}
+}
+
+func primaryValue(m map[string]any, key string) string {
+	v, ok := m[key]
+	if !ok {
+		return ""
+	}
+	switch vv := v.(type) {
+	case string:
+		return vv
+	case float64:
+		return strconv.Itoa(int(vv))
+	case int:
+		return strconv.Itoa(vv)
+	default:
+		return ""
+	}
+}
+
+func leftPad2(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) >= 2 {
+		return s
+	}
+	if s == "" {
+		return "00"
+	}
+	return "0" + s
+}

--- a/internal/cmd/gmail_track_cmd_test.go
+++ b/internal/cmd/gmail_track_cmd_test.go
@@ -285,3 +285,19 @@ func TestGmailTrackOpens_NotConfigured(t *testing.T) {
 		t.Fatalf("expected error for unconfigured tracking")
 	}
 }
+
+func TestParseTrackingSince_FlexibleFormats(t *testing.T) {
+	t.Parallel()
+
+	if parsed, err := parseTrackingSince("2026-02-13T10:20"); err != nil || parsed == "" {
+		t.Fatalf("unexpected local datetime parse: %q err=%v", parsed, err)
+	}
+
+	parsedNano, err := parseTrackingSince("2026-02-13T10:20:30.123456789Z")
+	if err != nil {
+		t.Fatalf("unexpected RFC3339Nano parse error: %v", err)
+	}
+	if !strings.Contains(parsedNano, ".123456789Z") {
+		t.Fatalf("expected nano precision output, got %q", parsedNano)
+	}
+}

--- a/internal/cmd/gmail_track_opens.go
+++ b/internal/cmd/gmail_track_opens.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/timeparse"
 	"github.com/steipete/gogcli/internal/tracking"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -196,20 +197,12 @@ func parseTrackingSince(s string) (string, error) {
 		return "", usage("empty --since")
 	}
 
-	if d, err := time.ParseDuration(s); err == nil {
-		return time.Now().Add(-d).UTC().Format(time.RFC3339), nil
+	parsed, err := timeparse.ParseSince(s, time.Now(), time.Local)
+	if err != nil {
+		return "", usagef("invalid --since %q (use duration like 24h, date YYYY-MM-DD, or RFC3339)", s)
 	}
-
-	if t, err := time.Parse("2006-01-02", s); err == nil {
-		return t.UTC().Format(time.RFC3339), nil
+	if parsed.UseRFC3339Nano {
+		return parsed.Time.Format(time.RFC3339Nano), nil
 	}
-
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.UTC().Format(time.RFC3339), nil
-	}
-	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.UTC().Format(time.RFC3339Nano), nil
-	}
-
-	return "", usagef("invalid --since %q (use duration like 24h, date YYYY-MM-DD, or RFC3339)", s)
+	return parsed.Time.Format(time.RFC3339), nil
 }

--- a/internal/cmd/tasks_repeat_test.go
+++ b/internal/cmd/tasks_repeat_test.go
@@ -167,3 +167,40 @@ func TestTasksAddCmd_RepeatUntilDateOnlyWithTimeDue(t *testing.T) {
 		t.Fatalf("unexpected due schedule: %#v", gotDue)
 	}
 }
+
+func TestParseTaskDate_FlexibleFormats(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		value       string
+		wantErr     bool
+		wantHasTime bool
+	}{
+		{name: "date", value: "2026-02-13", wantHasTime: false},
+		{name: "rfc3339", value: "2026-02-13T10:20:30Z", wantHasTime: true},
+		{name: "local minutes T", value: "2026-02-13T10:20", wantHasTime: true},
+		{name: "local seconds space", value: "2026-02-13 10:20:30", wantHasTime: true},
+		{name: "iso offset", value: "2026-02-13T10:20:30-0800", wantHasTime: true},
+		{name: "invalid", value: "nope", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, gotHasTime, err := parseTaskDate(tc.value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseTaskDate: %v", err)
+			}
+			if gotHasTime != tc.wantHasTime {
+				t.Fatalf("hasTime=%v want %v", gotHasTime, tc.wantHasTime)
+			}
+		})
+	}
+}

--- a/internal/cmd/time_helpers_test.go
+++ b/internal/cmd/time_helpers_test.go
@@ -170,3 +170,21 @@ func TestParseWeekStartVariants(t *testing.T) {
 		t.Fatalf("expected invalid week start")
 	}
 }
+
+func TestParseTimeExpr_LocalMinutesWithT(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2025, 1, 10, 12, 0, 0, 0, time.UTC)
+	loc := time.FixedZone("Offset", -5*3600)
+
+	parsed, err := parseTimeExpr("2025-01-05T10:30", now, loc)
+	if err != nil {
+		t.Fatalf("parseTimeExpr local minutes: %v", err)
+	}
+	if parsed.Location() != loc {
+		t.Fatalf("expected loc, got %v", parsed.Location())
+	}
+	if parsed.Hour() != 10 || parsed.Minute() != 30 {
+		t.Fatalf("unexpected time: %v", parsed)
+	}
+}

--- a/internal/timeparse/parse.go
+++ b/internal/timeparse/parse.go
@@ -1,0 +1,207 @@
+package timeparse
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	ErrEmptyDate          = errors.New("empty date")
+	ErrInvalidDate        = errors.New("invalid date")
+	ErrEmptyDateTime      = errors.New("empty date/time")
+	ErrInvalidDateTime    = errors.New("invalid date/time")
+	ErrEmptyTimeExpr      = errors.New("empty time expression")
+	ErrInvalidTimeExpr    = errors.New("invalid time expression")
+	ErrEmptySince         = errors.New("empty since value")
+	ErrInvalidSince       = errors.New("invalid since value")
+	ErrInvalidDateLayouts = errors.New("invalid date format")
+)
+
+// ParsedDateTime represents a parsed time expression and whether the input
+// carried an explicit clock component.
+type ParsedDateTime struct {
+	Time    time.Time
+	HasTime bool
+}
+
+// SinceResult keeps normalized "since" values, preserving RFC3339Nano output
+// when the input used fractional seconds.
+type SinceResult struct {
+	Time           time.Time
+	UseRFC3339Nano bool
+}
+
+// ParseDate parses a strict date in YYYY-MM-DD format.
+func ParseDate(value string) (time.Time, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, ErrEmptyDate
+	}
+
+	t, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("%w: %q", ErrInvalidDate, value)
+	}
+
+	return t, nil
+}
+
+// ParseDateTimeOrDate parses flexible date inputs commonly used across commands.
+// Supported: RFC3339/RFC3339Nano, ISO-8601 numeric offset (-0800),
+// YYYY-MM-DD, and local datetime layouts without timezone.
+func ParseDateTimeOrDate(value string, loc *time.Location) (ParsedDateTime, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ParsedDateTime{}, ErrEmptyDateTime
+	}
+
+	if loc == nil {
+		loc = time.Local
+	}
+
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return ParsedDateTime{Time: t, HasTime: true}, nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return ParsedDateTime{Time: t, HasTime: true}, nil
+	}
+
+	if t, err := time.Parse("2006-01-02T15:04:05-0700", value); err == nil {
+		return ParsedDateTime{Time: t, HasTime: true}, nil
+	}
+
+	if t, err := time.ParseInLocation("2006-01-02", value, loc); err == nil {
+		return ParsedDateTime{Time: t, HasTime: false}, nil
+	}
+
+	for _, layout := range []string{
+		"2006-01-02T15:04:05",
+		"2006-01-02T15:04",
+		"2006-01-02 15:04:05",
+		"2006-01-02 15:04",
+	} {
+		if t, err := time.ParseInLocation(layout, value, loc); err == nil {
+			return ParsedDateTime{Time: t, HasTime: true}, nil
+		}
+	}
+
+	return ParsedDateTime{}, fmt.Errorf("%w: %q", ErrInvalidDateTime, value)
+}
+
+// ParseRangeExpr parses calendar range expressions.
+// Supported: absolute datetime/date forms from ParseDateTimeOrDate plus
+// relative forms (now/today/tomorrow/yesterday/monday/next monday).
+func ParseRangeExpr(expr string, now time.Time, loc *time.Location) (time.Time, error) {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return time.Time{}, ErrEmptyTimeExpr
+	}
+
+	exprLower := strings.ToLower(expr)
+	switch exprLower {
+	case "now":
+		return now, nil
+	case "today":
+		return startOfDay(now), nil
+	case "tomorrow":
+		return startOfDay(now.AddDate(0, 0, 1)), nil
+	case "yesterday":
+		return startOfDay(now.AddDate(0, 0, -1)), nil
+	}
+
+	if t, ok := parseWeekday(exprLower, now); ok {
+		return t, nil
+	}
+
+	parsed, err := ParseDateTimeOrDate(expr, loc)
+	if err == nil {
+		return parsed.Time, nil
+	}
+
+	return time.Time{}, fmt.Errorf("%w: %q (try: 2026-01-05, today, tomorrow, monday)", ErrInvalidTimeExpr, expr)
+}
+
+// ParseSince parses --since values for tracking style queries.
+// Supported: duration (24h), date (YYYY-MM-DD), RFC3339(+nano), and
+// local datetime layouts.
+func ParseSince(value string, now time.Time, loc *time.Location) (SinceResult, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return SinceResult{}, ErrEmptySince
+	}
+
+	if d, err := time.ParseDuration(value); err == nil {
+		return SinceResult{Time: now.Add(-d).UTC()}, nil
+	}
+
+	if t, err := ParseDate(value); err == nil {
+		return SinceResult{Time: t.UTC()}, nil
+	}
+
+	if t, err := time.Parse(time.RFC3339Nano, value); err == nil {
+		return SinceResult{Time: t.UTC(), UseRFC3339Nano: strings.Contains(value, ".")}, nil
+	}
+
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return SinceResult{Time: t.UTC()}, nil
+	}
+
+	parsed, err := ParseDateTimeOrDate(value, loc)
+	if err == nil {
+		return SinceResult{Time: parsed.Time.UTC()}, nil
+	}
+
+	return SinceResult{}, fmt.Errorf("%w: %q", ErrInvalidSince, value)
+}
+
+func parseWeekday(expr string, now time.Time) (time.Time, bool) {
+	expr = strings.TrimSpace(expr)
+
+	next := false
+	if strings.HasPrefix(expr, "next ") {
+		next = true
+		expr = strings.TrimPrefix(expr, "next ")
+	}
+
+	weekdays := map[string]time.Weekday{
+		"sunday":    time.Sunday,
+		"sun":       time.Sunday,
+		"monday":    time.Monday,
+		"mon":       time.Monday,
+		"tuesday":   time.Tuesday,
+		"tue":       time.Tuesday,
+		"wednesday": time.Wednesday,
+		"wed":       time.Wednesday,
+		"thursday":  time.Thursday,
+		"thu":       time.Thursday,
+		"friday":    time.Friday,
+		"fri":       time.Friday,
+		"saturday":  time.Saturday,
+		"sat":       time.Saturday,
+	}
+
+	targetDay, ok := weekdays[expr]
+	if !ok {
+		return time.Time{}, false
+	}
+
+	currentDay := now.Weekday()
+
+	daysUntil := int(targetDay) - int(currentDay)
+	if daysUntil < 0 || (daysUntil == 0 && next) {
+		daysUntil += 7
+	}
+
+	if daysUntil == 0 {
+		return startOfDay(now), true
+	}
+
+	return startOfDay(now.AddDate(0, 0, daysUntil)), true
+}
+
+func startOfDay(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
+}

--- a/internal/timeparse/parse_test.go
+++ b/internal/timeparse/parse_test.go
@@ -1,0 +1,181 @@
+package timeparse
+
+import (
+	"testing"
+	"time"
+)
+
+//nolint:wsl_v5
+func TestParseDate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		value   string
+		wantErr bool
+	}{
+		{name: "valid", value: "2026-02-13"},
+		{name: "trimmed", value: " 2026-02-13 "},
+		{name: "invalid separator", value: "2026/02/13", wantErr: true},
+		{name: "empty", value: "", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseDate(tc.value)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDate: %v", err)
+			}
+			if got.Format("2006-01-02") != "2026-02-13" {
+				t.Fatalf("unexpected date: %s", got.Format("2006-01-02"))
+			}
+		})
+	}
+}
+
+//nolint:wsl_v5
+func TestParseDateTimeOrDate(t *testing.T) {
+	t.Parallel()
+
+	loc := time.FixedZone("Offset", -8*3600)
+	testCases := []struct {
+		name        string
+		value       string
+		wantErr     bool
+		wantHasTime bool
+		wantHour    int
+		wantMin     int
+		wantOffset  int
+	}{
+		{name: "rfc3339", value: "2026-02-13T10:20:30Z", wantHasTime: true, wantHour: 10, wantMin: 20, wantOffset: 0},
+		{name: "rfc3339 nano", value: "2026-02-13T10:20:30.123456789Z", wantHasTime: true, wantHour: 10, wantMin: 20, wantOffset: 0},
+		{name: "iso tz no colon", value: "2026-02-13T10:20:30-0800", wantHasTime: true, wantHour: 10, wantMin: 20, wantOffset: -8 * 3600},
+		{name: "date only", value: "2026-02-13", wantHasTime: false, wantHour: 0, wantMin: 0, wantOffset: -8 * 3600},
+		{name: "local datetime seconds", value: "2026-02-13T10:20:30", wantHasTime: true, wantHour: 10, wantMin: 20, wantOffset: -8 * 3600},
+		{name: "local datetime minutes", value: "2026-02-13 10:20", wantHasTime: true, wantHour: 10, wantMin: 20, wantOffset: -8 * 3600},
+		{name: "invalid", value: "nope", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseDateTimeOrDate(tc.value, loc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDateTimeOrDate: %v", err)
+			}
+			if got.HasTime != tc.wantHasTime {
+				t.Fatalf("HasTime=%v want %v", got.HasTime, tc.wantHasTime)
+			}
+			if got.Time.Hour() != tc.wantHour || got.Time.Minute() != tc.wantMin {
+				t.Fatalf("unexpected time: %v", got.Time)
+			}
+			_, offset := got.Time.Zone()
+			if offset != tc.wantOffset {
+				t.Fatalf("offset=%d want %d", offset, tc.wantOffset)
+			}
+		})
+	}
+}
+
+//nolint:wsl_v5
+func TestParseRangeExpr(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 13, 15, 45, 0, 0, time.UTC)
+	loc := time.FixedZone("Offset", -5*3600)
+	testCases := []struct {
+		name      string
+		value     string
+		wantErr   bool
+		wantDay   int
+		wantMonth time.Month
+		wantHour  int
+		wantWeek  time.Weekday
+	}{
+		{name: "now", value: "now", wantDay: 13, wantMonth: time.February, wantHour: 15, wantWeek: time.Friday},
+		{name: "today", value: "today", wantDay: 13, wantMonth: time.February, wantHour: 0, wantWeek: time.Friday},
+		{name: "tomorrow", value: "tomorrow", wantDay: 14, wantMonth: time.February, wantHour: 0, wantWeek: time.Saturday},
+		{name: "weekday", value: "monday", wantDay: 16, wantMonth: time.February, wantHour: 0, wantWeek: time.Monday},
+		{name: "next weekday", value: "next friday", wantDay: 20, wantMonth: time.February, wantHour: 0, wantWeek: time.Friday},
+		{name: "date", value: "2026-02-01", wantDay: 1, wantMonth: time.February, wantHour: 0, wantWeek: time.Sunday},
+		{name: "datetime", value: "2026-02-01T10:30:00", wantDay: 1, wantMonth: time.February, wantHour: 10, wantWeek: time.Sunday},
+		{name: "invalid", value: "yolo", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseRangeExpr(tc.value, now, loc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseRangeExpr: %v", err)
+			}
+			if got.Day() != tc.wantDay || got.Month() != tc.wantMonth || got.Hour() != tc.wantHour || got.Weekday() != tc.wantWeek {
+				t.Fatalf("unexpected parsed range: %v", got)
+			}
+		})
+	}
+}
+
+//nolint:wsl_v5
+func TestParseSince(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 13, 15, 45, 0, 0, time.UTC)
+	loc := time.FixedZone("Offset", -8*3600)
+	testCases := []struct {
+		name     string
+		value    string
+		wantErr  bool
+		want     time.Time
+		wantNano bool
+	}{
+		{name: "duration", value: "24h", want: now.Add(-24 * time.Hour).UTC()},
+		{name: "date", value: "2026-02-01", want: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
+		{name: "rfc3339", value: "2026-02-01T10:20:30Z", want: time.Date(2026, 2, 1, 10, 20, 30, 0, time.UTC)},
+		{name: "rfc3339nano", value: "2026-02-01T10:20:30.123456789Z", want: time.Date(2026, 2, 1, 10, 20, 30, 123456789, time.UTC), wantNano: true},
+		{name: "local datetime", value: "2026-02-01 10:20", want: time.Date(2026, 2, 1, 18, 20, 0, 0, time.UTC)},
+		{name: "invalid", value: "nope", wantErr: true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseSince(tc.value, now, loc)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseSince: %v", err)
+			}
+			if !got.Time.Equal(tc.want) {
+				t.Fatalf("time=%v want %v", got.Time, tc.want)
+			}
+			if got.UseRFC3339Nano != tc.wantNano {
+				t.Fatalf("UseRFC3339Nano=%v want %v", got.UseRFC3339Nano, tc.wantNano)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR extends `gog contacts update` to support updating two additional People API fields that users commonly need but that weren't previously exposed:

- `--birthday YYYY-MM-DD` (writes People API `birthdays`, primary)
- `--notes <text>` (writes People API `biographies`, primary; `TEXT_PLAIN`)

Both flags support clearing by passing an empty string.

Implementation details:
- Fetches existing contact with `birthdays,biographies` included in the PersonFields mask when running update.
- Adds the appropriate `UpdatePersonFields` entries (`birthdays`, `biographies`).
- Parses birthday via Go time parsing (`YYYY-MM-DD`).

Motivation: we hit this gap while automating contact hygiene, and the underlying People API supports these fields; it's mainly a CLI UX/coverage gap.

Testing:
- `go test ./...` passes in a clean env.
