### PR TITLE
feat(gmail): add --full flag to messages search to disable body truncation

### DIFF
--- a/internal/cmd/gmail_messages.go
+++ b/internal/cmd/gmail_messages.go
@@ -28,9 +28,13 @@ type GmailMessagesSearchCmd struct {
 	Timezone    string   `name:"timezone" short:"z" help:"Output timezone (IANA name, e.g. America/New_York, UTC). Default: local"`
 	Local       bool     `name:"local" help:"Use local timezone (default behavior, useful to override --timezone)"`
 	IncludeBody bool     `name:"include-body" help:"Include decoded message body (JSON is full; text output is truncated)"`
+	Full        bool     `name:"full" help:"Show full message bodies without truncation (implies --include-body)"`
 }
 
 func (c *GmailMessagesSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if c.Full {
+		c.IncludeBody = true
+	}
 	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
 	if err != nil {
@@ -137,7 +141,7 @@ func (c *GmailMessagesSearchCmd) Run(ctx context.Context, flags *RootFlags) erro
 	for _, it := range items {
 		body := ""
 		if c.IncludeBody {
-			body = sanitizeMessageBody(it.Body)
+			body = sanitizeMessageBody(it.Body, c.Full)
 		}
 		if c.IncludeBody {
 			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n", it.ID, it.ThreadID, it.Date, it.From, it.Subject, strings.Join(it.Labels, ","), body)
@@ -327,7 +331,7 @@ func fetchMessageDetails(ctx context.Context, svc *gmail.Service, messages []*gm
 	return items, nil
 }
 
-func sanitizeMessageBody(body string) string {
+func sanitizeMessageBody(body string, full bool) string {
 	if body == "" {
 		return ""
 	}
@@ -338,6 +342,9 @@ func sanitizeMessageBody(body string) string {
 	body = strings.ReplaceAll(body, "\n", " ")
 	body = strings.ReplaceAll(body, "\r", " ")
 	body = strings.TrimSpace(body)
+	if full {
+		return body
+	}
 	return truncateRunes(body, 200)
 }
 

--- a/internal/cmd/gmail_messages_test.go
+++ b/internal/cmd/gmail_messages_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSanitizeMessageBody_TruncateUTF8(t *testing.T) {
 	long := strings.Repeat("€", 210)
-	got := sanitizeMessageBody(long)
+	got := sanitizeMessageBody(long, false)
 	if !strings.HasSuffix(got, "...") {
 		t.Fatalf("expected truncation suffix, got %q", got)
 	}
@@ -24,8 +24,19 @@ func TestSanitizeMessageBody_TruncateUTF8(t *testing.T) {
 	}
 }
 
+func TestSanitizeMessageBody_FullSkipsTruncation(t *testing.T) {
+	long := strings.Repeat("€", 210)
+	got := sanitizeMessageBody(long, true)
+	if strings.HasSuffix(got, "...") {
+		t.Fatalf("expected no truncation with full=true, got %q", got)
+	}
+	if len([]rune(got)) != 210 {
+		t.Fatalf("expected 210 runes, got %d", len([]rune(got)))
+	}
+}
+
 func TestSanitizeMessageBody_StripsHTML(t *testing.T) {
-	got := sanitizeMessageBody("<html><body>Hi</body></html>")
+	got := sanitizeMessageBody("<html><body>Hi</body></html>", false)
 	if got != "Hi" {
 		t.Fatalf("unexpected sanitized body: %q", got)
 	}


### PR DESCRIPTION
## Problem

`gog gmail messages search "query" --include-body` truncates message bodies to 200 characters in plain-text output. For longer emails this cuts off important content, forcing users to pipe through `--json` and manually extract the body field.

The `gmail thread get` command (`gog gmail read`) already has a `--full` flag that disables its 500-character truncation, but the messages search command has no equivalent.

## Solution

Add a `--full` flag to `GmailMessagesSearchCmd` that:

- Skips the 200-character truncation in `sanitizeMessageBody`
- Implies `--include-body` (so `--full` alone is sufficient)
- Preserves existing behaviour when `--full` is not passed

### Usage

```bash
# Before: body truncated at 200 chars
gog gmail messages search "invoice" --include-body

# After: full body in plain-text output
gog gmail messages search "invoice" --full
```

## Testing

- Added `TestSanitizeMessageBody_FullSkipsTruncation` test verifying full bodies are preserved
- Updated existing tests for the new function signature
- All tests pass (`make test`)
- Build passes (`make build`)
- Lint has one pre-existing `nilnil` issue in `gmail_filters_helpers.go` (present on main, not introduced by this PR)

## Changes

- `internal/cmd/gmail_messages.go`: Add `Full` field, thread it through to `sanitizeMessageBody`
- `internal/cmd/gmail_messages_test.go`: Add full-body test, update existing test signatures