### PR TITLE
fix(contacts): correct parameter types in apply functions

### DIFF
--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -247,7 +247,7 @@ func contactsURLs(values []string) []*people.Url {
 	return out
 }
 
-func contactsApplyPersonName(person *people.Person, givenSet bool, given, familySet bool, family string) {
+func contactsApplyPersonName(person *people.Person, givenSet bool, given string, familySet bool, family string) {
 	curGiven := ""
 	curFamily := ""
 	if len(person.Names) > 0 && person.Names[0] != nil {
@@ -263,7 +263,7 @@ func contactsApplyPersonName(person *people.Person, givenSet bool, given, family
 	person.Names = []*people.Name{{GivenName: curGiven, FamilyName: curFamily}}
 }
 
-func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org, titleSet bool, title string) {
+func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org string, titleSet bool, title string) {
 	curOrg := ""
 	curTitle := ""
 	if len(person.Organizations) > 0 && person.Organizations[0] != nil {


### PR DESCRIPTION
Fixes #285

Fix type mismatches where function parameters were incorrectly declared as bool instead of string, causing compilation errors when called with string arguments.

- contactsApplyPersonName: given parameter now string (was bool)
- contactsApplyPersonOrganization: org parameter now string (was bool)

Fixes Go 1.25 build failures on Fedora 43.

Amp-Thread-ID: https://ampcode.com/threads/T-019c8ec7-2e6a-709a-9958-69bff91e7194