### PR TITLE
feat(auth): add --extra-scopes flag for fine-grained custom OAuth scope selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.12.0 - Unreleased
 
 ### Added
+- Auth: add `--extra-scopes` flag to `auth add` for appending custom OAuth scope URIs beyond the built-in service scopes. (#420)
 - Sheets: add `sheets insert` to insert rows/columns into a sheet. (#203) — thanks @andybergon.
 - Sheets: add `sheets links` (alias `hyperlinks`) to list cell links from ranges, including rich-text links. (#374) — thanks @omothm.
 - Gmail: add `watch serve --history-types` filtering (`messageAdded|messageDeleted|labelAdded|labelRemoved`) and include `deletedMessageIds` in webhook payloads. (#168) — thanks @salmonumbrella.

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -486,6 +486,7 @@ type AuthAddCmd struct {
 	Readonly     bool          `name:"readonly" help:"Use read-only scopes where available (still includes OIDC identity scopes)"`
 	DriveScope   string        `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
 	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`
+	ExtraScopes  string        `name:"extra-scopes" help:"Comma-separated list of additional OAuth scope URIs to request (appended after service scopes)"`
 }
 
 func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -514,10 +515,20 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		driveScope == "readonly" ||
 		driveScope == strFile ||
 		gmailScope == "readonly"
+
+	var extraScopes []string
+	for _, s := range strings.Split(c.ExtraScopes, ",") {
+		s = strings.TrimSpace(s)
+		if s != "" {
+			extraScopes = append(extraScopes, s)
+		}
+	}
+
 	scopes, err := googleauth.ScopesForManageWithOptions(services, googleauth.ScopeOptions{
-		Readonly:   c.Readonly,
-		DriveScope: googleauth.DriveScopeMode(driveScope),
-		GmailScope: googleauth.GmailScopeMode(gmailScope),
+		Readonly:    c.Readonly,
+		DriveScope:  googleauth.DriveScopeMode(driveScope),
+		GmailScope:  googleauth.GmailScopeMode(gmailScope),
+		ExtraScopes: extraScopes,
 	})
 	if err != nil {
 		return err
@@ -599,6 +610,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"readonly":      c.Readonly,
 		"drive_scope":   c.DriveScope,
 		"gmail_scope":   c.GmailScope,
+		"extra_scopes":  extraScopes,
 	}); dryRunErr != nil {
 		return dryRunErr
 	}

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -773,6 +773,73 @@ func TestAuthAddCmd_AuthCode_PassesThrough(t *testing.T) {
 	}
 }
 
+func TestAuthAddCmd_ExtraScopes(t *testing.T) {
+	origAuth := authorizeGoogle
+	origOpen := openSecretsStore
+	origKeychain := ensureKeychainAccess
+	origFetch := fetchAuthorizedEmail
+	t.Cleanup(func() {
+		authorizeGoogle = origAuth
+		openSecretsStore = origOpen
+		ensureKeychainAccess = origKeychain
+		fetchAuthorizedEmail = origFetch
+	})
+
+	ensureKeychainAccess = func() error { return nil }
+
+	store := newMemSecretsStore()
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+
+	var gotOpts googleauth.AuthorizeOptions
+	authorizeGoogle = func(ctx context.Context, opts googleauth.AuthorizeOptions) (string, error) {
+		gotOpts = opts
+		gotOpts.Services = append([]googleauth.Service(nil), opts.Services...)
+		gotOpts.Scopes = append([]string(nil), opts.Scopes...)
+		return "rt", nil
+	}
+	fetchAuthorizedEmail = func(context.Context, string, string, []string, time.Duration) (string, error) {
+		return "user@example.com", nil
+	}
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"auth",
+				"add",
+				"user@example.com",
+				"--services",
+				"gmail",
+				"--gmail-scope",
+				"readonly",
+				"--extra-scopes",
+				"https://www.googleapis.com/auth/gmail.labels,https://www.googleapis.com/auth/gmail.readonly",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	// Extra scope should be present
+	if !containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/gmail.labels") {
+		t.Fatalf("missing gmail.labels in %v", gotOpts.Scopes)
+	}
+	// gmail.readonly from --gmail-scope=readonly should still be present
+	if !containsStringInSlice(gotOpts.Scopes, "https://www.googleapis.com/auth/gmail.readonly") {
+		t.Fatalf("missing gmail.readonly in %v", gotOpts.Scopes)
+	}
+	// Duplicate gmail.readonly (from extra-scopes) should be de-duplicated
+	count := 0
+	for _, s := range gotOpts.Scopes {
+		if s == "https://www.googleapis.com/auth/gmail.readonly" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected gmail.readonly exactly once, got %d in %v", count, gotOpts.Scopes)
+	}
+}
+
 func containsStringInSlice(items []string, want string) bool {
 	for _, it := range items {
 		if it == want {

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -55,9 +55,10 @@ const (
 )
 
 type ScopeOptions struct {
-	Readonly   bool
-	DriveScope DriveScopeMode
-	GmailScope GmailScopeMode
+	Readonly    bool
+	DriveScope  DriveScopeMode
+	GmailScope  GmailScopeMode
+	ExtraScopes []string
 }
 
 type serviceInfo struct {
@@ -374,7 +375,11 @@ func ScopesForManageWithOptions(services []Service, opts ScopeOptions) ([]string
 		return nil, err
 	}
 
-	return mergeScopes(scopes, []string{scopeOpenID, scopeEmail, scopeUserinfoEmail}), nil
+	merged := mergeScopes(scopes, []string{scopeOpenID, scopeEmail, scopeUserinfoEmail})
+	if len(opts.ExtraScopes) > 0 {
+		merged = mergeScopes(merged, opts.ExtraScopes)
+	}
+	return merged, nil
 }
 
 func scopesForServicesWithOptions(services []Service, opts ScopeOptions) ([]string, error) {

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -497,6 +497,39 @@ func TestScopesForServiceWithOptions_AppScriptReadonly(t *testing.T) {
 	}
 }
 
+func TestScopesForManageWithOptions_ExtraScopes(t *testing.T) {
+	scopes, err := ScopesForManageWithOptions([]Service{ServiceGmail}, ScopeOptions{
+		GmailScope: GmailScopeReadonly,
+		ExtraScopes: []string{
+			"https://www.googleapis.com/auth/gmail.labels",
+			"https://www.googleapis.com/auth/gmail.readonly", // duplicate
+		},
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if !containsScope(scopes, "https://www.googleapis.com/auth/gmail.labels") {
+		t.Fatalf("missing gmail.labels in %v", scopes)
+	}
+
+	if !containsScope(scopes, "https://www.googleapis.com/auth/gmail.readonly") {
+		t.Fatalf("missing gmail.readonly in %v", scopes)
+	}
+
+	// De-duplication: gmail.readonly should appear exactly once
+	count := 0
+	for _, s := range scopes {
+		if s == "https://www.googleapis.com/auth/gmail.readonly" {
+			count++
+		}
+	}
+
+	if count != 1 {
+		t.Fatalf("expected gmail.readonly exactly once, got %d in %v", count, scopes)
+	}
+}
+
 func TestScopes_UnknownService(t *testing.T) {
 	if _, err := Scopes(Service("nope")); err == nil {
 		t.Fatalf("expected error")


### PR DESCRIPTION
## Summary

Adds a new `--extra-scopes` flag to `gog auth add` that lets users specify additional raw Google API OAuth scope URIs, appended to (and deduplicated against) the scopes already requested by `--services`, `--readonly`, `--drive-scope`, and `--gmail-scope`.

Closes #420

## Problem

The existing predefined scope bundles don't support mixed permission sets. A concrete example: an AI assistant that needs to **read Gmail** (`gmail.readonly`) and **manage labels** (`gmail.labels`) — but absolutely must not be able to **send or delete**. Currently, `gmail.labels` requires granting `gmail.modify` (full read/write), which is a larger surface than necessary.

## Changes

- `internal/googleauth/service.go` — Added `ExtraScopes []string` to `ScopeOptions`; `ScopesForManageWithOptions` merges and deduplicates them after building service scopes
- `internal/cmd/auth.go` — Added `--extra-scopes` kong flag to `AuthAddCmd`; parses comma-separated URIs, trims whitespace, filters empties, passes to `ScopeOptions`; included in dry-run JSON output as `extra_scopes`
- `internal/cmd/auth_add_test.go` — `TestAuthAddCmd_ExtraScopes`: verifies extra scopes are included, work alongside `--gmail-scope=readonly`, and duplicates are deduplicated
- `internal/googleauth/service_test.go` — `TestScopesForManageWithOptions_ExtraScopes`: unit test for core scope-merging logic
- `CHANGELOG.md` — entry under Unreleased

## Usage

```bash
# Gmail read-only + label management only (no send, no delete)
gog auth add user@example.com \
  --services gmail \
  --gmail-scope=readonly \
  --extra-scopes="https://www.googleapis.com/auth/gmail.labels"

# Calendar read-only + manage calendar subscriptions
gog auth add user@example.com \
  --services calendar \
  --readonly \
  --extra-scopes="https://www.googleapis.com/auth/calendar.calendarlist"

# Multiple extra scopes
gog auth add user@example.com \
  --services gmail,drive \
  --gmail-scope=readonly \
  --drive-scope=readonly \
  --extra-scopes="https://www.googleapis.com/auth/gmail.labels,https://www.googleapis.com/auth/drive.metadata"
```

## Testing

```bash
make ci           # all lint + tests pass
# Smoke test:
./bin/gog auth add --extra-scopes=https://www.googleapis.com/auth/gmail.labels --dry-run test@example.com
# → scopes list includes gmail.labels; extra_scopes field appears in JSON
```