### PR TITLE
feat: add --gmail-scope=compose for read+draft+archive without send

### DIFF
--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -31,7 +31,7 @@ type AuthAddCmd struct {
 	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all or comma-separated ${auth_services} (Keep uses service account: gog auth service-account set)" default:"user"`
 	Readonly     bool          `name:"readonly" help:"Use read-only scopes where available (still includes OIDC identity scopes)"`
 	DriveScope   string        `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
-	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`
+	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full (all permissions), readonly (read-only), or compose (read, draft, and archive — no send)" enum:"full,readonly,compose" default:"full"`
 	ExtraScopes  string        `name:"extra-scopes" help:"Comma-separated list of additional OAuth scope URIs to request (appended after service scopes)"`
 }
 

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -53,6 +53,7 @@ type GmailScopeMode string
 const (
 	GmailScopeFull     GmailScopeMode = "full"
 	GmailScopeReadonly GmailScopeMode = "readonly"
+	GmailScopeCompose  GmailScopeMode = "compose"
 )
 
 type ScopeOptions struct {
@@ -429,9 +430,9 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 
 	gmailScope := strings.TrimSpace(string(opts.GmailScope))
 	switch gmailScope {
-	case "", string(GmailScopeFull), string(GmailScopeReadonly):
+	case "", string(GmailScopeFull), string(GmailScopeReadonly), string(GmailScopeCompose):
 	default:
-		return nil, fmt.Errorf("%w %q (expected full|readonly)", errInvalidGmailScope, opts.GmailScope)
+		return nil, fmt.Errorf("%w %q (expected full|readonly|compose)", errInvalidGmailScope, opts.GmailScope)
 	}
 
 	driveScopeValue := func() string {
@@ -453,6 +454,14 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 	case ServiceGmail:
 		if opts.Readonly || opts.GmailScope == GmailScopeReadonly {
 			return []string{"https://www.googleapis.com/auth/gmail.readonly"}, nil
+		}
+
+		if opts.GmailScope == GmailScopeCompose {
+			return []string{
+				"https://www.googleapis.com/auth/gmail.readonly",
+				"https://www.googleapis.com/auth/gmail.compose",
+				"https://www.googleapis.com/auth/gmail.modify",
+			}, nil
 		}
 
 		return Scopes(service)

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -306,6 +306,35 @@ func TestScopesForManageWithOptions_GmailScopeReadonly(t *testing.T) {
 	}
 }
 
+func TestScopesForManageWithOptions_GmailScopeCompose(t *testing.T) {
+	scopes, err := ScopesForManageWithOptions([]Service{ServiceGmail}, ScopeOptions{
+		GmailScope: GmailScopeCompose,
+	})
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	for _, want := range []string{
+		"https://www.googleapis.com/auth/gmail.readonly",
+		"https://www.googleapis.com/auth/gmail.compose",
+		"https://www.googleapis.com/auth/gmail.modify",
+	} {
+		if !containsScope(scopes, want) {
+			t.Fatalf("missing %q in %v", want, scopes)
+		}
+	}
+
+	for _, nw := range []string{
+		"https://www.googleapis.com/auth/gmail.send",
+		"https://www.googleapis.com/auth/gmail.settings.basic",
+		"https://www.googleapis.com/auth/gmail.settings.sharing",
+	} {
+		if containsScope(scopes, nw) {
+			t.Fatalf("unexpected %q in %v", nw, scopes)
+		}
+	}
+}
+
 func TestScopes_ServiceKeep_DefaultIsReadonly(t *testing.T) {
 	scopes, err := Scopes(ServiceKeep)
 	if err != nil {


### PR DESCRIPTION
Adds a 'compose' mode to the existing --gmail-scope flag that grants gmail.readonly, gmail.compose, and gmail.modify scopes — enabling email reading, draft creation, and archiving while excluding the gmail.send scope.

Useful for AI agent integrations (e.g. OpenClaw) where you want a hard OAuth-level guarantee that the agent cannot send emails directly, only create drafts for human review.