### PR TITLE
fix(gmail): use configured timezone for Date header (#472)

### DIFF
--- a/internal/cmd/gmail_mime.go
+++ b/internal/cmd/gmail_mime.go
@@ -86,7 +86,16 @@ func buildRFC822(opts mailOptions, cfg *rfc822Config) ([]byte, error) {
 		return nil, fmt.Errorf("invalid Subject: %w", err)
 	}
 	writeHeader(&b, "Subject", encodeHeaderIfNeeded(opts.Subject))
-	writeHeader(&b, "Date", time.Now().Format(time.RFC1123Z))
+
+	loc, err := getConfiguredTimezone("")
+	if err != nil {
+		return nil, err
+	}
+	if loc == nil {
+		loc = time.Local
+	}
+	writeHeader(&b, "Date", time.Now().In(loc).Format(time.RFC1123Z))
+
 	if !hasHeader(opts.AdditionalHeaders, "Message-ID") && !hasHeader(opts.AdditionalHeaders, "Message-Id") {
 		messageID, err := randomMessageID(opts.From)
 		if err != nil {


### PR DESCRIPTION
Fixes #472.

Instead of directly invoking `time.Now().Format()` using the system's runtime timezone, we now properly fetch the globally configured timezone through `getConfiguredTimezone`. This ensures the `Date` header correctly aligns with the application-wide explicit configuration and falls back to `time.Local` correctly if not set, avoiding the `+0900` timezone delivery misconfiguration.