### PR TITLE
Fix build

### DIFF
--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -247,7 +247,7 @@ func contactsURLs(values []string) []*people.Url {
 	return out
 }
 
-func contactsApplyPersonName(person *people.Person, givenSet bool, given, familySet bool, family string) {
+func contactsApplyPersonName(person *people.Person, givenSet bool, given string, familySet bool, family string) {
 	curGiven := ""
 	curFamily := ""
 	if len(person.Names) > 0 && person.Names[0] != nil {
@@ -263,7 +263,7 @@ func contactsApplyPersonName(person *people.Person, givenSet bool, given, family
 	person.Names = []*people.Name{{GivenName: curGiven, FamilyName: curFamily}}
 }
 
-func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org, titleSet bool, title string) {
+func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org string, titleSet bool, title string) {
 	curOrg := ""
 	curTitle := ""
 	if len(person.Organizations) > 0 && person.Organizations[0] != nil {


### PR DESCRIPTION
Fix build errors after refactoring from 957603e84c222eaf83a877716d53a1d5914cd010

Was getting errors similar to [these on CI](https://github.com/steipete/gogcli/actions/runs/22050244050/job/63706721677):

```
Error: internal/cmd/contacts_crud.go:258:32: cannot use given (variable of type bool) as string value in argument to strings.TrimSpace
Error: internal/cmd/contacts_crud.go:274:30: cannot use org (variable of type bool) as string value in argument to strings.TrimSpace
Error: internal/cmd/contacts_crud.go:410:48: cannot use c.Given (variable of type string) as bool value in argument to contactsApplyPersonName
Error: internal/cmd/contacts_crud.go:430:54: cannot use c.Organization (variable of type string) as bool value in argument to contactsApplyPersonOrganization
```