### PR TITLE
Restore markdown replace support in docs write

### DIFF
--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/alecthomas/kong"
 	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+	gapi "google.golang.org/api/googleapi"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
@@ -17,6 +19,8 @@ type DocsWriteCmd struct {
 	DocID    string `arg:"" name:"docId" help:"Doc ID"`
 	Text     string `name:"text" help:"Text to write"`
 	File     string `name:"file" help:"Text file path ('-' for stdin)"`
+	Replace  bool   `name:"replace" help:"Replace all content explicitly (required with --markdown)"`
+	Markdown bool   `name:"markdown" help:"Convert markdown to Google Docs formatting (requires --replace)"`
 	Append   bool   `name:"append" help:"Append instead of replacing the document body"`
 	Pageless bool   `name:"pageless" help:"Set document to pageless mode"`
 	TabID    string `name:"tab-id" help:"Target a specific tab by ID (see docs list-tabs)"`
@@ -38,6 +42,12 @@ func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootF
 	}
 	if text == "" {
 		return usage("empty text")
+	}
+	if c.Append && c.Replace {
+		return usage("--append cannot be combined with --replace")
+	}
+	if c.Markdown {
+		return c.writeMarkdown(ctx, flags, id, text)
 	}
 
 	svc, err := requireDocsService(ctx, flags)
@@ -110,6 +120,69 @@ func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootF
 	}
 	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
 		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
