### PR TITLE
feat: add `<group> raw` subcommand for lossless JSON API dumps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 - Gmail: add `gmail autoreply` to reply once to matching messages, label the thread for dedupe, and optionally archive/mark read. Includes docs and regression coverage for skip/reply flows.
+- Raw API dumps: new `gog docs raw`, `gog sheets raw`, `gog slides raw`, and `gog drive raw` subcommands emit the canonical Google API response as JSON for lossless scripting and LLM consumption. Compact by default; `--pretty` for indented output. `sheets raw` gates cell-level data behind `--include-grid-data` (off by default) and warns on stderr when grid data or `developerMetadata` is present. `drive raw` defaults to `fields=*` and redacts a small set of capability/token-shaped fields (thumbnailLink, webContentLink, exportLinks, resourceKey, appProperties, properties, contentHints.thumbnail.image); passing `--fields` honors the request verbatim so users who name a field get it. See `docs/raw-audit.md` for the redaction rationale.
+- Drive: `drive ls` and `drive get` now accept a `--fields` flag mapping directly to the Drive API field mask, so callers can request fields beyond the hard-coded default set (thumbnailLink, imageMediaMetadata, etc.). Closes #486.
 
 ## 0.12.0 - 2026-03-09
 

--- a/README.md
+++ b/README.md
@@ -914,6 +914,15 @@ gog drive unshare <fileId> --permission-id <permissionId>
 
 # Shared drives (Team Drives)
 gog drive drives --max 100
+
+# Request extra fields from the Drive API (closes #486)
+gog drive ls --fields "files(id,name,thumbnailLink),nextPageToken"
+gog drive get <fileId> --fields "id,name,thumbnailLink,imageMediaMetadata"
+
+# Raw API dump (lossless JSON for scripting/LLMs)
+gog drive raw <fileId>                            # fields=*, sensitive fields redacted by default
+gog drive raw <fileId> --fields "id,name,thumbnailLink"  # honors user-named fields verbatim
+gog drive raw <fileId> --pretty
 ```
 
 ### Docs / Slides / Sheets
@@ -938,6 +947,8 @@ gog docs write <docId> --text "Rewrite one tab" --tab-id t.notes
 gog docs write <docId> --file ./body.txt --append --pageless
 gog docs find-replace <docId> "old" "new"
 gog docs find-replace <docId> "old" "new" --tab-id t.notes
+gog docs raw <docId>                                # Lossless JSON dump of Documents.Get (LLM/scripting)
+gog docs raw <docId> --pretty
 
 # Slides
 gog slides info <presentationId>
@@ -950,6 +961,7 @@ gog slides list-slides <presentationId>
 gog slides add-slide <presentationId> ./slide.png --notes "Speaker notes"
 gog slides update-notes <presentationId> <slideId> --notes "Updated notes"
 gog slides replace-slide <presentationId> <slideId> ./new-slide.png --notes "New notes"
+gog slides raw <presentationId>                     # Lossless JSON dump of Presentations.Get
 
 # Sheets
 gog sheets copy <spreadsheetId> "My Sheet Copy"
@@ -969,7 +981,26 @@ gog sheets links <spreadsheetId> 'Sheet1!A1:B10'
 gog sheets add-tab <spreadsheetId> <tabName>
 gog sheets rename-tab <spreadsheetId> <oldName> <newName>
 gog sheets delete-tab <spreadsheetId> <tabName> --force
+gog sheets raw <spreadsheetId>                       # Lossless JSON dump of Spreadsheets.Get
+gog sheets raw <spreadsheetId> --include-grid-data   # Include cell-level data (off by default)
 ```
+
+**Raw vs other read subcommands.** Use `raw` when you need the full
+canonical Google API response as JSON (e.g. feeding a doc into an LLM,
+or scripting against structural fields `cat`/`structure` drop). Other
+read commands are lossier on purpose:
+
+- `docs info`, `sheets metadata`, `slides info`, `drive get` → metadata only (cheap)
+- `docs cat`, `docs structure` → plain text / simplified structure
+- `docs export`, `sheets export`, `slides export`, `drive download` → converted file formats (pdf/docx/xlsx/pptx/md)
+- `<group> raw` → full API response as JSON (verbose, lossless)
+
+`drive raw` defaults to `fields=*` and redacts a small set of
+capability/token-shaped fields (thumbnailLink, webContentLink,
+exportLinks, resourceKey, appProperties, properties,
+contentHints.thumbnail.image). When `--fields` is supplied the response
+is returned verbatim — the user named the field, they get it. See
+[`docs/raw-audit.md`](docs/raw-audit.md) for the redaction rationale.
 
 ### Contacts
 

--- a/docs/raw-audit.md
+++ b/docs/raw-audit.md
@@ -28,12 +28,16 @@ Go type: <https://pkg.go.dev/google.golang.org/api/docs/v1#Document>
 
 | Field | Risk | Default handling |
 |---|---|---|
-| `inlineObjects.*.embeddedObject.imageProperties.contentUri` | Short-lived (~30 min) bearer-style authenticated image URL | Redact |
-| `inlineObjects.*.embeddedObject.imageProperties.sourceUri` | May reference private source URLs | Redact |
+| `inlineObjects.*.embeddedObject.imageProperties.contentUri` | Short-lived (~30 min) bearer-style authenticated image URL | **Ship as-is** |
+| `inlineObjects.*.embeddedObject.imageProperties.sourceUri` | May reference private source URLs | **Ship as-is** |
 
-No credentials, tokens, or OAuth metadata in the response. Document body,
-named ranges, suggestions, headers/footers are user content the caller
-already has read access to — ship as-is.
+**Why not redact:** the Docs API has no field mask, so the principled
+"redact only what the user didn't name" rule has no escape hatch.
+These image URIs are short-lived (~30 min) and require the caller's
+auth anyway — substantially lower risk than Drive's `thumbnailLink`.
+The lossless guarantee is valued more than the marginal hardening.
+
+No credentials, tokens, or OAuth metadata in the response.
 
 ### 2. `sheets.Spreadsheets.Get` — `gog sheets raw`
 
@@ -58,9 +62,12 @@ Go type: <https://pkg.go.dev/google.golang.org/api/slides/v1#Presentation>
 
 | Field | Risk | Default handling |
 |---|---|---|
-| `slides[].pageElements[].image.contentUrl` | Short-lived authenticated image URL (same class as Docs `contentUri`) | Redact |
-| `slides[].pageElements[].image.sourceUrl` | Possibly private origin URL | Redact |
-| `slides[].pageElements[].video.url` | Drive video refs may carry signed access | Redact |
+| `slides[].pageElements[].image.contentUrl` | Short-lived authenticated image URL (same class as Docs `contentUri`) | **Ship as-is** |
+| `slides[].pageElements[].image.sourceUrl` | Possibly private origin URL | **Ship as-is** |
+| `slides[].pageElements[].video.url` | Drive video refs may carry signed access | **Ship as-is** |
+
+Same rationale as Docs: no field mask, short-lived URLs, auth-gated,
+lower risk than Drive. Lossless guarantee preferred.
 
 ### 4. `drive.Files.Get` with `fields=*` — `gog drive raw` *(highest risk)*
 

