### PR TITLE
feat(gmail): add archive, read, unread, trash convenience commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Calendar: reject ambiguous calendar-name selectors for `calendar events` instead of guessing. (#131) — thanks @salmonumbrella.
 - Gmail: `drafts update --quote` now picks a non-draft, non-self message from thread fallback (or errors clearly), avoiding self-quote loops and wrong reply headers. (#394) — thanks @salmonumbrella.
 - Auth: add `--gmail-scope full|readonly`, and disable `include_granted_scopes` for readonly/limited auth requests to avoid Drive/Gmail scope accumulation. (#113) — thanks @salmonumbrella.
+- Gmail: `gmail archive|read|unread|trash` convenience commands now honor `--dry-run` and emit action-specific dry-run ops. (#385) — thanks @yeager.
 
 ## 0.11.0 - 2026-02-15
 

--- a/internal/cmd/gmail.go
+++ b/internal/cmd/gmail.go
@@ -27,11 +27,11 @@ type GmailCmd struct {
 	URL        GmailURLCmd        `cmd:"" name:"url" group:"Read" help:"Print Gmail web URLs for threads"`
 	History    GmailHistoryCmd    `cmd:"" name:"history" group:"Read" help:"Gmail history"`
 
-	Labels GmailLabelsCmd `cmd:"" name:"labels" aliases:"label" group:"Organize" help:"Label operations"`
-	Batch  GmailBatchCmd  `cmd:"" name:"batch" group:"Organize" help:"Batch operations"`
-	Archive GmailArchiveCmd `cmd:"" name:"archive" group:"Organize" help:"Archive messages (remove from inbox)"`
-	Read    GmailReadCmd    `cmd:"" name:"read" aliases:"mark-read" group:"Organize" help:"Mark messages as read"`
-	Unread  GmailUnreadCmd  `cmd:"" name:"unread" aliases:"mark-unread" group:"Organize" help:"Mark messages as unread"`
+	Labels  GmailLabelsCmd   `cmd:"" name:"labels" aliases:"label" group:"Organize" help:"Label operations"`
+	Batch   GmailBatchCmd    `cmd:"" name:"batch" group:"Organize" help:"Batch operations"`
+	Archive GmailArchiveCmd  `cmd:"" name:"archive" group:"Organize" help:"Archive messages (remove from inbox)"`
+	Read    GmailReadCmd     `cmd:"" name:"mark-read" aliases:"read-messages" group:"Organize" help:"Mark messages as read"`
+	Unread  GmailUnreadCmd   `cmd:"" name:"unread" aliases:"mark-unread" group:"Organize" help:"Mark messages as unread"`
 	Trash   GmailTrashMsgCmd `cmd:"" name:"trash" group:"Organize" help:"Move messages to trash"`
 
 	Send   GmailSendCmd   `cmd:"" name:"send" group:"Write" help:"Send an email"`

--- a/internal/cmd/gmail_archive.go
+++ b/internal/cmd/gmail_archive.go
@@ -20,7 +20,7 @@ type GmailArchiveCmd struct {
 }
 
 func (c *GmailArchiveCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, nil, []string{"INBOX"}, "archived")
+	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, nil, []string{"INBOX"}, "archived", "gmail.archive")
 }
 
 // GmailTrashMsgCmd moves messages to trash.
@@ -31,7 +31,7 @@ type GmailTrashMsgCmd struct {
 }
 
 func (c *GmailTrashMsgCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, []string{"TRASH"}, []string{"INBOX"}, "trashed")
+	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, []string{"TRASH"}, []string{"INBOX"}, "trashed", "gmail.trash")
 }
 
 // GmailReadCmd marks messages as read.
@@ -42,7 +42,7 @@ type GmailReadCmd struct {
 }
 
 func (c *GmailReadCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, nil, []string{"UNREAD"}, "marked as read")
+	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, nil, []string{"UNREAD"}, "marked as read", "gmail.read")
 }
 
 // GmailUnreadCmd marks messages as unread.
@@ -53,15 +53,34 @@ type GmailUnreadCmd struct {
 }
 
 func (c *GmailUnreadCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, []string{"UNREAD"}, nil, "marked as unread")
+	return gmailBulkLabelOp(ctx, flags, c.MessageIDs, c.Query, c.Max, []string{"UNREAD"}, nil, "marked as unread", "gmail.unread")
 }
 
 // gmailBulkLabelOp handles the common pattern: resolve IDs (from args or query), then batch modify labels.
