### PR TITLE
feat(sheets): add --parent flag to create spreadsheet in a folder

### DIFF
--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/tabwriter"
 
+	"google.golang.org/api/drive/v3"
 	"google.golang.org/api/sheets/v4"
 
 	"github.com/steipete/gogcli/internal/googleapi"
@@ -464,6 +465,7 @@ func (c *SheetsMetadataCmd) Run(ctx context.Context, flags *RootFlags) error {
 type SheetsCreateCmd struct {
 	Title  string `arg:"" name:"title" help:"Spreadsheet title"`
 	Sheets string `name:"sheets" help:"Comma-separated sheet names to create"`
+	Parent string `name:"parent" help:"Destination folder ID"`
 }
 
 func (c *SheetsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -511,6 +513,25 @@ func (c *SheetsCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	resp, err := svc.Spreadsheets.Create(spreadsheet).Do()
 	if err != nil {
 		return err
+	}
+
+	// Move to parent folder if specified
+	if c.Parent != "" {
+		var parentDriveSvc *drive.Service
+		parentDriveSvc, err = newDriveService(ctx, account)
+		if err != nil {
+			return err
+		}
+
+		_, err = parentDriveSvc.Files.Update(resp.SpreadsheetId, &drive.File{}).
+			AddParents(c.Parent).
+			SupportsAllDrives(true).
+			Context(ctx).
+			Do()
+		if err != nil {
+			u.Out().Errorf("Failed to move spreadsheet to folder: %v", err)
+			u.Out().Println("Spreadsheet created in Drive root. Move to desired folder if needed.")
+		}
 	}
 
 	if outfmt.IsJSON(ctx) {


### PR DESCRIPTION
## Summary
Add a `--parent` flag to `sheets create` so new spreadsheets can be created directly in a specific Drive folder (by folder ID).

## Changes
- **`sheets create`**: New optional `--parent <folderId>` argument. When provided, the spreadsheet is created via the Sheets API and then moved to the given folder using the Drive API (`Files.Update` + `AddParents`).
- If the move fails (e.g. invalid folder ID or permissions), the spreadsheet is still created in the root of My Drive; the error is reported and the user is informed they can move it manually.

Fixes #417 

## Usage
```bash
gog sheets create "My Sheet" --parent <folderId>