### PR TITLE
fix(gmail): skip charset re-decoding when body is already valid UTF-8

### DIFF
--- a/internal/cmd/gmail_thread.go
+++ b/internal/cmd/gmail_thread.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	"golang.org/x/net/html/charset"
 	"golang.org/x/text/encoding/ianaindex"
@@ -493,6 +494,15 @@ func decodeBodyCharset(data []byte, contentType string) []byte {
 	charsetLabel := charsetLabelFromContentType(contentType)
 	normalized := strings.ToLower(strings.ReplaceAll(strings.TrimSpace(charsetLabel), "_", "-"))
 	if charsetLabel == "" || normalized == "utf-8" || normalized == "utf8" {
+		return data
+	}
+	// The Gmail API normalizes body.data to UTF-8 before base64url-encoding,
+	// but preserves the original MIME Content-Type headers verbatim. If the
+	// data is already valid UTF-8, skip charset re-decoding to avoid garbling
+	// content (e.g., ISO-2022-JP or Shift-JIS messages already converted by
+	// the API). Genuine non-UTF-8 raw bytes are almost never valid UTF-8, so
+	// this guard is safe.
+	if utf8.Valid(data) {
 		return data
 	}
 	if decoded, ok := decodeWithCharsetLabel(data, charsetLabel); ok {


### PR DESCRIPTION
## Summary

`decodeBodyCharset` re-decodes already-UTF-8 data as the original charset (e.g., ISO-2022-JP, Shift-JIS, GBK) when the MIME header declares a non-UTF-8 charset, producing garbled output. The Gmail API normalizes `body.data` to UTF-8 before base64url-encoding but preserves the original MIME headers verbatim.

## Steps to Reproduce (before fix)

1. Receive an email with `Content-Type: text/plain; charset="iso-2022-jp"`
2. Run `gog gmail read <threadId>`
3. Body text is garbled (replacement characters `\ufffd`)

## Changes

Add a `utf8.Valid(data)` guard before charset conversion. If the data is already valid UTF-8, skip re-decoding. Genuine non-UTF-8 raw bytes (like ISO-2022-JP or Shift-JIS) are almost never valid UTF-8, so this guard is safe.

## Affected Encodings

Confirmed: `iso-2022-jp`. Likely also: `shift_jis`, `euc-jp`, `gb2312`, `gbk`, `euc-kr`, `windows-1252`, `iso-8859-1`.

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/cmd/... -run GmailGet -v` passes
- [ ] Manual test: read an ISO-2022-JP encoded email and verify it displays correctly

Closes #446