### PR TITLE
fix: handle invalid_grant errors and add 401 retry logic

### DIFF
--- a/internal/googleapi/errors.go
+++ b/internal/googleapi/errors.go
@@ -122,3 +122,23 @@ func IsPermissionDeniedError(err error) bool {
 	var e *PermissionDeniedError
 	return errors.As(err, &e)
 }
+
+// InvalidGrantError indicates the OAuth refresh token has been expired or
+// revoked. The user must re-authorize to obtain a new refresh token.
+type InvalidGrantError struct {
+	Cause error
+}
+
+func (e *InvalidGrantError) Error() string {
+	return fmt.Sprintf("oauth2 refresh token expired or revoked (re-authorize with: gog auth add --force-consent): %v", e.Cause)
+}
+
+func (e *InvalidGrantError) Unwrap() error {
+	return e.Cause
+}
+
+// IsInvalidGrantError checks if the error is an invalid grant error
+func IsInvalidGrantError(err error) bool {
+	var e *InvalidGrantError
+	return errors.As(err, &e)
+}

--- a/internal/googleapi/errors_test.go
+++ b/internal/googleapi/errors_test.go
@@ -33,6 +33,10 @@ func TestErrors_IsHelpers(t *testing.T) {
 	if !IsPermissionDeniedError(&PermissionDeniedError{Resource: "file", Action: "read"}) {
 		t.Fatalf("expected IsPermissionDeniedError")
 	}
+
+	if !IsInvalidGrantError(&InvalidGrantError{Cause: errBase}) {
+		t.Fatalf("expected IsInvalidGrantError")
+	}
 }
 
 func TestErrors_Messages(t *testing.T) {
@@ -79,5 +83,14 @@ func TestErrors_Messages(t *testing.T) {
 
 	if got := (&QuotaExceededError{}).Error(); got != "API quota exceeded" {
 		t.Fatalf("unexpected: %q", got)
+	}
+
+	igErr := &InvalidGrantError{Cause: errBase}
+	if got := igErr.Error(); !strings.Contains(got, "expired or revoked") || !strings.Contains(got, "--force-consent") {
+		t.Fatalf("unexpected: %q", got)
+	}
+
+	if !errors.Is(igErr, errBase) {
+		t.Fatalf("expected unwrap to match base")
 	}
 }

--- a/internal/googleapi/retry_constants.go
+++ b/internal/googleapi/retry_constants.go
@@ -11,4 +11,11 @@ const (
 	Max5xxRetries = 1
 	// ServerErrorRetryDelay is the delay before retrying on 5xx errors.
 	ServerErrorRetryDelay = 1 * time.Second
+	// MaxUnauthorizedRetries is the maximum retries for 401 responses.
+	// A single retry allows the oauth2.Transport to re-fetch an access
+	// token using the refresh token when the current one has been revoked
+	// or expired server-side before its local expiry.
+	MaxUnauthorizedRetries = 1
+	// UnauthorizedRetryDelay is the delay before retrying on 401 errors.
+	UnauthorizedRetryDelay = 500 * time.Millisecond
 )

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -8,6 +8,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -50,6 +51,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var err error
 	retries429 := 0
 	retries5xx := 0
+	retries401 := 0
 
 	for {
 		// Reset body for retry
@@ -67,6 +69,10 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		resp, err = t.Base.RoundTrip(req)
 		if err != nil {
+			if isInvalidGrant(err) {
+				return nil, &InvalidGrantError{Cause: err}
+			}
+
 			return nil, fmt.Errorf("round trip: %w", err)
 		}
 
@@ -127,7 +133,29 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			continue
 		}
 
-		// Other errors (4xx except 429): don't retry
+		// Unauthorized (401): access token may have been revoked before
+		// expiry. Retry once so the oauth2.Transport can re-fetch a new
+		// access token using the refresh token.
+		if resp.StatusCode == http.StatusUnauthorized {
+			if retries401 >= MaxUnauthorizedRetries {
+				return resp, nil
+			}
+
+			slog.Debug("unauthorized, retrying to refresh access token",
+				"attempt", retries401+1)
+
+			drainAndClose(resp.Body)
+
+			if err := t.sleep(req.Context(), UnauthorizedRetryDelay); err != nil {
+				return nil, err
+			}
+
+			retries401++
+
+			continue
+		}
+
+		// Other errors (4xx except 429, 401): don't retry
 		return resp, nil
 	}
 }
@@ -236,4 +264,14 @@ func drainAndClose(body io.ReadCloser) {
 	}
 	_, _ = io.Copy(io.Discard, io.LimitReader(body, 1<<20))
 	_ = body.Close()
+}
+
+// isInvalidGrant checks whether the error indicates an OAuth invalid_grant
+// response, which means the refresh token has expired or been revoked.
+func isInvalidGrant(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	return strings.Contains(err.Error(), "invalid_grant")
 }

