### PR TITLE
feat(gmail): implement Safe Mode (drafts-only) via --safe flag

### DIFF
--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -484,6 +484,7 @@ type AuthAddCmd struct {
 	ForceConsent bool          `name:"force-consent" help:"Force consent screen to obtain a refresh token"`
 	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all or comma-separated ${auth_services} (Keep uses service account: gog auth service-account set)" default:"user"`
 	Readonly     bool          `name:"readonly" help:"Use read-only scopes where available (still includes OIDC identity scopes)"`
+	Safe         bool          `name:"safe" help:"Use safe/restricted scopes (eg. Gmail drafts only, no send)"`
 	DriveScope   string        `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
 }
 
@@ -509,6 +510,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	scopes, err := googleauth.ScopesForManageWithOptions(services, googleauth.ScopeOptions{
 		Readonly:   c.Readonly,
+		Safe:       c.Safe,
 		DriveScope: googleauth.DriveScopeMode(c.DriveScope),
 	})
 	if err != nil {
@@ -599,15 +601,16 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	refreshToken, err := authorizeGoogle(ctx, googleauth.AuthorizeOptions{
-		Services:     services,
-		Scopes:       scopes,
-		Manual:       manual,
-		ForceConsent: c.ForceConsent,
-		Timeout:      timeout,
-		Client:       client,
-		AuthURL:      authURL,
-		AuthCode:     authCode,
-		RequireState: c.Remote,
+		Services:             services,
+		Scopes:               scopes,
+		Manual:               manual,
+		ForceConsent:         c.ForceConsent,
+		Timeout:              timeout,
+		Client:               client,
+		AuthURL:              authURL,
+		AuthCode:             authCode,
+		RequireState:         c.Remote,
+		IncludeGrantedScopes: !c.Safe,
 	})
 	if err != nil {
 		return err

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -469,7 +469,13 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	draft, err := svc.Users.Drafts.Create("me", &gmail.Draft{Message: msg}).Do()
 	if err != nil {
-		return err
+		// Fallback for safe mode (requires insert scope)
+		msg.LabelIds = []string{"DRAFT"}
+		insertedMsg, insertErr := svc.Users.Messages.Insert("me", msg).Do()
+		if insertErr != nil {
+			return fmt.Errorf("%w \n %v", err, insertErr)
+		}
+		draft = &gmail.Draft{Message: insertedMsg}
 	}
 	return writeDraftResult(ctx, u, draft, threadID)
 }

--- a/internal/googleauth/accounts_server.go
+++ b/internal/googleauth/accounts_server.go
@@ -256,7 +256,7 @@ func (ms *ManageServer) handleAuthStart(w http.ResponseWriter, r *http.Request) 
 		Scopes:       scopes,
 	}
 
-	authURL := cfg.AuthCodeURL(state, authURLParams(ms.opts.ForceConsent)...)
+	authURL := cfg.AuthCodeURL(state, authURLParams(ms.opts.ForceConsent, true)...)
 	http.Redirect(w, r, authURL, http.StatusFound)
 }
 
@@ -304,7 +304,7 @@ func (ms *ManageServer) handleAuthUpgrade(w http.ResponseWriter, r *http.Request
 	// Always force consent for upgrades to ensure user sees all scopes
 	// Add login_hint to pre-select the account
 	authURL := cfg.AuthCodeURL(state,
-		append(authURLParams(true),
+		append(authURLParams(true, true),
 			oauth2.SetAuthURLParam("login_hint", email))...)
 
 	http.Redirect(w, r, authURL, http.StatusFound)

--- a/internal/googleauth/oauth_flow.go
+++ b/internal/googleauth/oauth_flow.go
@@ -20,15 +20,16 @@ import (
 )
 
 type AuthorizeOptions struct {
-	Services     []Service
-	Scopes       []string
-	Manual       bool
-	ForceConsent bool
-	Timeout      time.Duration
-	Client       string
-	AuthCode     string
-	AuthURL      string
-	RequireState bool
+	Services             []Service
+	Scopes               []string
+	Manual               bool
+	ForceConsent         bool
+	Timeout              time.Duration
+	Client               string
+	AuthCode             string
+	AuthURL              string
+	RequireState         bool
+	IncludeGrantedScopes bool
 }
 
 type ManualAuthURLResult struct {
@@ -204,7 +205,7 @@ func authorizeServer(ctx context.Context, opts AuthorizeOptions, creds config.Cl
 		}
 	}()
 
-	authURL := cfg.AuthCodeURL(state, authURLParams(opts.ForceConsent)...)
+	authURL := cfg.AuthCodeURL(state, authURLParams(opts.ForceConsent, opts.IncludeGrantedScopes)...)
 
 	fmt.Fprintln(os.Stderr, "Opening browser for authorization…")
 	fmt.Fprintln(os.Stderr, "If the browser doesn't open, visit this URL:")
@@ -245,10 +246,12 @@ func authorizeServer(ctx context.Context, opts AuthorizeOptions, creds config.Cl
 	}
 }
 
-func authURLParams(forceConsent bool) []oauth2.AuthCodeOption {
+func authURLParams(forceConsent bool, includeGrantedScopes bool) []oauth2.AuthCodeOption {
 	opts := []oauth2.AuthCodeOption{
 		oauth2.AccessTypeOffline,
-		oauth2.SetAuthURLParam("include_granted_scopes", "true"),
+	}
+	if includeGrantedScopes {
+		opts = append(opts, oauth2.SetAuthURLParam("include_granted_scopes", "true"))
 	}
 	if forceConsent {
 		opts = append(opts, oauth2.SetAuthURLParam("prompt", "consent"))

--- a/internal/googleauth/oauth_flow_manual.go
+++ b/internal/googleauth/oauth_flow_manual.go
@@ -117,7 +117,7 @@ func authorizeManualInteractive(ctx context.Context, opts AuthorizeOptions, cfg 
 	}
 
 	cfg.RedirectURL = setup.redirectURI
-	authURL := cfg.AuthCodeURL(setup.state, authURLParams(opts.ForceConsent)...)
+	authURL := cfg.AuthCodeURL(setup.state, authURLParams(opts.ForceConsent, opts.IncludeGrantedScopes)...)
 
 	fmt.Fprintln(os.Stderr, "Visit this URL to authorize:")
 	fmt.Fprintln(os.Stderr, authURL)
@@ -247,7 +247,7 @@ func ManualAuthURL(ctx context.Context, opts AuthorizeOptions) (ManualAuthURLRes
 	}
 
 	return ManualAuthURLResult{
-		URL:         cfg.AuthCodeURL(setup.state, authURLParams(opts.ForceConsent)...),
+		URL:         cfg.AuthCodeURL(setup.state, authURLParams(opts.ForceConsent, opts.IncludeGrantedScopes)...),
 		StateReused: setup.reused,
 	}, nil
 }

--- a/internal/googleauth/oauth_flow_more_test.go
+++ b/internal/googleauth/oauth_flow_more_test.go
@@ -18,7 +18,7 @@ func TestAuthURLParams(t *testing.T) {
 		Scopes:      []string{"s1"},
 	}
 
-	u1 := cfg.AuthCodeURL("state", authURLParams(false)...)
+	u1 := cfg.AuthCodeURL("state", authURLParams(false, true)...)
 	var parsed1 *url.URL
 
 	if p, err := url.Parse(u1); err != nil {
@@ -39,7 +39,7 @@ func TestAuthURLParams(t *testing.T) {
 		t.Fatalf("expected no prompt, got: %q", prompt)
 	}
 
-	u2 := cfg.AuthCodeURL("state", authURLParams(true)...)
+	u2 := cfg.AuthCodeURL("state", authURLParams(true, true)...)
 	var parsed2 *url.URL
 
 	if p, err := url.Parse(u2); err != nil {

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -48,6 +48,7 @@ const (
 
 type ScopeOptions struct {
 	Readonly   bool
+	Safe       bool
 	DriveScope DriveScopeMode
 }
 
@@ -419,6 +420,12 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 	case ServiceGmail:
 		if opts.Readonly {
 			return []string{"https://www.googleapis.com/auth/gmail.readonly"}, nil
+		}
+		if opts.Safe {
+			return []string{
+				"https://www.googleapis.com/auth/gmail.insert", // The safe scope, allows only drafting emails
+				"https://www.googleapis.com/auth/gmail.readonly",
+			}, nil
 		}
 
 		return Scopes(service)


### PR DESCRIPTION
# Description
This PR implements a "Safe Mode" for Gmail interactions, designed to ensure a "Human-in-the-Loop" workflow. When enabled, the CLI can create drafts but is cryptographically restricted from sending emails via the Google API.

# Key Changes
New Flag: Added --safe to gog auth add.
Restricted Scopes: Authentication with --safe requests only gmail.insert and gmail.readonly scopes (no gmail.send or gmail.compose).
Security Fix: Patched 

internal/googleauth/oauth_flow.go
to support disabling include_granted_scopes. This prevents new tokens from silently inheriting dangerous permissions from previous sessions.
Smart Fallback: Updated gog gmail drafts create to automatically fallback to the messages.insert API if the standard drafts.create permission is missing.
Verification

### Authenticate in Safe Mode:

`gog auth add <email> --services gmail --safe`

### Create a Draft (Should Succeed):

`gog gmail drafts create --to <email> --subject "Safe Test" --body "Hello"`

### Attempt to Send (Should Fail):
#### First, get the draft ID

`gog gmail drafts list`

#### Then try to send
`gog gmail drafts send <DRAFT_ID>`

Expected Result: Google API error (403 insufficientPermissions)


Fixes #239 