### PR TITLE
fix(cli): generate native zsh completions

### DIFF
--- a/internal/cmd/completion_scripts.go
+++ b/internal/cmd/completion_scripts.go
@@ -37,9 +37,24 @@ complete -F _gog_complete gog
 func zshCompletionScript() string {
 	return `#compdef gog
 
-autoload -Uz bashcompinit
-bashcompinit
-` + bashCompletionScript()
+_gog() {
+  local -a args completions
+
+  args=("${(@)words[1,CURRENT]}")
+  if (( CURRENT > ${#words} )); then
+    args+=("")
+  fi
+
+  completions=("${(@f)$(gog __complete --cword "$((${#args[@]} - 1))" -- "${args[@]}" 2>/dev/null)}")
+  if (( ${#completions[@]} == 0 )); then
+    return 1
+  fi
+
+  compadd -Q -S '' -- "${completions[@]}"
+}
+
+compdef _gog gog
+`
 }
 
 func fishCompletionScript() string {

--- a/internal/cmd/completion_test.go
+++ b/internal/cmd/completion_test.go
@@ -9,7 +9,7 @@ import (
 func TestCompletionCmd(t *testing.T) {
 	cases := map[string]string{
 		"bash":       "complete -F _gog_complete gog",
-		"zsh":        "bashcompinit",
+		"zsh":        "compdef _gog gog",
 		"fish":       "complete -c gog",
 		"powershell": "Register-ArgumentCompleter",
 	}


### PR DESCRIPTION
## Summary
- replace the zsh completion output with a native `_gog` zsh completer
- keep the implementation small by calling `gog __complete` directly from zsh
- update the existing completion test to expect the native zsh marker

## Why
The current `gog completion zsh` output is a bash compatibility shim using `bashcompinit`, which is awkward in zsh and does not install as a normal native zsh completion script.

## Validation
- `go test ./internal/cmd`
- `go test ./...`
- `go run ./cmd/gog completion zsh | sed -n '1,40p'`
