### PR TITLE
feat(drive): convert Markdown uploads and strip YAML frontmatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Auth: add `auth credentials remove` to delete stored OAuth client credentials and associated refresh tokens. (#473) — thanks @yamagucci.
+- Drive: convert Markdown uploads to Google Docs and strip leading YAML frontmatter by default, with `--keep-frontmatter` to opt out. (#487) — thanks @johnbenjaminlewis.
 - Gmail: add `gmail autoreply` to reply once to matching messages, label the thread for dedupe, and optionally archive/mark read. Includes docs and regression coverage for skip/reply flows.
 - Gmail: add `gmail messages search --full` to print complete message bodies instead of truncating text output. (#447) — thanks @GodsBoy.
 - Drive: allow `drive share --role commenter` for comment-only sharing. (#443) — thanks @pavelzak.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fast, script-friendly CLI for Gmail, Calendar, Chat, Classroom, Drive, Docs, Sli
 - **Calendar** - list/create/update/delete events, manage invitations, aliases, subscriptions, team calendars, free/busy/conflicts, propose new times, focus/OOO/working-location events, recurrence, and reminders
 - **Classroom** - manage courses, roster, coursework/materials, submissions, announcements, topics, invitations, guardians, profiles
 - **Chat** - list/find/create spaces, list messages/threads, send messages and DMs, and manage emoji reactions (Workspace-only)
-- **Drive** - list/search/upload/download files, replace uploads in-place, convert uploads, manage permissions/comments, organize folders, and list shared drives
+- **Drive** - list/search/upload/download files, replace uploads in-place, convert uploads (including Markdown to Google Doc), manage permissions/comments, organize folders, and list shared drives
 - **Contacts** - search/create/update contacts, including addresses, relations, org/title metadata, custom fields, Workspace directory, and other contacts
 - **Tasks** - manage tasklists and tasks: get/create/add/update/done/undo/delete/clear, plus repeat schedule materialization with RRULE aliases
 - **Sheets** - read/write/update spreadsheets, insert rows/cols, manage tabs and named ranges, format/merge/freeze/resize cells, read/write notes, inspect formats, find/replace text, list links, and create/export sheets
@@ -895,6 +895,8 @@ gog time now --timezone UTC
 
 ### Drive
 
+When you turn a Markdown file into a Google Doc, use **`--convert`** (extension-based) or **`--convert-to doc`**. Leading YAML frontmatter between **`---`** lines is **removed before upload** unless you pass **`--keep-frontmatter`**. That step only looks for opening and closing delimiter lines—it is **not** a full YAML parse, so odd edge cases may need **`--keep-frontmatter`** or editing the file first.
+
 ```bash
 # List and search
 gog drive ls --max 20
@@ -914,9 +916,11 @@ gog drive upload ./path/to/file --replace <fileId>  # Replace file content in-pl
 gog drive upload ./report.docx --convert
 gog drive upload ./chart.png --convert-to sheet
 gog drive upload ./report.docx --convert --name report.docx
+gog drive upload ./notes.md --convert                              # Markdown → Google Doc (or use --convert-to doc)
 gog drive download <fileId> --out ./downloaded.bin
 gog drive download <fileId> --format pdf --out ./exported.pdf     # Google Workspace files only
 gog drive download <fileId> --format docx --out ./doc.docx
+gog drive download <fileId> --format md --out ./note.md            # Google Doc → Markdown
 gog drive download <fileId> --format pptx --out ./slides.pptx
 
 # Organize

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -188,8 +188,8 @@ Flag aliases:
 - `gog drive ls [--all] [--parent ID] [--max N] [--page TOKEN] [--query Q] [--[no-]all-drives]` (`--all` and `--parent` are mutually exclusive)
 - `gog drive search <text> [--raw-query] [--max N] [--page TOKEN] [--[no-]all-drives]`
 - `gog drive get <fileId>`
-- `gog drive download <fileId> [--out PATH] [--format F]` (`--format` only applies to Google Workspace files)
-- `gog drive upload <localPath> [--name N] [--parent ID] [--convert] [--convert-to doc|sheet|slides]`
+- `gog drive download <fileId> [--out PATH] [--format F]` (`--format` only applies to Google Workspace files; `--format md` exports a Google Doc as Markdown)
+- `gog drive upload <localPath> [--name N] [--parent ID] [--convert] [--convert-to doc|sheet|slides] [--keep-frontmatter]` (Markdown → Google Doc with `--convert` or `--convert-to doc`: leading `---`/`---` frontmatter is stripped before upload unless `--keep-frontmatter`; delimiter-based, not a full YAML parse)
 - `gog drive mkdir <name> [--parent ID]`
 - `gog drive delete <fileId> [--permanent]`
 - `gog drive move <fileId> --parent ID`

--- a/internal/cmd/docs_sed_helpers.go
+++ b/internal/cmd/docs_sed_helpers.go
@@ -441,7 +441,7 @@ func canUseNativeReplace(replacement string) bool {
 	}
 	// Horizontal rule
 	trimmedRepl := strings.TrimSpace(replacement)
-	if trimmedRepl == "---" || trimmedRepl == "***" || trimmedRepl == "___" {
+	if trimmedRepl == literalMarkdownTripleDash || trimmedRepl == "***" || trimmedRepl == "___" {
 		return false
 	}
 	// Numbered list pattern

--- a/internal/cmd/docs_sed_parse.go
+++ b/internal/cmd/docs_sed_parse.go
@@ -179,7 +179,7 @@ func parseMarkdownReplacement(repl string) (text string, formats []string) {
 	// Horizontal rule (---, ***, ___) — must be exactly 3 of the same char
 	// (not 4+ which could be bold/italic markers)
 	trimmed := strings.TrimSpace(text)
-	if trimmed == "---" || trimmed == "***" || trimmed == "___" {
+	if trimmed == literalMarkdownTripleDash || trimmed == "***" || trimmed == "___" {
 		return "\n", []string{"hrule"}
 	}
 

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -234,6 +234,7 @@ type DriveUploadCmd struct {
 	KeepRevisionForever bool   `name:"keep-revision-forever" help:"Keep the new head revision forever (binary files only)"`
 	Convert             bool   `name:"convert" help:"Auto-convert to native Google format based on file extension (create only)"`
 	ConvertTo           string `name:"convert-to" help:"Convert to a specific Google format: doc|sheet|slides (create only)"`
+	KeepFrontmatter     bool   `name:"keep-frontmatter" help:"Keep YAML frontmatter (---) in Markdown when converting to a Google Doc (--convert or --convert-to doc; default: strip)"`
 }
 
 type DriveMkdirCmd struct {
@@ -1121,7 +1122,7 @@ func googleConvertMimeType(path string) (string, bool) {
 		return driveMimeGoogleSheet, true
 	case extPptx, ".ppt":
 		return driveMimeGoogleSlides, true
-	case extTXT, ".html":
+	case extTXT, ".html", extMD:
 		return driveMimeGoogleDoc, true
 	default:
 		return "", false
@@ -1156,7 +1157,7 @@ func driveUploadConvertMimeType(path string, auto bool, target string) (string, 
 
 	mimeType, ok := googleConvertMimeType(path)
 	if !ok {
-		return "", false, fmt.Errorf("--convert: unsupported file type %q (supported: docx, xlsx, pptx, doc, xls, ppt, csv, txt, html)", filepath.Ext(path))
+		return "", false, fmt.Errorf("--convert: unsupported file type %q (supported: docx, xlsx, pptx, doc, xls, ppt, csv, txt, html, md)", filepath.Ext(path))
 	}
 	return mimeType, true, nil
 }
@@ -1166,7 +1167,7 @@ func driveUploadConvertMimeType(path string, auto bool, target string) (string, 
 func stripOfficeExt(name string) string {
 	ext := strings.ToLower(filepath.Ext(name))
 	switch ext {
-	case extDocx, ".doc", extXlsx, ".xls", extPptx, ".ppt":
+	case extDocx, ".doc", extXlsx, ".xls", extPptx, ".ppt", extMD:
 		return strings.TrimSuffix(name, filepath.Ext(name))
 	default:
 		return name

--- a/internal/cmd/drive_commands_more_test.go
+++ b/internal/cmd/drive_commands_more_test.go
@@ -21,6 +21,7 @@ import (
 type fakeDriveCommands struct {
 	run         func(args ...string) string
 	uploadMetas func() []map[string]any
+	uploadMedia func() []string
 }
 
 func newFakeDriveCommands(t *testing.T) *fakeDriveCommands {
@@ -30,6 +31,7 @@ func newFakeDriveCommands(t *testing.T) *fakeDriveCommands {
 	t.Cleanup(func() { newDriveService = origNew })
 
 	uploadMetas := make([]map[string]any, 0, 4)
+	uploadMedia := make([]string, 0, 4)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/drive/v3")
@@ -114,12 +116,13 @@ func newFakeDriveCommands(t *testing.T) *fakeDriveCommands {
 			respName := "New"
 			respMimeType := "text/plain"
 			if isUpload {
-				meta, err := readUploadMetadata(r)
+				meta, media, err := readUploadRequest(r)
 				if err != nil {
 					http.Error(w, err.Error(), http.StatusBadRequest)
 					return
 				}
 				uploadMetas = append(uploadMetas, meta)
+				uploadMedia = append(uploadMedia, media)
 				if v, ok := meta["name"].(string); ok && strings.TrimSpace(v) != "" {
 					respName = v
 				}
@@ -238,6 +241,7 @@ func newFakeDriveCommands(t *testing.T) *fakeDriveCommands {
 	return &fakeDriveCommands{
 		run:         run,
 		uploadMetas: func() []map[string]any { return uploadMetas },
+		uploadMedia: func() []string { return uploadMedia },
 	}
 }
 
@@ -328,6 +332,39 @@ func TestDriveCommands_UploadVariants(t *testing.T) {
 	if got := toString(explicitMeta["name"]); got != "chart.png" {
 		t.Fatalf("upload --convert-to name = %q, want chart.png", got)
 	}
+
+	mdTmp := filepath.Join(t.TempDir(), "notes.md")
+	mdContent := "---\ntitle: Secret\n---\n\n# Public\n"
+	if err := os.WriteFile(mdTmp, []byte(mdContent), 0o600); err != nil {
+		t.Fatalf("write temp markdown: %v", err)
+	}
+	out = run("--json", "--account", "a@b.com", "drive", "upload", mdTmp, "--convert")
+	if !strings.Contains(out, "\"file\"") {
+		t.Fatalf("unexpected upload markdown --convert json: %q", out)
+	}
+	mdMeta := latestUploadMeta(t, fake.uploadMetas())
+	if got := toString(mdMeta["mimeType"]); got != driveMimeGoogleDoc {
+		t.Fatalf("upload markdown --convert mimeType = %q, want %q", got, driveMimeGoogleDoc)
+	}
+	if got := toString(mdMeta["name"]); got != "notes" {
+		t.Fatalf("upload markdown --convert name = %q, want notes", got)
+	}
+	mdMedia := latestUploadMedia(t, fake.uploadMedia())
+	if strings.Contains(mdMedia, "title: Secret") || strings.HasPrefix(mdMedia, "---") {
+		t.Fatalf("expected frontmatter stripped from markdown media, got %q", mdMedia)
+	}
+	if mdMedia != "\n# Public\n" {
+		t.Fatalf("markdown media = %q, want stripped body", mdMedia)
+	}
+
+	out = run("--json", "--account", "a@b.com", "drive", "upload", mdTmp, "--convert", "--keep-frontmatter")
+	if !strings.Contains(out, "\"file\"") {
+		t.Fatalf("unexpected upload markdown --keep-frontmatter json: %q", out)
+	}
+	keptMedia := latestUploadMedia(t, fake.uploadMedia())
+	if keptMedia != mdContent {
+		t.Fatalf("markdown media with --keep-frontmatter = %q, want %q", keptMedia, mdContent)
+	}
 }
 
 func TestDriveCommands_MutateShareAndPermissions(t *testing.T) {
@@ -382,42 +419,50 @@ func TestDriveCommands_MutateShareAndPermissions(t *testing.T) {
 	}
 }
 
-func readUploadMetadata(r *http.Request) (map[string]any, error) {
+func readUploadRequest(r *http.Request) (map[string]any, string, error) {
 	mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
 	if err != nil {
-		return nil, fmt.Errorf("parse content-type: %w", err)
+		return nil, "", fmt.Errorf("parse content-type: %w", err)
 	}
 	if !strings.HasPrefix(mediaType, "multipart/") {
-		return nil, fmt.Errorf("unexpected content-type: %q", mediaType)
+		return nil, "", fmt.Errorf("unexpected content-type: %q", mediaType)
 	}
 	boundary := params["boundary"]
 	if boundary == "" {
-		return nil, fmt.Errorf("missing multipart boundary")
+		return nil, "", fmt.Errorf("missing multipart boundary")
 	}
 
 	reader := multipart.NewReader(r.Body, boundary)
+	var meta map[string]any
+	var media []byte
 	for {
 		part, partErr := reader.NextPart()
 		if partErr == io.EOF {
 			break
 		}
 		if partErr != nil {
-			return nil, fmt.Errorf("read multipart: %w", partErr)
+			return nil, "", fmt.Errorf("read multipart: %w", partErr)
 		}
 
 		contentType := part.Header.Get("Content-Type")
 		if !strings.HasPrefix(contentType, "application/json") {
+			body, readErr := io.ReadAll(part)
+			if readErr != nil {
+				return nil, "", fmt.Errorf("read media part: %w", readErr)
+			}
+			media = body
 			continue
 		}
 
-		var meta map[string]any
 		if err := json.NewDecoder(part).Decode(&meta); err != nil {
-			return nil, fmt.Errorf("decode metadata json: %w", err)
+			return nil, "", fmt.Errorf("decode metadata json: %w", err)
 		}
-		return meta, nil
 	}
 
-	return nil, fmt.Errorf("metadata part not found")
+	if meta == nil {
+		return nil, "", fmt.Errorf("metadata part not found")
+	}
+	return meta, string(media), nil
 }
 
 func latestUploadMeta(t *testing.T, uploadMetas []map[string]any) map[string]any {
@@ -426,6 +471,14 @@ func latestUploadMeta(t *testing.T, uploadMetas []map[string]any) map[string]any
 		t.Fatalf("expected at least one upload metadata entry")
 	}
 	return uploadMetas[len(uploadMetas)-1]
+}
+
+func latestUploadMedia(t *testing.T, uploadMedia []string) string {
+	t.Helper()
+	if len(uploadMedia) == 0 {
+		t.Fatalf("expected at least one upload media entry")
+	}
+	return uploadMedia[len(uploadMedia)-1]
 }
 
 func toString(v any) string {

--- a/internal/cmd/drive_markdown_frontmatter.go
+++ b/internal/cmd/drive_markdown_frontmatter.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+)
+
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
+// stripYAMLFrontmatter removes a leading YAML frontmatter block: the file must
+// begin (after optional UTF-8 BOM) with a line that trims to "---", followed by
+// a later line that trims to "---". If no closing delimiter exists, b is
+// returned unchanged.
+func stripYAMLFrontmatter(b []byte) []byte {
+	orig := b
+	b = bytes.TrimPrefix(b, utf8BOM)
+	s := string(b)
+	if !strings.HasPrefix(s, literalMarkdownTripleDash) {
+		return orig
+	}
+	firstNL := strings.IndexByte(s, '\n')
+	if firstNL < 0 {
+		return orig
+	}
+	if strings.TrimSpace(s[:firstNL]) != literalMarkdownTripleDash {
+		return orig
+	}
+	rest := s[firstNL+1:]
+	restLines := strings.Split(rest, "\n")
+	for i, line := range restLines {
+		if strings.TrimSpace(line) == literalMarkdownTripleDash {
+			body := strings.Join(restLines[i+1:], "\n")
+			return []byte(body)
+		}
+	}
+	return orig
+}

--- a/internal/cmd/drive_markdown_frontmatter.go
+++ b/internal/cmd/drive_markdown_frontmatter.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"bytes"
-	"strings"
 )
 
 var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
@@ -14,24 +13,35 @@ var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
 func stripYAMLFrontmatter(b []byte) []byte {
 	orig := b
 	b = bytes.TrimPrefix(b, utf8BOM)
-	s := string(b)
-	if !strings.HasPrefix(s, literalMarkdownTripleDash) {
+	firstLine, rest, ok := cutMarkdownLine(b)
+	if !ok || !isYAMLFrontmatterDelimiter(firstLine) {
 		return orig
 	}
-	firstNL := strings.IndexByte(s, '\n')
-	if firstNL < 0 {
-		return orig
-	}
-	if strings.TrimSpace(s[:firstNL]) != literalMarkdownTripleDash {
-		return orig
-	}
-	rest := s[firstNL+1:]
-	restLines := strings.Split(rest, "\n")
-	for i, line := range restLines {
-		if strings.TrimSpace(line) == literalMarkdownTripleDash {
-			body := strings.Join(restLines[i+1:], "\n")
-			return []byte(body)
+
+	for len(rest) > 0 {
+		var line []byte
+		line, rest, ok = cutMarkdownLine(rest)
+		if isYAMLFrontmatterDelimiter(line) {
+			if ok {
+				return rest
+			}
+			return nil
+		}
+		if !ok {
+			break
 		}
 	}
 	return orig
+}
+
+func cutMarkdownLine(b []byte) (line []byte, rest []byte, ok bool) {
+	i := bytes.IndexByte(b, '\n')
+	if i < 0 {
+		return bytes.TrimSuffix(b, []byte{'\r'}), nil, false
+	}
+	return bytes.TrimSuffix(b[:i], []byte{'\r'}), b[i+1:], true
+}
+
+func isYAMLFrontmatterDelimiter(line []byte) bool {
+	return string(bytes.TrimSpace(line)) == literalMarkdownTripleDash
 }

--- a/internal/cmd/drive_markdown_frontmatter_test.go
+++ b/internal/cmd/drive_markdown_frontmatter_test.go
@@ -23,6 +23,16 @@ func TestStripYAMLFrontmatter(t *testing.T) {
 			want: "body",
 		},
 		{
+			name: "closing_delimiter_at_eof",
+			in:   "---\nx: 1\n---",
+			want: "",
+		},
+		{
+			name: "crlf",
+			in:   "---\r\nx: 1\r\n---\r\nbody\r\n",
+			want: "body\r\n",
+		},
+		{
 			name: "empty_body",
 			in:   "---\nx: 1\n---\n",
 			want: "",

--- a/internal/cmd/drive_markdown_frontmatter_test.go
+++ b/internal/cmd/drive_markdown_frontmatter_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestStripYAMLFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "standard",
+			in:   "---\ntitle: T\n---\n\n# Hi\n",
+			want: "\n# Hi\n",
+		},
+		{
+			name: "no_trailing_newline_after_body",
+			in:   "---\nx: 1\n---\nbody",
+			want: "body",
+		},
+		{
+			name: "empty_body",
+			in:   "---\nx: 1\n---\n",
+			want: "",
+		},
+		{
+			name: "bom_then_frontmatter",
+			in:   string(utf8BOM) + "---\na: b\n---\nText",
+			want: "Text",
+		},
+		{
+			name: "no_frontmatter",
+			in:   "# Just markdown\n",
+			want: "# Just markdown\n",
+		},
+		{
+			name: "only_opening_delimiter",
+			in:   "---\ntitle: no close\n",
+			want: "---\ntitle: no close\n",
+		},
+		{
+			name: "four_dashes_not_frontmatter",
+			in:   "----\nnot fm\n",
+			want: "----\nnot fm\n",
+		},
+		{
+			name: "blank_lines_inside_fm",
+			in:   "---\n\nx: 1\n\n---\n\nHello",
+			want: "\nHello",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := string(stripYAMLFrontmatter([]byte(tc.in)))
+			if got != tc.want {
+				t.Fatalf("stripYAMLFrontmatter() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/drive_upload.go
+++ b/internal/cmd/drive_upload.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -40,15 +41,25 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	defer file.Close()
 
+	reader := io.Reader(file)
+	if driveUploadShouldStripMarkdownFrontmatter(opts, c.KeepFrontmatter) {
+		data, readErr := io.ReadAll(file)
+		if readErr != nil {
+			return readErr
+		}
+		data = stripYAMLFrontmatter(data)
+		reader = bytes.NewReader(data)
+	}
+
 	_, svc, err := requireDriveService(ctx, flags)
 	if err != nil {
 		return err
 	}
 
 	if opts.replaceFileID == "" {
-		return runDriveCreateUpload(ctx, svc, file, opts)
+		return runDriveCreateUpload(ctx, svc, reader, opts)
 	}
-	return runDriveReplaceUpload(ctx, svc, file, opts)
+	return runDriveReplaceUpload(ctx, svc, reader, opts)
 }
 
 func prepareDriveUpload(c *DriveUploadCmd) (driveUploadOptions, error) {
@@ -92,6 +103,10 @@ func prepareDriveUpload(c *DriveUploadCmd) (driveUploadOptions, error) {
 	}
 
 	return opts, nil
+}
+
+func driveUploadShouldStripMarkdownFrontmatter(opts driveUploadOptions, keepFrontmatter bool) bool {
+	return !keepFrontmatter && opts.convert && opts.mimeType == mimeTextMarkdown
 }
 
 func runDriveCreateUpload(ctx context.Context, svc *drive.Service, file io.Reader, opts driveUploadOptions) error {

--- a/internal/cmd/drive_upload.go
+++ b/internal/cmd/drive_upload.go
@@ -35,21 +35,11 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	file, err := os.Open(opts.localPath)
+	media, err := openDriveUploadMedia(opts, c.KeepFrontmatter)
 	if err != nil {
 		return err
 	}
-	defer file.Close()
-
-	reader := io.Reader(file)
-	if driveUploadShouldStripMarkdownFrontmatter(opts, c.KeepFrontmatter) {
-		data, readErr := io.ReadAll(file)
-		if readErr != nil {
-			return readErr
-		}
-		data = stripYAMLFrontmatter(data)
-		reader = bytes.NewReader(data)
-	}
+	defer media.Close()
 
 	_, svc, err := requireDriveService(ctx, flags)
 	if err != nil {
@@ -57,9 +47,9 @@ func (c *DriveUploadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if opts.replaceFileID == "" {
-		return runDriveCreateUpload(ctx, svc, reader, opts)
+		return runDriveCreateUpload(ctx, svc, media, opts)
 	}
-	return runDriveReplaceUpload(ctx, svc, reader, opts)
+	return runDriveReplaceUpload(ctx, svc, media, opts)
 }
 
 func prepareDriveUpload(c *DriveUploadCmd) (driveUploadOptions, error) {
@@ -107,6 +97,26 @@ func prepareDriveUpload(c *DriveUploadCmd) (driveUploadOptions, error) {
 
 func driveUploadShouldStripMarkdownFrontmatter(opts driveUploadOptions, keepFrontmatter bool) bool {
 	return !keepFrontmatter && opts.convert && opts.mimeType == mimeTextMarkdown
+}
+
+func openDriveUploadMedia(opts driveUploadOptions, keepFrontmatter bool) (io.ReadCloser, error) {
+	file, err := os.Open(opts.localPath)
+	if err != nil {
+		return nil, err
+	}
+	if !driveUploadShouldStripMarkdownFrontmatter(opts, keepFrontmatter) {
+		return file, nil
+	}
+
+	data, readErr := io.ReadAll(file)
+	closeErr := file.Close()
+	if readErr != nil {
+		return nil, readErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	return io.NopCloser(bytes.NewReader(stripYAMLFrontmatter(data))), nil
 }
 
 func runDriveCreateUpload(ctx context.Context, svc *drive.Service, file io.Reader, opts driveUploadOptions) error {

--- a/internal/cmd/drive_validation_more_test.go
+++ b/internal/cmd/drive_validation_more_test.go
@@ -352,6 +352,7 @@ func TestGoogleConvertMimeType(t *testing.T) {
 		{"deck.pptx", driveMimeGoogleSlides, true},
 		{"deck.ppt", driveMimeGoogleSlides, true},
 		{"notes.txt", driveMimeGoogleDoc, true},
+		{"notes.md", driveMimeGoogleDoc, true},
 		{"page.html", driveMimeGoogleDoc, true},
 		{"photo.png", "", false},
 		{"archive.zip", "", false},
@@ -394,6 +395,14 @@ func TestDriveUploadConvertMimeType(t *testing.T) {
 		t.Fatalf("auto convert = (%q, %v), want (%q, true)", mimeType, convert, driveMimeGoogleDoc)
 	}
 
+	mimeType, convert, err = driveUploadConvertMimeType("notes.md", true, "")
+	if err != nil {
+		t.Fatalf("auto convert md: %v", err)
+	}
+	if !convert || mimeType != driveMimeGoogleDoc {
+		t.Fatalf("auto convert md = (%q, %v), want (%q, true)", mimeType, convert, driveMimeGoogleDoc)
+	}
+
 	mimeType, convert, err = driveUploadConvertMimeType("photo.png", false, "sheet")
 	if err != nil {
 		t.Fatalf("explicit convert: %v", err)
@@ -426,6 +435,7 @@ func TestStripOfficeExt(t *testing.T) {
 		{"budget.xls", "budget"},
 		{"deck.pptx", "deck"},
 		{"deck.ppt", "deck"},
+		{"notes.md", "notes"},
 		{"notes.txt", "notes.txt"},
 		{"photo.png", "photo.png"},
 		{"no-ext", "no-ext"},

--- a/internal/cmd/literals.go
+++ b/internal/cmd/literals.go
@@ -7,4 +7,8 @@ package cmd
 // coupling to unrelated semantic constants.
 const (
 	literalAll = "all"
+
+	// literalMarkdownTripleDash is the three-dash token used for YAML
+	// frontmatter delimiters, horizontal rules, and slide separators.
+	literalMarkdownTripleDash = "---"
 )

--- a/internal/cmd/slides_markdown.go
+++ b/internal/cmd/slides_markdown.go
@@ -41,7 +41,7 @@ func ParseMarkdownToSlides(markdown string) []Slide {
 	inSlide := false
 
 	for _, line := range lines {
-		if strings.TrimSpace(line) == "---" {
+		if strings.TrimSpace(line) == literalMarkdownTripleDash {
 			if currentSlide.Len() > 0 {
 				slide := parseSlide(currentSlide.String())
 				if slide.Title != "" {


### PR DESCRIPTION
## **Summary**

* **Markdown to Doc Conversion:** Treat `.md` as convertible to native Google Docs when using `gog drive upload --convert`. (Uses `application/vnd.google-apps.document` metadata).  
* **Frontmatter Handling:** Strips leading YAML frontmatter (`---` ... `---`) by default to ensure clean Drive imports.  
* **New Flag:** Added `--keep-frontmatter` for users who want to preserve the header.  
* **Implementation:** Frontmatter removal is delimiter-based (no heavy YAML dependency). Centralized `---` literal in `internal/cmd/literals.go` to satisfy `goconst`.  
* **Documentation:** Updated README and `docs/spec.md` to reflect new flags and existing Google Doc → Markdown export logic.

## **User-facing changes**

* `gog drive upload file.md --convert`: Creates a Google Doc; strips frontmatter.  
* `gog drive upload file.md --convert --keep-frontmatter`: Creates a Google Doc; keeps frontmatter.

## **Test plan**

* \[x\] `make ci`  
* \[x\] **Unit tests:** Validated `stripYAMLFrontmatter`, MIME conversion logic, and edge cases.  
* \[x\] **Manual:** Verified against live Drive API (Doc creation and frontmatter stripping confirmed).

Relates to \#272 (Provides a workaround via `drive upload` import).

