### PR TITLE
feat: add runtime read-only command guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,17 @@ Notes:
 - `--drive-scope readonly` is enough for listing/downloading/exporting via Drive (write operations will 403).
 - `--drive-scope file` is write-capable (limited to files created/opened by this app) and can’t be combined with `--readonly`.
 
+Runtime read-only mode (command guard):
+
+```bash
+gog --read-only <command>
+# or
+export GOG_READ_ONLY=true
+```
+
+When enabled, mutating commands (`create`, `update`, `delete`, `send`, etc.) are blocked before execution.
+This is useful when you want one CLI profile that is strictly browse-only.
+
 If you need to add services later and Google doesn't return a refresh token, re-run with `--force-consent`:
 
 ```bash

--- a/internal/cmd/readonly.go
+++ b/internal/cmd/readonly.go
@@ -1,0 +1,114 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/alecthomas/kong"
+)
+
+var readOnlyBlockedTokens = map[string]struct{}{
+	"accept":    {},
+	"add":       {},
+	"append":    {},
+	"archive":   {},
+	"clear":     {},
+	"copy":      {},
+	"create":    {},
+	"decline":   {},
+	"del":       {},
+	"delete":    {},
+	"done":      {},
+	"edit":      {},
+	"format":    {},
+	"grade":     {},
+	"insert":    {},
+	"join":      {},
+	"leave":     {},
+	"login":     {},
+	"logout":    {},
+	"mark":      {},
+	"modify":    {},
+	"move":      {},
+	"patch":     {},
+	"propose":   {},
+	"remove":    {},
+	"renew":     {},
+	"replace":   {},
+	"respond":   {},
+	"restore":   {},
+	"rm":        {},
+	"run":       {},
+	"sed":       {},
+	"send":      {},
+	"set":       {},
+	"setup":     {},
+	"start":     {},
+	"stop":      {},
+	"trash":     {},
+	"undo":      {},
+	"unarchive": {},
+	"unset":     {},
+	"untrash":   {},
+	"update":    {},
+	"upload":    {},
+	"verify":    {},
+	"watch":     {},
+	"write":     {},
+}
+
+var readOnlyBlockedPaths = map[string]struct{}{
+	"calendar focus-time":       {},
+	"calendar out-of-office":    {},
+	"calendar propose-time":     {},
+	"calendar working-location": {},
+	"chat dm space":             {},
+}
+
+func enforceReadOnlyCommand(kctx *kong.Context, enabled bool) error {
+	if !enabled || kctx == nil {
+		return nil
+	}
+
+	tokens := selectedCommandTokens(kctx)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	commandPath := strings.Join(tokens, " ")
+	if _, blocked := readOnlyBlockedPaths[commandPath]; blocked {
+		return usagef("read-only mode blocks mutating command: %s (re-run without --read-only to allow writes)", commandPath)
+	}
+
+	for _, token := range tokens {
+		if _, blocked := readOnlyBlockedTokens[token]; blocked {
+			return usagef("read-only mode blocks mutating command: %s (re-run without --read-only to allow writes)", commandPath)
+		}
+		for _, part := range strings.Split(token, "-") {
+			if _, blocked := readOnlyBlockedTokens[part]; blocked {
+				return usagef("read-only mode blocks mutating command: %s (re-run without --read-only to allow writes)", commandPath)
+			}
+		}
+	}
+
+	return nil
+}
+
+func selectedCommandTokens(kctx *kong.Context) []string {
+	if kctx == nil {
+		return nil
+	}
+
+	tokens := make([]string, 0, len(kctx.Path))
+	for _, p := range kctx.Path {
+		if p == nil || p.Command == nil {
+			continue
+		}
+		name := strings.TrimSpace(strings.ToLower(p.Command.Name))
+		if name == "" || name == "gog" {
+			continue
+		}
+		tokens = append(tokens, name)
+	}
+
+	return tokens
+}

--- a/internal/cmd/readonly_test.go
+++ b/internal/cmd/readonly_test.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSelectedCommandTokens(t *testing.T) {
+	parser, _, err := newParser("test")
+	if err != nil {
+		t.Fatalf("newParser: %v", err)
+	}
+
+	kctx, err := parser.Parse([]string{"config", "set", "foo", "bar"})
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	got := selectedCommandTokens(kctx)
+	want := []string{"config", "set"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected tokens: got=%v want=%v", got, want)
+	}
+}
+
+func TestExecute_ReadOnlyBlocksMutatingCommand(t *testing.T) {
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			err := Execute([]string{"--read-only", "config", "set", "foo", "bar"})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), "read-only mode blocks mutating command") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(errText, "read-only mode blocks mutating command") {
+		t.Fatalf("expected read-only error on stderr, got: %q", errText)
+	}
+}
+
+func TestExecute_ReadOnlyAllowsReadCommand(t *testing.T) {
+	_ = captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			if err := Execute([]string{"--read-only", "version"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}
+
+func TestExecute_ReadOnlyFromEnvBlocksMutatingCommand(t *testing.T) {
+	t.Setenv("GOG_READ_ONLY", "true")
+
+	errText := captureStderr(t, func() {
+		_ = captureStdout(t, func() {
+			err := Execute([]string{"config", "set", "foo", "bar"})
+			if err == nil {
+				t.Fatalf("expected error")
+			}
+			if !strings.Contains(err.Error(), "read-only mode blocks mutating command") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	})
+	if !strings.Contains(errText, "read-only mode blocks mutating command") {
+		t.Fatalf("expected read-only error on stderr, got: %q", errText)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -37,6 +37,7 @@ type RootFlags struct {
 	ResultsOnly    bool   `name:"results-only" help:"In JSON mode, emit only the primary result (drops envelope fields like nextPageToken)"`
 	Select         string `name:"select" aliases:"pick,project" help:"In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands."`
 	DryRun         bool   `help:"Do not make changes; print intended actions and exit successfully" aliases:"noop,preview,dryrun" short:"n"`
+	ReadOnly       bool   `name:"read-only" help:"Block mutating commands; allow read/list/get/search/export operations only" default:"${read_only}"`
 	Force          bool   `help:"Skip confirmations for destructive commands" aliases:"yes,assume-yes" short:"y"`
 	NoInput        bool   `help:"Never prompt; fail instead (useful for CI)" aliases:"non-interactive,noninteractive"`
 	Verbose        bool   `help:"Enable verbose logging" short:"v"`
@@ -118,6 +119,10 @@ func Execute(args []string) (err error) {
 	}
 
 	if err = enforceEnabledCommands(kctx, cli.EnableCommands); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
+		return err
+	}
+	if err = enforceReadOnlyCommand(kctx, cli.ReadOnly); err != nil {
 		_, _ = fmt.Fprintln(os.Stderr, errfmt.Format(err))
 		return err
 	}
@@ -303,6 +308,7 @@ func newParser(description string) (*kong.Kong, *CLI, error) {
 		"enabled_commands": envOr("GOG_ENABLE_COMMANDS", ""),
 		"json":             boolString(envMode.JSON),
 		"plain":            boolString(envMode.Plain),
+		"read_only":        envOr("GOG_READ_ONLY", "false"),
 		"version":          VersionString(),
 	}
 


### PR DESCRIPTION
## Summary

Adds a runtime read-only mode for `gog` that blocks mutating commands before execution.

### What’s included

- New global flag: `--read-only`
- New env var: `GOG_READ_ONLY=true`
- Pre-run enforcement in `Execute(...)` via `enforceReadOnlyCommand(...)`
- Command-path/token based mutating-command detection
- README docs for runtime read-only mode
- Tests for token extraction + flag/env behavior

## Why

`auth add --readonly` limits OAuth scopes, but users may still want an explicit runtime guardrail for day-to-day “browse only” usage. This adds a policy-layer command guard that prevents accidental write operations.

## Examples

- `gog --read-only gmail search "from:alerts"` ✅
- `gog --read-only calendar create ...` ❌ blocked
- `GOG_READ_ONLY=true gog config set x y` ❌ blocked

## Validation

- `go test ./internal/cmd -run 'TestSelectedCommandTokens|TestExecute_ReadOnly' -count=1`
- `go test ./... -run TestNonExistent -count=1`
