### PR TITLE
fix(secrets): verify token persisted after keyring write

### DIFF
--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -58,6 +58,7 @@ var (
 	errNoTTY                 = errors.New("no TTY available for keyring file backend password prompt")
 	errInvalidKeyringBackend = errors.New("invalid keyring backend")
 	errKeyringTimeout        = errors.New("keyring connection timed out")
+	errTokenVerifyFailed     = errors.New("token verification failed: keyring wrote 0 bytes")
 	openKeyringFunc          = openKeyring
 	keyringOpenFunc          = keyring.Open
 )
@@ -337,8 +338,21 @@ func (s *KeyringStore) SetToken(client string, email string, tok Token) error {
 		return fmt.Errorf("encode token: %w", err)
 	}
 
-	if err := s.ring.Set(keyringItem(tokenKey(normalizedClient, email), payload)); err != nil {
+	primaryKey := tokenKey(normalizedClient, email)
+	if err := s.ring.Set(keyringItem(primaryKey, payload)); err != nil {
 		return wrapKeychainError(fmt.Errorf("store token: %w", err))
+	}
+
+	// Verify the token was actually persisted. On macOS, the Keychain can
+	// silently write 0 bytes when it is locked in a headless/server environment
+	// even though Set returns no error. Read back to catch this.
+	if item, readErr := s.ring.Get(primaryKey); readErr != nil {
+		return fmt.Errorf("%w: could not read back token after write: %w\n\n"+
+			"Workaround: switch to file-based keyring with: gog auth keyring file", errTokenVerifyFailed, readErr)
+	} else if len(item.Data) == 0 {
+		return fmt.Errorf("%w\n\n"+
+			"This usually happens when the macOS Keychain is locked in a headless environment.\n"+
+			"Workaround: switch to file-based keyring with: gog auth keyring file", errTokenVerifyFailed)
 	}
 
 	if normalizedClient == config.DefaultClientName {

--- a/internal/secrets/store_more_test.go
+++ b/internal/secrets/store_more_test.go
@@ -251,6 +251,61 @@ func TestGetTokenMigrationSetsLabel(t *testing.T) {
 	}
 }
 
+// silentDropKeyring simulates a macOS Keychain that silently writes 0 bytes.
+// Set returns nil (success), but Get returns an item with empty Data.
+type silentDropKeyring struct {
+	keyring.ArrayKeyring
+}
+
+func (s *silentDropKeyring) Set(_ keyring.Item) error { return nil }
+func (s *silentDropKeyring) Get(_ string) (keyring.Item, error) {
+	return keyring.Item{Data: nil}, nil
+}
+func (s *silentDropKeyring) Keys() ([]string, error) { return nil, nil }
+
+func TestSetTokenVerifyCatchesEmptyWrite(t *testing.T) {
+	store := &KeyringStore{ring: &silentDropKeyring{}}
+	client := config.DefaultClientName
+
+	err := store.SetToken(client, "a@b.com", Token{RefreshToken: "rt", CreatedAt: time.Now()})
+	if err == nil {
+		t.Fatal("expected error when keyring silently drops data")
+	}
+	if !errors.Is(err, errTokenVerifyFailed) {
+		t.Fatalf("expected errTokenVerifyFailed, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "gog auth keyring file") {
+		t.Fatalf("expected workaround suggestion in error, got: %v", err)
+	}
+}
+
+// readBackErrorKeyring simulates a keyring where Set succeeds but Get fails.
+type readBackErrorKeyring struct {
+	keyring.ArrayKeyring
+}
+
+func (r *readBackErrorKeyring) Set(_ keyring.Item) error { return nil }
+func (r *readBackErrorKeyring) Get(_ string) (keyring.Item, error) {
+	return keyring.Item{}, errors.New("read failed")
+}
+func (r *readBackErrorKeyring) Keys() ([]string, error) { return nil, nil }
+
+func TestSetTokenVerifyCatchesReadBackError(t *testing.T) {
+	store := &KeyringStore{ring: &readBackErrorKeyring{}}
+	client := config.DefaultClientName
+
+	err := store.SetToken(client, "a@b.com", Token{RefreshToken: "rt", CreatedAt: time.Now()})
+	if err == nil {
+		t.Fatal("expected error when keyring read-back fails")
+	}
+	if !errors.Is(err, errTokenVerifyFailed) {
+		t.Fatalf("expected errTokenVerifyFailed, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "could not read back") {
+		t.Fatalf("expected read-back error detail, got: %v", err)
+	}
+}
+
 func TestSetSecretSetsLabel(t *testing.T) {
 	ring := keyring.NewArrayKeyring(nil)
 	origOpen := openKeyringFunc


### PR DESCRIPTION
## Summary
Fixes #206

On macOS, the Keychain can silently write 0-byte entries when locked in a headless/server environment, even though `Set` returns no error. The existing pre-flight check (`EnsureKeychainAccess`) doesn't catch every case because `security show-keychain-info` can report the keychain as unlocked while the Security framework still drops data.

This PR adds a **post-write read-back verification** in `SetToken`: after the primary keyring write succeeds, it reads the item back and checks that the data is non-empty. If verification fails, an actionable error is returned suggesting `gog auth keyring file` as a workaround.

## Changes
- Add `errTokenVerifyFailed` sentinel error in `internal/secrets/store.go`
- After `ring.Set()` in `SetToken`, read back via `ring.Get()` and verify data is non-empty
- Error message includes workaround: `gog auth keyring file`
- Add two test cases: silent 0-byte write and read-back failure, using mock keyrings

## Test plan
- [x] `go test ./internal/secrets/ -run TestSetTokenVerify` — both new tests pass
- [x] `go test ./internal/cmd/ -run TestAuthAdd` — all existing auth add tests pass
- [x] `go test ./...` — full suite green
- [x] `go build ./...` — clean compile

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)