### PR TITLE
fix(calendar): Loading calendars from service account

### DIFF
--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -135,7 +135,8 @@ func TestCalendarCreateCmd_RecurringOffsetTimezoneFallback(t *testing.T) {
 				"id": "ev3",
 			})
 			return
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/users/me/calendarList/"):
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/calendars/") && !strings.Contains(r.URL.Path, "/events"):
+			// Calendars.Get for timezone lookup
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",
@@ -509,8 +510,8 @@ func TestCalendarUpdateCmd_SendUpdates(t *testing.T) {
 				},
 			})
 			return
-		case r.Method == http.MethodGet && strings.HasPrefix(path, "/users/me/calendarList/"):
-			// getCalendarLocation() fetches the calendar timezone via CalendarList.Get.
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/") && !strings.Contains(path, "/events"):
+			// Calendars.Get for timezone lookup
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "cal",

--- a/internal/cmd/calendar_delete_test.go
+++ b/internal/cmd/calendar_delete_test.go
@@ -107,7 +107,8 @@ func TestCalendarDeleteCmd_SendUpdates(t *testing.T) {
 				},
 			})
 			return
-		case r.Method == http.MethodGet && strings.HasPrefix(path, "/users/me/calendarList/"):
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/") && !strings.Contains(path, "/events"):
+			// Calendars.Get for timezone lookup
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "cal",

--- a/internal/cmd/calendar_time_test.go
+++ b/internal/cmd/calendar_time_test.go
@@ -20,7 +20,7 @@ func TestCalendarTimeCmd_JSON(t *testing.T) {
 	t.Cleanup(func() { newCalendarService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/users/me/calendarList/primary") && r.Method == http.MethodGet {
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",
@@ -81,7 +81,7 @@ func TestCalendarTimeCmd_TableOutput(t *testing.T) {
 	t.Cleanup(func() { newCalendarService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/users/me/calendarList/primary") && r.Method == http.MethodGet {
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",
@@ -276,7 +276,7 @@ func TestCalendarTimeCmd_CustomCalendar(t *testing.T) {
 	t.Cleanup(func() { newCalendarService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/users/me/calendarList/custom-cal-id@example.com") && r.Method == http.MethodGet {
+		if strings.Contains(r.URL.Path, "/calendars/custom-cal-id@example.com") && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "custom-cal-id@example.com",

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -18,11 +18,11 @@ import (
 
 // withPrimaryCalendar wraps an http.Handler to also respond to primary calendar requests
 // with a default timezone. This is needed because time-aware commands now fetch the
-// user's timezone from their primary calendar.
+// user's timezone from their primary calendar via Calendars.Get.
 func withPrimaryCalendar(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Handle primary calendar list request for timezone
-		if strings.Contains(r.URL.Path, "/calendarList/primary") && r.Method == http.MethodGet {
+		// Handle primary calendar request for timezone (Calendars.Get)
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",

--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -31,13 +31,15 @@ type TimeRange struct {
 }
 
 // getCalendarLocation fetches a calendar's timezone and returns it as a location.
+// Uses Calendars.Get (not CalendarList.Get) so it works for service accounts
+// whose "primary" calendar may not appear in their CalendarList.
 func getCalendarLocation(ctx context.Context, svc *calendar.Service, calendarID string) (string, *time.Location, error) {
 	calendarID = strings.TrimSpace(calendarID)
 	if calendarID == "" {
 		return "", nil, fmt.Errorf("calendarId required")
 	}
 
-	cal, err := svc.CalendarList.Get(calendarID).Context(ctx).Do()
+	cal, err := svc.Calendars.Get(calendarID).Context(ctx).Do()
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get calendar %q: %w", calendarID, err)
 	}
@@ -52,8 +54,10 @@ func getCalendarLocation(ctx context.Context, svc *calendar.Service, calendarID 
 }
 
 // getUserTimezone fetches the timezone from the user's primary calendar.
+// Uses Calendars.Get (not CalendarList.Get) so it works for service accounts
+// whose "primary" calendar may not appear in their CalendarList.
 func getUserTimezone(ctx context.Context, svc *calendar.Service) (*time.Location, error) {
-	cal, err := svc.CalendarList.Get("primary").Context(ctx).Do()
+	cal, err := svc.Calendars.Get("primary").Context(ctx).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get primary calendar: %w", err)
 	}

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +16,7 @@ func newCalendarServiceWithTimezone(t *testing.T, tz string) *calendar.Service {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/calendarList/primary") && r.Method == http.MethodGet {
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",


### PR DESCRIPTION
Note: This change needs to be rebased against upstream:main, but right now main is broken so it's tested with service accounts on v0.11.0.

use Calendars.Get instead of CalendarList.Get for timezone lookup
CalendarList.Get("primary") returns 404 for service accounts because the SA's own primary calendar is not in its CalendarList, even though Calendars.Get("primary") and Events.List work fine.

Switch getUserTimezone() and getCalendarLocation() to use svc.Calendars.Get(), which works for both OAuth users and service accounts. Update test mocks to match the new endpoint.