### PR TITLE
fix(auth): restrict Keep service account to Keep API calls only

### DIFF
--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -99,7 +99,7 @@ func optionsForAccountScopes(ctx context.Context, serviceLabel string, email str
 
 	var ts oauth2.TokenSource
 
-	if serviceAccountTS, saPath, ok, err := tokenSourceForServiceAccountScopes(ctx, email, scopes); err != nil {
+	if serviceAccountTS, saPath, ok, err := tokenSourceForServiceAccountScopes(ctx, serviceLabel, email, scopes); err != nil {
 		return nil, fmt.Errorf("service account token source: %w", err)
 	} else if ok {
 		slog.Debug("using service account credentials", "email", email, "path", saPath)

--- a/internal/googleapi/service_account.go
+++ b/internal/googleapi/service_account.go
@@ -25,7 +25,7 @@ var newServiceAccountTokenSource = func(ctx context.Context, keyJSON []byte, sub
 	return cfg.TokenSource(ctx), nil
 }
 
-func tokenSourceForServiceAccountScopes(ctx context.Context, email string, scopes []string) (oauth2.TokenSource, string, bool, error) {
+func tokenSourceForServiceAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) (oauth2.TokenSource, string, bool, error) {
 	saPath, err := config.ServiceAccountPath(email)
 	if err != nil {
 		return nil, "", false, fmt.Errorf("service account path: %w", err)
@@ -43,6 +43,11 @@ func tokenSourceForServiceAccountScopes(ctx context.Context, email string, scope
 
 	if !os.IsNotExist(readErr) {
 		return nil, "", false, fmt.Errorf("read service account key: %w", readErr)
+	}
+
+	// Keep-specific service account files should only be used for Keep.
+	if serviceLabel != "keep" {
+		return nil, "", false, nil
 	}
 
 	// Backwards compatibility: Keep used a dedicated stored service account file.


### PR DESCRIPTION
## Summary

- When only a Keep-specific service account file (`keep-sa-*.json`) exists (no generic `sa-*.json`), `tokenSourceForServiceAccountScopes` falls back to the Keep SA for **all** API calls, causing 401 errors on Calendar, Gmail, Drive, and other services that should use OAuth
- This adds a `serviceLabel` check so Keep SA files are only used when `serviceLabel == "keep"`, allowing other services to correctly fall through to OAuth authentication

## Reproduction

1. Configure OAuth: `gog auth add user@domain.com`
2. Configure Keep SA: `gog auth keep --key sa.json user@domain.com`
3. Run: `gog calendar events primary --today` → **401 Unauthorized** (uses Keep SA instead of OAuth)

## Test plan

- [x] `go test ./internal/googleapi/...` passes
- [x] Manual test: Calendar uses OAuth after fix
- [x] Manual test: Keep still uses service account after fix
- [x] Manual test: Gmail, Drive also work via OAuth

🤖 Generated with [Claude Code](https://claude.com/claude-code)