### PR TITLE
fix(secrets): timeout keyring.Open() on macOS to prevent indefinite hang (#513)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+- Secrets: extend the `keyring.Open()` timeout safety net to macOS when the backend is `auto` or `keychain`. Previously only Linux used a timeout, so a macOS Security framework prompt that couldn't surface (e.g., non-interactive runs, post-Homebrew-upgrade re-authorization) would hang every auth-requiring command indefinitely until the process was killed. The timeout now also covers macOS and returns a clear error with guidance to run from a terminal and click "Always Allow", or switch to `GOG_KEYRING_BACKEND=file`. Bumps the timeout from 5s to 10s to tolerate slower macOS Keychain responses. Fixes #513.
+
 ## 0.13.0 - 2026-04-20
 
 ### Highlights

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -156,14 +156,33 @@ func keyringServiceName() string {
 // keyringOpenTimeout is the maximum time to wait for keyring.Open() to complete.
 // On headless Linux, D-Bus SecretService can hang indefinitely if gnome-keyring
 // is installed but not running.
-const keyringOpenTimeout = 5 * time.Second
+//
+// On macOS, keyring.Open() can hang when the Security framework waits for a GUI
+// permission prompt that cannot surface (e.g., non-interactive runs after a
+// Homebrew upgrade installs a new binary hash, breaking the previous
+// "Always Allow" grant).
+const keyringOpenTimeout = 10 * time.Second
 
 func shouldForceFileBackend(goos string, backendInfo KeyringBackendInfo, dbusAddr string) bool {
 	return goos == "linux" && backendInfo.Value == keyringBackendAuto && dbusAddr == ""
 }
 
+// shouldUseKeyringTimeout returns true when keyring.Open() should be wrapped
+// in a timeout to prevent indefinite hangs.
+//
+//   - Linux with "auto" backend and a D-Bus session: SecretService may be
+//     installed but unresponsive (e.g., gnome-keyring not running).
+//   - macOS with "auto" or "keychain" backend: Security framework may block
+//     on a GUI permission prompt that cannot surface in non-interactive
+//     contexts or after a Homebrew upgrade.
 func shouldUseKeyringTimeout(goos string, backendInfo KeyringBackendInfo, dbusAddr string) bool {
-	return goos == "linux" && backendInfo.Value == "auto" && dbusAddr != ""
+	if goos == "linux" && backendInfo.Value == "auto" && dbusAddr != "" {
+		return true
+	}
+	if goos == "darwin" && (backendInfo.Value == keyringBackendAuto || backendInfo.Value == "keychain") {
+		return true
+	}
+	return false
 }
 
 func openKeyring() (keyring.Keyring, error) {
@@ -228,8 +247,13 @@ type keyringResult struct {
 }
 
 // openKeyringWithTimeout wraps keyring.Open with a timeout to prevent indefinite
-// hangs when D-Bus SecretService is unresponsive (e.g., gnome-keyring installed
-// but not running on headless Linux).
+// hangs when the platform keyring is unresponsive:
+//
+//   - Linux: D-Bus SecretService may hang (e.g., gnome-keyring installed but
+//     not running on headless systems).
+//   - macOS: Security framework may block on a GUI permission prompt that
+//     cannot surface (e.g., non-interactive contexts, post-Homebrew-upgrade
+//     prompts that don't reach the user).
 //
 // Note: If timeout occurs, the spawned goroutine continues blocking on keyring.Open()
 // and will leak. This is acceptable for a CLI tool since the process exits on this
@@ -250,9 +274,24 @@ func openKeyringWithTimeout(cfg keyring.Config, timeout time.Duration) (keyring.
 
 		return res.ring, nil
 	case <-time.After(timeout):
-		return nil, fmt.Errorf("%w after %v (D-Bus SecretService may be unresponsive); "+
+		return nil, fmt.Errorf("%w after %v (%s); "+
 			"set GOG_KEYRING_BACKEND=file and GOG_KEYRING_PASSWORD=<password> to use encrypted file storage instead",
-			errKeyringTimeout, timeout)
+			errKeyringTimeout, timeout, keyringTimeoutHint(runtime.GOOS))
+	}
+}
+
+// keyringTimeoutHint returns a platform-specific hint for the likely cause
+// of a keyring open timeout.
+func keyringTimeoutHint(goos string) string {
+	switch goos {
+	case "darwin":
+		return "macOS Keychain may be waiting for a permission prompt — " +
+			"run `gog auth list` from a terminal and click \"Always Allow\" when prompted " +
+			"(common after Homebrew upgrades; see https://github.com/steipete/gogcli/issues/86)"
+	case "linux":
+		return "D-Bus SecretService may be unresponsive"
+	default:
+		return "keyring backend may be unresponsive"
 	}
 }
 

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -180,6 +180,30 @@ func TestKeyringDbusGuards(t *testing.T) {
 			wantForce:   false,
 			wantTimeout: false,
 		},
+		{
+			name:        "darwin auto uses timeout",
+			goos:        "darwin",
+			backend:     "auto",
+			dbusAddr:    "",
+			wantForce:   false,
+			wantTimeout: true,
+		},
+		{
+			name:        "darwin keychain uses timeout",
+			goos:        "darwin",
+			backend:     "keychain",
+			dbusAddr:    "",
+			wantForce:   false,
+			wantTimeout: true,
+		},
+		{
+			name:        "darwin explicit file no timeout",
+			goos:        "darwin",
+			backend:     "file",
+			dbusAddr:    "",
+			wantForce:   false,
+			wantTimeout: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -191,6 +215,26 @@ func TestKeyringDbusGuards(t *testing.T) {
 
 			if got := shouldUseKeyringTimeout(tt.goos, info, tt.dbusAddr); got != tt.wantTimeout {
 				t.Fatalf("shouldUseKeyringTimeout=%v, want %v", got, tt.wantTimeout)
+			}
+		})
+	}
+}
+
+func TestKeyringTimeoutHint(t *testing.T) {
+	tests := []struct {
+		goos        string
+		wantSubstr  string
+	}{
+		{"darwin", "Always Allow"},
+		{"linux", "D-Bus SecretService"},
+		{"windows", "keyring backend"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			hint := keyringTimeoutHint(tt.goos)
+			if !strings.Contains(hint, tt.wantSubstr) {
+				t.Fatalf("keyringTimeoutHint(%q) = %q; want substring %q", tt.goos, hint, tt.wantSubstr)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #513.

## The bug

After upgrading gogcli via Homebrew, every command that reads stored tokens (`gog auth list`, `gog gmail search`, etc.) hangs indefinitely on macOS and is eventually SIGKILL'd — no output, no prompt, no actionable error.

The root cause is that the `keyring.Open()` timeout safety net introduced for headless Linux (#XXX) only fires when `goos == "linux"`. On macOS, the Security framework waits for a Keychain GUI permission prompt that can't surface in non-interactive contexts (cron jobs, agents, subprocesses) — or, per the existing comment referencing #86, after a Homebrew upgrade installs a new binary hash and the previous "Always Allow" grant no longer applies. The process just hangs.

## The fix

Extend `shouldUseKeyringTimeout` to include `darwin` when the backend is `auto` or `keychain`. If the Keychain doesn't respond within the timeout, return a clear error with platform-specific guidance instead of hanging forever.

Also bump the timeout from 5s → 10s to tolerate slower macOS Keychain responses on first post-upgrade access (still short enough to feel like a real error, long enough to not false-positive on a cold keychain).

## Error message before

```
$ gog auth list
(hangs forever, then SIGKILL with no output)
```

## Error message after

```
$ gog auth list
Error: keyring open timed out after 10s (macOS Keychain may be waiting for a
permission prompt — run `gog auth list` from a terminal and click "Always Allow"
when prompted (common after Homebrew upgrades; see
https://github.com/steipete/gogcli/issues/86)); set GOG_KEYRING_BACKEND=file
and GOG_KEYRING_PASSWORD=<password> to use encrypted file storage instead
```

## What's covered

| Platform / backend       | Pre-PR timeout | Post-PR timeout |
|--------------------------|----------------|-----------------|
| Linux auto + D-Bus       | ✅ 5s          | ✅ 10s          |
| Linux auto, no D-Bus     | n/a (forced to file) | n/a    |
| Linux explicit file      | n/a            | n/a             |
| **macOS auto**           | ❌ hangs        | ✅ 10s          |
| **macOS keychain**       | ❌ hangs        | ✅ 10s          |
| macOS explicit file      | n/a            | n/a             |
| Windows auto             | n/a            | n/a             |

## Tests

- Extends `TestKeyringDbusGuards` with three darwin cases: `auto` → timeout, `keychain` → timeout, `file` → no timeout
- New `TestKeyringTimeoutHint` verifies platform-specific hint text for darwin/linux/windows
- Existing `TestOpenKeyringWithTimeout_Timeout` still passes (my change kept the `GOG_KEYRING_BACKEND=file` fallback text the test asserts on)

## Why 10s instead of 5s

On macOS, Keychain can briefly block when it's cold (first access after login, or first access after a binary-hash change). 5s was occasionally false-positive even when the prompt would eventually surface. 10s is comfortably long enough for a real prompt to complete while still failing fast on a deadlocked Security framework.

## Caveat / follow-up

The hang is really in `keyring.Keys()` on subsequent calls if the permission grant isn't cached — but in practice `keyring.Open()` probes the backend during construction, which is where the GUI prompt is triggered, so timing out `Open()` catches almost all real-world cases. A full-coverage fix would also wrap `Keys()`/`Get()` with a timeout, but that's more invasive and deserves a separate PR.

## Discovery

I hit this the night after #513 — upgraded from v0.12.0 to v0.13.0 via `brew upgrade`, and every `gog` command that touched auth hung. Rolled back to v0.12.0 (same OAuth tokens in Keychain), everything worked instantly again. Didn't re-upgrade until I could trace it.

Tested manually on:
- macOS 15.3.1 (build 24D70) — Apple Silicon (arm64)
- Existing keychain items from a prior v0.12.0 install
