### PR TITLE
fix(gmail): combine --name with directory --out in attachment download

### DIFF
--- a/internal/cmd/gmail_attachment.go
+++ b/internal/cmd/gmail_attachment.go
@@ -20,7 +20,7 @@ type GmailAttachmentCmd struct {
 	MessageID    string         `arg:"" name:"messageId" help:"Message ID"`
 	AttachmentID string         `arg:"" name:"attachmentId" help:"Attachment ID"`
 	Output       OutputPathFlag `embed:""`
-	Name         string         `name:"name" help:"Filename (only used when --out is empty)"`
+	Name         string         `name:"name" help:"Filename (used with default dir or when --out is a directory)"`
 }
 
 const defaultGmailAttachmentFilename = "attachment.bin"
@@ -57,6 +57,17 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 		outPath, err := config.ExpandPath(outPathFlag)
 		if err != nil {
 			return err
+		}
+		if info, statErr := os.Stat(outPath); statErr == nil && info.IsDir() {
+			filename := strings.TrimSpace(c.Name)
+			if filename == "" {
+				filename = defaultGmailAttachmentFilename
+			}
+			safeFilename := filepath.Base(filename)
+			if safeFilename == "" || safeFilename == "." || safeFilename == ".." {
+				safeFilename = defaultGmailAttachmentFilename
+			}
+			outPath = filepath.Join(outPath, safeFilename)
 		}
 		destPath = outPath
 	}
@@ -115,6 +126,17 @@ func (c *GmailAttachmentCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
+	if info, statErr := os.Stat(outPath); statErr == nil && info.IsDir() {
+		filename := strings.TrimSpace(c.Name)
+		if filename == "" {
+			filename = defaultGmailAttachmentFilename
+		}
+		safeFilename := filepath.Base(filename)
+		if safeFilename == "" || safeFilename == "." || safeFilename == ".." {
+			safeFilename = defaultGmailAttachmentFilename
+		}
+		outPath = filepath.Join(outPath, safeFilename)
+	}
 	path, cached, bytes, err := downloadAttachmentToPath(ctx, svc, messageID, attachmentID, outPath, -1)
 	if err != nil {
 		return err
@@ -141,11 +163,11 @@ func downloadAttachmentToPath(
 	}
 
 	if expectedSize > 0 {
-		if st, err := os.Stat(outPath); err == nil && st.Size() == expectedSize {
+		if st, err := os.Stat(outPath); err == nil && st.Mode().IsRegular() && st.Size() == expectedSize {
 			return outPath, true, st.Size(), nil
 		}
 	} else if expectedSize == -1 {
-		if st, err := os.Stat(outPath); err == nil && st.Size() > 0 {
+		if st, err := os.Stat(outPath); err == nil && st.Mode().IsRegular() && st.Size() > 0 {
 			return outPath, true, st.Size(), nil
 		}
 	}

--- a/internal/cmd/gmail_attachment_more_test.go
+++ b/internal/cmd/gmail_attachment_more_test.go
@@ -94,6 +94,59 @@ func TestDownloadAttachmentToPath_EmptyData(t *testing.T) {
 	}
 }
 
+func TestDownloadAttachmentToPath_DirectoryNotCached(t *testing.T) {
+	dir := t.TempDir()
+	// A directory should not be treated as a cached attachment even though
+	// os.Stat succeeds and Size() > 0 on directories.
+	srv := httptestServerForAttachment(t, base64.RawURLEncoding.EncodeToString([]byte("data")))
+	gsvc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	outPath := filepath.Join(dir, "subdir")
+	if err := os.Mkdir(outPath, 0o700); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+
+	// With expectedSize == -1, a directory should NOT be returned as cached.
+	// Instead it should attempt download and fail trying to write to the dir path.
+	_, _, _, dlErr := downloadAttachmentToPath(context.Background(), gsvc, "m1", "a1", outPath, -1)
+	// We expect an error because outPath is a directory and WriteFile to a dir fails.
+	if dlErr == nil {
+		t.Fatalf("expected error when outPath is a directory")
+	}
+}
+
+func TestDownloadAttachmentToPath_DirectoryNotCachedBySize(t *testing.T) {
+	dir := t.TempDir()
+	// Even with a positive expectedSize matching the directory's metadata
+	// size, a directory should not be treated as a cached file.
+	srv := httptestServerForAttachment(t, base64.RawURLEncoding.EncodeToString([]byte("data")))
+	gsvc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+
+	// Pass the directory size as expectedSize — should NOT match because
+	// the path is a directory, not a regular file.
+	info, _ := os.Stat(dir)
+	_, cached, _, dlErr := downloadAttachmentToPath(context.Background(), gsvc, "m1", "a1", dir, info.Size())
+	// It should not return cached=true; it will try to download and fail
+	// because WriteFile to a directory fails.
+	if dlErr == nil && cached {
+		t.Fatalf("directory should not be treated as cached file")
+	}
+}
+
 func httptestServerForAttachment(t *testing.T, data string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
Fixes #222

When `--out` points to a directory (e.g. `--out /tmp/`), the `--name` flag was silently ignored and the directory path itself was used as the output file path. This caused two problems:

1. **`--name` ignored**: `--out /tmp/ --name invoice.pdf` would write to `/tmp/` instead of `/tmp/invoice.pdf`
2. **False cache hit**: The cache check accepted directories as valid cached attachments because `os.Stat` succeeds on directories and `Size() > 0` is always true for them

## Changes
- When `--out` resolves to an existing directory, combine it with `--name` (or the default filename) via `filepath.Join`
- Add `st.Mode().IsRegular()` to cache validation in `downloadAttachmentToPath` so directories never produce false cache hits
- Update `--name` help text to reflect that it works with directory `--out` values

## Test Plan
- [x] `go test ./...` passes (all packages green)
- [x] New test: directory path with `expectedSize == -1` is not treated as cache hit
- [x] New test: directory path with matching `expectedSize > 0` is not treated as cache hit
- [x] `make lint` passes (0 issues)
- [x] `make build` succeeds

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) (issue-hunter-pro)