### PR TITLE
feat(auth): support pure service account mode without impersonation

### DIFF
--- a/internal/googleapi/service_account.go
+++ b/internal/googleapi/service_account.go
@@ -17,7 +17,13 @@ var newServiceAccountTokenSource = func(ctx context.Context, keyJSON []byte, sub
 	if err != nil {
 		return nil, fmt.Errorf("parse service account: %w", err)
 	}
-	cfg.Subject = subject
+	// Only set Subject (impersonation) when the caller requests a different
+	// identity than the service account itself.  When subject matches the
+	// SA's client_email we run in "pure SA mode" — no Domain-Wide Delegation
+	// required; the SA can only access resources explicitly shared with it.
+	if subject != "" && subject != cfg.Email {
+		cfg.Subject = subject
+	}
 
 	// Ensure token exchanges don't hang forever.
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: defaultHTTPTimeout})

--- a/internal/googleapi/service_account_test.go
+++ b/internal/googleapi/service_account_test.go
@@ -1,0 +1,83 @@
+package googleapi
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"testing"
+)
+
+func generateTestSAKeyJSON(t *testing.T, clientEmail string) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+
+	der := x509.MarshalPKCS1PrivateKey(key)
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}
+	keyPEM := string(pem.EncodeToMemory(block))
+
+	return []byte(fmt.Sprintf(`{
+		"type": "service_account",
+		"project_id": "test-project",
+		"private_key_id": "key-id",
+		"private_key": %q,
+		"client_email": %q,
+		"client_id": "123456",
+		"auth_uri": "https://accounts.google.com/o/oauth2/auth",
+		"token_uri": "https://oauth2.googleapis.com/token"
+	}`, keyPEM, clientEmail))
+}
+
+func TestNewServiceAccountTokenSource_PureSAMode(t *testing.T) {
+	const saEmail = "sa@test-project.iam.gserviceaccount.com"
+	keyJSON := generateTestSAKeyJSON(t, saEmail)
+
+	// Pure SA mode: subject matches the SA's own client_email.
+	// cfg.Subject should NOT be set, so no DWD is required.
+	ts, err := newServiceAccountTokenSource(context.Background(), keyJSON, saEmail, []string{"https://www.googleapis.com/auth/calendar"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ts == nil {
+		t.Fatalf("expected non-nil token source")
+	}
+}
+
+func TestNewServiceAccountTokenSource_Impersonation(t *testing.T) {
+	const saEmail = "sa@test-project.iam.gserviceaccount.com"
+	const userEmail = "user@example.com"
+	keyJSON := generateTestSAKeyJSON(t, saEmail)
+
+	// Impersonation mode: subject differs from the SA's client_email.
+	// cfg.Subject should be set to the user email (DWD required).
+	ts, err := newServiceAccountTokenSource(context.Background(), keyJSON, userEmail, []string{"https://www.googleapis.com/auth/calendar"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ts == nil {
+		t.Fatalf("expected non-nil token source")
+	}
+}
+
+func TestNewServiceAccountTokenSource_EmptySubject(t *testing.T) {
+	const saEmail = "sa@test-project.iam.gserviceaccount.com"
+	keyJSON := generateTestSAKeyJSON(t, saEmail)
+
+	// Empty subject: should not set cfg.Subject.
+	ts, err := newServiceAccountTokenSource(context.Background(), keyJSON, "", []string{"https://www.googleapis.com/auth/calendar"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ts == nil {
+		t.Fatalf("expected non-nil token source")
+	}
+}


### PR DESCRIPTION
## Summary

When a service account is configured via `gog auth service-account set`, the CLI always sets `cfg.Subject` (the JWT `sub` claim), which triggers Domain-Wide Delegation. This makes it impossible to use a service account in "pure" mode — where it accesses only resources explicitly shared with its own email address.

This PR skips setting `cfg.Subject` when the provided subject matches the service account's own `client_email`. This enables a common automation pattern: share a Drive folder or Calendar with the SA email, and access only those resources — no DWD required.

## Changes

- **`internal/googleapi/service_account.go`** — guard `cfg.Subject` assignment: only set when subject differs from the SA's `client_email`
- **`internal/googleapi/service_account_test.go`** — 3 test cases: pure SA mode, impersonation mode, empty subject

## Test plan

- [x] `go test ./internal/googleapi/` — all existing + new tests pass
- [x] `go build ./...` — compiles cleanly

Closes #346

✍️ Author: Claude Code with @carrotRakko (AI-written, human-approved)