### PR TITLE
fix(docs): use UTF-16 sed offsets and preserve & replacements

### DIFF
--- a/internal/cmd/docs_sed.go
+++ b/internal/cmd/docs_sed.go
@@ -102,14 +102,11 @@ type indexedExpr struct {
 	expr  sedExpr
 }
 
-// literalReplacement returns the replacement string with Go regex escaping undone,
+// literalReplacement returns the replacement string with Go regex dollar escaping undone,
 // suitable for direct text insertion (not through regexp.ReplaceAllString).
 func literalReplacement(repl string) string {
 	// $$ → $ (Go regex literal dollar)
-	result := strings.ReplaceAll(repl, "$$", "$")
-	// Remove ${0} (whole match backref has no meaning in direct insertion without context)
-	// Table wildcard code handles & expansion separately before calling this.
-	return result
+	return strings.ReplaceAll(repl, "$$", "$")
 }
 
 func (c *DocsSedCmd) Run(ctx context.Context, flags *RootFlags) error {

--- a/internal/cmd/docs_sed_commands.go
+++ b/internal/cmd/docs_sed_commands.go
@@ -443,8 +443,9 @@ func (c *DocsSedCmd) runAddressedSubstitute(ctx context.Context, u *ui.UI, accou
 			m := matches[j]
 			matchText := text[m[0]:m[1]]
 			replText := re.ReplaceAllString(matchText, expr.replacement)
-			// Unescape Go regex $$ to literal $
-			replText = literalReplacement(replText)
+			// Unescape Go regex $$ to literal $ after regex expansion.
+			// Keep expanded whole-match/capture substitutions intact.
+			replText = strings.ReplaceAll(replText, "$$", "$")
 
 			absStart := para.StartIndex + int64(m[0])
 			absEnd := para.StartIndex + int64(m[1])

--- a/internal/cmd/docs_sed_commands_test.go
+++ b/internal/cmd/docs_sed_commands_test.go
@@ -381,6 +381,13 @@ func TestBuildCellReplaceRequests(t *testing.T) {
 	reqs = buildCellReplaceRequests(10, 15, "hello", []string{"bold"})
 	assert.Equal(t, 3, len(reqs)) // delete + insert + format
 
+	// Formatting ranges must use UTF-16 code units, not UTF-8 byte length.
+	reqs = buildCellReplaceRequests(10, 10, "A🐢", []string{"bold"})
+	require.Len(t, reqs, 2)
+	require.NotNil(t, reqs[1].UpdateTextStyle)
+	assert.Equal(t, int64(10), reqs[1].UpdateTextStyle.Range.StartIndex)
+	assert.Equal(t, int64(13), reqs[1].UpdateTextStyle.Range.EndIndex)
+
 	// Empty text
 	reqs = buildCellReplaceRequests(10, 15, "", nil)
 	assert.Equal(t, 1, len(reqs)) // delete only

--- a/internal/cmd/docs_sed_helpers.go
+++ b/internal/cmd/docs_sed_helpers.go
@@ -119,7 +119,7 @@ func buildCellReplaceRequests(startIdx, deleteEnd int64, plainText string, forma
 			},
 		})
 		if len(formats) > 0 {
-			end := startIdx + int64(len(plainText))
+			end := startIdx + utf16Len(plainText)
 			requests = append(requests, buildTextStyleRequests(formats, startIdx, end)...)
 		}
 	}

--- a/internal/cmd/docs_sed_insert.go
+++ b/internal/cmd/docs_sed_insert.go
@@ -53,14 +53,14 @@ func (c *DocsSedCmd) doPositionalInsert(ctx context.Context, docsSvc *docs.Servi
 
 		// Apply text formatting if any
 		if len(formats) > 0 {
-			end := idx + int64(len(plainText))
+			end := idx + utf16Len(plainText)
 			requests = append(requests, buildTextStyleRequests(formats, idx, end)...)
 		}
 	}
 
 	// After inserting text, reset paragraph styles and apply heading/bullet if requested
 	if tableSpec == nil && imgSpec == nil && plainText != "" {
-		end := idx + int64(len(plainText))
+		end := idx + utf16Len(plainText)
 
 		// Reset paragraph to NORMAL_TEXT (removes inherited heading styles)
 		requests = append(requests, &docs.Request{

--- a/internal/cmd/docs_sed_manual.go
+++ b/internal/cmd/docs_sed_manual.go
@@ -281,7 +281,7 @@ func (c *DocsSedCmd) runManualInner(ctx context.Context, docsSvc *docs.Service, 
 				}
 				formatRanges = append(formatRanges, formatRange{
 					start:      m.start,
-					end:        m.start + int64(len(m.newText)),
+					end:        m.start + utf16Len(m.newText),
 					formats:    fmts,
 					hasTab:     strings.HasPrefix(m.newText, "\t"),
 					braceExpr:  m.braceExpr,

--- a/internal/cmd/docs_sed_regex_test.go
+++ b/internal/cmd/docs_sed_regex_test.go
@@ -53,6 +53,13 @@ func TestDocsSedCmd_RegexMatching(t *testing.T) {
 			want:  "dog catalog bobcat dog",
 			wantN: 2,
 		},
+		{
+			name:  "whole match backreference ampersand",
+			expr:  `s/foo/&/`,
+			input: "foo",
+			want:  "foo",
+			wantN: 1,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/cmd/docs_sed_table_create.go
+++ b/internal/cmd/docs_sed_table_create.go
@@ -193,7 +193,7 @@ func (c *DocsSedCmd) fillTableCells(ctx context.Context, docsSvc *docs.Service, 
 				},
 			})
 
-			fillRequests = append(fillRequests, buildTextStyleRequests(formats, insertIdx, insertIdx+int64(len(plainText)))...)
+			fillRequests = append(fillRequests, buildTextStyleRequests(formats, insertIdx, insertIdx+utf16Len(plainText))...)
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix Google Docs API range calculations in sed formatting paths to use UTF-16 code unit lengths instead of Go byte lengths
- preserve whole-match `&` replacements in addressed substitutions after regex expansion
- add regression coverage for UTF-16 style ranges and `s/foo/&/`

## Testing
- `go build ./...`
- `go test ./internal/cmd/... -run Sed -v -count=1`

## Notes
- This PR intentionally does **not** refactor paragraph-addressed brace formatting (`runAddressedSubstitute`) to emit formatting requests. That bug is real, but it is a larger behavior change and felt too risky to mix into the UTF-16/data-corruption fix.
