### PR TITLE
feat(slides): Get or download a rendered thumbnail for a slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 - Auth: add `auth credentials remove` to delete stored OAuth client credentials and associated refresh tokens. (#473) — thanks @yamagucci.
 - Drive: convert Markdown uploads to Google Docs and strip leading YAML frontmatter by default, with `--keep-frontmatter` to opt out. (#487) — thanks @johnbenjaminlewis.
+- Slides: add `slides thumbnail` / `slides thumb` to fetch rendered slide thumbnail URLs or download PNG/JPEG images. (#498) — thanks @gianpaj.
 - Gmail: add `gmail autoreply` to reply once to matching messages, label the thread for dedupe, and optionally archive/mark read. Includes docs and regression coverage for skip/reply flows.
 - Gmail: add `gmail messages search --full` to print complete message bodies instead of truncating text output. (#447) — thanks @GodsBoy.
 - Drive: allow `drive share --role commenter` for comment-only sharing. (#443) — thanks @pavelzak.

--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,21 @@ EOF
 
 gog slides create-from-template <templateId> "Monthly Report" \
   --replacements replacements.json
+
+# Read slide content (text, notes, images)
+gog slides read-slide <presentationId> <slideId>
+
+# Include grouped elements, word art, and tables
+gog slides read-slide <presentationId> <slideId> --recursive --json
+
+# Get a rendered slide thumbnail URL
+gog slides thumbnail <presentationId> <slideId>
+
+# Download a rendered slide thumbnail
+gog slides thumbnail <presentationId> <slideId> --output ./slide.png
+
+# Control thumbnail size and format
+gog slides thumbnail <presentationId> <slideId> --size medium --format jpeg --output ./slide.jpg
 ```
 
 ## Output Formats

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -199,6 +199,7 @@ Flag aliases:
 - `gog drive unshare <fileId> <permissionId>`
 - `gog drive url <fileIds...>`
 - `gog drive drives [--max N] [--page TOKEN] [--query Q]`
+- `gog slides thumbnail <presentationId> <slideId> [--size small|medium|large] [--format png|jpeg] [--out PATH]`
 - `gog calendar calendars`
 - `gog calendar acl <calendarId>`
 - `gog calendar events <calendarId> [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339] [--to RFC3339] [--max N] [--page TOKEN] [--query Q] [--weekday]`

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -30,6 +30,7 @@ type SlidesCmd struct {
 	ListSlides         SlidesListSlidesCmd         `cmd:"" name:"list-slides" help:"List all slides with their object IDs"`
 	DeleteSlide        SlidesDeleteSlideCmd        `cmd:"" name:"delete-slide" help:"Delete a slide by object ID"`
 	ReadSlide          SlidesReadSlideCmd          `cmd:"" name:"read-slide" help:"Read slide content: speaker notes, text elements, and images"`
+	Thumbnail          SlidesThumbnailCmd          `cmd:"" name:"thumbnail" aliases:"thumb" help:"Get or download a rendered thumbnail for a slide"`
 	UpdateNotes        SlidesUpdateNotesCmd        `cmd:"" name:"update-notes" help:"Update speaker notes on an existing slide"`
 	ReplaceSlide       SlidesReplaceSlideCmd       `cmd:"" name:"replace-slide" help:"Replace the image on an existing slide in-place"`
 }

--- a/internal/cmd/slides_thumbnail.go
+++ b/internal/cmd/slides_thumbnail.go
@@ -1,0 +1,168 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+var slidesThumbnailHTTPClient = http.DefaultClient
+
+type SlidesThumbnailCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	SlideID        string `arg:"" name:"slideId" help:"Slide object ID (use 'slides list-slides' to find IDs)"`
+	Size           string `name:"size" help:"Thumbnail size: small|medium|large" default:"large"`
+	Format         string `name:"format" help:"Thumbnail format: png|jpeg" default:"png"`
+	Output         string `name:"output" help:"Write the thumbnail image to a local file"`
+}
+
+func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	presentationID := strings.TrimSpace(c.PresentationID)
+	if presentationID == "" {
+		return usage("empty presentationId")
+	}
+	slideID := strings.TrimSpace(c.SlideID)
+	if slideID == "" {
+		return usage("empty slideId")
+	}
+
+	size, err := normalizeSlidesThumbnailSize(c.Size)
+	if err != nil {
+		return err
+	}
+	format, err := normalizeSlidesThumbnailFormat(c.Format)
+	if err != nil {
+		return err
+	}
+
+	slidesSvc, err := newSlidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	call := slidesSvc.Presentations.Pages.GetThumbnail(presentationID, slideID).
+		ThumbnailPropertiesThumbnailSize(size).
+		ThumbnailPropertiesMimeType(format)
+
+	thumb, err := call.Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("get thumbnail: %w", err)
+	}
+	if thumb == nil || strings.TrimSpace(thumb.ContentUrl) == "" {
+		return fmt.Errorf("get thumbnail: empty content URL")
+	}
+
+	result := map[string]any{
+		"presentationId": presentationID,
+		"slideId":        slideID,
+		"contentUrl":     thumb.ContentUrl,
+		"width":          thumb.Width,
+		"height":         thumb.Height,
+		"size":           strings.ToLower(size),
+		"format":         strings.ToLower(format),
+	}
+
+	if c.Output != "" {
+		written, err := downloadSlidesThumbnail(ctx, thumb.ContentUrl, c.Output)
+		if err != nil {
+			return err
+		}
+		result["output"] = c.Output
+		result["bytes"] = written
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, result)
+	}
+
+	u.Out().Printf("presentationId\t%s", presentationID)
+	u.Out().Printf("slideId\t%s", slideID)
+	u.Out().Printf("url\t%s", thumb.ContentUrl)
+	if thumb.Width > 0 {
+		u.Out().Printf("width\t%d", thumb.Width)
+	}
+	if thumb.Height > 0 {
+		u.Out().Printf("height\t%d", thumb.Height)
+	}
+	u.Out().Printf("size\t%s", strings.ToLower(size))
+	u.Out().Printf("format\t%s", strings.ToLower(format))
+	if c.Output != "" {
+		u.Out().Printf("output\t%s", c.Output)
+		if bytes, ok := result["bytes"].(int64); ok {
+			u.Out().Printf("bytes\t%d", bytes)
+		}
+	}
+
+	return nil
+}
+
+func normalizeSlidesThumbnailSize(v string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "large":
+		return "LARGE", nil
+	case "medium":
+		return "MEDIUM", nil
+	case "small":
+		return "SMALL", nil
+	default:
+		return "", fmt.Errorf("invalid thumbnail size %q (expected small, medium, or large)", v)
+	}
+}
+
+func normalizeSlidesThumbnailFormat(v string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "", "png":
+		return "PNG", nil
+	case "jpeg", "jpg":
+		return "JPEG", nil
+	default:
+		return "", fmt.Errorf("invalid thumbnail format %q (expected png or jpeg)", v)
+	}
+}
+
+func downloadSlidesThumbnail(ctx context.Context, url, outputPath string) (int64, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("build thumbnail download request: %w", err)
+	}
+
+	resp, err := slidesThumbnailHTTPClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("download thumbnail: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("download thumbnail: unexpected status %s", resp.Status)
+	}
+
+	f, err := os.Create(outputPath)
+	if err != nil {
+		return 0, fmt.Errorf("create output file: %w", err)
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return 0, fmt.Errorf("write output file: %w", err)
+	}
+
+	return n, nil
+}
+
+var _ = slides.Thumbnail{}

--- a/internal/cmd/slides_thumbnail.go
+++ b/internal/cmd/slides_thumbnail.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"strings"
 
-	"google.golang.org/api/slides/v1"
-
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -21,7 +19,7 @@ type SlidesThumbnailCmd struct {
 	SlideID        string `arg:"" name:"slideId" help:"Slide object ID (use 'slides list-slides' to find IDs)"`
 	Size           string `name:"size" help:"Thumbnail size: small|medium|large" default:"large"`
 	Format         string `name:"format" help:"Thumbnail format: png|jpeg" default:"png"`
-	Output         string `name:"output" help:"Write the thumbnail image to a local file"`
+	Output         string `name:"out" aliases:"output" help:"Write the thumbnail image to a local file"`
 }
 
 func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -77,12 +75,14 @@ func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"format":         strings.ToLower(format),
 	}
 
-	if c.Output != "" {
-		written, err := downloadSlidesThumbnail(ctx, thumb.ContentUrl, c.Output)
+	outputPath := strings.TrimSpace(c.Output)
+	if outputPath != "" {
+		written, writtenPath, err := downloadSlidesThumbnail(ctx, thumb.ContentUrl, outputPath)
 		if err != nil {
 			return err
 		}
-		result["output"] = c.Output
+		outputPath = writtenPath
+		result["output"] = writtenPath
 		result["bytes"] = written
 	}
 
@@ -101,8 +101,8 @@ func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	u.Out().Printf("size\t%s", strings.ToLower(size))
 	u.Out().Printf("format\t%s", strings.ToLower(format))
-	if c.Output != "" {
-		u.Out().Printf("output\t%s", c.Output)
+	if outputPath != "" {
+		u.Out().Printf("output\t%s", outputPath)
 		if bytes, ok := result["bytes"].(int64); ok {
 			u.Out().Printf("bytes\t%d", bytes)
 		}
@@ -135,34 +135,35 @@ func normalizeSlidesThumbnailFormat(v string) (string, error) {
 	}
 }
 
-func downloadSlidesThumbnail(ctx context.Context, url, outputPath string) (int64, error) {
+func downloadSlidesThumbnail(ctx context.Context, url, outputPath string) (int64, string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		return 0, fmt.Errorf("build thumbnail download request: %w", err)
+		return 0, "", fmt.Errorf("build thumbnail download request: %w", err)
 	}
 
 	resp, err := slidesThumbnailHTTPClient.Do(req)
 	if err != nil {
-		return 0, fmt.Errorf("download thumbnail: %w", err)
+		return 0, "", fmt.Errorf("download thumbnail: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return 0, fmt.Errorf("download thumbnail: unexpected status %s", resp.Status)
+		return 0, "", fmt.Errorf("download thumbnail: unexpected status %s", resp.Status)
 	}
 
-	f, err := os.Create(outputPath)
+	f, expandedPath, err := createUserOutputFile(outputPath)
 	if err != nil {
-		return 0, fmt.Errorf("create output file: %w", err)
+		return 0, "", fmt.Errorf("create output file: %w", err)
 	}
-	defer f.Close()
 
 	n, err := io.Copy(f, resp.Body)
 	if err != nil {
-		return 0, fmt.Errorf("write output file: %w", err)
+		_ = f.Close()
+		return 0, "", fmt.Errorf("write output file: %w", err)
+	}
+	if err := f.Close(); err != nil {
+		return 0, "", fmt.Errorf("close output file: %w", err)
 	}
 
-	return n, nil
+	return n, expandedPath, nil
 }
-
-var _ = slides.Thumbnail{}

--- a/internal/cmd/slides_thumbnail_test.go
+++ b/internal/cmd/slides_thumbnail_test.go
@@ -1,0 +1,370 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func newSlidesThumbnailTestService(t *testing.T, handler http.Handler) *slides.Service {
+	t.Helper()
+
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	svc, err := slides.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("slides.NewService: %v", err)
+	}
+	return svc
+}
+
+func TestSlidesThumbnail(t *testing.T) {
+	origSlides := newSlidesService
+	t.Cleanup(func() { newSlidesService = origSlides })
+
+	svc := newSlidesThumbnailTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/presentations/pres1/pages/slide_1/thumbnail") && r.Method == http.MethodGet {
+			if got := r.URL.Query().Get("thumbnailProperties.thumbnailSize"); got != "LARGE" {
+				t.Fatalf("expected thumbnail size LARGE, got %q", got)
+			}
+			if got := r.URL.Query().Get("thumbnailProperties.mimeType"); got != "PNG" {
+				t.Fatalf("expected mime type PNG, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"contentUrl": "https://example.com/thumb.png",
+				"width":      1600,
+				"height":     900,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+
+		cmd := &SlidesThumbnailCmd{
+			PresentationID: "pres1",
+			SlideID:        "slide_1",
+		}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "presentationId\tpres1") {
+		t.Errorf("expected presentationId in output, got: %q", out)
+	}
+	if !strings.Contains(out, "slideId\tslide_1") {
+		t.Errorf("expected slideId in output, got: %q", out)
+	}
+	if !strings.Contains(out, "url\thttps://example.com/thumb.png") {
+		t.Errorf("expected thumbnail URL in output, got: %q", out)
+	}
+	if !strings.Contains(out, "width\t1600") {
+		t.Errorf("expected width in output, got: %q", out)
+	}
+	if !strings.Contains(out, "height\t900") {
+		t.Errorf("expected height in output, got: %q", out)
+	}
+	if !strings.Contains(out, "size\tlarge") {
+		t.Errorf("expected size in output, got: %q", out)
+	}
+	if !strings.Contains(out, "format\tpng") {
+		t.Errorf("expected format in output, got: %q", out)
+	}
+}
+
+func TestSlidesThumbnail_JSON(t *testing.T) {
+	origSlides := newSlidesService
+	t.Cleanup(func() { newSlidesService = origSlides })
+
+	svc := newSlidesThumbnailTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/presentations/pres1/pages/slide_1/thumbnail") && r.Method == http.MethodGet {
+			if got := r.URL.Query().Get("thumbnailProperties.thumbnailSize"); got != "MEDIUM" {
+				t.Fatalf("expected thumbnail size MEDIUM, got %q", got)
+			}
+			if got := r.URL.Query().Get("thumbnailProperties.mimeType"); got != "JPEG" {
+				t.Fatalf("expected mime type JPEG, got %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"contentUrl": "https://example.com/thumb.jpg",
+				"width":      800,
+				"height":     450,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		ctx = outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+
+		cmd := &SlidesThumbnailCmd{
+			PresentationID: "pres1",
+			SlideID:        "slide_1",
+			Size:           "medium",
+			Format:         "jpeg",
+		}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("JSON parse: %v\noutput: %q", err, out)
+	}
+
+	if got := result["presentationId"]; got != "pres1" {
+		t.Errorf("expected presentationId=pres1, got %v", got)
+	}
+	if got := result["slideId"]; got != "slide_1" {
+		t.Errorf("expected slideId=slide_1, got %v", got)
+	}
+	if got := result["contentUrl"]; got != "https://example.com/thumb.jpg" {
+		t.Errorf("expected contentUrl, got %v", got)
+	}
+	if got := result["width"]; got != float64(800) {
+		t.Errorf("expected width=800, got %v", got)
+	}
+	if got := result["height"]; got != float64(450) {
+		t.Errorf("expected height=450, got %v", got)
+	}
+	if got := result["size"]; got != "medium" {
+		t.Errorf("expected size=medium, got %v", got)
+	}
+	if got := result["format"]; got != "jpeg" {
+		t.Errorf("expected format=jpeg, got %v", got)
+	}
+}
+
+func TestSlidesThumbnail_Download(t *testing.T) {
+	origSlides := newSlidesService
+	origHTTPClient := slidesThumbnailHTTPClient
+	t.Cleanup(func() {
+		newSlidesService = origSlides
+		slidesThumbnailHTTPClient = origHTTPClient
+	})
+
+	imageBytes := []byte("fake-image-bytes")
+
+	downloadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(imageBytes)
+	}))
+	t.Cleanup(downloadSrv.Close)
+
+	svc := newSlidesThumbnailTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/presentations/pres1/pages/slide_1/thumbnail") && r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"contentUrl": downloadSrv.URL + "/thumb.png",
+				"width":      1600,
+				"height":     900,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return svc, nil }
+	slidesThumbnailHTTPClient = downloadSrv.Client()
+
+	flags := &RootFlags{Account: "a@b.com"}
+	outputPath := filepath.Join(t.TempDir(), "slide.png")
+
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+
+		cmd := &SlidesThumbnailCmd{
+			PresentationID: "pres1",
+			SlideID:        "slide_1",
+			Output:         outputPath,
+		}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	gotBytes, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(gotBytes) != string(imageBytes) {
+		t.Fatalf("expected downloaded bytes %q, got %q", string(imageBytes), string(gotBytes))
+	}
+
+	if !strings.Contains(out, "output\t"+outputPath) {
+		t.Errorf("expected output path in output, got: %q", out)
+	}
+	if !strings.Contains(out, "bytes\t16") {
+		t.Errorf("expected byte count in output, got: %q", out)
+	}
+}
+
+func TestSlidesThumbnail_InvalidSize(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &SlidesThumbnailCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide_1",
+		Size:           "giant",
+	}
+	err := cmd.Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), `invalid thumbnail size "giant"`) {
+		t.Fatalf("expected invalid size error, got: %v", err)
+	}
+}
+
+func TestSlidesThumbnail_InvalidFormat(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &SlidesThumbnailCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide_1",
+		Format:         "gif",
+	}
+	err := cmd.Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), `invalid thumbnail format "gif"`) {
+		t.Fatalf("expected invalid format error, got: %v", err)
+	}
+}
+
+func TestSlidesThumbnail_MissingSlideID(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &SlidesThumbnailCmd{
+		PresentationID: "pres1",
+	}
+	err := cmd.Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "empty slideId") {
+		t.Fatalf("expected empty slideId error, got: %v", err)
+	}
+}
+
+func TestSlidesThumbnail_APIFailure(t *testing.T) {
+	origSlides := newSlidesService
+	t.Cleanup(func() { newSlidesService = origSlides })
+
+	svc := newSlidesThumbnailTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"error":{"message":"boom"}}`, http.StatusInternalServerError)
+	}))
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &SlidesThumbnailCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide_1",
+	}
+	err := cmd.Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "get thumbnail:") {
+		t.Fatalf("expected get thumbnail error, got: %v", err)
+	}
+}
+
+func TestSlidesThumbnail_DownloadFailure(t *testing.T) {
+	origSlides := newSlidesService
+	origHTTPClient := slidesThumbnailHTTPClient
+	t.Cleanup(func() {
+		newSlidesService = origSlides
+		slidesThumbnailHTTPClient = origHTTPClient
+	})
+
+	downloadSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "missing", http.StatusNotFound)
+	}))
+	t.Cleanup(downloadSrv.Close)
+
+	svc := newSlidesThumbnailTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/presentations/pres1/pages/slide_1/thumbnail") && r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"contentUrl": downloadSrv.URL + "/thumb.png",
+				"width":      1600,
+				"height":     900,
+			})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return svc, nil }
+	slidesThumbnailHTTPClient = downloadSrv.Client()
+
+	flags := &RootFlags{Account: "a@b.com"}
+	outputPath := filepath.Join(t.TempDir(), "slide.png")
+
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &SlidesThumbnailCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide_1",
+		Output:         outputPath,
+	}
+	err := cmd.Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "download thumbnail: unexpected status 404 Not Found") {
+		t.Fatalf("expected download failure, got: %v", err)
+	}
+}

