### PR TITLE
fix(tasks): clear due date when --due= is set to empty

### DIFF
--- a/internal/cmd/tasks_items.go
+++ b/internal/cmd/tasks_items.go
@@ -491,14 +491,18 @@ func (c *TasksUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Roo
 		changed = true
 	}
 	if flagProvided(kctx, "due") {
-		if !outfmt.IsJSON(ctx) {
-			warnTasksDueTime(u, c.Due)
-		}
 		dueValue, dueErr := normalizeTaskDue(c.Due)
 		if dueErr != nil {
 			return dueErr
 		}
-		patch.Due = dueValue
+		if dueValue == "" {
+			patch.NullFields = append(patch.NullFields, "Due")
+		} else {
+			if !outfmt.IsJSON(ctx) {
+				warnTasksDueTime(u, c.Due)
+			}
+			patch.Due = dueValue
+		}
 		changed = true
 	}
 	if flagProvided(kctx, "status") {


### PR DESCRIPTION
## Summary

When `gog tasks update --due=` was used with an empty value, the due date was not actually cleared despite the help text stating "set empty to clear". The Google Tasks API PATCH treats an empty string the same as an omitted field due to `omitempty` JSON tagging, so the due date remained unchanged.

This fix adds `"Due"` to `NullFields` when the due value is empty, which forces the API to send an explicit `null` in the PATCH request body, properly clearing the due date.

## Steps to Reproduce (before fix)

1. Have a task with a due date set
2. Run: `gog tasks update <listId> <taskId> --due= --force`
3. Observe the due date is unchanged

## Expected Behavior

The due date should be cleared (set to null).

## Changes

- When `--due=` is provided with an empty value, add `"Due"` to `patch.NullFields` instead of setting `patch.Due = ""`
- Move the `warnTasksDueTime` call inside the non-empty branch since it's only relevant when a due date is being set

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/cmd/... -run TestTasksValidation` passes
- [ ] Manual test: `gog tasks update <listId> <taskId> --due= --force` clears the due date
- [ ] Manual test: `gog tasks update <listId> <taskId> --due=2026-05-01` still sets the due date normally

Closes #437