### PR TITLE
fix(drafts): use existing draft message ID for In-Reply-To/References headers

### DIFF
--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -601,6 +601,9 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if strings.TrimSpace(replyToMessageID) == "" {
 		replyToThreadID = existingThreadID
 	}
+	if strings.TrimSpace(replyToMessageID) == "" && strings.TrimSpace(existingMessageID) != "" {
+		replyToMessageID = existingMessageID
+	}
 	if c.Quote && strings.TrimSpace(replyToMessageID) == "" && strings.TrimSpace(replyToThreadID) == "" {
 		return usage("--quote requires --reply-to-message-id or existing draft thread")
 	}


### PR DESCRIPTION
Fixes #512

When updating a draft with --quote but without --reply-to-message-id, the existing draft's message ID (existingMessageID) was fetched but never used to set the In-Reply-To and References headers. This caused replies to lose proper threading information.

The fix ensures that when no --reply-to-message-id is explicitly provided, the existing draft's message ID is used as a fallback, maintaining proper email threading.