### PR TITLE
fix(gmail): avoid QP decode corrupting URLs with =XX

### DIFF
--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -569,7 +569,19 @@ func decodeQuotedPrintableUTF8Safe(data []byte) []byte {
 				continue
 			}
 
-			// Ambiguous ASCII escapes (e.g. "=2F") are left intact.
+			// Decode ASCII escapes (space, punctuation, etc). These are valid
+			// quoted-printable sequences and are extremely common (e.g. =20, =26).
+			//
+			// We *don't* decode non-ASCII bytes unless they form valid UTF-8 (above),
+			// which is what prevents malformed fragments like "&p=91" from turning
+			// into U+FFFD.
+			if decoded == '\t' || decoded == '\n' || decoded == '\r' || (decoded >= 0x20 && decoded <= 0x7E) {
+				out = append(out, decoded)
+				i += 2
+				continue
+			}
+
+			// Other control bytes are preserved literally.
 			out = append(out, '=', data[i+1], data[i+2])
 			i += 2
 			continue

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -179,6 +179,29 @@ func TestFindPartBody_PreservesURLsWhenAlreadyDecoded(t *testing.T) {
 	}
 }
 
+func TestFindPartBody_DecodesQuotedPrintableButPreservesLiteralHexPairs(t *testing.T) {
+	// A body can contain real quoted-printable markers (=3D, =20, etc) *and*
+	// also contain malformed literal fragments like "&p=91".
+	//
+	// We should still decode the valid QP escapes while leaving the malformed
+	// ones intact.
+	qp := "hello=3Dworld=26x=20https://example.com/?post_type=product&p=91"
+	encoded := base64.RawURLEncoding.EncodeToString([]byte(qp))
+	part := &gmail.MessagePart{
+		MimeType: "text/plain",
+		Headers: []*gmail.MessagePartHeader{
+			{Name: "Content-Transfer-Encoding", Value: "quoted-printable"},
+			{Name: "Content-Type", Value: "text/plain; charset=utf-8"},
+		},
+		Body: &gmail.MessagePartBody{Data: encoded},
+	}
+	got := findPartBody(part, "text/plain")
+	want := "hello=world&x https://example.com/?post_type=product&p=91"
+	if got != want {
+		t.Fatalf("unexpected decoded body: got %q, want %q", got, want)
+	}
+}
+
 func TestFindPartBody_PreservesURLsWithHexPairParametersWhenDecodingQuotedPrintable(t *testing.T) {
 	// Some messages contain literal URL parameters like "&p=91" while also
 	// containing other QP markers (e.g. =3D). A naive QP decoder will interpret


### PR DESCRIPTION
Fixes #245

When Gmail returns bodies that contain literal sequences like `&p=91`, a strict quoted-printable decoder interprets `=91` as hex byte 0x91, which becomes U+FFFD in UTF-8 JSON output.

This change decodes quoted-printable *conservatively* for UTF-8 parts: always decode `=3D` and soft line breaks, but only decode non-ASCII `=XX` runs when the resulting bytes form valid UTF-8. This preserves URLs while still decoding real UTF-8 quoted-printable content.

- add regression coverage for URLs with `=XX`
- keep existing QP decode behavior for non-UTF-8 charsets

Tested: `GOTOOLCHAIN=go1.25.7 go test ./...`