### PR TITLE
feat: add Google Ads as an auth service

### DIFF
--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -25,6 +25,7 @@ const (
 	ServiceAppScript Service = "appscript"
 	ServiceGroups    Service = "groups"
 	ServiceKeep      Service = "keep"
+	ServiceAds       Service = "ads"
 )
 
 const (
@@ -74,6 +75,7 @@ var serviceOrder = []Service{
 	ServiceAppScript,
 	ServiceGroups,
 	ServiceKeep,
+	ServiceAds,
 }
 
 var serviceInfoByService = map[Service]serviceInfo{
@@ -202,6 +204,12 @@ var serviceInfoByService = map[Service]serviceInfo{
 		user:   false,
 		apis:   []string{"Keep API"},
 		note:   "Workspace only; service account (domain-wide delegation)",
+	},
+	ServiceAds: {
+		scopes: []string{"https://www.googleapis.com/auth/adwords"},
+		user:   true,
+		apis:   []string{"Google Ads API"},
+		note:   "Auth only; use token with Google Ads API directly",
 	},
 }
 
@@ -521,6 +529,8 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 	case ServiceGroups:
 		return Scopes(service)
 	case ServiceKeep:
+		return Scopes(service)
+	case ServiceAds:
 		return Scopes(service)
 	default:
 		return nil, errUnknownService

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -65,7 +65,7 @@ func TestExtractCodeAndState_Errors(t *testing.T) {
 
 func TestAllServices(t *testing.T) {
 	svcs := AllServices()
-	if len(svcs) != 15 {
+	if len(svcs) != 16 {
 		t.Fatalf("unexpected: %v", svcs)
 	}
 	seen := make(map[Service]bool)
@@ -74,7 +74,7 @@ func TestAllServices(t *testing.T) {
 		seen[s] = true
 	}
 
-	for _, want := range []Service{ServiceGmail, ServiceCalendar, ServiceChat, ServiceClassroom, ServiceDrive, ServiceDocs, ServiceSlides, ServiceContacts, ServiceTasks, ServicePeople, ServiceSheets, ServiceForms, ServiceAppScript, ServiceGroups, ServiceKeep} {
+	for _, want := range []Service{ServiceGmail, ServiceCalendar, ServiceChat, ServiceClassroom, ServiceDrive, ServiceDocs, ServiceSlides, ServiceContacts, ServiceTasks, ServicePeople, ServiceSheets, ServiceForms, ServiceAppScript, ServiceGroups, ServiceKeep, ServiceAds} {
 		if !seen[want] {
 			t.Fatalf("missing %q", want)
 		}
@@ -83,7 +83,7 @@ func TestAllServices(t *testing.T) {
 
 func TestUserServices(t *testing.T) {
 	svcs := UserServices()
-	if len(svcs) != 13 {
+	if len(svcs) != 14 {
 		t.Fatalf("unexpected: %v", svcs)
 	}
 
@@ -113,7 +113,7 @@ func TestUserServices(t *testing.T) {
 }
 
 func TestUserServiceCSV(t *testing.T) {
-	want := "gmail,calendar,chat,classroom,drive,docs,slides,contacts,tasks,sheets,people,forms,appscript"
+	want := "gmail,calendar,chat,classroom,drive,docs,slides,contacts,tasks,sheets,people,forms,appscript,ads"
 	if got := UserServiceCSV(); got != want {
 		t.Fatalf("unexpected user services csv: %q", got)
 	}


### PR DESCRIPTION
Adds `ads` as a new service for `gog auth add`, enabling OAuth tokens with the `https://www.googleapis.com/auth/adwords` scope.

## What

- New `ServiceAds` in the services list
- `gog auth add user@example.com --services ads` obtains a token with the Google Ads API scope
- Auth-only for now — no CLI commands, but the refresh token works with any Google Ads API client

## Why

Google Ads API requires OAuth with the adwords scope. Currently there's no way to get this through gog, so users managing Google Workspace + Ads for the same account need a separate auth flow. This lets them use gog's existing auth infrastructure.

## Changes

- `internal/googleauth/service.go`: Add `ServiceAds` constant, scope mapping, and switch case
- `internal/googleauth/service_test.go`: Update test expectations

14 lines added, 4 changed. Tests pass.