### PR TITLE
feat(docs): add --tab-id flag to editing commands

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -356,6 +356,7 @@ type DocsUpdateCmd struct {
 	Format      string `name:"format" help:"Content format: plain|markdown" default:"plain"`
 	Append      bool   `name:"append" help:"Append to end of document instead of replacing all content"`
 	Debug       bool   `name:"debug" help:"Enable debug output for markdown formatter"`
+	TabID       string `name:"tab-id" help:"Target a specific tab by ID (see list-tabs)"`
 }
 
 const (
@@ -409,22 +410,52 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	doc, err := svc.Documents.Get(id).
-		Context(ctx).
-		Do()
-	if err != nil {
-		if isDocsNotFound(err) {
-			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+	// Fetch document — use tab-aware API when --tab-id is set.
+	var bodyContent []*docs.StructuralElement
+	if c.TabID != "" {
+		doc, fetchErr := svc.Documents.Get(id).IncludeTabsContent(true).Context(ctx).Do()
+		if fetchErr != nil {
+			if isDocsNotFound(fetchErr) {
+				return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+			}
+			return fetchErr
 		}
-		return err
-	}
-	if doc == nil {
-		return errors.New("doc not found")
+		if doc == nil {
+			return errors.New("doc not found")
+		}
+		tabs := flattenTabs(doc.Tabs)
+		var found bool
+		for _, tab := range tabs {
+			if tab.TabProperties != nil && tab.TabProperties.TabId == c.TabID {
+				if tab.DocumentTab != nil && tab.DocumentTab.Body != nil {
+					bodyContent = tab.DocumentTab.Body.Content
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("tab not found: %s", c.TabID)
+		}
+	} else {
+		doc, fetchErr := svc.Documents.Get(id).Context(ctx).Do()
+		if fetchErr != nil {
+			if isDocsNotFound(fetchErr) {
+				return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+			}
+			return fetchErr
+		}
+		if doc == nil {
+			return errors.New("doc not found")
+		}
+		if doc.Body != nil {
+			bodyContent = doc.Body.Content
+		}
 	}
 
 	insertIndex := int64(1)
-	if c.Append && doc.Body != nil && len(doc.Body.Content) > 0 {
-		lastEl := doc.Body.Content[len(doc.Body.Content)-1]
+	if c.Append && len(bodyContent) > 0 {
+		lastEl := bodyContent[len(bodyContent)-1]
 		if lastEl != nil && lastEl.EndIndex > 1 {
 			insertIndex = lastEl.EndIndex - 1
 		}
@@ -450,16 +481,17 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Append {
 		requests = append(requests, &docs.Request{
 			InsertText: &docs.InsertTextRequest{
-				Location: &docs.Location{Index: insertIndex},
+				Location: &docs.Location{Index: insertIndex, TabId: c.TabID},
 				Text:     textToInsert,
 			},
 		})
 		if format == docsContentFormatMarkdown {
+			setTabIdOnRequests(formattingRequests, c.TabID)
 			requests = append(requests, formattingRequests...)
 		}
 	} else {
-		if doc.Body != nil && len(doc.Body.Content) > 0 {
-			lastEl := doc.Body.Content[len(doc.Body.Content)-1]
+		if len(bodyContent) > 0 {
+			lastEl := bodyContent[len(bodyContent)-1]
 			if lastEl != nil && lastEl.EndIndex > 2 {
 				endIdx := lastEl.EndIndex - 1
 				requests = append(requests, &docs.Request{
@@ -467,6 +499,7 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 						Range: &docs.Range{
 							StartIndex: 1,
 							EndIndex:   endIdx,
+							TabId:      c.TabID,
 						},
 					},
 				})
@@ -475,12 +508,13 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 		requests = append(requests, &docs.Request{
 			InsertText: &docs.InsertTextRequest{
-				Location: &docs.Location{Index: 1},
+				Location: &docs.Location{Index: 1, TabId: c.TabID},
 				Text:     textToInsert,
 			},
 		})
 
 		if format == docsContentFormatMarkdown {
+			setTabIdOnRequests(formattingRequests, c.TabID)
 			requests = append(requests, formattingRequests...)
 		}
 	}
@@ -654,6 +688,7 @@ type DocsWriteCmd struct {
 	File     string `name:"file" short:"f" help:"Read content from file (use - for stdin)"`
 	Replace  bool   `name:"replace" help:"Replace all content (default: append)"`
 	Markdown bool   `name:"markdown" help:"Convert markdown to Google Docs formatting (requires --replace)"`
+	TabID    string `name:"tab-id" help:"Target a specific tab by ID (see list-tabs)"`
 }
 
 func (c *DocsWriteCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -686,6 +721,12 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, account, docID, conten
 
 	if !c.Replace {
 		return usage("--markdown requires --replace (cannot append formatted markdown)")
+	}
+
+	// When targeting a specific tab, use Docs API batch approach since
+	// Drive API import cannot target tabs.
+	if c.TabID != "" {
+		return c.writeMarkdownToTab(ctx, account, docID, content)
 	}
 
 	driveSvc, err := newDriveService(ctx, account)
@@ -721,6 +762,94 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, account, docID, conten
 	return nil
 }
 
+// writeMarkdownToTab replaces a tab's content with formatted markdown using
+// the Docs API batch approach (ParseMarkdown → MarkdownToDocsRequests).
+func (c *DocsWriteCmd) writeMarkdownToTab(ctx context.Context, account, docID, content string) error {
+	u := ui.FromContext(ctx)
+
+	svc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	endIndex, err := c.fetchEndIndex(ctx, svc, docID)
+	if err != nil {
+		return err
+	}
+
+	var requests []*docs.Request
+
+	// Delete existing tab content.
+	if endIndex > 1 {
+		requests = append(requests, &docs.Request{
+			DeleteContentRange: &docs.DeleteContentRangeRequest{
+				Range: &docs.Range{
+					StartIndex: 1,
+					EndIndex:   endIndex,
+					TabId:      c.TabID,
+				},
+			},
+		})
+	}
+
+	// Convert markdown to Docs API requests.
+	elements := ParseMarkdown(content)
+	formattingRequests, textToInsert, tables := MarkdownToDocsRequests(elements, 1)
+
+	requests = append(requests, &docs.Request{
+		InsertText: &docs.InsertTextRequest{
+			Text: textToInsert,
+			Location: &docs.Location{
+				Index: 1,
+				TabId: c.TabID,
+			},
+		},
+	})
+
+	// Stamp TabId on all formatting requests.
+	setTabIdOnRequests(formattingRequests, c.TabID)
+	requests = append(requests, formattingRequests...)
+
+	_, err = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: requests,
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("writing markdown to tab: %w", err)
+	}
+
+	// Insert native tables if any.
+	if len(tables) > 0 {
+		tableInserter := NewTableInserter(svc, docID)
+		tableOffset := int64(0)
+		for _, table := range tables {
+			tableIndex := table.StartIndex + tableOffset
+			tableEnd, tableErr := tableInserter.InsertNativeTable(ctx, tableIndex, table.Cells)
+			if tableErr != nil {
+				return fmt.Errorf("insert native table: %w", tableErr)
+			}
+			if tableEnd > tableIndex {
+				tableOffset += (tableEnd - tableIndex) - 1
+			}
+		}
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": docID,
+			"written":    len(content),
+			"replaced":   true,
+			"markdown":   true,
+			"tabId":      c.TabID,
+		})
+	}
+
+	u.Out().Printf("documentId\t%s", docID)
+	u.Out().Printf("written\t%d bytes", len(content))
+	u.Out().Printf("mode\treplaced (markdown converted)")
+	u.Out().Printf("tabId\t%s", c.TabID)
+	return nil
+}
+
 func (c *DocsWriteCmd) writePlainText(ctx context.Context, account, docID, content string) error {
 	u := ui.FromContext(ctx)
 
@@ -732,24 +861,9 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, account, docID, conte
 	var requests []*docs.Request
 
 	if c.Replace {
-		var doc *docs.Document
-		doc, err = svc.Documents.Get(docID).Context(ctx).Do()
-		if err != nil {
-			if isDocsNotFound(err) {
-				return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
-			}
-			return fmt.Errorf("getting document: %w", err)
-		}
-		if doc == nil {
-			return errors.New("doc not found")
-		}
-
-		endIndex := int64(0)
-		if doc.Body != nil && len(doc.Body.Content) > 0 {
-			lastEl := doc.Body.Content[len(doc.Body.Content)-1]
-			if lastEl != nil && lastEl.EndIndex > 1 {
-				endIndex = lastEl.EndIndex - 1
-			}
+		endIndex, fetchErr := c.fetchEndIndex(ctx, svc, docID)
+		if fetchErr != nil {
+			return fetchErr
 		}
 		if endIndex > 1 {
 			requests = append(requests, &docs.Request{
@@ -757,6 +871,7 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, account, docID, conte
 					Range: &docs.Range{
 						StartIndex: 1,
 						EndIndex:   endIndex,
+						TabId:      c.TabID,
 					},
 				},
 			})
@@ -766,7 +881,7 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, account, docID, conte
 	requests = append(requests, &docs.Request{
 		InsertText: &docs.InsertTextRequest{
 			Text:                 content,
-			EndOfSegmentLocation: &docs.EndOfSegmentLocation{},
+			EndOfSegmentLocation: &docs.EndOfSegmentLocation{TabId: c.TabID},
 		},
 	})
 
@@ -795,11 +910,63 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, account, docID, conte
 	return nil
 }
 
+// fetchEndIndex returns the end index of the body content, fetching tab-aware
+// content when --tab-id is set.
+func (c *DocsWriteCmd) fetchEndIndex(ctx context.Context, svc *docs.Service, docID string) (int64, error) {
+	if c.TabID != "" {
+		doc, err := svc.Documents.Get(docID).IncludeTabsContent(true).Context(ctx).Do()
+		if err != nil {
+			if isDocsNotFound(err) {
+				return 0, fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+			}
+			return 0, fmt.Errorf("getting document: %w", err)
+		}
+		if doc == nil {
+			return 0, errors.New("doc not found")
+		}
+		tabs := flattenTabs(doc.Tabs)
+		for _, tab := range tabs {
+			if tab.TabProperties != nil && tab.TabProperties.TabId == c.TabID {
+				if tab.DocumentTab != nil && tab.DocumentTab.Body != nil {
+					content := tab.DocumentTab.Body.Content
+					if len(content) > 0 {
+						lastEl := content[len(content)-1]
+						if lastEl != nil && lastEl.EndIndex > 1 {
+							return lastEl.EndIndex - 1, nil
+						}
+					}
+				}
+				return 0, nil
+			}
+		}
+		return 0, fmt.Errorf("tab not found: %s", c.TabID)
+	}
+
+	doc, err := svc.Documents.Get(docID).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return 0, fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return 0, fmt.Errorf("getting document: %w", err)
+	}
+	if doc == nil {
+		return 0, errors.New("doc not found")
+	}
+	if doc.Body != nil && len(doc.Body.Content) > 0 {
+		lastEl := doc.Body.Content[len(doc.Body.Content)-1]
+		if lastEl != nil && lastEl.EndIndex > 1 {
+			return lastEl.EndIndex - 1, nil
+		}
+	}
+	return 0, nil
+}
+
 type DocsInsertCmd struct {
 	DocID   string `arg:"" name:"docId" help:"Doc ID"`
 	Content string `arg:"" optional:"" name:"content" help:"Text to insert (or use --file / stdin)"`
 	Index   int64  `name:"index" help:"Character index to insert at (1 = beginning)" default:"1"`
 	File    string `name:"file" short:"f" help:"Read content from file (use - for stdin)"`
+	TabID   string `name:"tab-id" help:"Target a specific tab by ID (see list-tabs)"`
 }
 
 func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -837,6 +1004,7 @@ func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Text: content,
 				Location: &docs.Location{
 					Index: c.Index,
+					TabId: c.TabID,
 				},
 			},
 		}},
@@ -863,6 +1031,7 @@ type DocsDeleteCmd struct {
 	DocID string `arg:"" name:"docId" help:"Doc ID"`
 	Start int64  `name:"start" required:"" help:"Start index (>= 1)"`
 	End   int64  `name:"end" required:"" help:"End index (> start)"`
+	TabID string `name:"tab-id" help:"Target a specific tab by ID (see list-tabs)"`
 }
 
 func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -895,6 +1064,7 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Range: &docs.Range{
 					StartIndex: c.Start,
 					EndIndex:   c.End,
+					TabId:      c.TabID,
 				},
 			},
 		}},
@@ -942,6 +1112,7 @@ type DocsFindReplaceCmd struct {
 	Find        string `arg:"" name:"find" help:"Text to find"`
 	ReplaceText string `arg:"" name:"replace" help:"Replacement text"`
 	MatchCase   bool   `name:"match-case" help:"Case-sensitive matching"`
+	TabID       string `name:"tab-id" help:"Target a specific tab by ID (see list-tabs)"`
 }
 
 func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -964,16 +1135,19 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	req := &docs.ReplaceAllTextRequest{
+		ContainsText: &docs.SubstringMatchCriteria{
+			Text:      c.Find,
+			MatchCase: c.MatchCase,
+		},
+		ReplaceText: c.ReplaceText,
+	}
+	if c.TabID != "" {
+		req.TabsCriteria = &docs.TabsCriteria{TabIds: []string{c.TabID}}
+	}
+
 	result, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
-		Requests: []*docs.Request{{
-			ReplaceAllText: &docs.ReplaceAllTextRequest{
-				ContainsText: &docs.SubstringMatchCriteria{
-					Text:      c.Find,
-					MatchCase: c.MatchCase,
-				},
-				ReplaceText: c.ReplaceText,
-			},
-		}},
+		Requests: []*docs.Request{{ReplaceAllText: req}},
 	}).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("find-replace: %w", err)
