### PR TITLE
fix(gmail): preserve --client context in watch serve push handling

### DIFF
--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -14,6 +14,7 @@ import (
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/idtoken"
 
+	"github.com/steipete/gogcli/internal/authclient"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -345,12 +346,20 @@ func (c *GmailWatchServeCmd) Run(ctx context.Context, kctx *kong.Context, flags 
 		cfg.MaxBodyBytes = defaultHookMaxBytes
 	}
 
+	selectedClient := strings.TrimSpace(flags.Client)
+	serviceFactory := func(ctx context.Context, account string) (*gmail.Service, error) {
+		if selectedClient != "" {
+			ctx = authclient.WithClient(ctx, selectedClient)
+		}
+		return newGmailService(ctx, account)
+	}
+
 	hookClient := &http.Client{Timeout: cfg.HookTimeout}
 	server := &gmailWatchServer{
 		cfg:             cfg,
 		store:           store,
 		validator:       validator,
-		newService:      newGmailService,
+		newService:      serviceFactory,
 		hookClient:      hookClient,
 		excludeLabelIDs: stringSet(cfg.ExcludeLabels),
 		logf:            u.Err().Printf,

--- a/internal/cmd/gmail_watch_serve_test.go
+++ b/internal/cmd/gmail_watch_serve_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/idtoken"
 
+	"github.com/steipete/gogcli/internal/authclient"
 	"github.com/steipete/gogcli/internal/ui"
 )
 
@@ -221,5 +223,59 @@ func TestGmailWatchServeCmd_SaveHookAndOIDC(t *testing.T) {
 	}
 	if loaded.Get().Hook == nil || loaded.Get().Hook.URL != "http://example.com/hook" {
 		t.Fatalf("expected hook saved, got %#v", loaded.Get().Hook)
+	}
+}
+
+func TestGmailWatchServeCmd_PreservesClientOverrideForRequestContexts(t *testing.T) {
+	origListen := listenAndServe
+	origNew := newGmailService
+	t.Cleanup(func() {
+		listenAndServe = origListen
+		newGmailService = origNew
+	})
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store, err := newGmailWatchStore("a@b.com")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	updateErr := store.Update(func(s *gmailWatchState) error {
+		s.Account = "a@b.com"
+		return nil
+	})
+	if updateErr != nil {
+		t.Fatalf("seed: %v", updateErr)
+	}
+
+	flags := &RootFlags{Account: "a@b.com", Client: "personal"}
+	var got *gmailWatchServer
+	listenAndServe = func(srv *http.Server) error {
+		if gs, ok := srv.Handler.(*gmailWatchServer); ok {
+			got = gs
+		}
+		return nil
+	}
+
+	newGmailService = func(ctx context.Context, _ string) (*gmail.Service, error) {
+		if client := authclient.ClientOverrideFromContext(ctx); client != "personal" {
+			t.Fatalf("expected client override personal, got %q", client)
+		}
+		return nil, nil
+	}
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	if execErr := runKong(t, &GmailWatchServeCmd{}, []string{"--port", "9999", "--path", "/hook"}, ui.WithUI(context.Background(), u), flags); execErr != nil {
+		t.Fatalf("execute: %v", execErr)
+	}
+	if got == nil {
+		t.Fatalf("expected server")
+	}
+	if _, callErr := got.newService(context.Background(), "a@b.com"); callErr != nil {
+		t.Fatalf("newService: %v", callErr)
 	}
 }


### PR DESCRIPTION
## Summary
- preserve the selected `--client` override for request-time contexts inside `gmail watch serve`
- wrap `newService` in `GmailWatchServeCmd.Run` so push handler API calls do not fall back to `client default`
- add regression coverage in `TestGmailWatchServeCmd_PreservesClientOverrideForRequestContexts`

Fixes #410.

## Test plan
- [x] `docker run --rm -v \"$PWD:/src\" -w /src golang:1.25 go test ./internal/cmd -run \"TestGmailWatchServeCmd_PreservesClientOverrideForRequestContexts\"`
- [x] Manual validation in a Docker container environment using patched `gog`: `gog --client personal gmail watch serve ...`
- [x] Confirm push handling no longer logs `auth required ... (client default)` for non-default client path under patched binary