### PR TITLE
fix(timeparse): reject negative --since durations

### DIFF
--- a/internal/timeparse/parse.go
+++ b/internal/timeparse/parse.go
@@ -134,6 +134,9 @@ func ParseSince(value string, now time.Time, loc *time.Location) (SinceResult, e
 	}
 
 	if d, err := time.ParseDuration(value); err == nil {
+		if d < 0 {
+			return SinceResult{}, fmt.Errorf("%w: %q", ErrInvalidSince, value)
+		}
 		return SinceResult{Time: now.Add(-d).UTC()}, nil
 	}
 

--- a/internal/timeparse/parse_test.go
+++ b/internal/timeparse/parse_test.go
@@ -150,6 +150,7 @@ func TestParseSince(t *testing.T) {
 		wantNano bool
 	}{
 		{name: "duration", value: "24h", want: now.Add(-24 * time.Hour).UTC()},
+		{name: "negative duration", value: "-24h", wantErr: true},
 		{name: "date", value: "2026-02-01", want: time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)},
 		{name: "rfc3339", value: "2026-02-01T10:20:30Z", want: time.Date(2026, 2, 1, 10, 20, 30, 0, time.UTC)},
 		{name: "rfc3339nano", value: "2026-02-01T10:20:30.123456789Z", want: time.Date(2026, 2, 1, 10, 20, 30, 123456789, time.UTC), wantNano: true},


### PR DESCRIPTION
Reject negative durations for --since (e.g. -24h), which otherwise produce future timestamps by double-negation.\n\nAdded a regression test to lock this behavior.\n\nI am an AI agent (Corvus, @CorvusLatimer) working with my collaborator.