### PR TITLE
feat(docs): add markdown export support to docs export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1140,6 +1140,7 @@ Note: Classroom commands require a Google Workspace for Education account. Perso
 gog docs export <docId> --format pdf --out ./doc.pdf
 gog docs export <docId> --format docx --out ./doc.docx
 gog docs export <docId> --format txt --out ./doc.txt
+gog docs export <docId> --format md --out ./doc.md
 ```
 
 ### Slides

--- a/docs/refactor/exports.md
+++ b/docs/refactor/exports.md
@@ -16,6 +16,7 @@ Goal: one implementation for “export Google *Thing* via Drive”.
 
 Each service command is a thin wrapper:
 
+- `gog docs export <docId> --format pdf|docx|txt|md|markdown`
 - `gog docs export <docId> --format pdf|docx|txt`
 - `gog slides export <presentationId> --format pdf|pptx`
 - `gog sheets export <spreadsheetId> --format pdf|xlsx|csv`

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -22,7 +22,7 @@ import (
 var newDocsService = googleapi.NewDocs
 
 type DocsCmd struct {
-	Export      DocsExportCmd      `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Doc (pdf|docx|txt)"`
+	Export      DocsExportCmd      `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Doc (pdf|docx|txt|md|markdown)"`
 	Info        DocsInfoCmd        `cmd:"" name:"info" aliases:"get,show" help:"Get Google Doc metadata"`
 	Create      DocsCreateCmd      `cmd:"" name:"create" aliases:"add,new" help:"Create a Google Doc"`
 	Copy        DocsCopyCmd        `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Doc"`
@@ -38,7 +38,7 @@ type DocsCmd struct {
 type DocsExportCmd struct {
 	DocID  string         `arg:"" name:"docId" help:"Doc ID"`
 	Output OutputPathFlag `embed:""`
-	Format string         `name:"format" help:"Export format: pdf|docx|txt" default:"pdf"`
+	Format string         `name:"format" help:"Export format: pdf|docx|txt|md|markdown" default:"pdf"`
 }
 
 func (c *DocsExportCmd) Run(ctx context.Context, flags *RootFlags) error {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -44,6 +44,7 @@ const (
 	mimePptx               = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 	mimePNG                = "image/png"
 	mimeTextPlain          = "text/plain"
+	mimeMarkdown           = "text/markdown"
 	extPDF                 = ".pdf"
 	extCSV                 = ".csv"
 	extXlsx                = ".xlsx"
@@ -51,6 +52,7 @@ const (
 	extPptx                = ".pptx"
 	extPNG                 = ".png"
 	extTXT                 = ".txt"
+	extMD                  = ".md"
 
 	driveShareToAnyone = "anyone"
 	driveShareToUser   = "user"
@@ -1188,10 +1190,10 @@ func validateDriveDownloadFormatFlag(format string) error {
 		return nil
 	}
 	switch format {
-	case "pdf", "csv", "xlsx", "pptx", "txt", "png", "docx":
+	case "pdf", "csv", "xlsx", "pptx", "txt", "png", "docx", "md", "markdown":
 		return nil
 	default:
-		return usagef("invalid --format %q (use pdf|csv|xlsx|pptx|txt|png|docx)", format)
+		return usagef("invalid --format %q (use pdf|csv|xlsx|pptx|txt|png|docx|md|markdown)", format)
 	}
 }
 
@@ -1252,8 +1254,10 @@ func driveExportMimeTypeForFormat(googleMimeType string, format string) (string,
 			return mimeDocx, nil
 		case "txt":
 			return mimeTextPlain, nil
+		case "md", "markdown":
+			return mimeMarkdown, nil
 		default:
-			return "", fmt.Errorf("invalid --format %q for Google Doc (use pdf|docx|txt)", format)
+			return "", fmt.Errorf("invalid --format %q for Google Doc (use pdf|docx|txt|md|markdown)", format)
 		}
 	case driveMimeGoogleSheet:
 		switch format {
@@ -1308,6 +1312,8 @@ func driveExportExtension(mimeType string) string {
 		return extPNG
 	case mimeTextPlain:
 		return extTXT
+	case mimeMarkdown:
+		return extMD
 	default:
 		return extPDF
 	}

--- a/internal/cmd/drive_export_format_test.go
+++ b/internal/cmd/drive_export_format_test.go
@@ -47,6 +47,18 @@ func TestDriveExportMimeTypeForFormat(t *testing.T) {
 			wantMime:   "text/plain",
 		},
 		{
+			name:       "doc_md",
+			googleMime: "application/vnd.google-apps.document",
+			format:     "md",
+			wantMime:   "text/markdown",
+		},
+		{
+			name:       "doc_markdown",
+			googleMime: "application/vnd.google-apps.document",
+			format:     "markdown",
+			wantMime:   "text/markdown",
+		},
+		{
 			name:        "doc_invalid",
 			googleMime:  "application/vnd.google-apps.document",
 			format:      "xlsx",

--- a/internal/cmd/drive_helpers_more_test.go
+++ b/internal/cmd/drive_helpers_more_test.go
@@ -54,4 +54,7 @@ func TestDriveExportExtension(t *testing.T) {
 	if got := driveExportExtension("nope"); got != ".pdf" {
 		t.Fatalf("unexpected: %q", got)
 	}
+	if got := driveExportExtension("text/markdown"); got != ".md" {
+		t.Fatalf("unexpected: %q", got)
+	}
 }

--- a/internal/cmd/execute_export_via_drive_test.go
+++ b/internal/cmd/execute_export_via_drive_test.go
@@ -95,6 +95,86 @@ func TestExecute_DocsExport_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_DocsExport_FormatMD(t *testing.T) {
+	origNew := newDriveService
+	origExport := driveExportDownload
+	t.Cleanup(func() {
+		newDriveService = origNew
+		driveExportDownload = origExport
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/files/id1") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "id1",
+			"name":     "Doc",
+			"mimeType": "application/vnd.google-apps.document",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	var gotExportMime string
+	driveExportDownload = func(_ context.Context, _ *drive.Service, _ string, mimeType string) (*http.Response, error) {
+		gotExportMime = mimeType
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader("# doc")),
+		}, nil
+	}
+
+	outBase := filepath.Join(t.TempDir(), "out")
+
+	stdout := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if execErr := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"docs", "export", "id1",
+				"--out", outBase,
+				"--format", "md",
+			}); execErr != nil {
+				t.Fatalf("Execute: %v", execErr)
+			}
+		})
+	})
+
+	var parsed struct {
+		Path string `json:"path"`
+		Size int64  `json:"size"`
+	}
+	if unmarshalErr := json.Unmarshal([]byte(stdout), &parsed); unmarshalErr != nil {
+		t.Fatalf("json parse: %v\nout=%q", unmarshalErr, stdout)
+	}
+	if want := outBase + ".md"; parsed.Path != want || parsed.Size != 6 {
+		t.Fatalf("unexpected: %#v", parsed)
+	}
+	if gotExportMime != "text/markdown" {
+		t.Fatalf("unexpected export mime type: %q", gotExportMime)
+	}
+	b, err := os.ReadFile(outBase + ".md")
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(b) != "# doc" {
+		t.Fatalf("unexpected file contents: %q", string(b))
+	}
+}
+
 func TestExecute_DocsExport_TypeMismatch(t *testing.T) {
 	origNew := newDriveService
 	t.Cleanup(func() { newDriveService = origNew })


### PR DESCRIPTION
Add --format md and --format markdown to gog docs export using Drive
export MIME type text/markdown. Default remains pdf.