### PR TITLE
docs: fix headless auth flow - replace --remote --step with --manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,17 +109,16 @@ This will open a browser window for OAuth authorization. The refresh token is st
 Headless / remote server flow (no browser on the server):
 
 ```bash
-# Step 1: print auth URL (open it locally in a browser)
-gog auth add you@gmail.com --services user --remote --step 1
-
-# Step 2: paste the full redirect URL from your browser address bar
-gog auth add you@gmail.com --services user --remote --step 2 --auth-url 'http://localhost:1/?code=...&state=...'
+# Browserless auth flow - prints URL, then paste the redirect URL when prompted
+gog auth add you@gmail.com --services user --manual
 ```
 
 Notes:
 
-- The `state` is cached on disk for a short time (about 10 minutes). If it expires, rerun step 1.
-- Remote step 2 requires a redirect URL that includes `state` (state check mandatory).
+- The CLI will print an authorization URL. Open it in your local browser.
+- After approving, Google will redirect to localhost with a code. Copy that full URL.
+- Paste the redirect URL back into the terminal when prompted.
+- If the state expires (about 10 minutes), just rerun the command.
 
 ### 4. Test Authentication
 


### PR DESCRIPTION
## Issue
The README documents `--remote --step 1` and `--remote --step 2` flags for headless/remote server authentication, but these flags don't exist in the current v0.9.0 release. Users following the docs get:

unknown flag --remote

## Fix
Replace the two-step `--remote` flow with the actual working `--manual` flag:

```bash
# Before (broken):
gog auth add you@gmail.com --services user --remote --step 1
gog auth add you@gmail.com --services user --remote --step 2 --auth-url '...'

# After (working):
gog auth add you@gmail.com --services user --manual

## Verification

Tested with gogcli v0.9.0 (99d9575):

$ gog auth add --help
...
Flags:
  ...
  --manual                Browserless auth flow (paste redirect URL)

The --manual flag correctly handles the headless flow in a single command.

## Related

• --remote flags appear to be planned/unreleased features documented prematurely
• This fix aligns the README with the actual v0.9.0 CLI behavior