### PR TITLE
feat(gmail): add html body file support

### DIFF
--- a/internal/cmd/gmail_body_input.go
+++ b/internal/cmd/gmail_body_input.go
@@ -35,3 +35,31 @@ func resolveBodyInput(body, bodyFile string) (string, error) {
 	}
 	return string(b), nil
 }
+
+func resolveBodyHTMLInput(bodyHTML, bodyHTMLFile string) (string, error) {
+	bodyHTMLFile = strings.TrimSpace(bodyHTMLFile)
+	if bodyHTMLFile == "" {
+		return bodyHTML, nil
+	}
+	if strings.TrimSpace(bodyHTML) != "" {
+		return "", usage("use only one of --body-html or --body-html-file")
+	}
+
+	var (
+		b   []byte
+		err error
+	)
+	if bodyHTMLFile == "-" {
+		b, err = io.ReadAll(os.Stdin)
+	} else {
+		bodyHTMLFile, err = config.ExpandPath(bodyHTMLFile)
+		if err != nil {
+			return "", err
+		}
+		b, err = os.ReadFile(bodyHTMLFile) //nolint:gosec // user-provided path
+	}
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -255,6 +255,7 @@ type GmailDraftsCreateCmd struct {
 	Body             string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
 	BodyFile         string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
 	BodyHTML         string   `name:"body-html" help:"Body (HTML; optional)"`
+	BodyHTMLFile     string   `name:"body-html-file" help:"Body HTML file path ( '-' for stdin)"`
 	ReplyToMessageID string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
 	ReplyTo          string   `name:"reply-to" help:"Reply-To header address"`
 	Quote            bool     `name:"quote" help:"Include quoted original message in reply (requires --reply-to-message-id)"`
@@ -282,7 +283,7 @@ func (c draftComposeInput) validate() error {
 		return usage("required: --subject")
 	}
 	if strings.TrimSpace(c.Body) == "" && strings.TrimSpace(c.BodyHTML) == "" {
-		return usage("required: --body, --body-file, or --body-html")
+		return usage("required: --body, --body-file, --body-html, or --body-html-file")
 	}
 	return nil
 }
@@ -445,6 +446,10 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if err != nil {
 		return err
 	}
+	bodyHTML, err := resolveBodyHTMLInput(c.BodyHTML, c.BodyHTMLFile)
+	if err != nil {
+		return err
+	}
 	replyToMessageID := normalizeGmailMessageID(c.ReplyToMessageID)
 	if c.Quote && replyToMessageID == "" {
 		return usage("--quote requires --reply-to-message-id")
@@ -461,7 +466,7 @@ func (c *GmailDraftsCreateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		Bcc:              c.Bcc,
 		Subject:          c.Subject,
 		Body:             body,
-		BodyHTML:         c.BodyHTML,
+		BodyHTML:         bodyHTML,
 		ReplyToMessageID: replyToMessageID,
 		ReplyToThreadID:  "",
 		ReplyTo:          c.ReplyTo,
@@ -515,6 +520,7 @@ type GmailDraftsUpdateCmd struct {
 	Body             string   `name:"body" help:"Body (plain text; required unless --body-html is set)"`
 	BodyFile         string   `name:"body-file" help:"Body file path (plain text; '-' for stdin)"`
 	BodyHTML         string   `name:"body-html" help:"Body (HTML; optional)"`
+	BodyHTMLFile     string   `name:"body-html-file" help:"Body HTML file path ( '-' for stdin)"`
 	ReplyToMessageID string   `name:"reply-to-message-id" help:"Reply to Gmail message ID (sets In-Reply-To/References and thread)"`
 	ReplyTo          string   `name:"reply-to" help:"Reply-To header address"`
 	Quote            bool     `name:"quote" help:"Include quoted original message in reply"`
@@ -540,6 +546,10 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if err != nil {
 		return err
 	}
+	bodyHTML, err := resolveBodyHTMLInput(c.BodyHTML, c.BodyHTMLFile)
+	if err != nil {
+		return err
+	}
 	replyToMessageID := normalizeGmailMessageID(c.ReplyToMessageID)
 
 	attachPaths, err := expandComposeAttachmentPaths(c.Attach)
@@ -553,7 +563,7 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		Bcc:              c.Bcc,
 		Subject:          c.Subject,
 		Body:             body,
-		BodyHTML:         c.BodyHTML,
+		BodyHTML:         bodyHTML,
 		ReplyToMessageID: replyToMessageID,
 		ReplyToThreadID:  "",
 		ReplyTo:          c.ReplyTo,


### PR DESCRIPTION
The changes add --BodyHTMLFile flag to both gmail.drafts.create and gmail.drafts.update commands:

Changes made:

gmail_body_input.go:
 - Added resolveBodyHTMLInput() function (mirrors resolveBodyInput() but for HTML body)

gmail_drafts.go:

- Added BodyHTMLFile string \name:"body-html-file"`toGmailDraftsCreateCmdandGmailDraftsUpdateCmd`
- Updated GmailDraftsCreateCmd.Run() to call resolveBodyHTMLInput(c.BodyHTML, c.BodyHTMLFile)
- Updated GmailDraftsUpdateCmd.Run() similarly
- Updated validation error message to include --body-html-file

The new flag works like --body-file but reads the file content as the HTML body instead of plain text. It supports - for stdin and path expansion just like --body-file.