### PR TITLE
feat(sheets): add `gog sheets rename` command to rename sheet tabs

### DIFF
--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -247,7 +247,7 @@ func contactsURLs(values []string) []*people.Url {
 	return out
 }
 
-func contactsApplyPersonName(person *people.Person, givenSet bool, given, familySet bool, family string) {
+func contactsApplyPersonName(person *people.Person, givenSet bool, given string, familySet bool, family string) {
 	curGiven := ""
 	curFamily := ""
 	if len(person.Names) > 0 && person.Names[0] != nil {
@@ -263,7 +263,7 @@ func contactsApplyPersonName(person *people.Person, givenSet bool, given, family
 	person.Names = []*people.Name{{GivenName: curGiven, FamilyName: curFamily}}
 }
 
-func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org, titleSet bool, title string) {
+func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org string, titleSet bool, title string) {
 	curOrg := ""
 	curTitle := ""
 	if len(person.Organizations) > 0 && person.Organizations[0] != nil {

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -33,6 +33,7 @@ type SheetsCmd struct {
 	Notes    SheetsNotesCmd    `cmd:"" name:"notes" help:"Get cell notes from a range"`
 	Metadata SheetsMetadataCmd `cmd:"" name:"metadata" aliases:"info" help:"Get spreadsheet metadata"`
 	Create   SheetsCreateCmd   `cmd:"" name:"create" aliases:"new" help:"Create a new spreadsheet"`
+	Rename   SheetsRenameCmd   `cmd:"" name:"rename" aliases:"mv" help:"Rename a sheet tab (by index or name)"`
 	Copy     SheetsCopyCmd     `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Sheet"`
 	Export   SheetsExportCmd   `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Sheet (pdf|xlsx|csv) via Drive"`
 }

--- a/internal/cmd/sheets_rename.go
+++ b/internal/cmd/sheets_rename.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// SheetsRenameCmd renames a sheet tab (worksheet) within a Google Spreadsheet.
+// The sheet can be identified by its 0-based index or by its current name.
+//
+// Examples:
+//
+//	gog sheets rename <spreadsheetId> 0 "New Name"       # rename first tab by index
+//	gog sheets rename <spreadsheetId> "OldName" "New Name" # rename by current name
+type SheetsRenameCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	Sheet         string `arg:"" name:"sheet" help:"Sheet tab to rename: 0-based index or current tab name"`
+	NewName       string `arg:"" name:"newName" help:"New name for the sheet tab"`
+}
+
+func (c *SheetsRenameCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	sheetRef := strings.TrimSpace(c.Sheet)
+	newName := strings.TrimSpace(c.NewName)
+
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+	if sheetRef == "" {
+		return usage("empty sheet (provide 0-based index or current sheet name)")
+	}
+	if newName == "" {
+		return usage("empty newName")
+	}
+
+	if err := dryRunExit(ctx, flags, "sheets.rename", map[string]any{
+		"spreadsheet_id": spreadsheetID,
+		"sheet":          sheetRef,
+		"new_name":       newName,
+	}); err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	svc, err := newSheetsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	// Fetch sheet metadata to resolve sheetRef → numeric SheetId.
+	call := svc.Spreadsheets.Get(spreadsheetID).
+		Fields("sheets(properties(sheetId,title))")
+	resp, err := call.Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("get spreadsheet metadata: %w", err)
+	}
+
+	sheetID, oldName, err := resolveSheetRef(resp.Sheets, sheetRef)
+	if err != nil {
+		return err
+	}
+
+	req := &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: []*sheets.Request{
+			{
+				UpdateSheetProperties: &sheets.UpdateSheetPropertiesRequest{
+					Properties: &sheets.SheetProperties{
+						SheetId: sheetID,
+						Title:   newName,
+					},
+					Fields: "title",
+				},
+			},
+		},
+	}
+
+	if _, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, req).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("rename sheet: %w", err)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"spreadsheetId": spreadsheetID,
+			"sheetId":       sheetID,
+			"oldName":       oldName,
+			"newName":       newName,
+		})
+	}
+
+	u.Out().Printf("Renamed sheet %q → %q", oldName, newName)
+	return nil
+}
+
+// resolveSheetRef resolves a sheet reference (0-based index string or sheet name) to
+// the numeric SheetId used by the Sheets API, plus the current sheet title.
+func resolveSheetRef(sheets []*sheets.Sheet, ref string) (sheetID int64, title string, err error) {
+	// Try numeric index first.
+	if idx, parseErr := strconv.ParseInt(ref, 10, 64); parseErr == nil {
+		if idx < 0 || idx >= int64(len(sheets)) {
+			return 0, "", fmt.Errorf("sheet index %d out of range (spreadsheet has %d sheet(s))", idx, len(sheets))
+		}
+		props := sheets[idx].Properties
+		return props.SheetId, props.Title, nil
+	}
+
+	// Fall back to matching by name.
+	for _, s := range sheets {
+		if s.Properties == nil {
+			continue
+		}
+		if strings.EqualFold(s.Properties.Title, ref) {
+			return s.Properties.SheetId, s.Properties.Title, nil
+		}
+	}
+	return 0, "", fmt.Errorf("no sheet found with name %q", ref)
+}

