### PR TITLE
fix: bump Go to 1.25.7 (CVE-2025-68121)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/steipete/gogcli
 
-go 1.24.0
+go 1.25.7
 
 require (
 	github.com/99designs/keyring v1.2.2


### PR DESCRIPTION
## Summary

Pre-built release binaries are flagged by Trivy as CRITICAL due to CVE-2025-68121 — unexpected session resumption in `crypto/tls`. All Go versions before 1.24.13 / 1.25.7 are affected.

## Changes

- Bump `go` directive in `go.mod` from `1.24.0` to `1.25.7`

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./...`

A new release would need to be cut after merging to produce patched binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)