### PR TITLE
chore(worker): bump compatibility_date and set D1 database ID

### DIFF
--- a/internal/tracking/worker/wrangler.toml
+++ b/internal/tracking/worker/wrangler.toml
@@ -1,8 +1,8 @@
 name = "gog-email-tracker"
 main = "src/index.ts"
-compatibility_date = "2024-12-01"
+compatibility_date = "2026-01-01"
 
 [[d1_databases]]
 binding = "DB"
 database_name = "gog-email-tracker"
-database_id = "placeholder-will-be-replaced"
+database_id = "b47d9d90-2c92-4b22-a13a-21e9c1d28a0f"


### PR DESCRIPTION
## Summary

- Bumped `compatibility_date` from `2024-12-01` to `2026-01-01` to stay current with Cloudflare Workers runtime
- Set `database_id` to the provisioned D1 database (`b47d9d90-2c92-4b22-a13a-21e9c1d28a0f`)

## Test plan

- [ ] Worker deploys successfully via `wrangler deploy`
- [ ] Schema migration applies cleanly via `wrangler d1 execute --remote --file schema.sql`
- [ ] `gog gmail send --track` sends email with pixel
- [ ] `/q/:tracking_id` returns open events after email is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)