@@ -1201,6 +1375,36 @@ func tabInfoJSON(tab *docs.Tab) map[string]any {
 		}
 	}
 	return m
+}
+
+// setTabIdOnRequests stamps TabId on all Location/Range/EndOfSegmentLocation
+// fields in a slice of requests, used for targeting tab-specific operations.
+func setTabIdOnRequests(requests []*docs.Request, tabID string) {
+	if tabID == "" {
+		return
+	}
+	for _, r := range requests {
+		if r == nil {
+			continue
+		}
+		if r.InsertText != nil {
+			if r.InsertText.Location != nil {
+				r.InsertText.Location.TabId = tabID
+			}
+			if r.InsertText.EndOfSegmentLocation != nil {
+				r.InsertText.EndOfSegmentLocation.TabId = tabID
+			}
+		}
+		if r.DeleteContentRange != nil && r.DeleteContentRange.Range != nil {
+			r.DeleteContentRange.Range.TabId = tabID
+		}
+		if r.UpdateParagraphStyle != nil && r.UpdateParagraphStyle.Range != nil {
+			r.UpdateParagraphStyle.Range.TabId = tabID
+		}
+		if r.UpdateTextStyle != nil && r.UpdateTextStyle.Range != nil {
+			r.UpdateTextStyle.Range.TabId = tabID
+		}
+	}
 }
 
 func isDocsNotFound(err error) bool {

--- a/internal/cmd/docs_tab_id_test.go
+++ b/internal/cmd/docs_tab_id_test.go
@@ -1,0 +1,512 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func newDocsServiceForTest(t *testing.T, h http.HandlerFunc) (*docs.Service, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(h)
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		srv.Close()
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	return docSvc, srv.Close
+}
+
+func newDocsCmdContext(t *testing.T) context.Context {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	return ui.WithUI(context.Background(), u)
+}
+
+// tabsDocWithEndIndex returns a multi-tab doc response where each tab has
+// content with proper endIndex values (needed for --replace calculations).
+func tabsDocWithEndIndex() map[string]any {
+	return map[string]any{
+		"documentId": "doc1",
+		"title":      "Multi-Tab Doc",
+		"tabs": []any{
+			map[string]any{
+				"tabProperties": map[string]any{
+					"tabId": "t.first",
+					"title": "First",
+					"index": 0,
+				},
+				"documentTab": map[string]any{
+					"body": map[string]any{
+						"content": []any{
+							map[string]any{
+								"endIndex": 10,
+								"paragraph": map[string]any{
+									"elements": []any{
+										map[string]any{
+											"textRun": map[string]any{"content": "first tab"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			map[string]any{
+				"tabProperties": map[string]any{
+					"tabId": "t.second",
+					"title": "Second",
+					"index": 1,
+				},
+				"documentTab": map[string]any{
+					"body": map[string]any{
+						"content": []any{
+							map[string]any{
+								"endIndex": 20,
+								"paragraph": map[string]any{
+									"elements": []any{
+										map[string]any{
+											"textRun": map[string]any{"content": "second tab content"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestDocsInsert_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate") {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsInsertCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "hello", "--index", "5", "--tab-id", "t.abc"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs insert --tab-id: %v", err)
+	}
+
+	if len(got.Requests) != 1 || got.Requests[0].InsertText == nil {
+		t.Fatalf("unexpected request payload: %#v", got.Requests)
+	}
+	loc := got.Requests[0].InsertText.Location
+	if loc == nil || loc.Index != 5 || loc.TabId != "t.abc" {
+		t.Fatalf("expected TabId=t.abc at Index=5, got: %#v", loc)
+	}
+}
+
+func TestDocsDelete_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate") {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsDeleteCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--start", "2", "--end", "7", "--tab-id", "t.xyz"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs delete --tab-id: %v", err)
+	}
+
+	if len(got.Requests) != 1 || got.Requests[0].DeleteContentRange == nil {
+		t.Fatalf("unexpected request payload: %#v", got.Requests)
+	}
+	rng := got.Requests[0].DeleteContentRange.Range
+	if rng.StartIndex != 2 || rng.EndIndex != 7 || rng.TabId != "t.xyz" {
+		t.Fatalf("expected TabId=t.xyz range 2-7, got: %#v", rng)
+	}
+}
+
+func TestDocsFindReplace_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate") {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{"replaceAllText": map[string]any{"occurrencesChanged": 1}}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsFindReplaceCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "foo", "bar", "--tab-id", "t.abc"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs find-replace --tab-id: %v", err)
+	}
+
+	if len(got.Requests) != 1 || got.Requests[0].ReplaceAllText == nil {
+		t.Fatalf("unexpected request payload: %#v", got.Requests)
+	}
+	r := got.Requests[0].ReplaceAllText
+	if r.TabsCriteria == nil || len(r.TabsCriteria.TabIds) != 1 || r.TabsCriteria.TabIds[0] != "t.abc" {
+		t.Fatalf("expected TabsCriteria with t.abc, got: %#v", r.TabsCriteria)
+	}
+}
+
+func TestDocsFindReplace_WithoutTabID_NoTabsCriteria(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate") {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{"replaceAllText": map[string]any{"occurrencesChanged": 0}}},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsFindReplaceCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "foo", "bar"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs find-replace: %v", err)
+	}
+
+	if len(got.Requests) != 1 || got.Requests[0].ReplaceAllText == nil {
+		t.Fatalf("unexpected request payload: %#v", got.Requests)
+	}
+	if got.Requests[0].ReplaceAllText.TabsCriteria != nil {
+		t.Fatalf("expected no TabsCriteria without --tab-id, got: %#v", got.Requests[0].ReplaceAllText.TabsCriteria)
+	}
+}
+
+func TestDocsWriteAppend_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate") {
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsWriteCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "hello", "--tab-id", "t.abc"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs write --tab-id: %v", err)
+	}
+
+	if len(got.Requests) != 1 || got.Requests[0].InsertText == nil {
+		t.Fatalf("unexpected request payload: %#v", got.Requests)
+	}
+	eol := got.Requests[0].InsertText.EndOfSegmentLocation
+	if eol == nil || eol.TabId != "t.abc" {
+		t.Fatalf("expected EndOfSegmentLocation.TabId=t.abc, got: %#v", eol)
+	}
+}
+
+func TestDocsWriteReplace_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsWriteCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "new content", "--replace", "--tab-id", "t.second"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs write --replace --tab-id: %v", err)
+	}
+
+	// Should have delete + insert requests, both with TabId set.
+	if len(got.Requests) != 2 {
+		t.Fatalf("expected 2 requests (delete+insert), got %d", len(got.Requests))
+	}
+
+	del := got.Requests[0].DeleteContentRange
+	if del == nil || del.Range == nil || del.Range.TabId != "t.second" {
+		t.Fatalf("expected delete with TabId=t.second, got: %#v", del)
+	}
+	if del.Range.EndIndex != 19 {
+		t.Fatalf("expected endIndex=19 (20-1), got: %d", del.Range.EndIndex)
+	}
+
+	ins := got.Requests[1].InsertText
+	if ins == nil || ins.EndOfSegmentLocation == nil || ins.EndOfSegmentLocation.TabId != "t.second" {
+		t.Fatalf("expected insert with TabId=t.second, got: %#v", ins)
+	}
+}
+
+func TestDocsWriteReplace_WithTabID_TabNotFound(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsWriteCmd{}
+	err := runKong(t, cmd, []string{"doc1", "content", "--replace", "--tab-id", "t.nonexistent"}, newDocsCmdContext(t), flags)
+	if err == nil {
+		t.Fatal("expected error for nonexistent tab")
+	}
+	if !strings.Contains(err.Error(), "tab not found") {
+		t.Fatalf("expected 'tab not found' error, got: %v", err)
+	}
+}
+
+func TestSetTabIdOnRequests(t *testing.T) {
+	reqs := []*docs.Request{
+		{InsertText: &docs.InsertTextRequest{
+			Location: &docs.Location{Index: 1},
+		}},
+		{InsertText: &docs.InsertTextRequest{
+			EndOfSegmentLocation: &docs.EndOfSegmentLocation{},
+		}},
+		{DeleteContentRange: &docs.DeleteContentRangeRequest{
+			Range: &docs.Range{StartIndex: 1, EndIndex: 5},
+		}},
+		{UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
+			Range: &docs.Range{StartIndex: 1, EndIndex: 3},
+		}},
+		{UpdateTextStyle: &docs.UpdateTextStyleRequest{
+			Range: &docs.Range{StartIndex: 2, EndIndex: 4},
+		}},
+		nil,
+	}
+
+	setTabIdOnRequests(reqs, "t.test")
+
+	if reqs[0].InsertText.Location.TabId != "t.test" {
+		t.Fatalf("InsertText.Location.TabId not set")
+	}
+	if reqs[1].InsertText.EndOfSegmentLocation.TabId != "t.test" {
+		t.Fatalf("InsertText.EndOfSegmentLocation.TabId not set")
+	}
+	if reqs[2].DeleteContentRange.Range.TabId != "t.test" {
+		t.Fatalf("DeleteContentRange.Range.TabId not set")
+	}
+	if reqs[3].UpdateParagraphStyle.Range.TabId != "t.test" {
+		t.Fatalf("UpdateParagraphStyle.Range.TabId not set")
+	}
+	if reqs[4].UpdateTextStyle.Range.TabId != "t.test" {
+		t.Fatalf("UpdateTextStyle.Range.TabId not set")
+	}
+}
+
+func TestSetTabIdOnRequests_EmptyTabID(t *testing.T) {
+	reqs := []*docs.Request{
+		{InsertText: &docs.InsertTextRequest{
+			Location: &docs.Location{Index: 1},
+		}},
+	}
+
+	setTabIdOnRequests(reqs, "")
+
+	if reqs[0].InsertText.Location.TabId != "" {
+		t.Fatalf("expected empty TabId when called with empty string")
+	}
+}
+
+func TestDocsUpdateReplace_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--content", "new text", "--tab-id", "t.second"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs update --tab-id: %v", err)
+	}
+
+	// Should have delete + insert requests, both with TabId.
+	if len(got.Requests) != 2 {
+		t.Fatalf("expected 2 requests (delete+insert), got %d", len(got.Requests))
+	}
+
+	del := got.Requests[0].DeleteContentRange
+	if del == nil || del.Range == nil || del.Range.TabId != "t.second" {
+		t.Fatalf("expected delete with TabId=t.second, got: %#v", del)
+	}
+
+	ins := got.Requests[1].InsertText
+	if ins == nil || ins.Location == nil || ins.Location.TabId != "t.second" {
+		t.Fatalf("expected insert with TabId=t.second, got: %#v", ins)
+	}
+}
+
+func TestDocsUpdateAppend_WithTabID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--content", "appended", "--append", "--tab-id", "t.second"}, newDocsCmdContext(t), flags); err != nil {
+		t.Fatalf("docs update --append --tab-id: %v", err)
+	}
+
+	// Append: only insert, no delete.
+	if len(got.Requests) != 1 {
+		t.Fatalf("expected 1 request (insert), got %d", len(got.Requests))
+	}
+
+	ins := got.Requests[0].InsertText
+	if ins == nil || ins.Location == nil || ins.Location.TabId != "t.second" {
+		t.Fatalf("expected insert with TabId=t.second, got: %#v", ins)
+	}
+	// Append index should be endIndex-1 = 19.
+	if ins.Location.Index != 19 {
+		t.Fatalf("expected append at index 19, got %d", ins.Location.Index)
+	}
+}
+
+func TestDocsUpdate_WithTabID_TabNotFound(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+			return
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	cmd := &DocsUpdateCmd{}
+	err := runKong(t, cmd, []string{"doc1", "--content", "text", "--tab-id", "t.nope"}, newDocsCmdContext(t), flags)
+	if err == nil {
+		t.Fatal("expected error for nonexistent tab")
+	}
+	if !strings.Contains(err.Error(), "tab not found") {
+		t.Fatalf("expected 'tab not found' error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `--tab-id` flag to `write`, `insert`, `delete`, `find-replace`, and `update` commands to target specific document tabs
- Markdown write with `--tab-id` uses Docs API batch approach (Drive API can't target tabs)
- Plain text write/replace with `--tab-id` fetches tab-aware content for correct endIndex calculation
- `find-replace` uses `TabsCriteria` on `ReplaceAllTextRequest` per the API contract
- Includes `setTabIdOnRequests` helper to stamp `TabId` on all `Location`/`Range`/`EndOfSegmentLocation` in batch requests

Closes #323

## Design decisions

- **`--tab-id` (raw ID, no title resolution):** Clients get tab IDs via `gog docs list-tabs`. No extra API call, no business logic for name matching on write paths. `cat --tab` stays as-is since it already fetches the doc so title resolution is free there.
- **`docs update` included:** Same pattern as other editing commands — tab-aware doc fetch + `setTabIdOnRequests` on formatting requests.
- **Markdown + tab-id:** Uses Docs API `BatchUpdate` (delete tab content → insert markdown-converted requests with `TabId` stamped) instead of Drive API `Files.Update`.

## What's NOT included

- `docs update` refactoring to support new markdown features (separate issue)

## Also fixes

- Pre-existing bug in `contacts_crud.go`: function parameter types were incorrectly typed as bool due to Go's shorthand syntax (`given, familySet bool` instead of `given string, familySet bool`)

## Test plan

- [x] 12 new unit tests covering all 5 commands with/without `--tab-id`
- [x] Tab-not-found error cases tested
- [x] `make fmt` passes
- [x] `make test` passes (all packages)
- [x] `make lint` passes for our changes (5 pre-existing issues in contacts code)
- [x] Full E2E integration test against live Google Doc with multi-tab document
  - write, insert, delete, find-replace, update (all modes)
  - markdown write + replace to specific tab
  - bad tab ID error handling
  - backward compat (no --tab-id)
  - tab isolation verified (non-targeted tabs untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)