+func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docID, content string) error {
+	u := ui.FromContext(ctx)
+
+	if !c.Replace {
+		return usage("--markdown requires --replace")
+	}
+	if c.Append {
+		return usage("--markdown cannot be combined with --append")
+	}
+	if c.TabID != "" {
+		return usage("--markdown cannot be combined with --tab-id")
+	}
+
+	_, driveSvc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	updated, err := driveSvc.Files.Update(docID, &drive.File{}).
+		Media(strings.NewReader(content), gapi.ContentType(mimeTextMarkdown)).
+		SupportsAllDrives(true).
+		Fields("id,name,webViewLink").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return fmt.Errorf("writing markdown to document: %w", err)
+	}
+
+	if c.Pageless {
+		docsSvc, svcErr := requireDocsService(ctx, flags)
+		if svcErr != nil {
+			return svcErr
+		}
+		if err := setDocumentPageless(ctx, docsSvc, docID); err != nil {
+			return fmt.Errorf("set pageless mode: %w", err)
+		}
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": updated.Id,
+			"written":    len(content),
+			"replaced":   true,
+			"markdown":   true,
+		}
+		if c.Pageless {
+			payload["pageless"] = true
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+
+	u.Out().Printf("documentId\t%s", updated.Id)
+	u.Out().Printf("written\t%d", len(content))
+	u.Out().Printf("mode\treplaced (markdown converted)")
+	if c.Pageless {
+		u.Out().Printf("pageless\ttrue")
+	}
+	if updated.WebViewLink != "" {
+		u.Out().Printf("link\t%s", updated.WebViewLink)
 	}
 	return nil
 }

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -4,14 +4,18 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"io/fs"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
 )
 
 func TestDocsWriteUpdate_JSON(t *testing.T) {
@@ -351,5 +355,76 @@ func TestDocsWriteUpdate_FileInputErrors(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "use only one of --text or --file") {
 		t.Fatalf("expected mutual exclusion error, got: %v", err)
+	}
+}
+
+func TestDocsWrite_MarkdownReplaceUsesDriveUpdate(t *testing.T) {
+	origDocs := newDocsService
+	origDrive := newDriveService
+	t.Cleanup(func() {
+		newDocsService = origDocs
+		newDriveService = origDrive
+	})
+
+	var sawDriveUpdate bool
+	var uploadBody string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/upload/drive/v3/files/doc1"):
+			sawDriveUpdate = true
+			if qerr := driveAllDrivesQueryError(r, false); qerr != "" {
+				t.Fatalf("drive update query: %s", qerr)
+			}
+			if got := r.Header.Get("Content-Type"); !strings.Contains(got, "text/markdown") && !strings.Contains(got, "multipart/related") {
+				t.Fatalf("unexpected content type: %s", got)
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read body: %v", err)
+			}
+			uploadBody = string(body)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "doc1",
+				"name":        "Doc",
+				"webViewLink": "https://docs.google.com/document/d/doc1/edit",
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer srv.Close()
+
+	driveSvc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/drive/v3/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDriveService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return driveSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	ctx := newDocsJSONContext(t)
+
+	tmpDir := t.TempDir()
+	mdFile := filepath.Join(tmpDir, "test.md")
+	markdown := "# Hello\n\n- item\n"
+	if err := os.WriteFile(mdFile, []byte(markdown), 0o600); err != nil {
+		t.Fatalf("write markdown temp file: %v", err)
+	}
+
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--file", mdFile, "--replace", "--markdown"}, ctx, flags); err != nil {
+		t.Fatalf("markdown replace write: %v", err)
+	}
+	if !sawDriveUpdate {
+		t.Fatal("expected markdown replace path to call Drive update")
+	}
+	if !strings.Contains(uploadBody, "# Hello") {
+		t.Fatalf("expected upload body to contain markdown content, got: %q", uploadBody)
 	}
 }

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -373,8 +373,8 @@ func TestDocsWrite_MarkdownReplaceUsesDriveUpdate(t *testing.T) {
 		switch {
 		case strings.HasPrefix(r.URL.Path, "/upload/drive/v3/files/doc1"):
 			sawDriveUpdate = true
-			if qerr := driveAllDrivesQueryError(r, false); qerr != "" {
-				t.Fatalf("drive update query: %s", qerr)
+			if got := r.URL.Query().Get("supportsAllDrives"); got != "true" {
+				t.Fatalf("drive update query: missing supportsAllDrives=true, got %q", got)
 			}
 			if got := r.Header.Get("Content-Type"); !strings.Contains(got, "text/markdown") && !strings.Contains(got, "multipart/related") {
 				t.Fatalf("unexpected content type: %s", got)


### PR DESCRIPTION
## Summary
This restores `docs write --replace --markdown`, which worked in `v0.11.0` and regressed in later docs refactors.

## Root cause
In `v0.11.0`, markdown replacement used the Drive API update path, which preserved native Google Docs formatting. Later refactors turned `docs write` into a plain-text Docs mutation command and removed that markdown-aware replace path. That caused formatting loss for workflows that sync markdown into existing Google Docs.

## Backward compatibility
Default plain-text `docs write` behavior stays on the newer Docs API mutation path. This only restores the markdown-preserving update path for `docs write --replace --markdown`.

## Fix
- restore `--replace` on `docs write`
- restore `--markdown` on `docs write`
- route `docs write --replace --markdown` back through the Drive API update path
- keep the current split docs command layout from `main`
- keep the newer plain-text Docs API write behavior for non-markdown usage
- add a regression test covering the markdown replace path

## Validation
- added regression test in `internal/cmd/docs_write_update_test.go`
- `go test ./internal/cmd -run TestDocsWrite_MarkdownReplaceUsesDriveUpdate`
- `make ci`

## Prompt Used
```text
Create a GitHub PR for steipete/gogcli.

Branch:
fix/docs-markdown-write-regression

Base:
main

State the regression clearly up front:
`docs write --replace --markdown` worked in v0.11.0, where markdown replacement used the Drive API update path. In later docs refactors, `docs write` became a plain-text Docs mutation command, which removed that markdown-aware replace path and caused formatting loss for existing markdown sync workflows.

What this branch does:
- restores `--replace` on `docs write`
- restores `--markdown` on `docs write`
- routes `docs write --replace --markdown` back through the Drive API update path
- keeps the newer plain-text Docs API write behavior for non-markdown usage
- adds a regression test proving markdown replace uses Drive update instead of plain-text Docs mutation

Validation:
- focused docs tests pass
- regression test added in `internal/cmd/docs_write_update_test.go`

Write:
- a short, technical PR title
- a compact PR body
- be direct and explicit about regression cause and compatibility impact
- avoid marketing tone
- use sections:
  - Summary
  - Root cause
  - Fix
  - Validation
```