### PR TITLE
fix(calendar): ensure 0-minute reminders are sent to API

### DIFF
--- a/internal/cmd/calendar_build.go
+++ b/internal/cmd/calendar_build.go
@@ -206,8 +206,9 @@ func buildReminders(reminders []string) (*calendar.EventReminders, error) {
 			return nil, err
 		}
 		overrides = append(overrides, &calendar.EventReminder{
-			Method:  method,
-			Minutes: minutes,
+			Method:          method,
+			Minutes:         minutes,
+			ForceSendFields: []string{"Minutes"},
 		})
 	}
 


### PR DESCRIPTION
Added ForceSendFields for minutes when creating an eventReminder.
Omitempty field caused reminders set to `0m` (at the time of the event) to be omitted from the JSON payload because `0` is the zero value for an int64.

Fixes #302 