### PR TITLE
fix(calendar): use buildEventDateTime in focus time command

### DIFF
--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -36,8 +36,8 @@ func (c *CalendarFocusTimeCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	event := &calendar.Event{
 		Summary:      strings.TrimSpace(c.Summary),
-		Start:        &calendar.EventDateTime{DateTime: strings.TrimSpace(c.From)},
-		End:          &calendar.EventDateTime{DateTime: strings.TrimSpace(c.To)},
+		Start:        buildEventDateTime(c.From, false),
+		End:          buildEventDateTime(c.To, false),
 		EventType:    eventTypeFocusTime,
 		Transparency: "opaque",
 		FocusTimeProperties: &calendar.EventFocusTimeProperties{


### PR DESCRIPTION
## Summary

The `calendar focus-time` command was constructing `EventDateTime` directly without calling `buildEventDateTime()`, which extracts IANA timezone names from RFC3339 offsets. This meant recurring focus-time events received no IANA timezone — only a numeric offset — causing DST-transition errors.

The `calendar out-of-office` command already uses `buildEventDateTime` correctly.

## Impact

Without IANA timezone info, Google Calendar uses a fixed offset for recurring focus-time events. When DST transitions occur, these events appear at the wrong time. For example, a recurring focus time at 9:00 AM CET would shift to 10:00 AM after a DST change because `Etc/GMT-1` doesn't account for CET/CEST.

## Changes

- Replace `&calendar.EventDateTime{DateTime: strings.TrimSpace(c.From)}` with `buildEventDateTime(c.From, false)` (and same for `c.To`)
- This brings focus time in line with the out-of-office command, which already uses `buildEventDateTime`

## Test plan

- [x] `go build ./...` compiles cleanly
- [ ] Create a recurring focus time event and verify the IANA timezone is included in the API request
- [ ] Verify DST transitions are handled correctly for recurring focus time events

Related to #422, #423, #493