### PR TITLE
feat(chat): add react shorthand command for reactions create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 - Admin: add Workspace Admin Directory commands for users and groups, including user list/get/create/suspend and group membership list/add/remove. (#403) — thanks @dl-alexandre.
 - Auth: add `--access-token` / `GOG_ACCESS_TOKEN` for direct access-token auth in headless or CI flows, bypassing stored refresh tokens. (#419) — thanks @mmkal.
-- Chat: add `chat messages reactions create|list|delete` to manage emoji reactions on messages; `react` and `reaction` are aliases for the reactions command group. (#426) — thanks @fernandopps.
+- Chat: add `chat messages reactions create|list|delete` to manage emoji reactions on messages; `chat messages react <message> <emoji>` as a shorthand for creating reactions; `reaction` is an alias for `reactions`. (#426) — thanks @fernandopps.
 - Sheets: add named range management (`sheets named-ranges`) and let range-based Sheets commands accept named range names where GridRange-backed operations are needed. (#278) — thanks @TheCrazyLex.
 - Sheets: add `add-tab`, `rename-tab`, and `delete-tab` commands for managing spreadsheet tabs, with delete dry-run/confirmation guardrails. (#309) — thanks @JulienMalige.
 - Docs: add `--tab-id` to editing commands so write/update/insert/delete/find-replace can target a specific Google Docs tab. (#330) — thanks @ignacioreyna.

--- a/README.md
+++ b/README.md
@@ -1119,7 +1119,7 @@ gog chat messages list spaces/<spaceId> --thread <threadId>
 gog chat messages list spaces/<spaceId> --unread
 gog chat messages send spaces/<spaceId> --text "Build complete!" --thread spaces/<spaceId>/threads/<threadId>
 gog chat messages reactions list spaces/<spaceId>/messages/<messageId>
-gog chat messages react spaces/<spaceId>/messages/<messageId> "👍"
+gog chat messages react spaces/<spaceId>/messages/<messageId> "👍"  # shorthand for reactions create
 gog chat messages reactions delete spaces/<spaceId>/messages/<messageId>/reactions/<reactionId>
 
 # Threads

--- a/internal/cmd/chat_messages.go
+++ b/internal/cmd/chat_messages.go
@@ -15,7 +15,8 @@ import (
 type ChatMessagesCmd struct {
 	List      ChatMessagesListCmd      `cmd:"" name:"list" aliases:"ls" help:"List messages"`
 	Send      ChatMessagesSendCmd      `cmd:"" name:"send" aliases:"create,post" help:"Send a message"`
-	Reactions ChatMessagesReactionsCmd `cmd:"" name:"reactions" aliases:"react,reaction" help:"Manage emoji reactions on a message"`
+	React     ChatMessagesReactCmd     `cmd:"" name:"react" help:"Add an emoji reaction to a message"`
+	Reactions ChatMessagesReactionsCmd `cmd:"" name:"reactions" aliases:"reaction" help:"Manage emoji reactions on a message"`
 }
 
 type ChatMessagesListCmd struct {

--- a/internal/cmd/chat_reactions.go
+++ b/internal/cmd/chat_reactions.go
@@ -12,6 +12,17 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+type ChatMessagesReactCmd struct {
+	Message string `arg:"" name:"message" help:"Message resource (spaces/.../messages/...) or bare message ID"`
+	Emoji   string `arg:"" name:"emoji" help:"Emoji unicode character (e.g. 👍)"`
+	Space   string `name:"space" help:"Space name (required when message is a bare ID)"`
+}
+
+func (c *ChatMessagesReactCmd) Run(ctx context.Context, flags *RootFlags) error {
+	cmd := &ChatMessagesReactionsCreateCmd{Message: c.Message, Emoji: c.Emoji, Space: c.Space}
+	return cmd.Run(ctx, flags)
+}
+
 type ChatMessagesReactionsCmd struct {
 	Create ChatMessagesReactionsCreateCmd `cmd:"" name:"create" aliases:"add" help:"Add an emoji reaction to a message"`
 	List   ChatMessagesReactionsListCmd   `cmd:"" name:"list" aliases:"ls" help:"List reactions on a message"`


### PR DESCRIPTION
The README showed `gog chat messages react <message> <emoji>` as a valid command, but this was never implemented — `react` was only an alias for the `reactions` command group, so it still required a subcommand (`create`, `list`, or `delete`).

This PR fixes the inconsistency by implementing `react` as a proper standalone shorthand command that takes `<message>` and `<emoji>` as positional arguments, delegating directly to `reactions create`.

## Changes

- Add `ChatMessagesReactCmd` — positional `<message> <emoji>`, delegates to `reactions create`
- Remove `react` from `reactions` aliases (was misleading; `reaction` singular kept as alias for the group)
- Fix CHANGELOG entry which incorrectly described `react` as an alias
- Add inline comment to README to clarify `react` is a shorthand

## Test plan

- [x] `gog chat messages react spaces/<spaceId>/messages/<messageId> "👍"` creates a reaction
- [x] `gog chat messages reactions list|create|delete` still works as before
- [x] `gog chat messages reaction` (singular alias) still works as alias for `reactions`