### PR TITLE
security: suggested patches for semgrep high findings

### DIFF
--- a/security/patches/README_PATCH.md
+++ b/security/patches/README_PATCH.md
@@ -1,0 +1,29 @@
+gogcli security patches - suggested changes
+
+This folder contains suggested fixes for high-severity findings reported by semgrep.
+
+1) Avoid github context interpolation in GitHub Actions run steps
+ - Change `run:` steps that use `${{ github.* }}` directly to use `env:` variables and reference them safely.
+ - Example change (in .github/workflows/release.yml):
+
+   # BAD
+   run: echo "Releasing ${{ github.ref }}" && ./release.sh
+
+   # GOOD
+   env:
+     GITHUB_REF: "${{ github.ref }}"
+   run: |
+     echo "Releasing \"$GITHUB_REF\""
+     ./release.sh
+
+2) Sanitize exec.Command inputs
+ - Avoid passing unchecked user input to exec.Command. Validate against an allowlist or construct fixed arguments.
+ - Example fix: if opening a browser with a URL, ensure the URL is validated and not directly concatenated into a shell command.
+
+3) Open redirect mitigation
+ - For endpoints that redirect to user-provided URLs, implement an allowlist of domains or only permit relative paths.
+
+4) ResponseWriter XSS mitigation
+ - Use html/template for rendering and ensure values are escaped.
+
+For each recommended change below there is a suggested diff file (UNAPPLIED) and a short explanation.

--- a/security/patches/fix_exec_command.diff
+++ b/security/patches/fix_exec_command.diff
@@ -1,0 +1,26 @@
+*** Begin Patch
+*** Update File: internal/googleauth/open_browser.go
+@@
+-    cmd := exec.Command("open", url)
+-    _ = cmd.Run()
++    // Validate URL before opening. Allow only http/https and simple hostnames.
++    if !isAllowedURL(url) {
++        return fmt.Errorf("disallowed URL")
++    }
++    // Use exec.Command with validated argument (no shell interpolation)
++    cmd := exec.Command("open", url)
++    _ = cmd.Run()
++
++// isAllowedURL performs a conservative check on the URL.
++func isAllowedURL(u string) bool {
++    parsed, err := url.Parse(u)
++    if err != nil {
++        return false
++    }
++    if parsed.Scheme != "http" && parsed.Scheme != "https" {
++        return false
++    }
++    // Optionally enforce an allowlist of hosts here.
++    return true
++}
+*** End Patch

--- a/security/patches/fix_workflow_run_env.diff
+++ b/security/patches/fix_workflow_run_env.diff
@@ -1,0 +1,14 @@
+*** Begin Patch
+*** Update File: .github/workflows/release.yml
+@@
+-      - name: Release
+-        run: |
+-          echo "Releasing ${{ github.ref }}"
+-          ./scripts/release.sh "${{ github.ref }}"
++      - name: Release
++        env:
++          GITHUB_REF: "${{ github.ref }}"
++        run: |
++          echo "Releasing \"$GITHUB_REF\""
++          ./scripts/release.sh "$GITHUB_REF"
+*** End Patch


### PR DESCRIPTION
gogcli security patches - suggested changes

This folder contains suggested fixes for high-severity findings reported by semgrep.

1) Avoid github context interpolation in GitHub Actions run steps
 - Change `run:` steps that use `${{ github.* }}` directly to use `env:` variables and reference them safely.
 - Example change (in .github/workflows/release.yml):

   # BAD
   run: echo "Releasing ${{ github.ref }}" && ./release.sh

   # GOOD
   env:
     GITHUB_REF: "${{ github.ref }}"
   run: |
     echo "Releasing \"$GITHUB_REF\""
     ./release.sh

2) Sanitize exec.Command inputs
 - Avoid passing unchecked user input to exec.Command. Validate against an allowlist or construct fixed arguments.
 - Example fix: if opening a browser with a URL, ensure the URL is validated and not directly concatenated into a shell command.

3) Open redirect mitigation
 - For endpoints that redirect to user-provided URLs, implement an allowlist of domains or only permit relative paths.

4) ResponseWriter XSS mitigation
 - Use html/template for rendering and ensure values are escaped.

For each recommended change below there is a suggested diff file (UNAPPLIED) and a short explanation.