### PR TITLE
fix(gmail): respect --name flag when --out is a directory and reject directories as cache hits

### DIFF
--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -75,6 +75,18 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
+	// When --out is a directory, combine it with --name (or a default filename)
+	if fi, statErr := os.Stat(outPath); statErr == nil && fi.IsDir() {
+		filename := strings.TrimSpace(c.Name)
+		if filename == "" {
+			shortID := attachmentID
+			if len(shortID) > 8 {
+				shortID = shortID[:8]
+			}
+			filename = fmt.Sprintf("%s_%s_attachment.bin", messageID, shortID)
+		}
+		outPath = filepath.Join(outPath, filepath.Base(filename))
+	}
 	path, cached, bytes, err := downloadAttachmentToPath(ctx, svc, messageID, attachmentID, outPath, -1)
 	if err != nil {
 		return err
@@ -100,12 +112,11 @@ func downloadAttachmentToPath(
 		return "", false, 0, errors.New("missing outPath")
 	}
 
-	if expectedSize > 0 {
-		if st, err := os.Stat(outPath); err == nil && st.Size() == expectedSize {
+	if st, err := os.Stat(outPath); err == nil && !st.IsDir() {
+		if expectedSize > 0 && st.Size() == expectedSize {
 			return outPath, true, st.Size(), nil
 		}
-	} else if expectedSize == -1 {
-		if st, err := os.Stat(outPath); err == nil && st.Size() > 0 {
+		if expectedSize == -1 && st.Size() > 0 {
 			return outPath, true, st.Size(), nil
 		}
 	}


### PR DESCRIPTION
Two related fixes for `gog gmail attachment`:

### 1. `--name` silently ignored when `--out` is a directory (fixes #222)

```bash
gog gmail attachment <msgId> <attId> --out /tmp/ --name invoice.pdf
# Before: writes to /tmp/ (tries to use directory as file path)
# After:  writes to /tmp/invoice.pdf
```

When `--out` is an existing directory, the fix combines it with `--name` (or generates a default filename like `{msgId}_{shortAttId}_attachment.bin`).

### 2. Cache false hits on directories (fixes #223)

`downloadAttachmentToPath` treated directories as valid cached files because `os.Stat(dir).Size() > 0` is always true for directories (64-512 bytes depending on filesystem). The cache check now explicitly skips directories with `!st.IsDir()`.