### PR TITLE
fix(contacts): correct parameter types in contactsApplyPersonName and contactsApplyPersonOrganization

### DIFF
--- a/internal/cmd/contacts_crud.go
+++ b/internal/cmd/contacts_crud.go
@@ -247,7 +247,7 @@ func contactsURLs(values []string) []*people.Url {
 	return out
 }
 
-func contactsApplyPersonName(person *people.Person, givenSet bool, given, familySet bool, family string) {
+func contactsApplyPersonName(person *people.Person, givenSet bool, given string, familySet bool, family string) {
 	curGiven := ""
 	curFamily := ""
 	if len(person.Names) > 0 && person.Names[0] != nil {
@@ -263,7 +263,7 @@ func contactsApplyPersonName(person *people.Person, givenSet bool, given, family
 	person.Names = []*people.Name{{GivenName: curGiven, FamilyName: curFamily}}
 }
 
-func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org, titleSet bool, title string) {
+func contactsApplyPersonOrganization(person *people.Person, orgSet bool, org string, titleSet bool, title string) {
 	curOrg := ""
 	curTitle := ""
 	if len(person.Organizations) > 0 && person.Organizations[0] != nil {


### PR DESCRIPTION
## Summary

Fixes #371

- `contactsApplyPersonName`: `given, familySet bool` → `given string, familySet bool`
- `contactsApplyPersonOrganization`: `org, titleSet bool` → `org string, titleSet bool`

Go's grouped parameter shorthand `a, b Type` declares both as `Type`. The `given` and `org` parameters were intended to be `string`, not `bool`, causing a compile failure on `main`.

## Test plan

- [x] `make build` compiles successfully
- [x] `./bin/gog --version` runs correctly