### PR TITLE
security: Added confirmation for sensitive operations

### DIFF
--- a/internal/cmd/confirm.go
+++ b/internal/cmd/confirm.go
@@ -40,3 +40,9 @@ func confirmDestructive(ctx context.Context, flags *RootFlags, action string) er
 	}
 	return &ExitError{Code: 1, Err: errors.New("cancelled")}
 }
+
+// Made a new function to handle sensitive operations
+// Does the same work as confirmDestructive but with different name to eleminate confusion.
+func confirmSensitive(ctx context.Context, flags *RootFlags, action string) error {
+	return confirmDestructive(ctx, flags, action)
+}

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -785,6 +785,12 @@ func (c *DriveShareCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	if to == driveShareToAnyone {
+		if confirmErr := confirmSensitive(ctx, flags, fmt.Sprintf("share drive file %s with anyone (public)", fileID)); confirmErr != nil {
+			return confirmErr
+		}
+	}
+
 	perm := &drive.Permission{Role: role}
 	switch to {
 	case driveShareToAnyone:

--- a/internal/cmd/gmail_delegates.go
+++ b/internal/cmd/gmail_delegates.go
@@ -120,6 +120,10 @@ func (c *GmailDelegatesAddCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 
+	if confirmErr := confirmSensitive(ctx, flags, fmt.Sprintf("add gmail delegate %s (grants mailbox read access)", delegateEmail)); confirmErr != nil {
+		return confirmErr
+	}
+
 	delegate := &gmail.Delegate{
 		DelegateEmail: delegateEmail,
 	}

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -279,6 +279,9 @@ func (c *GmailFiltersCreateCmd) Run(ctx context.Context, flags *RootFlags) error
 	}
 
 	if c.Forward != "" {
+		if confirmErr := confirmSensitive(ctx, flags, fmt.Sprintf("create gmail filter forwarding to %s", c.Forward)); confirmErr != nil {
+			return confirmErr
+		}
 		action.Forward = c.Forward
 	}
 


### PR DESCRIPTION
I have created a new function named confirmSensitive() which does the same work as confirmDestructive() but is named to better reflect operations that are sensitive (security-wise) rather than strictly destructive (data loss).

I applied this new check to the following commands:
1. `gmail delegates add` (granting mailbox access)
2. `gmail filters create --forward` (auto-forwarding emails)
3.  `drive share --to=anyone` (making files public)

Fixes #291 