### PR TITLE
fix(calendar): use midnight of next day as endOfDay to avoid truncation

### DIFF
--- a/internal/cmd/time_helpers.go
+++ b/internal/cmd/time_helpers.go
@@ -305,9 +305,12 @@ func startOfDay(t time.Time) time.Time {
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, t.Location())
 }
 
-// endOfDay returns the end of the day (23:59:59.999) in the given time's location.
+// endOfDay returns the start of the next day so that when formatted as
+// RFC3339 (second precision) and used as an exclusive timeMax, the entire
+// target day is included. Previously, 23:59:59.999999999 was truncated to
+// 23:59:59 by time.RFC3339, which excluded events starting at that second.
 func endOfDay(t time.Time) time.Time {
-	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 999999999, t.Location())
+	return startOfDay(t.AddDate(0, 0, 1))
 }
 
 // startOfWeek returns the start of the week for the given time.

--- a/internal/cmd/time_range_more_test.go
+++ b/internal/cmd/time_range_more_test.go
@@ -48,8 +48,11 @@ func TestResolveTimeRangeWithDefaultsToday(t *testing.T) {
 		t.Fatalf("expected start of day, got %v", tr.From)
 	}
 
-	if tr.To.Hour() != 23 || tr.To.Minute() != 59 || tr.To.Second() != 59 {
-		t.Fatalf("expected end of day, got %v", tr.To)
+	// endOfDay now returns start of next day (midnight) so that RFC3339
+	// second-precision formatting doesn't truncate 23:59:59.999999999 to
+	// 23:59:59, which would exclude events at that second via exclusive timeMax.
+	if tr.To.Hour() != 0 || tr.To.Minute() != 0 || tr.To.Second() != 0 {
+		t.Fatalf("expected start of next day (end-of-day), got %v", tr.To)
 	}
 
 	if !tr.From.Before(tr.To) {
@@ -87,7 +90,7 @@ func TestResolveTimeRangeWithDefaultsToDateOnlyEndOfDay(t *testing.T) {
 	}
 
 	expectedFrom := time.Date(2025, 1, 5, 10, 0, 0, 0, time.UTC)
-	expectedTo := time.Date(2025, 1, 5, 23, 59, 59, 999999999, time.UTC)
+	expectedTo := time.Date(2025, 1, 6, 0, 0, 0, 0, time.UTC)
 	if !tr.From.Equal(expectedFrom) {
 		t.Fatalf("unexpected from: %v", tr.From)
 	}
@@ -230,7 +233,8 @@ func TestResolveTimeRangeWithDefaultsToTomorrowEndOfDay(t *testing.T) {
 
 	// "tomorrow" is relative to now, so we calculate expected tomorrow
 	expectedTomorrow := now.AddDate(0, 0, 1)
-	expectedTo := time.Date(expectedTomorrow.Year(), expectedTomorrow.Month(), expectedTomorrow.Day(), 23, 59, 59, 999999999, time.UTC)
+	// endOfDay returns start of next day, so for tomorrow that's day after tomorrow
+	expectedTo := time.Date(expectedTomorrow.Year(), expectedTomorrow.Month(), expectedTomorrow.Day()+1, 0, 0, 0, 0, time.UTC)
 
 	if !tr.To.Equal(expectedTo) {
 		t.Fatalf("expected --to tomorrow to expand to end-of-day %v, got %v", expectedTo, tr.To)
@@ -261,8 +265,8 @@ func TestResolveTimeRangeWithDefaultsToNowNoExpansion(t *testing.T) {
 		t.Fatalf("expected --to now to be current time (between %v and %v), got %v", before, after, tr.To)
 	}
 
-	// Verify it's NOT end-of-day (23:59:59.999999999)
-	if tr.To.Hour() == 23 && tr.To.Minute() == 59 && tr.To.Second() == 59 && tr.To.Nanosecond() == 999999999 {
+	// Verify it's NOT midnight of next day (the new endOfDay)
+	if tr.To.Hour() == 0 && tr.To.Minute() == 0 && tr.To.Second() == 0 && tr.To.Nanosecond() == 0 {
 		t.Fatalf("expected --to now NOT to expand to end-of-day, but got %v", tr.To)
 	}
 }
@@ -295,7 +299,8 @@ func TestResolveTimeRangeWithDefaultsToMondayEndOfDay(t *testing.T) {
 		daysUntil += 7
 	}
 	expectedMonday := now.AddDate(0, 0, daysUntil)
-	expectedTo := time.Date(expectedMonday.Year(), expectedMonday.Month(), expectedMonday.Day(), 23, 59, 59, 999999999, time.UTC)
+	// endOfDay returns start of next day
+	expectedTo := time.Date(expectedMonday.Year(), expectedMonday.Month(), expectedMonday.Day()+1, 0, 0, 0, 0, time.UTC)
 
 	if !tr.To.Equal(expectedTo) {
 		t.Fatalf("expected --to monday to expand to end-of-day %v, got %v", expectedTo, tr.To)


### PR DESCRIPTION
## Summary

`endOfDay()` previously returned `23:59:59.999999999`, but `FormatRFC3339()` uses `time.RFC3339` which truncates to second precision, producing `23:59:59`. Since the Google Calendar API's `timeMax` parameter is **exclusive**, events starting at exactly 23:59:59 are silently dropped from `--today`, `--week`, and `--days` queries.

## Impact

This is the root cause of issue #367 where `calendar events list` returns 404 or missing results when using `--today`, `--from`, or `--days` flags. Events near midnight are silently excluded.

## Changes

- Change `endOfDay()` to return midnight of the next day (`startOfDay(t.AddDate(0, 0, 1))`) instead of `23:59:59.999999999`
- This ensures RFC3339 second-precision formatting still includes the entire target day when used as an exclusive `timeMax`
- Update existing tests to match the new expected values

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/cmd/... -run TimeRange -v` — all pass
- [ ] Manual test: `gog calendar events list --today` includes events at 23:59
- [ ] Manual test: `gog calendar events list --week` covers the full week

Closes #367