### PR TITLE
feat(drive): add --convert flag to upload

### DIFF
--- a/internal/cmd/drive_commands_more_test.go
+++ b/internal/cmd/drive_commands_more_test.go
@@ -226,6 +226,16 @@ func TestDriveCommands_MoreCoverage(t *testing.T) {
 		t.Fatalf("unexpected upload json: %q", out)
 	}
 
+	// Upload with --convert
+	docxTmp := filepath.Join(t.TempDir(), "report.docx")
+	if err := os.WriteFile(docxTmp, []byte("docx-data"), 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+	out = run("--json", "--account", "a@b.com", "drive", "upload", docxTmp, "--convert")
+	if !strings.Contains(out, "\"file\"") {
+		t.Fatalf("unexpected upload --convert json: %q", out)
+	}
+
 	out = run("--account", "a@b.com", "drive", "mkdir", "Folder")
 	if !strings.Contains(out, "id") {
 		t.Fatalf("unexpected mkdir output: %q", out)

--- a/internal/cmd/drive_validation_more_test.go
+++ b/internal/cmd/drive_validation_more_test.go
@@ -191,6 +191,84 @@ func TestDownloadDriveFile_ErrorPaths(t *testing.T) {
 	}
 }
 
+func TestGoogleConvertMimeType(t *testing.T) {
+	cases := []struct {
+		path     string
+		wantMime string
+		wantOK   bool
+	}{
+		{"report.docx", driveMimeGoogleDoc, true},
+		{"report.DOCX", driveMimeGoogleDoc, true},
+		{"old.doc", driveMimeGoogleDoc, true},
+		{"budget.xlsx", driveMimeGoogleSheet, true},
+		{"budget.xls", driveMimeGoogleSheet, true},
+		{"data.csv", driveMimeGoogleSheet, true},
+		{"deck.pptx", driveMimeGoogleSlides, true},
+		{"deck.ppt", driveMimeGoogleSlides, true},
+		{"notes.txt", driveMimeGoogleDoc, true},
+		{"page.html", driveMimeGoogleDoc, true},
+		{"photo.png", "", false},
+		{"archive.zip", "", false},
+		{"binary.exe", "", false},
+	}
+	for _, tc := range cases {
+		mime, ok := googleConvertMimeType(tc.path)
+		if ok != tc.wantOK || mime != tc.wantMime {
+			t.Errorf("googleConvertMimeType(%q) = (%q, %v), want (%q, %v)", tc.path, mime, ok, tc.wantMime, tc.wantOK)
+		}
+	}
+}
+
+func TestStripOfficeExt(t *testing.T) {
+	cases := []struct {
+		name string
+		want string
+	}{
+		{"report.docx", "report"},
+		{"report.doc", "report"},
+		{"budget.xlsx", "budget"},
+		{"budget.xls", "budget"},
+		{"deck.pptx", "deck"},
+		{"deck.ppt", "deck"},
+		{"notes.txt", "notes.txt"},
+		{"photo.png", "photo.png"},
+		{"no-ext", "no-ext"},
+	}
+	for _, tc := range cases {
+		got := stripOfficeExt(tc.name)
+		if got != tc.want {
+			t.Errorf("stripOfficeExt(%q) = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestDriveUpload_ConvertUnsupported(t *testing.T) {
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	tmp := filepath.Join(t.TempDir(), "photo.png")
+	if err := os.WriteFile(tmp, []byte("png-data"), 0o600); err != nil {
+		t.Fatalf("write temp: %v", err)
+	}
+
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+	newDriveService = func(context.Context, string) (*drive.Service, error) {
+		return &drive.Service{}, nil
+	}
+
+	cmd := &DriveUploadCmd{LocalPath: tmp, Convert: true}
+	if err := cmd.Run(ctx, flags); err == nil {
+		t.Fatalf("expected error for unsupported --convert type")
+	} else if !strings.Contains(err.Error(), "--convert: unsupported") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestDriveWebLink_Error(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "boom", http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

- Adds a `--convert` flag to `gog drive upload` that converts Office files to native Google formats on upload
- Supported conversions: `.docx`/`.doc` → Google Doc, `.xlsx`/`.xls`/`.csv` → Google Sheet, `.pptx`/`.ppt` → Google Slides, `.txt`/`.html` → Google Doc
- Automatically strips Office extensions from the filename (e.g., `report.docx` → `report`)
- Returns a clear error when `--convert` is used with an unsupported file type

## Usage

```bash
gog drive upload report.docx --convert
gog drive upload budget.xlsx --convert --parent=<folderId>
```

## Test plan

- [x] Unit tests for `googleConvertMimeType()` — 13 cases covering all supported and unsupported extensions
- [x] Unit tests for `stripOfficeExt()` — 9 cases for extension stripping
- [x] Integration test for upload with `--convert` flag
- [x] Error path test for unsupported file type with `--convert`
- [x] Full test suite passes
- [x] Manual test: uploaded a `.docx` and confirmed it appears as a native Google Doc in Drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)