### PR TITLE
Fix: Clarify RFC3339 timezone requirement for calendar events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Security: require confirmation before public Drive shares, Gmail forwarding filters, and Gmail delegate grants in no-input/agent flows. (#317) — thanks @salmonumbrella.
 - CLI: show root help instead of a parse error when `gog` is run with no arguments. (#342) — thanks @cstenglein.
 - Gmail: preserve `Cc` metadata output in plain `gmail get --format metadata` even when Gmail returns uppercase `CC` headers. (#343) — thanks @salmonumbrella.
+- Calendar: clarify that RFC3339 `--from/--to` timestamps must include a timezone while keeping date and relative-time help intact. (#409) — thanks @dbhurley.
 - Auth: keep Keep-only service-account fallback isolated to Keep commands so other Google services do not accidentally pick it up. (#414) — thanks @jgwesterlund.
 - Contacts: send the required `copyMask` when deleting "other contacts", avoiding People API 400 errors. (#384) — thanks @rbansal42.
 - Calendar: hide cancelled/deleted events from `calendar events` list output by explicitly setting `showDeleted=false`. (#362) — thanks @sharukh010.

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -249,8 +249,8 @@ type CalendarEventsCmd struct {
 	CalendarID        string   `arg:"" name:"calendarId" optional:"" help:"Calendar ID (default: primary)"`
 	Cal               []string `name:"cal" help:"Calendar ID or name (can be repeated)"`
 	Calendars         string   `name:"calendars" help:"Comma-separated calendar IDs, names, or indices from 'calendar calendars'"`
-	From              string   `name:"from" help:"Start time (RFC3339 with timezone, e.g. 2026-01-02T00:00:00-08:00)"`
-	To                string   `name:"to" help:"End time (RFC3339 with timezone, e.g. 2026-01-02T23:59:59-08:00)"`
+	From              string   `name:"from" help:"Start time (RFC3339 with timezone, date, or relative: today, tomorrow, monday)"`
+	To                string   `name:"to" help:"End time (RFC3339 with timezone, date, or relative)"`
 	Today             bool     `name:"today" help:"Today only (timezone-aware)"`
 	Tomorrow          bool     `name:"tomorrow" help:"Tomorrow only (timezone-aware)"`
 	Week              bool     `name:"week" help:"This week (uses --week-start, default Mon)"`


### PR DESCRIPTION
Fixes #104 (reported in openclaw/openclaw).

The Google Calendar API requires RFC3339 format with timezone (e.g. `2026-01-02T00:00:00-08:00`). This update clarifies the help text for `--from` and `--to` flags to indicate this requirement explicitly.

**Steps to reproduce:**
```
gog calendar events primary --from 2026-01-02T00:00:00 --to 2026-01-03T23:59:59
```

**Fix:**
Updated help text in `calendar.go` to mention RFC3339 with timezone.