### PR TITLE
feat(calendar): add subscribe command for calendarList.insert API

### DIFF
--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -14,6 +14,7 @@ import (
 
 type CalendarCmd struct {
 	Calendars       CalendarCalendarsCmd       `cmd:"" name:"calendars" help:"List calendars"`
+	Subscribe       CalendarSubscribeCmd       `cmd:"" name:"subscribe" aliases:"sub,add-calendar" help:"Add a calendar to your calendar list"`
 	ACL             CalendarAclCmd             `cmd:"" name:"acl" aliases:"permissions,perms" help:"List calendar ACL"`
 	Events          CalendarEventsCmd          `cmd:"" name:"events" aliases:"list,ls" help:"List events from a calendar or all calendars"`
 	Event           CalendarEventCmd           `cmd:"" name:"event" aliases:"get,info,show" help:"Get event"`
@@ -104,6 +105,51 @@ func (c *CalendarCalendarsCmd) Run(ctx context.Context, flags *RootFlags) error 
 		fmt.Fprintf(w, "%s\t%s\t%s\n", cal.Id, cal.Summary, cal.AccessRole)
 	}
 	printNextPageHint(u, nextPageToken)
+	return nil
+}
+
+type CalendarSubscribeCmd struct {
+	CalendarID string `arg:"" name:"calendarId" help:"Calendar ID to subscribe to (e.g., user@example.com or calendar ID)"`
+	ColorID    string `name:"color-id" help:"Color ID (1-24, see 'calendar colors')"`
+	Hidden     bool   `name:"hidden" help:"Hide from the calendar list UI"`
+	Selected   bool   `name:"selected" help:"Show events in the calendar UI" default:"true" negatable:""`
+}
+
+func (c *CalendarSubscribeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	calendarID := strings.TrimSpace(c.CalendarID)
+	if calendarID == "" {
+		return usage("calendarId required")
+	}
+
+	svc, err := newCalendarService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	entry := &calendar.CalendarListEntry{
+		Id:       calendarID,
+		Hidden:   c.Hidden,
+		Selected: c.Selected,
+	}
+	if c.ColorID != "" {
+		entry.ColorId = c.ColorID
+	}
+
+	added, err := svc.CalendarList.Insert(entry).Do()
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"calendar": added})
+	}
+	u.Out().Printf("subscribed\t%s", added.Id)
+	u.Out().Printf("name\t%s", added.Summary)
+	u.Out().Printf("role\t%s", added.AccessRole)
 	return nil
 }
 

--- a/internal/cmd/execute_calendar_test.go
+++ b/internal/cmd/execute_calendar_test.go
@@ -64,3 +64,106 @@ func TestExecute_CalendarCalendars_JSON(t *testing.T) {
 		t.Fatalf("unexpected calendars: %#v", parsed.Calendars)
 	}
 }
+
+func TestExecute_CalendarSubscribe_JSON(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "calendarList") && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         req["id"],
+			"summary":    "Test Calendar",
+			"accessRole": "reader",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "calendar", "subscribe", "test@example.com"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Calendar struct {
+			ID         string `json:"id"`
+			Summary    string `json:"summary"`
+			AccessRole string `json:"accessRole"`
+		} `json:"calendar"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	if parsed.Calendar.ID != "test@example.com" {
+		t.Fatalf("unexpected calendar id: %s", parsed.Calendar.ID)
+	}
+	if parsed.Calendar.AccessRole != "reader" {
+		t.Fatalf("unexpected access role: %s", parsed.Calendar.AccessRole)
+	}
+}
+
+func TestExecute_CalendarSubscribe_Text(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(strings.Contains(r.URL.Path, "calendarList") && r.Method == http.MethodPost) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":         "user@example.com",
+			"summary":    "User Calendar",
+			"accessRole": "writer",
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := calendar.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--account", "a@b.com", "calendar", "subscribe", "user@example.com"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if !strings.Contains(out, "user@example.com") {
+		t.Fatalf("expected calendar id in output: %s", out)
+	}
+	if !strings.Contains(out, "writer") {
+		t.Fatalf("expected access role in output: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `calendar subscribe` command that implements the Google Calendar API's [calendarList.insert](https://developers.google.com/workspace/calendar/api/v3/reference/calendarList/insert) endpoint, allowing users to add an existing calendar to their calendar list.

- New command: `gog calendar subscribe <calendarId>`
- Aliases: `sub`, `add-calendar`
- Optional flags:
  - `--color-id` — Set calendar color (1-24, see `calendar colors`)
  - `--hidden` — Hide from calendar list UI
  - `--no-selected` — Don't show events in calendar UI

## Use case

Service accounts and users who have been granted access to a shared calendar need to explicitly add it to their calendar list before they can query events. This command enables that workflow.

## Test plan

- [x] Unit tests for JSON and text output modes
- [x] Manual testing with service account: successfully subscribed to shared calendar and verified with `calendar calendars`
- [x] `make build` passes
- [x] `make fmt` passes
- [x] New tests pass (`go test -run TestExecute_CalendarSubscribe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)