--- a/internal/cmd/slides_thumbnail_test.go
+++ b/internal/cmd/slides_thumbnail_test.go
@@ -295,6 +295,23 @@ func TestSlidesThumbnail_MissingSlideID(t *testing.T) {
 	}
 }
 
+func TestSlidesThumbnail_MissingPresentationID(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	cmd := &SlidesThumbnailCmd{
+		SlideID: "slide_1",
+	}
+	err := cmd.Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "empty presentationId") {
+		t.Fatalf("expected empty presentationId error, got: %v", err)
+	}
+}
+
 func TestSlidesThumbnail_APIFailure(t *testing.T) {
 	origSlides := newSlidesService
 	t.Cleanup(func() { newSlidesService = origSlides })


### PR DESCRIPTION
Using the Google Workspace API:
https://developers.google.com/workspace/slides/api/reference/rest/v1/presentations.pages/getThumbnail

```sh
# Get a rendered slide thumbnail URL
gog slides thumbnail <presentationId> <slideId>

# Download a rendered slide thumbnail
gog slides thumbnail <presentationId> <slideId> --output ./slide.png

# Control thumbnail size and format
gog slides thumbnail <presentationId> <slideId> --size medium --format jpeg --output ./slide.jpg
```

Example:
```sh
$ gog slides list-slides 1bnEb7_gvB5SH-xxx
Presentation: Mars: The New Frontier (7 slides)

#  OBJECT ID
1  p
2  slide_1
3  slide_2
4  slide_3
5  slide_4
6  slide_5
7  slide_6

$ gog slides thumbnail 1bnEb7_gvB5SH-xxx slide_1 --output slide-2.png

presentationId	1bnEb7_gvB5SH-xxx
slideId	slide_1
url	https://lh7-us.googleusercontent.com/docsdf/xxx-eZm-zzz-yyy=s1600
width	1600
height	900
size	large
format	png
output	slide-2.png
bytes	60950
```

## downloaded img 
<img width="1600" height="900" alt="slide-2" src="https://github.com/user-attachments/assets/41761dce-b31f-4fda-acba-b5847640d7bf" />


<img width="1106" height="657" alt="image" src="https://github.com/user-attachments/assets/d7b3a114-348d-4a89-92f0-f280e14e1f58" />