--- a/internal/googleapi/transport_test.go
+++ b/internal/googleapi/transport_test.go
@@ -3,6 +3,7 @@ package googleapi
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -344,6 +345,125 @@ func TestRetryTransport_RetryAfterHeader(t *testing.T) {
 	// Should have waited ~1 second based on Retry-After header
 	if elapsed < 900*time.Millisecond || elapsed > 2*time.Second {
 		t.Errorf("expected ~1s delay from Retry-After, got %v", elapsed)
+	}
+}
+
+func TestRetryTransport_InvalidGrant(t *testing.T) {
+	mock := &mockTransport{
+		errors: []error{
+			fmt.Errorf("oauth2: cannot fetch token: 400 Bad Request\nResponse: {\"error\":\"invalid_grant\",\"error_description\":\"Token has been expired or revoked.\"}"),
+		},
+	}
+
+	rt := NewRetryTransport(mock)
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com", nil)
+
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !IsInvalidGrantError(err) {
+		t.Errorf("expected InvalidGrantError, got %T: %v", err, err)
+	}
+
+	// Verify the error message includes re-auth guidance
+	if !strings.Contains(err.Error(), "--force-consent") {
+		t.Errorf("expected --force-consent hint in error: %v", err)
+	}
+}
+
+func TestRetryTransport_NonInvalidGrantError(t *testing.T) {
+	mock := &mockTransport{
+		errors: []error{
+			errors.New("network connection refused"),
+		},
+	}
+
+	rt := NewRetryTransport(mock)
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com", nil)
+
+	resp, err := rt.RoundTrip(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if IsInvalidGrantError(err) {
+		t.Errorf("should NOT be InvalidGrantError for a network error")
+	}
+}
+
+func TestRetryTransport_401_Retry(t *testing.T) {
+	mock := &mockTransport{
+		responses: []*http.Response{
+			{StatusCode: 401, Body: io.NopCloser(strings.NewReader("unauthorized"))},
+			{StatusCode: 200, Body: io.NopCloser(strings.NewReader("ok"))},
+		},
+	}
+
+	rt := NewRetryTransport(mock)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com", nil)
+	var resp *http.Response
+
+	if r, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else {
+		resp = r
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+
+	if mock.calls != 2 {
+		t.Errorf("expected 2 calls (1 retry), got %d", mock.calls)
+	}
+}
+
+func TestRetryTransport_401_MaxRetries(t *testing.T) {
+	mock := &mockTransport{
+		responses: []*http.Response{
+			{StatusCode: 401, Body: io.NopCloser(strings.NewReader("unauthorized"))},
+			{StatusCode: 401, Body: io.NopCloser(strings.NewReader("unauthorized"))},
+			{StatusCode: 401, Body: io.NopCloser(strings.NewReader("unauthorized"))},
+		},
+	}
+
+	rt := NewRetryTransport(mock)
+
+	req, _ := http.NewRequestWithContext(context.Background(), "GET", "https://example.com", nil)
+	var resp *http.Response
+
+	if r, err := rt.RoundTrip(req); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else {
+		resp = r
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != 401 {
+		t.Errorf("expected 401 after max retries, got %d", resp.StatusCode)
+	}
+	// 1 initial + 1 retry = 2 total (MaxUnauthorizedRetries = 1)
+
+	if mock.calls != 2 {
+		t.Errorf("expected 2 calls, got %d", mock.calls)
 	}
 }
 


### PR DESCRIPTION
## Problem

Users frequently get logged out with `oauth2: invalid_grant Token has been expired or revoked` errors. This is especially common with Google's 7-day refresh token expiry for OAuth apps in "testing" mode.

The current behavior:
1. **No actionable error message** - the error is wrapped as a generic "round trip: ..." with no guidance
2. **No retry on 401** - if an access token is revoked server-side before local expiry, every request fails

## Solution

### 1. `InvalidGrantError` type (errors.go)
- New structured error with clear message: `"oauth2 refresh token expired or revoked (re-authorize with: gog auth add --force-consent): ..."`
- Implements `Unwrap()` for error chain inspection
- Added `IsInvalidGrantError()` helper

### 2. Transport improvements (transport.go)
- **Detect `invalid_grant`** in `RetryTransport` and wrap as `InvalidGrantError`
- **Retry once on 401** so `oauth2.Transport` can re-fetch an access token when the current one was revoked server-side

### 3. Constants (retry_constants.go)
- `MaxUnauthorizedRetries = 1`
- `UnauthorizedRetryDelay = 500ms`

## Tests

Added comprehensive tests:
- `TestRetryTransport_InvalidGrant` - verifies invalid_grant is caught and wrapped
- `TestRetryTransport_NonInvalidGrantError` - verifies normal errors aren't misidentified
- `TestRetryTransport_401_Retry` - verifies 401 retry succeeds
- `TestRetryTransport_401_MaxRetries` - verifies retry limit is respected

## What was already fine
- `access_type=offline` was already set in `authURLParams()`
- Token storage in keyring works correctly
- `errNoRefreshToken` already mentions `--force-consent`