### PR TITLE
fix(calendar): use Calendars.Get for TZ lookup to fix SA 404

### DIFF
--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -159,7 +159,7 @@ func TestCalendarCreateCmd_RecurringOffsetTimezoneFallback(t *testing.T) {
 				"id": "ev3",
 			})
 			return
-		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/users/me/calendarList/"):
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/calendars/") && !strings.Contains(r.URL.Path, "/events"):
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",
@@ -533,8 +533,8 @@ func TestCalendarUpdateCmd_SendUpdates(t *testing.T) {
 				},
 			})
 			return
-		case r.Method == http.MethodGet && strings.HasPrefix(path, "/users/me/calendarList/"):
-			// getCalendarLocation() fetches the calendar timezone via CalendarList.Get.
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/") && !strings.Contains(path, "/events"):
+			// getCalendarLocation() fetches the calendar timezone.
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "cal",

--- a/internal/cmd/calendar_delete_test.go
+++ b/internal/cmd/calendar_delete_test.go
@@ -107,7 +107,7 @@ func TestCalendarDeleteCmd_SendUpdates(t *testing.T) {
 				},
 			})
 			return
-		case r.Method == http.MethodGet && strings.HasPrefix(path, "/users/me/calendarList/"):
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/calendars/") && !strings.Contains(path, "/events"):
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "cal",

--- a/internal/cmd/calendar_time_test.go
+++ b/internal/cmd/calendar_time_test.go
@@ -20,7 +20,7 @@ func TestCalendarTimeCmd_JSON(t *testing.T) {
 	t.Cleanup(func() { newCalendarService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/users/me/calendarList/primary") && r.Method == http.MethodGet {
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",
@@ -81,7 +81,7 @@ func TestCalendarTimeCmd_TableOutput(t *testing.T) {
 	t.Cleanup(func() { newCalendarService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/users/me/calendarList/primary") && r.Method == http.MethodGet {
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",
@@ -276,7 +276,7 @@ func TestCalendarTimeCmd_CustomCalendar(t *testing.T) {
 	t.Cleanup(func() { newCalendarService = origNew })
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/users/me/calendarList/custom-cal-id@example.com") && r.Method == http.MethodGet {
+		if strings.Contains(r.URL.Path, "/calendars/custom-cal-id@example.com") && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "custom-cal-id@example.com",

--- a/internal/cmd/testutil_test.go
+++ b/internal/cmd/testutil_test.go
@@ -21,8 +21,8 @@ import (
 // user's timezone from their primary calendar.
 func withPrimaryCalendar(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// Handle primary calendar list request for timezone
-		if strings.Contains(r.URL.Path, "/calendarList/primary") && r.Method == http.MethodGet {
+		// Handle primary calendar request for timezone
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",

--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -31,13 +31,15 @@ type TimeRange struct {
 }
 
 // getCalendarLocation fetches a calendar's timezone and returns it as a location.
+// Uses Calendars.Get (not CalendarList.Get) so it works for service accounts
+// whose "primary" calendar may not appear in their CalendarList.
 func getCalendarLocation(ctx context.Context, svc *calendar.Service, calendarID string) (string, *time.Location, error) {
 	calendarID = strings.TrimSpace(calendarID)
 	if calendarID == "" {
 		return "", nil, fmt.Errorf("calendarId required")
 	}
 
-	cal, err := svc.CalendarList.Get(calendarID).Context(ctx).Do()
+	cal, err := svc.Calendars.Get(calendarID).Context(ctx).Do()
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to get calendar %q: %w", calendarID, err)
 	}
@@ -52,8 +54,10 @@ func getCalendarLocation(ctx context.Context, svc *calendar.Service, calendarID 
 }
 
 // getUserTimezone fetches the timezone from the user's primary calendar.
+// Uses Calendars.Get (not CalendarList.Get) so it works for service accounts
+// whose "primary" calendar may not appear in their CalendarList.
 func getUserTimezone(ctx context.Context, svc *calendar.Service) (*time.Location, error) {
-	cal, err := svc.CalendarList.Get("primary").Context(ctx).Do()
+	cal, err := svc.Calendars.Get("primary").Context(ctx).Do()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get primary calendar: %w", err)
 	}

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 	"time"
 
@@ -17,7 +16,7 @@ func newCalendarServiceWithTimezone(t *testing.T, tz string) *calendar.Service {
 	t.Helper()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/calendarList/primary") && r.Method == http.MethodGet {
+		if r.URL.Path == "/calendars/primary" && r.Method == http.MethodGet {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "primary",


### PR DESCRIPTION
Hi @steipete,

When using with a service account, I ran into some 404s when running: `gog calendar list email@example.com` (or events). This was true even when `gog calendar calendars` did in fact return a couple calendars.

It appears this is an issue with how service accounts manage their list of calendars. In time_helpers.go, we call CalendarList.get(calendarID):

```
 // getCalendarLocation fetches a calendar's timezone and returns it as a location.
func getCalendarLocation(ctx context.Context, svc *calendar.Service, calendarID string) (string, *time.Location, error) {
        //...

        cal, err := svc.CalendarList.Get(calendarID).Context(ctx).Do()
        //...
```
But svc.CalendarList doesn't contain the calendar for the service account, so it fails. Instead this change will use `svc.Calendars.Get` in order to always be able to lookup the calendars. I'm unsure what exactly controls this list for service accounts, but in my case I somehow had the calendars in the list, and then suddenly didn't. The documentation I found for the differences is [here](https://developers.google.com/workspace/calendar/api/concepts/events-calendars#calendar_list). There's also a similar change for the time zone helper.

I also manually retested this using the existing OAuth / standard flow documented in the README, and it appears to still 
work. I would expect something similar to happen with the CalendarCalendarsCmd usage of svc.CalendarList.List(), but in my testing that did not seem to be the case.

Please let me know if I can change / improve any of this. I know it's a slight change, so if it's not something you want to do I won't mind. I needed the code for a project I was working on, so figured I would share it in case it's useful to others.

Thanks!

Mark