### PR TITLE
feat(secrets): allow overriding keyring service name

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,14 @@ export GOG_KEYRING_BACKEND=file
 
 Precedence: `GOG_KEYRING_BACKEND` env var overrides `config.json`.
 
+Override the OS keyring service/collection/wallet name via env:
+
+```bash
+export GOG_KEYRING_SERVICE_NAME=kdewallet
+```
+
+This changes the keyring service name passed to the OS backend. On KDE/KWallet this controls the wallet name used by the native KWallet backend.
+
 ## Configuration
 
 ### Account Selection

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -142,6 +142,7 @@ Environment:
 - `GOG_CLIENT=work` (select OAuth client bucket; see `--client`)
 - `GOG_KEYRING_PASSWORD=...` (used when keyring falls back to encrypted file backend in non-interactive environments)
 - `GOG_KEYRING_BACKEND={auto|keychain|file}` (force backend; use `file` to avoid Keychain prompts and pair with `GOG_KEYRING_PASSWORD` for non-interactive)
+- `GOG_KEYRING_SERVICE_NAME=...` (override keyring `ServiceName`; on native KWallet this is the wallet name)
 - `GOG_TIMEZONE=America/New_York` (default output timezone; IANA name or `UTC`; `local` forces local timezone)
 - `GOG_ENABLE_COMMANDS=calendar,tasks` (optional allowlist of top-level commands)
 - `config.json` can also set `keyring_backend` (JSON5; env vars take precedence)

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -49,6 +49,7 @@ func keyringItem(key string, data []byte) keyring.Item {
 const (
 	keyringPasswordEnv = "GOG_KEYRING_PASSWORD" //nolint:gosec // env var name, not a credential
 	keyringBackendEnv  = "GOG_KEYRING_BACKEND"  //nolint:gosec // env var name, not a credential
+	keyringServiceEnv  = "GOG_KEYRING_SERVICE_NAME" //nolint:gosec // env var name, not a credential
 )
 
 var (
@@ -144,6 +145,14 @@ func normalizeKeyringBackend(value string) string {
 	return strings.ToLower(strings.TrimSpace(value))
 }
 
+func keyringServiceName() string {
+	if value := strings.TrimSpace(os.Getenv(keyringServiceEnv)); value != "" {
+		return value
+	}
+
+	return config.AppName
+}
+
 // keyringOpenTimeout is the maximum time to wait for keyring.Open() to complete.
 // On headless Linux, D-Bus SecretService can hang indefinitely if gnome-keyring
 // is installed but not running.
@@ -185,7 +194,7 @@ func openKeyring() (keyring.Keyring, error) {
 	}
 
 	cfg := keyring.Config{
-		ServiceName: config.AppName,
+		ServiceName: keyringServiceName(),
 		// KeychainTrustApplication is intentionally false to support Homebrew upgrades.
 		// When true, macOS Keychain ties access control to the specific binary hash.
 		// Homebrew upgrades install a new binary with a different hash, causing the

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -20,11 +20,27 @@ var errKeyringOpenBlocked = errors.New("keyring open blocked")
 // KeychainTrustApplication is false to match production config (see store.go).
 func keyringConfig(keyringDir string) keyring.Config {
 	return keyring.Config{
-		ServiceName:              config.AppName,
+		ServiceName:              keyringServiceName(),
 		KeychainTrustApplication: false,
 		AllowedBackends:          []keyring.BackendType{keyring.FileBackend},
 		FileDir:                  keyringDir,
 		FilePasswordFunc:         fileKeyringPasswordFunc(),
+	}
+}
+
+func TestKeyringServiceName_Default(t *testing.T) {
+	t.Setenv(keyringServiceEnv, "")
+
+	if got := keyringServiceName(); got != config.AppName {
+		t.Fatalf("expected default service name %q, got %q", config.AppName, got)
+	}
+}
+
+func TestKeyringServiceName_Env(t *testing.T) {
+	t.Setenv(keyringServiceEnv, "kdewallet")
+
+	if got := keyringServiceName(); got != "kdewallet" {
+		t.Fatalf("expected env service name %q, got %q", "kdewallet", got)
 	}
 }
 
@@ -286,5 +302,36 @@ func TestOpenKeyring_ExplicitBackend_IgnoresDBusDetection(t *testing.T) {
 
 	if store == nil {
 		t.Fatal("expected non-nil store")
+	}
+}
+
+func TestOpenKeyring_UsesEnvServiceName(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	t.Setenv("GOG_KEYRING_BACKEND", "file")
+	t.Setenv("GOG_KEYRING_PASSWORD", "testpw")
+	t.Setenv(keyringServiceEnv, "kdewallet")
+
+	originalOpen := keyringOpenFunc
+	t.Cleanup(func() { keyringOpenFunc = originalOpen })
+
+	var got keyring.Config
+	keyringOpenFunc = func(cfg keyring.Config) (keyring.Keyring, error) {
+		got = cfg
+		return keyring.NewArrayKeyring(nil), nil
+	}
+
+	ring, err := openKeyring()
+	if err != nil {
+		t.Fatalf("openKeyring: %v", err)
+	}
+
+	if ring == nil {
+		t.Fatal("expected non-nil keyring")
+	}
+
+	if got.ServiceName != "kdewallet" {
+		t.Fatalf("expected service name %q, got %q", "kdewallet", got.ServiceName)
 	}
 }


### PR DESCRIPTION
## Summary

Add `GOG_KEYRING_SERVICE_NAME` as an environment variable override for the keyring `ServiceName`.

This keeps the default behavior unchanged (`gogcli`), but allows Linux/KWallet users to point `gog` at a different wallet/collection name when needed, for example:

```bash
export GOG_KEYRING_SERVICE_NAME=kdewallet
```

## Changes

- add `GOG_KEYRING_SERVICE_NAME` support in internal/secrets/store.go
- keep the default service name as `gogcli` when the env var is unset
- add tests covering the default and override behavior
- document the new env var in `README.md` and `docs/spec.md`

## Test plan

- [x] GOCACHE=/tmp/go-build go test ./internal/secrets

## User-facing changes

- new env var: `GOG_KEYRING_SERVICE_NAME`
- no behavior change unless the env var is set
