### PR TITLE
Fix tracking config hydration when secrets stored in config file

### DIFF
--- a/internal/tracking/config.go
+++ b/internal/tracking/config.go
@@ -181,17 +181,18 @@ func (c *Config) IsConfigured() bool {
 }
 
 func hydrateConfig(account string, cfg *Config) (*Config, error) {
-	if strings.TrimSpace(cfg.TrackingKey) == "" || strings.TrimSpace(cfg.AdminKey) == "" || cfg.SecretsInKeyring {
+	// Only load from keyring if explicitly configured to do so
+	if cfg.SecretsInKeyring {
 		trackingKey, adminKey, secretErr := LoadSecrets(account)
 		if secretErr != nil {
 			return nil, secretErr
 		}
 
-		if strings.TrimSpace(cfg.TrackingKey) == "" {
+		if strings.TrimSpace(trackingKey) != "" {
 			cfg.TrackingKey = trackingKey
 		}
 
-		if strings.TrimSpace(cfg.AdminKey) == "" {
+		if strings.TrimSpace(adminKey) != "" {
 			cfg.AdminKey = adminKey
 		}
 	}

--- a/internal/tracking/config.go
+++ b/internal/tracking/config.go
@@ -181,8 +181,17 @@ func (c *Config) IsConfigured() bool {
 }
 
 func hydrateConfig(account string, cfg *Config) (*Config, error) {
-	// Only load from keyring if explicitly configured to do so
-	if cfg.SecretsInKeyring {
+	shouldLoadFromKeyring := cfg.SecretsInKeyring
+
+	// Backward compat: if no SecretsInKeyring flag but keys are empty,
+	// try keyring as fallback (legacy behavior)
+	if !shouldLoadFromKeyring &&
+		strings.TrimSpace(cfg.TrackingKey) == "" &&
+		strings.TrimSpace(cfg.AdminKey) == "" {
+		shouldLoadFromKeyring = true
+	}
+
+	if shouldLoadFromKeyring {
 		trackingKey, adminKey, secretErr := LoadSecrets(account)
 		if secretErr != nil {
 			return nil, secretErr


### PR DESCRIPTION
Fixes a bug where tracking configuration fails to load properly when credentials are stored directly in the config file rather than the keyring.

**Changes:**
- Ensures secrets from config file are properly hydrated into tracking config
- Maintains backward compatibility with legacy keyring-only configs
- All existing tests pass

**Testing:**
- Verified with configs using both keyring and file-based credential storage
- Confirmed tracking endpoints work correctly after fix