### PR TITLE
fix: populate CopyMask in contacts other delete to fix 400 error

### DIFF
--- a/internal/cmd/contacts_directory.go
+++ b/internal/cmd/contacts_directory.go
@@ -449,7 +449,11 @@ func deleteOtherContact(ctx context.Context, account, resourceName string) error
 	}
 	copied, err := otherSvc.OtherContacts.CopyOtherContactToMyContactsGroup(
 		resourceName,
-		&people.CopyOtherContactToMyContactsGroupRequest{},
+		&people.CopyOtherContactToMyContactsGroupRequest{
+			// CopyMask is required by the People API; omitting it causes a 400 "copyMask is required" error.
+			// See: https://developers.google.com/people/api/rest/v1/otherContacts/copyOtherContactToMyContactsGroup
+			CopyMask: "names,phoneNumbers,emailAddresses,organizations,biographies,urls,addresses,birthdays,events,relations,userDefined",
+		},
 	).Do()
 	if err != nil {
 		return fmt.Errorf("copy to my contacts: %w", err)


### PR DESCRIPTION
## Problem

`gog contacts other delete` fails with:
```
Google API error (400 badRequest): copyMask is required. Please specify one or more valid paths.
```

This makes the command completely unusable. Reported in #383.

## Root Cause

In `deleteOtherContact()`, the `CopyOtherContactToMyContactsGroup` API is called with an empty `CopyOtherContactToMyContactsGroupRequest{}`. The Google People API **requires** the `CopyMask` field — without it, the API returns a 400 error.

## Fix

Populate `CopyMask` with all relevant contact fields:

```go
&people.CopyOtherContactToMyContactsGroupRequest{
    CopyMask: "names,phoneNumbers,emailAddresses,organizations,biographies,urls,addresses,birthdays,events,relations,userDefined",
},
```

## Testing

Build passes (`go build ./...`). The fix can be verified by running `gog contacts other delete` against any `otherContacts/` resource — it should now successfully copy + delete instead of returning a 400.

Fixes #383