-func gmailBulkLabelOp(ctx context.Context, flags *RootFlags, messageIDs []string, query string, max int64, addLabels, removeLabels []string, verb string) error {
+func gmailBulkLabelOp(ctx context.Context, flags *RootFlags, messageIDs []string, query string, limit int64, addLabels, removeLabels []string, verb string, dryRunOp string) error {
 	u := ui.FromContext(ctx)
 
-	if len(messageIDs) == 0 && query == "" {
+	idsFromArgs := make([]string, 0, len(messageIDs))
+	for _, id := range messageIDs {
+		id = normalizeGmailMessageID(id)
+		if id != "" {
+			idsFromArgs = append(idsFromArgs, id)
+		}
+	}
+
+	if len(idsFromArgs) == 0 && query == "" {
 		return usage("provide message IDs or --query")
+	}
+
+	if err := dryRunExit(ctx, flags, dryRunOp, map[string]any{
+		"message_ids":    idsFromArgs,
+		"query":          strings.TrimSpace(query),
+		"max":            limit,
+		"added_labels":   nonNilStrings(addLabels),
+		"removed_labels": nonNilStrings(removeLabels),
+		"action":         verb,
+	}); err != nil {
+		return err
 	}
 
 	account, err := requireAccount(flags)
@@ -75,19 +94,14 @@ func gmailBulkLabelOp(ctx context.Context, flags *RootFlags, messageIDs []string
 	}
 
 	// Collect IDs: either from args or by searching
-	ids := make([]string, 0)
+	ids := make([]string, 0, len(idsFromArgs))
 	if query != "" {
-		ids, err = searchMessageIDs(ctx, svc, query, max)
+		ids, err = searchMessageIDs(ctx, svc, query, limit)
 		if err != nil {
 			return err
 		}
 	}
-	for _, id := range messageIDs {
-		id = normalizeGmailMessageID(id)
-		if id != "" {
-			ids = append(ids, id)
-		}
-	}
+	ids = append(ids, idsFromArgs...)
 
 	if len(ids) == 0 {
 		if outfmt.IsJSON(ctx) {
@@ -147,10 +161,10 @@ func gmailBulkLabelOp(ctx context.Context, flags *RootFlags, messageIDs []string
 }
 
 // searchMessageIDs returns message IDs matching a Gmail query.
-func searchMessageIDs(ctx context.Context, svc *gmail.Service, query string, max int64) ([]string, error) {
+func searchMessageIDs(ctx context.Context, svc *gmail.Service, query string, limit int64) ([]string, error) {
 	var ids []string
 	pageToken := ""
-	remaining := max
+	remaining := limit
 
 	for {
 		batchSize := remaining
@@ -200,4 +214,11 @@ func capitalizeFirst(s string) string {
 		return s
 	}
 	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
 }

--- a/internal/cmd/gmail_archive_test.go
+++ b/internal/cmd/gmail_archive_test.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+func runGmailBulkDryRun(t *testing.T, cmd any, args []string) map[string]any {
+	t.Helper()
+
+	ctx := outfmt.WithMode(context.Background(), outfmt.Mode{JSON: true})
+
+	out := captureStdout(t, func() {
+		err := runKong(t, cmd, args, ctx, &RootFlags{DryRun: true})
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+			t.Fatalf("expected dry-run exit code 0, got: %v", err)
+		}
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, out)
+	}
+	return got
+}
+
+func requestStringSlice(t *testing.T, req map[string]any, key string) []string {
+	t.Helper()
+
+	raw, ok := req[key].([]any)
+	if !ok {
+		t.Fatalf("expected request.%s array, got %T", key, req[key])
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		s, ok := v.(string)
+		if !ok {
+			t.Fatalf("expected string in request.%s, got %T", key, v)
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func requireRequestMap(t *testing.T, got map[string]any) map[string]any {
+	t.Helper()
+
+	req, ok := got["request"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected request object, got %T", got["request"])
+	}
+	return req
+}
+
+func TestGmailBulkOps_DryRun_UsesSpecificOpsAndLabels(t *testing.T) {
+	tests := []struct {
+		name       string
+		cmd        any
+		args       []string
+		wantOp     string
+		wantAdd    []string
+		wantRemove []string
+	}{
+		{
+			name:       "archive",
+			cmd:        &GmailArchiveCmd{},
+			args:       []string{"msg1"},
+			wantOp:     "gmail.archive",
+			wantAdd:    []string{},
+			wantRemove: []string{"INBOX"},
+		},
+		{
+			name:       "read",
+			cmd:        &GmailReadCmd{},
+			args:       []string{"msg1"},
+			wantOp:     "gmail.read",
+			wantAdd:    []string{},
+			wantRemove: []string{"UNREAD"},
+		},
+		{
+			name:       "unread",
+			cmd:        &GmailUnreadCmd{},
+			args:       []string{"msg1"},
+			wantOp:     "gmail.unread",
+			wantAdd:    []string{"UNREAD"},
+			wantRemove: []string{},
+		},
+		{
+			name:       "trash",
+			cmd:        &GmailTrashMsgCmd{},
+			args:       []string{"msg1"},
+			wantOp:     "gmail.trash",
+			wantAdd:    []string{"TRASH"},
+			wantRemove: []string{"INBOX"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runGmailBulkDryRun(t, tt.cmd, tt.args)
+
+			op, ok := got["op"].(string)
+			if !ok || op != tt.wantOp {
+				t.Fatalf("expected op=%q, got=%v", tt.wantOp, got["op"])
+			}
+
+			req := requireRequestMap(t, got)
+			messageIDs := requestStringSlice(t, req, "message_ids")
+			if len(messageIDs) != 1 || messageIDs[0] != "msg1" {
+				t.Fatalf("unexpected request.message_ids: %v", messageIDs)
+			}
+
+			added := requestStringSlice(t, req, "added_labels")
+			if len(added) != len(tt.wantAdd) {
+				t.Fatalf("unexpected request.added_labels len: got=%v want=%v", added, tt.wantAdd)
+			}
+			for i := range tt.wantAdd {
+				if added[i] != tt.wantAdd[i] {
+					t.Fatalf("unexpected request.added_labels: got=%v want=%v", added, tt.wantAdd)
+				}
+			}
+
+			removed := requestStringSlice(t, req, "removed_labels")
+			if len(removed) != len(tt.wantRemove) {
+				t.Fatalf("unexpected request.removed_labels len: got=%v want=%v", removed, tt.wantRemove)
+			}
+			for i := range tt.wantRemove {
+				if removed[i] != tt.wantRemove[i] {
+					t.Fatalf("unexpected request.removed_labels: got=%v want=%v", removed, tt.wantRemove)
+				}
+			}
+		})
+	}
+}
+
+func TestGmailArchiveCmd_DryRun_QueryMode_NoAccountRequired(t *testing.T) {
+	got := runGmailBulkDryRun(t, &GmailArchiveCmd{}, []string{"--query", "is:unread", "--max", "25"})
+
+	if op, _ := got["op"].(string); op != "gmail.archive" {
+		t.Fatalf("expected op gmail.archive, got %v", got["op"])
+	}
+
+	req := requireRequestMap(t, got)
+	if q, _ := req["query"].(string); q != "is:unread" {
+		t.Fatalf("unexpected query: %v", req["query"])
+	}
+	if limit, ok := req["max"].(float64); !ok || int(limit) != 25 {
+		t.Fatalf("unexpected max: %v", req["max"])
+	}
+	if ids := requestStringSlice(t, req, "message_ids"); len(ids) != 0 {
+		t.Fatalf("expected empty message_ids, got %v", ids)
+	}
+}


### PR DESCRIPTION
## Summary

Adds four top-level Gmail convenience commands that wrap `batch modify`:

| Command | Effect |
|---------|--------|
| `gog gmail archive` | Remove INBOX label |
| `gog gmail read` | Remove UNREAD label |
| `gog gmail unread` | Add UNREAD label |
| `gog gmail trash` | Add TRASH + remove INBOX |

## Usage

```bash
# Archive specific messages
gog gmail archive MSG_ID1 MSG_ID2

# Archive all unread older than 7 days
gog gmail archive -q 'is:unread older_than:7d'

# Mark all as read
gog gmail read -q 'is:unread' --max 500

# Trash by query
gog gmail trash -q 'from:noreply@example.com'
```

## Implementation

- Single new file: `internal/cmd/gmail_archive.go`
- Shared `gmailBulkLabelOp()` helper with auto-batching (1000/request)
- `searchMessageIDs()` for query-based bulk operations with pagination
- Registered as top-level commands under `GmailCmd` (Organize group)
- Supports JSON output, dry-run, all standard flags