### PR TITLE
chat spaces find: substring match by default, --exact for legacy behavior

### DIFF
--- a/internal/cmd/chat_spaces.go
+++ b/internal/cmd/chat_spaces.go
@@ -124,8 +124,9 @@ func (c *ChatSpacesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type ChatSpacesFindCmd struct {
-	DisplayName string `arg:"" name:"displayName" help:"Space display name"`
+	DisplayName string `arg:"" name:"displayName" help:"Space display name (substring match, case-insensitive)"`
 	Max         int64  `name:"max" aliases:"limit" help:"Max results per page" default:"100"`
+	Exact       bool   `name:"exact" help:"Require an exact, case-insensitive match on displayName instead of substring match"`
 }
 
 func (c *ChatSpacesFindCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -157,12 +158,19 @@ func (c *ChatSpacesFindCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if callErr != nil {
 			return nil, "", callErr
 		}
+		needle := strings.ToLower(displayName)
 		matches := make([]*chat.Space, 0, len(resp.Spaces))
 		for _, space := range resp.Spaces {
 			if space == nil {
 				continue
 			}
-			if strings.EqualFold(space.DisplayName, displayName) {
+			if c.Exact {
+				if strings.EqualFold(space.DisplayName, displayName) {
+					matches = append(matches, space)
+				}
+				continue
+			}
+			if strings.Contains(strings.ToLower(space.DisplayName), needle) {
 				matches = append(matches, space)
 			}
 		}

--- a/internal/cmd/execute_chat_test.go
+++ b/internal/cmd/execute_chat_test.go
@@ -138,6 +138,122 @@ func TestExecute_ChatSpacesFind_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_ChatSpacesFind_Substring(t *testing.T) {
+	origNew := newChatService
+	t.Cleanup(func() { newChatService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"spaces": []map[string]any{
+				{"name": "spaces/aaa", "displayName": "My Project Team", "spaceType": "SPACE"},
+				{"name": "spaces/bbb", "displayName": "Project Alpha", "spaceType": "SPACE"},
+				{"name": "spaces/ccc", "displayName": "Random Channel", "spaceType": "SPACE"},
+				{"name": "spaces/ddd", "displayName": "Old Project Archive", "spaceType": "SPACE"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := chat.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newChatService = func(context.Context, string) (*chat.Service, error) { return svc, nil }
+
+	// Default behavior: substring, case-insensitive. "project" must match all
+	// three entries whose DisplayName contains "Project", and must exclude the
+	// unrelated "Random Channel".
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "chat", "spaces", "find", "project"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Spaces []struct {
+			Resource string `json:"resource"`
+			Name     string `json:"name"`
+		} `json:"spaces"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	got := make(map[string]bool, len(parsed.Spaces))
+	for _, s := range parsed.Spaces {
+		got[s.Resource] = true
+	}
+	if len(got) != 3 || !got["spaces/aaa"] || !got["spaces/bbb"] || !got["spaces/ddd"] {
+		t.Fatalf("substring search must match all three 'Project' spaces, got %#v", parsed.Spaces)
+	}
+	if got["spaces/ccc"] {
+		t.Fatalf("substring search must not match 'Random Channel', got %#v", parsed.Spaces)
+	}
+}
+
+func TestExecute_ChatSpacesFind_Exact(t *testing.T) {
+	origNew := newChatService
+	t.Cleanup(func() { newChatService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !(r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/spaces")) {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"spaces": []map[string]any{
+				{"name": "spaces/aaa", "displayName": "My Project Team", "spaceType": "SPACE"},
+				{"name": "spaces/bbb", "displayName": "Project Alpha", "spaceType": "SPACE"},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := chat.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newChatService = func(context.Context, string) (*chat.Service, error) { return svc, nil }
+
+	// --exact must restore the legacy case-insensitive equality behavior: only
+	// the space whose DisplayName equals "project alpha" (ignoring case)
+	// is returned.
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "chat", "spaces", "find", "--exact", "project alpha"}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		Spaces []struct {
+			Resource string `json:"resource"`
+		} `json:"spaces"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(parsed.Spaces) != 1 || parsed.Spaces[0].Resource != "spaces/bbb" {
+		t.Fatalf("--exact must return only 'Project Alpha', got %#v", parsed.Spaces)
+	}
+}
+
 func TestExecute_ChatSpacesCreate_JSON(t *testing.T) {
 	origNew := newChatService
 	t.Cleanup(func() { newChatService = origNew })


### PR DESCRIPTION
Closes #503

\`gog chat spaces find\` previously required an exact, case-insensitive match on the full \`displayName\`. Searching \`Project\` against a space named \`My Project Team\` returned no results, and the documented workaround was \`gog chat spaces list --all -p | grep\`, which is slower and less ergonomic.

This change makes \`find\` do substring matching (case-insensitive) by default and adds an \`--exact\` flag to opt into the previous behavior. The underlying Google Chat \`Spaces.List\` API has no server-side display name filter, so both modes iterate the same paginated result set; substring matching is strictly more permissive. Scripts that relied on the exact-match behavior can add \`--exact\` to keep the old semantics.

Examples:

\`\`\`console
# default (substring, case-insensitive)
gog chat spaces find Project
# returns: My Project Team, Project Alpha, Old Project Archive

# legacy exact match
gog chat spaces find --exact \"Project Alpha\"
# returns: Project Alpha
\`\`\`

### Tests

- \`TestExecute_ChatSpacesFind_Substring\` - default search \`project\` matches \`My Project Team\`, \`Project Alpha\`, and \`Old Project Archive\`, and excludes \`Random Channel\`.
- \`TestExecute_ChatSpacesFind_Exact\` - \`--exact \"project alpha\"\` returns only the space whose \`displayName\` equals \`Project Alpha\` (case-insensitive).
- Existing \`TestExecute_ChatSpacesFind_JSON\` still passes (exact-named \`Engineering\` remains matched by the default substring behavior because it is a substring of itself).

\`go test ./internal/cmd/ -run TestExecute_ChatSpacesFind\` and \`go build ./...\` both clean locally.