### PR TITLE
fix(gmail): decode mime-type charset fallback

### DIFF
--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -462,7 +462,11 @@ func decodePartBody(p *gmail.MessagePart) (string, error) {
 		decoded = decodeTransferEncoding(decoded, cte)
 	}
 
-	if contentType := strings.TrimSpace(headerValue(p, "Content-Type")); contentType != "" {
+	contentType := strings.TrimSpace(headerValue(p, "Content-Type"))
+	if contentType == "" {
+		contentType = strings.TrimSpace(p.MimeType)
+	}
+	if contentType != "" {
 		decoded = decodeBodyCharset(decoded, contentType)
 	}
 

--- a/internal/cmd/gmail_thread_helpers_test.go
+++ b/internal/cmd/gmail_thread_helpers_test.go
@@ -7,7 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"golang.org/x/text/encoding/ianaindex"
 	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/simplifiedchinese"
 	"google.golang.org/api/gmail/v1"
 )
 
@@ -294,6 +296,40 @@ func TestDecodeBodyCharset_ISO2022JP_TruncatedEscapeSequence(t *testing.T) {
 	// Should gracefully handle and return something (original or partial decode)
 	if got == nil {
 		t.Fatalf("expected non-nil result for truncated escape sequence")
+	}
+}
+
+func TestDecodeBodyCharset_GBK(t *testing.T) {
+	source := "您的阿里云账户已欠费即将停服提醒"
+	enc, err := ianaindex.MIME.Encoding("gbk")
+	if err != nil || enc == nil {
+		t.Fatalf("lookup gbk encoding: %v", err)
+	}
+	encoded, err := enc.NewEncoder().Bytes([]byte(source))
+	if err != nil {
+		t.Fatalf("encode gbk: %v", err)
+	}
+	got := decodeBodyCharset(encoded, "text/plain; charset=gbk")
+	if string(got) != source {
+		t.Fatalf("unexpected decoded charset: expected %q, got %q", source, string(got))
+	}
+}
+
+func TestFindPartBody_UsesMimeTypeCharsetWhenHeaderMissing(t *testing.T) {
+	source := "您的阿里云账户已欠费即将停服提醒"
+	encodedBody, err := simplifiedchinese.GBK.NewEncoder().Bytes([]byte(source))
+	if err != nil {
+		t.Fatalf("encode gb2312: %v", err)
+	}
+	part := &gmail.MessagePart{
+		MimeType: "text/plain; charset=gb2312",
+		Body: &gmail.MessagePartBody{
+			Data: base64.RawURLEncoding.EncodeToString(encodedBody),
+		},
+	}
+	got := findPartBody(part, "text/plain")
+	if got != source {
+		t.Fatalf("unexpected decoded body: expected %q, got %q", source, got)
 	}
 }
 


### PR DESCRIPTION
Fixes #418.

## Summary
- fall back to the MIME part's `MimeType` when `Content-Type` headers are missing
- add GBK and GB2312 regressions through the real Gmail body helpers
- preserve existing Gmail output contracts

## Verification
- `go test ./internal/cmd -run 'TestDecodeBodyCharset_GBK|TestFindPartBody_UsesMimeTypeCharsetWhenHeaderMissing|TestDecodeBodyCharset_ISO2022JP|TestFindPartBody_DecodesQuotedPrintable'`\n- `go test ./internal/cmd`