--- a/internal/cmd/sheets_rename_test.go
+++ b/internal/cmd/sheets_rename_test.go
@@ -1,0 +1,226 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestSheetsRenameCmd(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	// fakeSheets is a minimal spreadsheet with two tabs.
+	fakeSpreadsheet := map[string]any{
+		"spreadsheetId": "s1",
+		"sheets": []map[string]any{
+			{"properties": map[string]any{"sheetId": 0, "title": "Sheet1"}},
+			{"properties": map[string]any{"sheetId": 42, "title": "Data"}},
+		},
+	}
+
+	var gotUpdate *sheets.UpdateSheetPropertiesRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/sheets/v4")
+		path = strings.TrimPrefix(path, "/v4")
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasPrefix(path, "/spreadsheets/s1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(fakeSpreadsheet)
+		case strings.Contains(path, "/spreadsheets/s1:batchUpdate") && r.Method == http.MethodPost:
+			var req sheets.BatchUpdateSpreadsheetRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 || req.Requests[0].UpdateSheetProperties == nil {
+				t.Fatalf("expected updateSheetProperties, got %#v", req.Requests)
+			}
+			gotUpdate = req.Requests[0].UpdateSheetProperties
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	t.Run("rename by index 0", func(t *testing.T) {
+		gotUpdate = nil
+		cmd := &SheetsRenameCmd{}
+		if err := runKong(t, cmd, []string{"s1", "0", "Renamed"}, ctx, flags); err != nil {
+			t.Fatalf("rename: %v", err)
+		}
+		if gotUpdate == nil {
+			t.Fatal("expected updateSheetProperties request")
+		}
+		if gotUpdate.Properties.SheetId != 0 {
+			t.Fatalf("wrong sheetId: got %d, want 0", gotUpdate.Properties.SheetId)
+		}
+		if gotUpdate.Properties.Title != "Renamed" {
+			t.Fatalf("wrong title: got %q, want %q", gotUpdate.Properties.Title, "Renamed")
+		}
+		if gotUpdate.Fields != "title" {
+			t.Fatalf("fields mask should be 'title', got %q", gotUpdate.Fields)
+		}
+	})
+
+	t.Run("rename by index 1", func(t *testing.T) {
+		gotUpdate = nil
+		cmd := &SheetsRenameCmd{}
+		if err := runKong(t, cmd, []string{"s1", "1", "NewData"}, ctx, flags); err != nil {
+			t.Fatalf("rename: %v", err)
+		}
+		if gotUpdate == nil {
+			t.Fatal("expected updateSheetProperties request")
+		}
+		if gotUpdate.Properties.SheetId != 42 {
+			t.Fatalf("wrong sheetId: got %d, want 42", gotUpdate.Properties.SheetId)
+		}
+		if gotUpdate.Properties.Title != "NewData" {
+			t.Fatalf("wrong title: got %q, want %q", gotUpdate.Properties.Title, "NewData")
+		}
+	})
+
+	t.Run("rename by name", func(t *testing.T) {
+		gotUpdate = nil
+		cmd := &SheetsRenameCmd{}
+		if err := runKong(t, cmd, []string{"s1", "Data", "Archive"}, ctx, flags); err != nil {
+			t.Fatalf("rename: %v", err)
+		}
+		if gotUpdate == nil {
+			t.Fatal("expected updateSheetProperties request")
+		}
+		if gotUpdate.Properties.SheetId != 42 {
+			t.Fatalf("wrong sheetId: got %d, want 42", gotUpdate.Properties.SheetId)
+		}
+		if gotUpdate.Properties.Title != "Archive" {
+			t.Fatalf("wrong title: got %q, want %q", gotUpdate.Properties.Title, "Archive")
+		}
+	})
+
+	t.Run("rename by name case-insensitive", func(t *testing.T) {
+		gotUpdate = nil
+		cmd := &SheetsRenameCmd{}
+		if err := runKong(t, cmd, []string{"s1", "data", "Lower"}, ctx, flags); err != nil {
+			t.Fatalf("rename: %v", err)
+		}
+		if gotUpdate == nil {
+			t.Fatal("expected updateSheetProperties request")
+		}
+		if gotUpdate.Properties.SheetId != 42 {
+			t.Fatalf("wrong sheetId: got %d, want 42", gotUpdate.Properties.SheetId)
+		}
+	})
+
+	t.Run("index out of range", func(t *testing.T) {
+		cmd := &SheetsRenameCmd{}
+		err := runKong(t, cmd, []string{"s1", "5", "Oops"}, ctx, flags)
+		if err == nil {
+			t.Fatal("expected error for out-of-range index")
+		}
+		if !strings.Contains(err.Error(), "out of range") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("unknown sheet name", func(t *testing.T) {
+		cmd := &SheetsRenameCmd{}
+		err := runKong(t, cmd, []string{"s1", "NoSuchSheet", "Oops"}, ctx, flags)
+		if err == nil {
+			t.Fatal("expected error for unknown sheet name")
+		}
+		if !strings.Contains(err.Error(), "no sheet found") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty newName rejected", func(t *testing.T) {
+		cmd := &SheetsRenameCmd{}
+		err := runKong(t, cmd, []string{"s1", "0", ""}, ctx, flags)
+		if err == nil {
+			t.Fatal("expected error for empty newName")
+		}
+	})
+}
+
+func TestResolveSheetRef(t *testing.T) {
+	makeSheets := func(titles ...string) []*sheets.Sheet {
+		result := make([]*sheets.Sheet, len(titles))
+		for i, title := range titles {
+			result[i] = &sheets.Sheet{
+				Properties: &sheets.SheetProperties{
+					SheetId: int64(i * 10),
+					Title:   title,
+				},
+			}
+		}
+		return result
+	}
+
+	tests := []struct {
+		name      string
+		ref       string
+		sheets    []*sheets.Sheet
+		wantID    int64
+		wantTitle string
+		wantErr   string
+	}{
+		{name: "index 0", ref: "0", sheets: makeSheets("Alpha", "Beta"), wantID: 0, wantTitle: "Alpha"},
+		{name: "index 1", ref: "1", sheets: makeSheets("Alpha", "Beta"), wantID: 10, wantTitle: "Beta"},
+		{name: "by name", ref: "Beta", sheets: makeSheets("Alpha", "Beta"), wantID: 10, wantTitle: "Beta"},
+		{name: "by name case-insensitive", ref: "beta", sheets: makeSheets("Alpha", "Beta"), wantID: 10, wantTitle: "Beta"},
+		{name: "negative index", ref: "-1", sheets: makeSheets("Alpha"), wantErr: "out of range"},
+		{name: "index too large", ref: "3", sheets: makeSheets("Alpha"), wantErr: "out of range"},
+		{name: "unknown name", ref: "Gamma", sheets: makeSheets("Alpha", "Beta"), wantErr: "no sheet found"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			id, title, err := resolveSheetRef(tc.sheets, tc.ref)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if id != tc.wantID {
+				t.Fatalf("sheetId: got %d, want %d", id, tc.wantID)
+			}
+			if title != tc.wantTitle {
+				t.Fatalf("title: got %q, want %q", title, tc.wantTitle)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `gog sheets rename <spreadsheetId> <sheet> <newName>` command that renames a Google Sheets tab (worksheet) using the Sheets API BatchUpdate/UpdateSheetProperties endpoint.

## Usage

```bash
# Rename first tab by 0-based index
gog sheets rename <spreadsheetId> 0 "New Tab Name"

# Rename by current tab name (case-insensitive)
gog sheets rename <spreadsheetId> "Old Name" "New Name"

# Alias
gog sheets mv <spreadsheetId> 0 "New Name"

# Dry run preview
gog sheets rename <spreadsheetId> 0 "New Name" --dry-run

# JSON output
gog sheets rename <spreadsheetId> 0 "New Name" --json
```

## Implementation

- The `<sheet>` argument accepts either a **0-based numeric index** or the **current tab name** (resolved case-insensitively)
- Uses `BatchUpdate` with `UpdateSheetProperties` (fields mask: `title`), consistent with how `sheets insert` and `sheets format` operate
- Supports `--dry-run`, `--json`, `--force` flags via the existing root flags infrastructure
- Registered as `rename` with alias `mv` in `SheetsCmd`

## Tests

14 new test cases in `sheets_rename_test.go`:
- Rename by index 0 / index 1
- Rename by name / case-insensitive name
- Out-of-range index error
- Unknown name error
- Empty `newName` validation
- `resolveSheetRef` unit tests (7 table-driven cases)

All existing tests continue to pass.

## Also fixes

A pre-existing compile error in `contacts_crud.go` introduced in commit 957603e where Go grouped parameter syntax caused `given` and `org` to be inferred as `bool` instead of `string`:

```go
// Before (broken — 'given' is bool, not string)
func contactsApplyPersonName(person *people.Person, givenSet bool, given, familySet bool, family string)

// After (fixed)
func contactsApplyPersonName(person *people.Person, givenSet bool, given string, familySet bool, family string)
```