### PR TITLE
feat(drive): add --all-drives flag to ls for cross-drive queries

### DIFF
--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -69,10 +69,11 @@ type DriveCmd struct {
 }
 
 type DriveLsCmd struct {
-	Max    int64  `name:"max" aliases:"limit" help:"Max results" default:"20"`
-	Page   string `name:"page" aliases:"cursor" help:"Page token"`
-	Query  string `name:"query" help:"Drive query filter"`
-	Parent string `name:"parent" help:"Folder ID to list (default: root)"`
+	Max       int64  `name:"max" aliases:"limit" help:"Max results" default:"20"`
+	Page      string `name:"page" aliases:"cursor" help:"Page token"`
+	Query     string `name:"query" help:"Drive query filter"`
+	Parent    string `name:"parent" help:"Folder ID to list (default: root)"`
+	AllDrives bool   `name:"all-drives" help:"Search across all drives without parent folder constraint"`
 }
 
 func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -82,26 +83,41 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	folderID := strings.TrimSpace(c.Parent)
-	if folderID == "" {
-		folderID = "root"
-	}
-
 	svc, err := newDriveService(ctx, account)
 	if err != nil {
 		return err
 	}
 
-	q := buildDriveListQuery(folderID, c.Query)
+	var q string
+	if c.AllDrives {
+		q = strings.TrimSpace(c.Query)
+		if q == "" {
+			return usage("--all-drives requires --query")
+		}
+		if !strings.Contains(q, "trashed") {
+			q += " and trashed = false"
+		}
+	} else {
+		folderID := strings.TrimSpace(c.Parent)
+		if folderID == "" {
+			folderID = "root"
+		}
+		q = buildDriveListQuery(folderID, c.Query)
+	}
 
-	resp, err := svc.Files.List().
+	call := svc.Files.List().
 		Q(q).
 		PageSize(c.Max).
 		PageToken(c.Page).
 		OrderBy("modifiedTime desc").
 		SupportsAllDrives(true).
 		IncludeItemsFromAllDrives(true).
-		Fields("nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink)").
+		Fields("nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink)")
+	if c.AllDrives {
+		call = call.Corpora("allDrives")
+	}
+
+	resp, err := call.
 		Context(ctx).
 		Do()
 	if err != nil {


### PR DESCRIPTION
## Problem

`gog drive ls` always scopes queries to a parent folder (default: `root`), and never sets `Corpora` on the API call (defaults to `user` = My Drive only).

This makes it impossible to run cross-drive queries like listing all starred files:

```bash
# Today: only returns starred files that are direct children of root in My Drive
gog drive ls --query "starred = true"
```

## Solution

Add `--all-drives` flag to `drive ls` that:

1. **Skips the parent folder constraint** — no `'root' in parents` appended to the query
2. **Sets `Corpora("allDrives")`** — searches across My Drive + all shared drives
3. **Requires `--query`** — since there is no folder scope, a query filter is mandatory
4. **Auto-appends `trashed = false`** if not already in the query (consistent with existing behavior)

## Usage

```bash
# List all starred files across My Drive and shared drives
gog drive ls --all-drives --query "starred = true" --max 100

# JSON output for programmatic use
gog drive ls --all-drives --query "starred = true" -j

# Other cross-drive queries work too
gog drive ls --all-drives --query "modifiedTime > '2026-02-01T00:00:00'"
```

## Use Case

I'm building a context ingestion pipeline that syncs starred Google Drive files for local indexing. Starring files in the Drive UI is a natural curation signal — this flag makes it programmatically accessible across all drives.

## Notes

- `SupportsAllDrives(true)` and `IncludeItemsFromAllDrives(true)` were already set on `ls` — this change adds the missing `Corpora("allDrives")` call
- No changes to `drive search` (which has its own query builder)
- Backward compatible — existing `ls` behavior is unchanged without the flag
