### PR TITLE
feat(docs): add markdown (md) export format

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -22,7 +22,7 @@ import (
 var newDocsService = googleapi.NewDocs
 
 type DocsCmd struct {
-	Export      DocsExportCmd      `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Doc (pdf|docx|txt)"`
+	Export      DocsExportCmd      `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Doc (pdf|docx|txt|md)"`
 	Info        DocsInfoCmd        `cmd:"" name:"info" aliases:"get,show" help:"Get Google Doc metadata"`
 	Create      DocsCreateCmd      `cmd:"" name:"create" aliases:"add,new" help:"Create a Google Doc"`
 	Copy        DocsCopyCmd        `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Doc"`
@@ -38,7 +38,7 @@ type DocsCmd struct {
 type DocsExportCmd struct {
 	DocID  string         `arg:"" name:"docId" help:"Doc ID"`
 	Output OutputPathFlag `embed:""`
-	Format string         `name:"format" help:"Export format: pdf|docx|txt" default:"pdf"`
+	Format string         `name:"format" help:"Export format: pdf|docx|txt|md" default:"pdf"`
 }
 
 func (c *DocsExportCmd) Run(ctx context.Context, flags *RootFlags) error {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -44,6 +44,7 @@ const (
 	mimePptx               = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 	mimePNG                = "image/png"
 	mimeTextPlain          = "text/plain"
+	mimeTextMarkdown       = "text/markdown"
 	extPDF                 = ".pdf"
 	extCSV                 = ".csv"
 	extXlsx                = ".xlsx"
@@ -51,6 +52,7 @@ const (
 	extPptx                = ".pptx"
 	extPNG                 = ".png"
 	extTXT                 = ".txt"
+	extMD                  = ".md"
 
 	driveShareToAnyone = "anyone"
 	driveShareToUser   = "user"
@@ -272,7 +274,7 @@ func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 type DriveDownloadCmd struct {
 	FileID string         `arg:"" name:"fileId" help:"File ID"`
 	Output OutputPathFlag `embed:""`
-	Format string         `name:"format" help:"Export format for Google Docs files: pdf|csv|xlsx|pptx|txt|png|docx (default: inferred)"`
+	Format string         `name:"format" help:"Export format for Google Docs files: pdf|csv|xlsx|pptx|txt|png|docx|md (default: inferred)"`
 }
 
 func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -1188,10 +1190,10 @@ func validateDriveDownloadFormatFlag(format string) error {
 		return nil
 	}
 	switch format {
-	case "pdf", "csv", "xlsx", "pptx", "txt", "png", "docx":
+	case "pdf", "csv", "xlsx", "pptx", "txt", "png", "docx", "md":
 		return nil
 	default:
-		return usagef("invalid --format %q (use pdf|csv|xlsx|pptx|txt|png|docx)", format)
+		return usagef("invalid --format %q (use pdf|csv|xlsx|pptx|txt|png|docx|md)", format)
 	}
 }
 
@@ -1252,8 +1254,10 @@ func driveExportMimeTypeForFormat(googleMimeType string, format string) (string,
 			return mimeDocx, nil
 		case "txt":
 			return mimeTextPlain, nil
+		case "md":
+			return mimeTextMarkdown, nil
 		default:
-			return "", fmt.Errorf("invalid --format %q for Google Doc (use pdf|docx|txt)", format)
+			return "", fmt.Errorf("invalid --format %q for Google Doc (use pdf|docx|txt|md)", format)
 		}
 	case driveMimeGoogleSheet:
 		switch format {
@@ -1308,6 +1312,8 @@ func driveExportExtension(mimeType string) string {
 		return extPNG
 	case mimeTextPlain:
 		return extTXT
+	case mimeTextMarkdown:
+		return extMD
 	default:
 		return extPDF
 	}

--- a/internal/cmd/drive_export_format_test.go
+++ b/internal/cmd/drive_export_format_test.go
@@ -47,6 +47,12 @@ func TestDriveExportMimeTypeForFormat(t *testing.T) {
 			wantMime:   "text/plain",
 		},
 		{
+			name:       "doc_md",
+			googleMime: "application/vnd.google-apps.document",
+			format:     "md",
+			wantMime:   "text/markdown",
+		},
+		{
 			name:        "doc_invalid",
 			googleMime:  "application/vnd.google-apps.document",
 			format:      "xlsx",

--- a/internal/cmd/drive_helpers_more_test.go
+++ b/internal/cmd/drive_helpers_more_test.go
@@ -51,6 +51,9 @@ func TestDriveExportExtension(t *testing.T) {
 	if got := driveExportExtension("text/plain"); got != ".txt" {
 		t.Fatalf("unexpected: %q", got)
 	}
+	if got := driveExportExtension("text/markdown"); got != ".md" {
+		t.Fatalf("unexpected: %q", got)
+	}
 	if got := driveExportExtension("nope"); got != ".pdf" {
 		t.Fatalf("unexpected: %q", got)
 	}


### PR DESCRIPTION
## Summary

- Adds `md` as a supported export format for Google Docs via `docs export --format md` and `drive download --format md`
- Uses Google's native `text/markdown` Drive API export (available since July 2024)
- Adds corresponding constants, MIME type mapping, file extension mapping, and test coverage

## Details

Google added native markdown export support for Google Docs in July 2024. This PR wires up the existing Drive export pipeline to support `--format md`, requiring only minimal changes:

- `mimeTextMarkdown` / `extMD` constants
- `driveExportMimeTypeForFormat()` — new `"md"` case for Google Docs
- `driveExportExtension()` — new `mimeTextMarkdown` → `.md` mapping
- `validateDriveDownloadFormatFlag()` — accepts `"md"`
- Help text updated across `docs export` and `drive download`
- Unit tests added for all new paths

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] All existing tests pass
- [x] New test cases pass (`doc_md` in `TestDriveExportMimeTypeForFormat`, markdown extension in `TestDriveExportExtension`)
- [x] Manual test: `gog docs export <docId> --format md --out /tmp/test.md` produces valid markdown with headings, tables, bold, lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)