--- a/docs/raw-audit.md
+++ b/docs/raw-audit.md
@@ -1,0 +1,94 @@
+# `gog <group> raw` — Sensitive Field Audit
+
+This document records the security audit performed before shipping the
+`gog <group> raw <id>` subcommands, which dump the canonical Google API
+response as JSON for programmatic / LLM consumption.
+
+## Redaction rule
+
+`raw` applies field-level redaction **only when the user did not explicitly
+name a field via `--fields`**. Rationale:
+
+- The default (implicit `fields=*` for Drive, or no mask for the other
+  APIs) pulls in capability URLs and third-party–stashed metadata that
+  callers rarely want and can leak if piped into an LLM, shared in a bug
+  report, or committed to a repo.
+- When a caller writes `--fields "id,name,thumbnailLink"`, they named
+  `thumbnailLink` deliberately. Redacting a user-named field would be
+  surprising and user-hostile.
+
+Summary: **redact what the user didn't ask for; honor what they did.**
+
+## Per-endpoint findings (PR #1 scope)
+
+### 1. `docs.Documents.Get` — `gog docs raw`
+
+REST ref: <https://developers.google.com/docs/api/reference/rest/v1/documents/get>
+Go type: <https://pkg.go.dev/google.golang.org/api/docs/v1#Document>
+
+| Field | Risk | Default handling |
+|---|---|---|
+| `inlineObjects.*.embeddedObject.imageProperties.contentUri` | Short-lived (~30 min) bearer-style authenticated image URL | Redact |
+| `inlineObjects.*.embeddedObject.imageProperties.sourceUri` | May reference private source URLs | Redact |
+
+No credentials, tokens, or OAuth metadata in the response. Document body,
+named ranges, suggestions, headers/footers are user content the caller
+already has read access to — ship as-is.
+
+### 2. `sheets.Spreadsheets.Get` — `gog sheets raw`
+
+REST ref: <https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get>
+Go type: <https://pkg.go.dev/google.golang.org/api/sheets/v4#Spreadsheet>
+
+| Field | Risk | Default handling |
+|---|---|---|
+| `developerMetadata` | Third-party apps may stash arbitrary KV including secrets | **Warn on stderr if present**, do not redact |
+| `sheets[].data.rowData.values[].userEnteredValue.formulaValue` (only with `--include-grid-data`) | Formulas can embed API keys via `IMPORTRANGE`, hardcoded tokens in cells | **Warn on stderr when `--include-grid-data` is set**, do not redact |
+
+`--include-grid-data` is **off by default** because grid payloads can be
+multi-MB and are the primary leakage vector.
+
+No redaction applied to Sheets output; warnings only. Redacting cell
+content would defeat the purpose of a lossless dump.
+
+### 3. `slides.Presentations.Get` — `gog slides raw`
+
+REST ref: <https://developers.google.com/slides/api/reference/rest/v1/presentations/get>
+Go type: <https://pkg.go.dev/google.golang.org/api/slides/v1#Presentation>
+
+| Field | Risk | Default handling |
+|---|---|---|
+| `slides[].pageElements[].image.contentUrl` | Short-lived authenticated image URL (same class as Docs `contentUri`) | Redact |
+| `slides[].pageElements[].image.sourceUrl` | Possibly private origin URL | Redact |
+| `slides[].pageElements[].video.url` | Drive video refs may carry signed access | Redact |
+
+### 4. `drive.Files.Get` with `fields=*` — `gog drive raw` *(highest risk)*
+
+REST ref: <https://developers.google.com/drive/api/reference/rest/v3/files/get>
+Go type: <https://pkg.go.dev/google.golang.org/api/drive/v3#File>
+
+| Field | Risk | Default handling |
+|---|---|---|
+| `thumbnailLink` | Time-limited signed URL that bypasses normal auth for ~hours. Classic leak vector. | Redact |
+| `webContentLink` | Direct download URL; capability URL | Redact |
+| `exportLinks` | Per-MIME authenticated export URLs | Redact |
+| `resourceKey` | Capability token for link-shared files; effectively a shared secret | Redact |
+| `appProperties` | Arbitrary app-stashed KV; apps commonly misuse for secrets | Redact |
+| `properties` | Public custom properties, still frequently (mis)used for tokens | Redact |
+| `contentHints.thumbnail.image` | Base64 thumbnail bytes; large and unnecessary | Redact |
+| `permissions[].emailAddress`, `owners[].emailAddress`, `sharingUser`, `lastModifyingUser`, `trashingUser` | Non-collaborator emails (PII) when `fields=*` enumerates full ACL | Not redacted — caller already has access to the file; enumeration is a conscious `--fields` choice |
+
+**Reminder:** all of the above are redacted **only when `--fields` is not
+set**. Passing `--fields "id,name,thumbnailLink"` returns `thumbnailLink`
+verbatim — the user named it.
+
+## Cross-cutting observations
+
+- Google APIs never return OAuth access tokens, refresh tokens, or client
+  secrets in resource responses. The risk is capability URLs and
+  app-stashed custom metadata, not credential disclosure in the API
+  contract itself.
+- `gog drive raw` is the most dangerous command; the others are modest in
+  comparison.
+- PR #2 will extend this audit to gmail / calendar / people / contacts /
+  tasks / forms before those commands ship.

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -34,6 +34,44 @@ type DocsCmd struct {
 	Sed         DocsSedCmd         `cmd:"" name:"sed" help:"Regex find/replace (sed-style: s/pattern/replacement/g)"`
 	Clear       DocsClearCmd       `cmd:"" name:"clear" help:"Clear all content from a Google Doc"`
 	Structure   DocsStructureCmd   `cmd:"" name:"structure" aliases:"struct" help:"Show document structure with numbered paragraphs"`
+	Raw         DocsRawCmd         `cmd:"" name:"raw" help:"Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)"`
+}
+
+// DocsRawCmd dumps the full Documents.Get response as JSON, with no Fields
+// restriction. Intended for programmatic / LLM consumption where the caller
+// wants the canonical Google Docs API tree (tables, suggestions, per-run
+// styling, list nesting, named ranges, inline objects) that `info` drops.
+//
+// REST reference: https://developers.google.com/docs/api/reference/rest/v1/documents/get
+// Go type: https://pkg.go.dev/google.golang.org/api/docs/v1#Document
+type DocsRawCmd struct {
+	DocID  string `arg:"" name:"docId" help:"Doc ID"`
+	Pretty bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
+}
+
+func (c *DocsRawCmd) Run(ctx context.Context, flags *RootFlags) error {
+	id := strings.TrimSpace(c.DocID)
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	doc, err := svc.Documents.Get(id).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return err
+	}
+	if doc == nil {
+		return errors.New("doc not found")
+	}
+
+	return outfmt.WriteRaw(ctx, os.Stdout, doc, outfmt.RawOptions{Pretty: c.Pretty})
 }
 
 type DocsExportCmd struct {

--- a/internal/cmd/docs_raw_test.go
+++ b/internal/cmd/docs_raw_test.go
@@ -1,0 +1,172 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// fullDocResponse returns a richer Document payload than DocsInfoCmd would
+// ever request (DocsInfoCmd restricts via Fields). This proves `raw` drops
+// that restriction and exposes the full API tree.
+func fullDocResponse(id string) map[string]any {
+	return map[string]any{
+		"documentId": id,
+		"title":      "Full Doc",
+		"revisionId": "rev1",
+		"body": map[string]any{
+			"content": []any{
+				map[string]any{
+					"startIndex": 1,
+					"endIndex":   10,
+					"paragraph": map[string]any{
+						"elements": []any{
+							map[string]any{
+								"textRun": map[string]any{
+									"content": "hello world\n",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"namedStyles": map[string]any{
+			"styles": []any{map[string]any{"namedStyleType": "NORMAL_TEXT"}},
+		},
+	}
+}
+
+// newDocsRawTestServer builds a test Docs server; if status != 0 it returns
+// that status instead of a successful response.
+func newDocsRawTestServer(t *testing.T, status int, body map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v1/documents/") || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		if status != 0 {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": status, "message": "mock error"},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func installMockDocsService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := newDocsService
+	t.Cleanup(func() { newDocsService = orig })
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+}
+
+func rawTestContext(t *testing.T) context.Context {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	return ui.WithUI(context.Background(), u)
+}
+
+func TestDocsRaw_HappyPath(t *testing.T) {
+	srv := newDocsRawTestServer(t, 0, fullDocResponse("doc1"))
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		cmd := &DocsRawCmd{}
+		if err := runKong(t, cmd, []string{"doc1"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %s", err, out)
+	}
+	// Bare struct: top-level keys must be Document fields, not a wrapper.
+	if got["documentId"] != "doc1" {
+		t.Fatalf("expected documentId=doc1, got: %v", got["documentId"])
+	}
+	// The whole point of raw: body.content must be present (info -j drops it).
+	body, ok := got["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected body object in output, got: %v", got["body"])
+	}
+	if _, ok := body["content"]; !ok {
+		t.Fatalf("expected body.content in raw output")
+	}
+}
+
+func TestDocsRaw_APIError(t *testing.T) {
+	srv := newDocsRawTestServer(t, http.StatusInternalServerError, nil)
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	_ = captureStdout(t, func() {
+		cmd := &DocsRawCmd{}
+		err := runKong(t, cmd, []string{"doc1"}, ctx, flags)
+		if err == nil {
+			t.Fatalf("expected error on 500, got nil")
+		}
+	})
+}
+
+func TestDocsRaw_NotFound(t *testing.T) {
+	srv := newDocsRawTestServer(t, http.StatusNotFound, nil)
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	_ = captureStdout(t, func() {
+		cmd := &DocsRawCmd{}
+		err := runKong(t, cmd, []string{"doc1"}, ctx, flags)
+		if err == nil {
+			t.Fatalf("expected error on 404")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Fatalf("expected 'not found' in error, got: %v", err)
+		}
+	})
+}
+
+func TestDocsRaw_EmptyDocID(t *testing.T) {
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	err := (&DocsRawCmd{}).Run(ctx, flags)
+	if err == nil {
+		t.Fatalf("expected error on empty docId")
+	}
+}

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"strings"
 
 	"google.golang.org/api/drive/v3"
+	gapi "google.golang.org/api/googleapi"
 
 	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
@@ -79,6 +81,94 @@ type DriveCmd struct {
 	URL         DriveURLCmd         `cmd:"" name:"url" help:"Print web URLs for files"`
 	Comments    DriveCommentsCmd    `cmd:"" name:"comments" help:"Manage comments on files"`
 	Drives      DriveDrivesCmd      `cmd:"" name:"drives" help:"List shared drives (Team Drives)"`
+	Raw         DriveRawCmd         `cmd:"" name:"raw" help:"Dump raw Google Drive API response as JSON (Files.Get; lossless; for scripting and LLM consumption)"`
+}
+
+// driveRawSensitiveFields is the set of top-level File fields redacted from
+// `gog drive raw` output when the user did not name them via --fields. See
+// docs/raw-audit.md for the rationale per field.
+var driveRawSensitiveFields = []string{
+	"thumbnailLink",
+	"webContentLink",
+	"exportLinks",
+	"resourceKey",
+	"appProperties",
+	"properties",
+}
+
+// DriveRawCmd dumps the full Files.Get response as JSON. Uses fields=* by
+// default to expose the entire File resource. When --fields is absent the
+// command redacts a small set of capability/token-shaped fields (see
+// driveRawSensitiveFields); when --fields is explicitly set the response is
+// returned verbatim, honoring exactly what the user asked for. This means
+// passing `--fields "id,name,thumbnailLink"` returns thumbnailLink as
+// requested.
+//
+// REST reference: https://developers.google.com/drive/api/reference/rest/v3/files/get
+// Go type: https://pkg.go.dev/google.golang.org/api/drive/v3#File
+type DriveRawCmd struct {
+	FileID string `arg:"" name:"fileId" help:"File ID"`
+	Fields string `name:"fields" help:"Drive API field mask (default: * with sensitive fields redacted client-side). Set explicitly to disable redaction."`
+	Pretty bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
+}
+
+func (c *DriveRawCmd) Run(ctx context.Context, flags *RootFlags) error {
+	fileID := strings.TrimSpace(c.FileID)
+	if fileID == "" {
+		return usage("empty fileId")
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := newDriveService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	userSetFields := strings.TrimSpace(c.Fields) != ""
+	mask := "*"
+	if userSetFields {
+		mask = c.Fields
+	}
+
+	f, err := svc.Files.Get(fileID).
+		SupportsAllDrives(true).
+		Fields(gapi.Field(mask)).
+		Context(ctx).
+		Do()
+	if err != nil {
+		return err
+	}
+	if f == nil {
+		return errors.New("file not found")
+	}
+
+	// Round-trip through JSON so we can redact by key when needed.
+	raw, err := json.Marshal(f)
+	if err != nil {
+		return fmt.Errorf("marshal drive file: %w", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return fmt.Errorf("unmarshal drive file: %w", err)
+	}
+
+	// Redact only when the user did not explicitly request fields.
+	if !userSetFields {
+		for _, key := range driveRawSensitiveFields {
+			delete(m, key)
+		}
+		// contentHints.thumbnail.image is the one nested leak.
+		if hints, ok := m["contentHints"].(map[string]any); ok {
+			if thumb, ok := hints["thumbnail"].(map[string]any); ok {
+				delete(thumb, "image")
+			}
+		}
+	}
+
+	return outfmt.WriteRaw(ctx, os.Stdout, m, outfmt.RawOptions{Pretty: c.Pretty})
 }
 
 type DriveLsCmd struct {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -178,6 +178,7 @@ type DriveLsCmd struct {
 	Parent    string `name:"parent" help:"Folder ID to list (default: root)"`
 	All       bool   `name:"all" aliases:"global" help:"List all accessible files (mutually exclusive with --parent)"`
 	AllDrives bool   `name:"all-drives" help:"Include shared drives (default: true; use --no-all-drives for My Drive only)" default:"true" negatable:"_"`
+	Fields    string `name:"fields" help:"Drive API field mask (overrides the default set; e.g. 'files(id,name,thumbnailLink),nextPageToken')"`
 }
 
 type DriveSearchCmd struct {
@@ -190,6 +191,7 @@ type DriveSearchCmd struct {
 
 type DriveGetCmd struct {
 	FileID string `arg:"" name:"fileId" help:"File ID"`
+	Fields string `name:"fields" help:"Drive API field mask (overrides the default set; e.g. 'id,name,thumbnailLink')"`
 }
 
 func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -208,9 +210,13 @@ func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	mask := "id, name, mimeType, size, modifiedTime, createdTime, parents, webViewLink, description, starred"
+	if strings.TrimSpace(c.Fields) != "" {
+		mask = c.Fields
+	}
 	f, err := svc.Files.Get(fileID).
 		SupportsAllDrives(true).
-		Fields("id, name, mimeType, size, modifiedTime, createdTime, parents, webViewLink, description, starred").
+		Fields(gapi.Field(mask)).
 		Context(ctx).
 		Do()
 	if err != nil {

--- a/internal/cmd/drive_fields_test.go
+++ b/internal/cmd/drive_fields_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type driveFieldsHit struct {
+	lastFields atomic.Value // string
+}
+
+func newDriveFieldsTestServer(t *testing.T, handler func(r *http.Request) map[string]any, hit *driveFieldsHit) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if hit != nil {
+			hit.lastFields.Store(r.URL.Query().Get("fields"))
+		}
+		body := handler(r)
+		if body == nil {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+// TestDriveGet_FieldsFlag proves --fields on `gog drive get` maps to the
+// Drive API fields parameter, enabling requests for fields the hard-coded
+// default did not include (e.g. thumbnailLink). Closes #486.
+func TestDriveGet_FieldsFlag(t *testing.T) {
+	hit := &driveFieldsHit{}
+	srv := newDriveFieldsTestServer(t, func(r *http.Request) map[string]any {
+		if !strings.Contains(r.URL.Path, "/files/f1") {
+			return nil
+		}
+		return map[string]any{
+			"id":            "f1",
+			"name":          "photo.png",
+			"mimeType":      "image/png",
+			"thumbnailLink": "https://drive.google.com/thumb/f1",
+		}
+	}, hit)
+	defer srv.Close()
+	installMockDriveService(t, srv)
+
+	u, err := ui.New(ui.Options{Stdout: nil, Stderr: nil, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		if err := runKong(t, &DriveGetCmd{}, []string{"f1", "--fields", "id,name,thumbnailLink"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	got, _ := hit.lastFields.Load().(string)
+	if !strings.Contains(got, "thumbnailLink") {
+		t.Fatalf("expected Drive API fields param to contain thumbnailLink, got: %q", got)
+	}
+	// Output should wrap under "file" per existing drive get -j contract.
+	var envelope map[string]any
+	if err := json.Unmarshal([]byte(out), &envelope); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, out)
+	}
+	file, ok := envelope["file"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected file envelope, got: %v", envelope)
+	}
+	if file["thumbnailLink"] != "https://drive.google.com/thumb/f1" {
+		t.Fatalf("expected thumbnailLink passthrough, got: %v", file["thumbnailLink"])
+	}
+}
+
+// TestDriveLs_FieldsFlag proves --fields on `gog drive ls` maps through to
+// the Drive API list fields parameter so consumers can request fields not
+// in the hard-coded default set.
+func TestDriveLs_FieldsFlag(t *testing.T) {
+	hit := &driveFieldsHit{}
+	srv := newDriveFieldsTestServer(t, func(r *http.Request) map[string]any {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v3")
+		if path != "/files" {
+			return nil
+		}
+		return map[string]any{
+			"files": []map[string]any{
+				{
+					"id":            "f1",
+					"name":          "photo.png",
+					"mimeType":      "image/png",
+					"thumbnailLink": "https://drive.google.com/thumb/f1",
+				},
+			},
+		}
+	}, hit)
+	defer srv.Close()
+	installMockDriveService(t, srv)
+
+	u, err := ui.New(ui.Options{Stdout: nil, Stderr: nil, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		if err := runKong(t, &DriveLsCmd{}, []string{"--fields", "files(id,name,thumbnailLink)"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	got, _ := hit.lastFields.Load().(string)
+	if !strings.Contains(got, "thumbnailLink") {
+		t.Fatalf("expected Drive API fields param to contain thumbnailLink, got: %q", got)
+	}
+	if !strings.Contains(out, "thumbnailLink") {
+		t.Fatalf("expected thumbnailLink in output, got: %q", out)
+	}
+}
+
+// Silence unused package warning when the test only references drive.Service
+// indirectly through installMockDriveService.
+var _ = drive.Service{}

--- a/internal/cmd/drive_listing.go
+++ b/internal/cmd/drive_listing.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"google.golang.org/api/drive/v3"
+	gapi "google.golang.org/api/googleapi"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
@@ -19,6 +20,7 @@ type driveFileListOptions struct {
 	max       int64
 	page      string
 	allDrives bool
+	fields    string // optional field mask override
 }
 
 func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -46,6 +48,7 @@ func (c *DriveLsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		max:       c.Max,
 		page:      c.Page,
 		allDrives: c.AllDrives,
+		fields:    c.Fields,
 	})
 	if err != nil {
 		return err
@@ -85,7 +88,11 @@ func listDriveFiles(ctx context.Context, svc *drive.Service, opts driveFileListO
 		PageToken(opts.page).
 		OrderBy("modifiedTime desc")
 	call = driveFilesListCallWithDriveSupport(call, opts.allDrives)
-	return call.Fields(driveFileListFields).Context(ctx).Do()
+	mask := driveFileListFields
+	if strings.TrimSpace(opts.fields) != "" {
+		mask = opts.fields
+	}
+	return call.Fields(gapi.Field(mask)).Context(ctx).Do()
 }
 
 func writeDriveFileList(ctx context.Context, resp *drive.FileList, emptyMessage string) error {

--- a/internal/cmd/drive_raw_test.go
+++ b/internal/cmd/drive_raw_test.go
@@ -1,0 +1,181 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+)
+
+type driveRawHit struct {
+	lastFields atomic.Value // string
+}
+
+func newDriveRawTestServer(t *testing.T, status int, body map[string]any, hit *driveRawHit) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/drive/v3")
+		if !strings.HasPrefix(path, "/files/") || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		if hit != nil {
+			hit.lastFields.Store(r.URL.Query().Get("fields"))
+		}
+		if status != 0 {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": status, "message": "mock error"},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func installMockDriveService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := newDriveService
+	t.Cleanup(func() { newDriveService = orig })
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+}
+
+// sensitiveDriveFile returns a File response containing every sensitive
+// field the audit says should be redacted by default.
+func sensitiveDriveFile(id string) map[string]any {
+	return map[string]any{
+		"id":             id,
+		"name":           "secrets.txt",
+		"mimeType":       "text/plain",
+		"thumbnailLink":  "https://drive.google.com/thumb/XYZ?token=LEAK",
+		"webContentLink": "https://drive.google.com/download?id=XYZ",
+		"exportLinks":    map[string]any{"application/pdf": "https://drive.google.com/export?id=XYZ"},
+		"resourceKey":    "rk-CAPABILITY-SECRET",
+		"appProperties":  map[string]any{"api_token": "sk-live-0000"},
+		"properties":     map[string]any{"webhook": "https://hooks.example/private"},
+		"webViewLink":    "https://docs.google.com/open?id=XYZ",
+		"createdTime":    "2026-01-01T00:00:00Z",
+		"modifiedTime":   "2026-01-02T00:00:00Z",
+	}
+}
+
+func TestDriveRaw_DefaultRedactsSensitiveFields(t *testing.T) {
+	hit := &driveRawHit{}
+	srv := newDriveRawTestServer(t, 0, sensitiveDriveFile("f1"), hit)
+	defer srv.Close()
+	installMockDriveService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		if err := runKong(t, &DriveRawCmd{}, []string{"f1"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	// Default must request fields=* from the API.
+	if got, _ := hit.lastFields.Load().(string); got != "*" {
+		t.Fatalf("expected fields=* by default, got: %q", got)
+	}
+
+	var fileOut map[string]any
+	if err := json.Unmarshal([]byte(out), &fileOut); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, out)
+	}
+	// Safe fields remain.
+	if fileOut["id"] != "f1" {
+		t.Fatalf("expected id=f1, got: %v", fileOut["id"])
+	}
+	if fileOut["name"] != "secrets.txt" {
+		t.Fatalf("expected name present, got: %v", fileOut["name"])
+	}
+	// Sensitive fields stripped.
+	for _, key := range []string{"thumbnailLink", "webContentLink", "exportLinks", "resourceKey", "appProperties", "properties"} {
+		if _, present := fileOut[key]; present {
+			t.Fatalf("expected %q to be redacted from default output, got: %v", key, fileOut[key])
+		}
+	}
+}
+
+func TestDriveRaw_ExplicitFieldsHonorsUserChoice(t *testing.T) {
+	hit := &driveRawHit{}
+	srv := newDriveRawTestServer(t, 0, sensitiveDriveFile("f1"), hit)
+	defer srv.Close()
+	installMockDriveService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		if err := runKong(t, &DriveRawCmd{}, []string{"f1", "--fields", "id,name,thumbnailLink"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	// The Google client library can munge the fields value slightly, but it
+	// must contain the user's requested field names.
+	got, _ := hit.lastFields.Load().(string)
+	if !strings.Contains(got, "thumbnailLink") {
+		t.Fatalf("expected thumbnailLink in fields query, got: %q", got)
+	}
+
+	var fileOut map[string]any
+	if err := json.Unmarshal([]byte(out), &fileOut); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, out)
+	}
+	// User-named field must NOT be redacted.
+	if fileOut["thumbnailLink"] != "https://drive.google.com/thumb/XYZ?token=LEAK" {
+		t.Fatalf("expected thumbnailLink to be preserved when user named it, got: %v", fileOut["thumbnailLink"])
+	}
+}
+
+func TestDriveRaw_APIError(t *testing.T) {
+	srv := newDriveRawTestServer(t, http.StatusInternalServerError, nil, nil)
+	defer srv.Close()
+	installMockDriveService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &DriveRawCmd{}, []string{"f1"}, ctx, flags); err == nil {
+			t.Fatalf("expected error on 500")
+		}
+	})
+}
+
+func TestDriveRaw_NotFound(t *testing.T) {
+	srv := newDriveRawTestServer(t, http.StatusNotFound, nil, nil)
+	defer srv.Close()
+	installMockDriveService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &DriveRawCmd{}, []string{"f1"}, ctx, flags); err == nil {
+			t.Fatalf("expected error on 404")
+		}
+	})
+}
+
+func TestDriveRaw_EmptyID(t *testing.T) {
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	if err := (&DriveRawCmd{}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected error on empty id")
+	}
+}

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -43,6 +44,7 @@ type SheetsCmd struct {
 	Links         SheetsLinksCmd         `cmd:"" name:"links" aliases:"hyperlinks" help:"Get cell hyperlinks from a range"`
 	Named         SheetsNamedRangesCmd   `cmd:"" name:"named-ranges" aliases:"namedranges,nr" help:"Manage named ranges"`
 	Metadata      SheetsMetadataCmd      `cmd:"" name:"metadata" aliases:"info" help:"Get spreadsheet metadata"`
+	Raw           SheetsRawCmd           `cmd:"" name:"raw" help:"Dump raw Google Sheets API response as JSON (Spreadsheets.Get; lossless; for scripting and LLM consumption)"`
 	Create        SheetsCreateCmd        `cmd:"" name:"create" aliases:"new" help:"Create a new spreadsheet"`
 	Copy          SheetsCopyCmd          `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Sheet"`
 	Export        SheetsExportCmd        `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Sheet (pdf|xlsx|csv) via Drive"`
@@ -413,6 +415,52 @@ func (c *SheetsClearCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	u.Out().Printf("Cleared %s", resp.ClearedRange)
 	return nil
+}
+
+// SheetsRawCmd dumps the full Spreadsheets.Get response as JSON, with no
+// Fields restriction. `--include-grid-data` opts into returning cell-level
+// data; it is off by default because grid payloads can be multi-MB and are
+// the primary leakage vector (formulas may embed API keys or tokens).
+//
+// REST reference: https://developers.google.com/sheets/api/reference/rest/v4/spreadsheets/get
+// Go type: https://pkg.go.dev/google.golang.org/api/sheets/v4#Spreadsheet
+type SheetsRawCmd struct {
+	SpreadsheetID   string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	IncludeGridData bool   `name:"include-grid-data" help:"Include cell-level grid data in the response (off by default; payloads can be large and may contain secrets in formulas)"`
+	Pretty          bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
+}
+
+func (c *SheetsRawCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+
+	_, svc, err := requireSheetsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	call := svc.Spreadsheets.Get(spreadsheetID).Context(ctx)
+	if c.IncludeGridData {
+		call = call.IncludeGridData(true)
+		u.Err().Println("warning: --include-grid-data may expose cell-level formulas that contain API keys or hardcoded secrets")
+	}
+
+	resp, err := call.Do()
+	if err != nil {
+		return err
+	}
+	if resp == nil {
+		return errors.New("spreadsheet not found")
+	}
+
+	if len(resp.DeveloperMetadata) > 0 {
+		u.Err().Println("warning: response contains developerMetadata which may hold third-party app secrets")
+	}
+
+	return outfmt.WriteRaw(ctx, os.Stdout, resp, outfmt.RawOptions{Pretty: c.Pretty})
 }
 
 type SheetsMetadataCmd struct {

--- a/internal/cmd/sheets_raw_test.go
+++ b/internal/cmd/sheets_raw_test.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type sheetsRawHit struct {
+	includeGridData atomic.Bool
+}
+
+func newSheetsRawTestServer(t *testing.T, status int, body map[string]any, hit *sheetsRawHit) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/sheets/v4")
+		path = strings.TrimPrefix(path, "/v4")
+		if !strings.HasPrefix(path, "/spreadsheets/") || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		if hit != nil && r.URL.Query().Get("includeGridData") == "true" {
+			hit.includeGridData.Store(true)
+		}
+		if status != 0 {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": status, "message": "mock error"},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func installMockSheetsService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := newSheetsService
+	t.Cleanup(func() { newSheetsService = orig })
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+}
+
+func fullSheetResponse(id string) map[string]any {
+	return map[string]any{
+		"spreadsheetId":  id,
+		"spreadsheetUrl": "http://example.com/" + id,
+		"properties": map[string]any{
+			"title":    "Full Sheet",
+			"locale":   "en_US",
+			"timeZone": "UTC",
+		},
+		"sheets": []map[string]any{
+			{
+				"properties": map[string]any{
+					"sheetId": 1,
+					"title":   "Sheet1",
+					"gridProperties": map[string]any{
+						"rowCount":    100,
+						"columnCount": 26,
+					},
+				},
+			},
+		},
+	}
+}
+
+func rawContextWithStderr(t *testing.T, stderr io.Writer) context.Context {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: stderr, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	return ui.WithUI(context.Background(), u)
+}
+
+func TestSheetsRaw_HappyPath_NoGridDataByDefault(t *testing.T) {
+	hit := &sheetsRawHit{}
+	srv := newSheetsRawTestServer(t, 0, fullSheetResponse("s1"), hit)
+	defer srv.Close()
+	installMockSheetsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		if err := runKong(t, &SheetsRawCmd{}, []string{"s1"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if hit.includeGridData.Load() {
+		t.Fatalf("--include-grid-data should not be set by default")
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, out)
+	}
+	if got["spreadsheetId"] != "s1" {
+		t.Fatalf("expected spreadsheetId=s1, got: %v", got["spreadsheetId"])
+	}
+	if _, ok := got["sheets"]; !ok {
+		t.Fatalf("expected sheets in raw output")
+	}
+}
+
+func TestSheetsRaw_IncludeGridDataFlag(t *testing.T) {
+	hit := &sheetsRawHit{}
+	srv := newSheetsRawTestServer(t, 0, fullSheetResponse("s1"), hit)
+	defer srv.Close()
+	installMockSheetsService(t, srv)
+
+	var stderr bytes.Buffer
+	ctx := rawContextWithStderr(t, &stderr)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &SheetsRawCmd{}, []string{"s1", "--include-grid-data"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if !hit.includeGridData.Load() {
+		t.Fatalf("expected includeGridData=true in request")
+	}
+	// Audit requires a stderr warning when grid data is included.
+	if !strings.Contains(stderr.String(), "grid") {
+		t.Fatalf("expected stderr warning mentioning 'grid', got: %q", stderr.String())
+	}
+}
+
+func TestSheetsRaw_APIError(t *testing.T) {
+	srv := newSheetsRawTestServer(t, http.StatusInternalServerError, nil, nil)
+	defer srv.Close()
+	installMockSheetsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		err := runKong(t, &SheetsRawCmd{}, []string{"s1"}, ctx, flags)
+		if err == nil {
+			t.Fatalf("expected error on 500")
+		}
+	})
+}
+
+func TestSheetsRaw_NotFound(t *testing.T) {
+	srv := newSheetsRawTestServer(t, http.StatusNotFound, nil, nil)
+	defer srv.Close()
+	installMockSheetsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		err := runKong(t, &SheetsRawCmd{}, []string{"s1"}, ctx, flags)
+		if err == nil {
+			t.Fatalf("expected error on 404")
+		}
+	})
+}
+
+func TestSheetsRaw_EmptyID(t *testing.T) {
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	if err := (&SheetsRawCmd{}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected error on empty id")
+	}
+}

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -32,6 +32,45 @@ type SlidesCmd struct {
 	ReadSlide          SlidesReadSlideCmd          `cmd:"" name:"read-slide" help:"Read slide content: speaker notes, text elements, and images"`
 	UpdateNotes        SlidesUpdateNotesCmd        `cmd:"" name:"update-notes" help:"Update speaker notes on an existing slide"`
 	ReplaceSlide       SlidesReplaceSlideCmd       `cmd:"" name:"replace-slide" help:"Replace the image on an existing slide in-place"`
+	Raw                SlidesRawCmd                `cmd:"" name:"raw" help:"Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)"`
+}
+
+// SlidesRawCmd dumps the full Presentations.Get response as JSON. The
+// Slides API has no field mask, so output is unconditionally lossless.
+// Note: response may contain short-lived authenticated image/video URLs
+// (see docs/raw-audit.md for the risk assessment).
+//
+// REST reference: https://developers.google.com/slides/api/reference/rest/v1/presentations/get
+// Go type: https://pkg.go.dev/google.golang.org/api/slides/v1#Presentation
+type SlidesRawCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	Pretty         bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
+}
+
+func (c *SlidesRawCmd) Run(ctx context.Context, flags *RootFlags) error {
+	id := strings.TrimSpace(c.PresentationID)
+	if id == "" {
+		return usage("empty presentationId")
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := newSlidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	pres, err := svc.Presentations.Get(id).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	if pres == nil {
+		return errors.New("presentation not found")
+	}
+
+	return outfmt.WriteRaw(ctx, os.Stdout, pres, outfmt.RawOptions{Pretty: c.Pretty})
 }
 
 type SlidesExportCmd struct {

--- a/internal/cmd/slides_raw_test.go
+++ b/internal/cmd/slides_raw_test.go
@@ -1,0 +1,133 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/slides/v1"
+)
+
+func newSlidesRawTestServer(t *testing.T, status int, body map[string]any) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/slides/v1")
+		path = strings.TrimPrefix(path, "/v1")
+		if !strings.HasPrefix(path, "/presentations/") || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+		if status != 0 {
+			w.WriteHeader(status)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error": map[string]any{"code": status, "message": "mock error"},
+			})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func installMockSlidesService(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	orig := newSlidesService
+	t.Cleanup(func() { newSlidesService = orig })
+
+	svc, err := slides.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return svc, nil }
+}
+
+func fullPresentationResponse(id string) map[string]any {
+	return map[string]any{
+		"presentationId": id,
+		"title":          "Full Deck",
+		"slides": []map[string]any{
+			{
+				"objectId": "slide1",
+				"pageElements": []map[string]any{
+					{
+						"objectId": "e1",
+						"shape": map[string]any{
+							"shapeType": "TEXT_BOX",
+						},
+					},
+				},
+			},
+		},
+		"masters": []map[string]any{{"objectId": "master1"}},
+		"layouts": []map[string]any{{"objectId": "layout1"}},
+	}
+}
+
+func TestSlidesRaw_HappyPath(t *testing.T) {
+	srv := newSlidesRawTestServer(t, 0, fullPresentationResponse("p1"))
+	defer srv.Close()
+	installMockSlidesService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		if err := runKong(t, &SlidesRawCmd{}, []string{"p1"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("invalid JSON: %v\nraw: %s", err, out)
+	}
+	if got["presentationId"] != "p1" {
+		t.Fatalf("expected presentationId=p1, got: %v", got["presentationId"])
+	}
+	if _, ok := got["slides"]; !ok {
+		t.Fatalf("expected slides in raw output")
+	}
+}
+
+func TestSlidesRaw_APIError(t *testing.T) {
+	srv := newSlidesRawTestServer(t, http.StatusInternalServerError, nil)
+	defer srv.Close()
+	installMockSlidesService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &SlidesRawCmd{}, []string{"p1"}, ctx, flags); err == nil {
+			t.Fatalf("expected error on 500")
+		}
+	})
+}
+
+func TestSlidesRaw_NotFound(t *testing.T) {
+	srv := newSlidesRawTestServer(t, http.StatusNotFound, nil)
+	defer srv.Close()
+	installMockSlidesService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &SlidesRawCmd{}, []string{"p1"}, ctx, flags); err == nil {
+			t.Fatalf("expected error on 404")
+		}
+	})
+}
+
+func TestSlidesRaw_EmptyID(t *testing.T) {
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	if err := (&SlidesRawCmd{}).Run(ctx, flags); err == nil {
+		t.Fatalf("expected error on empty id")
+	}
+}

--- a/internal/outfmt/raw.go
+++ b/internal/outfmt/raw.go
@@ -1,0 +1,33 @@
+package outfmt
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// RawOptions configures WriteRaw.
+type RawOptions struct {
+	// Pretty emits indented JSON (2-space). Default is compact single-line.
+	Pretty bool
+}
+
+// WriteRaw marshals v as JSON and writes it to w, emitting the value bare
+// (no envelope/wrapper). Intended for `gog <group> raw` subcommands that
+// expose the canonical Google API response for programmatic consumption.
+//
+// Compact by default; pass RawOptions{Pretty: true} for indented output.
+// Always appends a trailing newline for pipe friendliness.
+// HTML escaping is disabled so URLs with & survive unchanged.
+func WriteRaw(_ context.Context, w io.Writer, v any, opts RawOptions) error {
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	if opts.Pretty {
+		enc.SetIndent("", "  ")
+	}
+	if err := enc.Encode(v); err != nil {
+		return fmt.Errorf("encode raw json: %w", err)
+	}
+	return nil
+}

--- a/internal/outfmt/raw.go
+++ b/internal/outfmt/raw.go
@@ -23,11 +23,14 @@ type RawOptions struct {
 func WriteRaw(_ context.Context, w io.Writer, v any, opts RawOptions) error {
 	enc := json.NewEncoder(w)
 	enc.SetEscapeHTML(false)
+
 	if opts.Pretty {
 		enc.SetIndent("", "  ")
 	}
+
 	if err := enc.Encode(v); err != nil {
 		return fmt.Errorf("encode raw json: %w", err)
 	}
+
 	return nil
 }

--- a/internal/outfmt/raw_test.go
+++ b/internal/outfmt/raw_test.go
@@ -1,0 +1,95 @@
+package outfmt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestWriteRaw_CompactByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	in := map[string]any{"id": "abc", "nested": map[string]any{"k": "v"}}
+	if err := WriteRaw(context.Background(), &buf, in, RawOptions{}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	out := buf.String()
+	if strings.Contains(out, "  ") || strings.Contains(out, "\n ") {
+		t.Fatalf("expected compact output, got: %q", out)
+	}
+	// Must still end with newline for pipe friendliness.
+	if !strings.HasSuffix(out, "\n") {
+		t.Fatalf("expected trailing newline, got: %q", out)
+	}
+
+	var round map[string]any
+	if err := json.Unmarshal([]byte(out), &round); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if round["id"] != "abc" {
+		t.Fatalf("unexpected id: %v", round["id"])
+	}
+}
+
+func TestWriteRaw_Pretty(t *testing.T) {
+	var buf bytes.Buffer
+	in := map[string]any{"id": "abc", "nested": map[string]any{"k": "v"}}
+	if err := WriteRaw(context.Background(), &buf, in, RawOptions{Pretty: true}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "\n  ") {
+		t.Fatalf("expected indented output, got: %q", out)
+	}
+
+	var round map[string]any
+	if err := json.Unmarshal([]byte(out), &round); err != nil {
+		t.Fatalf("pretty output is not valid JSON: %v", err)
+	}
+}
+
+func TestWriteRaw_NoHTMLEscape(t *testing.T) {
+	var buf bytes.Buffer
+	in := map[string]any{"url": "https://example.com/?a=1&b=2"}
+	if err := WriteRaw(context.Background(), &buf, in, RawOptions{}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if strings.Contains(buf.String(), "\\u0026") {
+		t.Fatalf("expected raw & in output, got: %q", buf.String())
+	}
+}
+
+func TestWriteRaw_BareStruct_NoWrapper(t *testing.T) {
+	// raw must emit the value as-is, with no envelope/wrapper added.
+	type apiResp struct {
+		DocumentId string `json:"documentId"`
+		Title      string `json:"title"`
+	}
+	var buf bytes.Buffer
+	if err := WriteRaw(context.Background(), &buf, apiResp{DocumentId: "d1", Title: "t"}, RawOptions{}); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	var round map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &round); err != nil {
+		t.Fatalf("invalid json: %v", err)
+	}
+	if _, hasWrapper := round["document"]; hasWrapper {
+		t.Fatalf("raw output must not be wrapped under a key, got: %v", round)
+	}
+	if round["documentId"] != "d1" {
+		t.Fatalf("expected documentId=d1, got: %v", round["documentId"])
+	}
+}
+
+func TestWriteRaw_MarshalError(t *testing.T) {
+	var buf bytes.Buffer
+	// channels cannot be marshaled to JSON.
+	err := WriteRaw(context.Background(), &buf, make(chan int), RawOptions{})
+	if err == nil {
+		t.Fatalf("expected error marshaling channel")
+	}
+}

--- a/internal/outfmt/raw_test.go
+++ b/internal/outfmt/raw_test.go
@@ -10,7 +10,9 @@ import (
 
 func TestWriteRaw_CompactByDefault(t *testing.T) {
 	var buf bytes.Buffer
+
 	in := map[string]any{"id": "abc", "nested": map[string]any{"k": "v"}}
+
 	if err := WriteRaw(context.Background(), &buf, in, RawOptions{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -25,9 +27,11 @@ func TestWriteRaw_CompactByDefault(t *testing.T) {
 	}
 
 	var round map[string]any
+
 	if err := json.Unmarshal([]byte(out), &round); err != nil {
 		t.Fatalf("output is not valid JSON: %v", err)
 	}
+
 	if round["id"] != "abc" {
 		t.Fatalf("unexpected id: %v", round["id"])
 	}
@@ -35,7 +39,9 @@ func TestWriteRaw_CompactByDefault(t *testing.T) {
 
 func TestWriteRaw_Pretty(t *testing.T) {
 	var buf bytes.Buffer
+
 	in := map[string]any{"id": "abc", "nested": map[string]any{"k": "v"}}
+
 	if err := WriteRaw(context.Background(), &buf, in, RawOptions{Pretty: true}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -53,10 +59,13 @@ func TestWriteRaw_Pretty(t *testing.T) {
 
 func TestWriteRaw_NoHTMLEscape(t *testing.T) {
 	var buf bytes.Buffer
+
 	in := map[string]any{"url": "https://example.com/?a=1&b=2"}
+
 	if err := WriteRaw(context.Background(), &buf, in, RawOptions{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
+
 	if strings.Contains(buf.String(), "\\u0026") {
 		t.Fatalf("expected raw & in output, got: %q", buf.String())
 	}
@@ -69,17 +78,21 @@ func TestWriteRaw_BareStruct_NoWrapper(t *testing.T) {
 		Title      string `json:"title"`
 	}
 	var buf bytes.Buffer
+
 	if err := WriteRaw(context.Background(), &buf, apiResp{DocumentId: "d1", Title: "t"}, RawOptions{}); err != nil {
 		t.Fatalf("err: %v", err)
 	}
 
 	var round map[string]any
+
 	if err := json.Unmarshal(buf.Bytes(), &round); err != nil {
 		t.Fatalf("invalid json: %v", err)
 	}
+
 	if _, hasWrapper := round["document"]; hasWrapper {
 		t.Fatalf("raw output must not be wrapped under a key, got: %v", round)
 	}
+
 	if round["documentId"] != "d1" {
 		t.Fatalf("expected documentId=d1, got: %v", round["documentId"])
 	}
@@ -87,6 +100,7 @@ func TestWriteRaw_BareStruct_NoWrapper(t *testing.T) {
 
 func TestWriteRaw_MarshalError(t *testing.T) {
 	var buf bytes.Buffer
+
 	// channels cannot be marshaled to JSON.
 	err := WriteRaw(context.Background(), &buf, make(chan int), RawOptions{})
 	if err == nil {


### PR DESCRIPTION
## Summary

Adds a `raw` subcommand to `docs`, `sheets`, `slides`, and `drive` that emits the canonical Google API response as JSON for programmatic / LLM consumption. Existing `info`/`cat`/`structure`/`export` commands are deliberately lossy (table cells dropped, suggestions lost, formatting stripped, etc.); `raw` fills the gap where callers need the full API tree without writing their own API client.

Also addresses #486 in the same stroke: `drive ls` and `drive get` now accept a `--fields` flag that maps directly to the Drive API field mask, so users can request `thumbnailLink`, `imageMediaMetadata`, etc. that the hard-coded defaults exclude.

## New commands

- `gog docs raw <docId>` — `Documents.Get` with no Fields restriction
- `gog sheets raw <sheetId>` — `Spreadsheets.Get`; `--include-grid-data` off by default
- `gog slides raw <presentationId>` — `Presentations.Get`
- `gog drive raw <fileId>` — `Files.Get` with `fields=*`, principled redaction (see below)

All four:
- compact JSON by default, `--pretty` for indented
- `-j` / `-p` silently no-op (output is always JSON)
- backed by a new `outfmt.WriteRaw` helper that emits the value bare (no envelope/wrapper)

## Drive redaction rule

`drive raw` is the only command that applies redaction because it's the only one with a field mask mechanism (and also the riskiest — see `docs/raw-audit.md` for the full assessment). The rule:

> **Redact only what the user didn't name.** When `--fields` is absent (implicit `fields=*`), strip `thumbnailLink`, `webContentLink`, `exportLinks`, `resourceKey`, `appProperties`, `properties`, and `contentHints.thumbnail.image`. When `--fields` is set, honor it verbatim — passing `--fields "id,name,thumbnailLink"` returns `thumbnailLink` exactly.

This way the safe default protects against accidental leaks (time-limited signed URLs, app-stashed secrets) while explicit requests are never second-guessed.

Docs/Slides/Sheets ship as-is (no redaction) because they lack field masks and their audited sensitive fields are lower-risk (short-lived, auth-gated). Sheets emits a stderr warning when `--include-grid-data` is set or when `developerMetadata` is present in the response.

## Security audit

Full audit in [`docs/raw-audit.md`](docs/raw-audit.md) documenting sensitive fields per endpoint, the redaction rule, and rationale for each decision. TL;DR: Google APIs never return OAuth tokens/refresh tokens/client secrets in resource responses; the real risks are capability URLs (Drive `thumbnailLink`) and app-stashed custom metadata (`appProperties`, `developerMetadata`).

## Closes

Closes #486 via the Drive `--fields` flag expansion.

## Tests

Every new command has unit tests with mocked services (happy path + API error + not-found + empty-id, plus redaction/passthrough tests for Drive and grid-data + warning tests for Sheets). `outfmt.WriteRaw` has its own unit tests (compact/pretty, no HTML escape, bare struct, marshal error).

Full `go test ./...` passes locally.

## Follow-up

A stacked PR #496 (branched off this one) will extend `raw` to gmail, calendar, people, contacts, tasks, and forms.

## Test plan

- [ ] `gog docs raw <docId> | jq '.body.content | length'` returns a non-zero int
- [ ] `gog sheets raw <sheetId>` returns sheet metadata without grid data
- [ ] `gog sheets raw <sheetId> --include-grid-data` prints a stderr warning and returns cell data
- [ ] `gog slides raw <presentationId>` returns full slide tree
- [ ] `gog drive raw <fileId>` strips `thumbnailLink` by default
- [ ] `gog drive raw <fileId> --fields "id,name,thumbnailLink"` returns `thumbnailLink` verbatim
- [ ] `gog drive ls --fields "files(id,name,thumbnailLink),nextPageToken"` returns thumbnails
- [ ] `gog drive get <fileId> --fields "id,name,thumbnailLink"` returns the thumbnail link

🤖 Generated with [Claude Code](https://claude.com/claude-code)