### PR TITLE
fix: support client aliases for subdomain email accounts

### DIFF
--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -248,8 +248,12 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return fmt.Errorf("fetch authorized email: %w", err)
 	}
-	if normalizeEmail(authorizedEmail) != normalizeEmail(c.Email) {
-		return fmt.Errorf("authorized as %s, expected %s", authorizedEmail, c.Email)
+	// If c.Email looks like a client name (no "@"), skip the email match check —
+	// the user intentionally authorized with a client alias.
+	if strings.Contains(normalizeEmail(c.Email), "@") {
+		if normalizeEmail(authorizedEmail) != normalizeEmail(c.Email) {
+			return fmt.Errorf("authorized as %s, expected %s", authorizedEmail, c.Email)
+		}
 	}
 
 	store, err := openSecretsStore()

--- a/internal/cmd/auth_add_test.go
+++ b/internal/cmd/auth_add_test.go
@@ -200,6 +200,38 @@ func TestAuthAddCmd_KeepRejected(t *testing.T) {
 	}
 }
 
+func TestAuthAddCmd_ClientAliasSkipsEmailCheck(t *testing.T) {
+	// When a bare client name (no "@") is passed, the authorized email check
+	// should be skipped — the user is intentionally using a client alias.
+	origAuth := authorizeGoogle
+	origOpen := openSecretsStore
+	origKeychain := ensureKeychainAccess
+	origFetch := fetchAuthorizedEmail
+	t.Cleanup(func() {
+		authorizeGoogle = origAuth
+		openSecretsStore = origOpen
+		ensureKeychainAccess = origKeychain
+		fetchAuthorizedEmail = origFetch
+	})
+
+	ensureKeychainAccess = func() error { return nil }
+	store := newMemSecretsStore()
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+	authorizeGoogle = func(context.Context, googleauth.AuthorizeOptions) (string, error) {
+		return "rt", nil
+	}
+	fetchAuthorizedEmail = func(context.Context, string, string, []string, time.Duration) (string, error) {
+		// Authorized email has a different domain than the client alias
+		return "user@sub.company.ai", nil
+	}
+
+	// "company.ai" has no "@" so it's a client alias — should succeed without mismatch error
+	err := Execute([]string{"auth", "add", "company.ai", "--services", "gmail"})
+	if err != nil {
+		t.Fatalf("expected success with client alias, got: %v", err)
+	}
+}
+
 func TestAuthAddCmd_EmailMismatch(t *testing.T) {
 	origAuth := authorizeGoogle
 	origOpen := openSecretsStore

--- a/internal/config/clients.go
+++ b/internal/config/clients.go
@@ -83,6 +83,12 @@ func ResolveClientForAccount(cfg File, email string, override string) (string, e
 	}
 
 	email = strings.ToLower(strings.TrimSpace(email))
+
+	// If input has no "@", treat it as a direct client name (e.g. "baher.ai")
+	if email != "" && !strings.Contains(email, "@") {
+		return NormalizeClientNameOrDefault(email)
+	}
+
 	if email != "" {
 		if client, ok := cfg.AccountClients[email]; ok && strings.TrimSpace(client) != "" {
 			return NormalizeClientNameOrDefault(client)

--- a/internal/config/clients_test.go
+++ b/internal/config/clients_test.go
@@ -226,6 +226,36 @@ func TestResolveClientForAccount(t *testing.T) {
 			t.Fatalf("got %q, want %q", got, DefaultClientName)
 		}
 	})
+
+	t.Run("client name without @ is used as-is", func(t *testing.T) {
+		// When a bare client name like "company.ai" is passed (no @),
+		// it should be returned directly as the client name.
+		cfg := File{}
+		got, err := ResolveClientForAccount(cfg, "company.ai", "")
+		if err != nil {
+			t.Fatalf("ResolveClientForAccount: %v", err)
+		}
+		if got != "company.ai" {
+			t.Fatalf("got %q, want %q", got, "company.ai")
+		}
+	})
+
+	t.Run("subdomain email routes via account_clients mapping", func(t *testing.T) {
+		// Emails with subdomain domains (e.g. user@sub.company.ai) should be
+		// routable via account_clients config to the correct client.
+		cfg := File{
+			AccountClients: map[string]string{
+				"user@sub.company.ai": "company.ai",
+			},
+		}
+		got, err := ResolveClientForAccount(cfg, "user@sub.company.ai", "")
+		if err != nil {
+			t.Fatalf("ResolveClientForAccount: %v", err)
+		}
+		if got != "company.ai" {
+			t.Fatalf("got %q, want %q", got, "company.ai")
+		}
+	})
 }
 
 func TestListClientCredentials(t *testing.T) {


### PR DESCRIPTION
## Problem

When using `gog auth add` with a client alias for an account whose email has a subdomain (e.g. `user@sub.company.ai`), auth fails with:

```
authorized as user@sub.company.ai, expected company.ai
```

This affects any Google Workspace account on a subdomain domain (e.g. `baher@medicus.ai` using client alias `baher.ai`). Two bugs combine to cause this:

1. **`auth_add.go`**: The OAuth-authorized email is compared against the alias name, which never matches a bare client name, so the token is never saved.
2. **`clients.go`**: `ResolveClientForAccount` treats any input without `@` as a malformed email with no domain, falling through to `DefaultClientName` instead of treating it as a direct client name.

## Fix

- **`auth_add.go`**: Skip the email match check when `c.Email` has no `@` — the caller is intentionally using a client alias, not an email address.
- **`clients.go`**: Treat any input without `@` as a direct client name rather than attempting email/domain parsing.

## Usage after fix

```bash
# One-time setup in config.json:
# { "account_clients": { "user@sub.company.ai": "company.ai" } }

gog auth add company.ai --services gmail,calendar,drive,...
# sign in as user@sub.company.ai in the browser

gog gmail search "newer_than:1d" --account user@sub.company.ai  # works
```

## Tests

Added two new test cases:
- `TestAuthAddCmd_ClientAliasSkipsEmailCheck` — verifies auth succeeds when a client alias is passed
- `ResolveClientForAccount/client name without @ is used as-is` — verifies bare client name is returned directly
- `ResolveClientForAccount/subdomain email routes via account_clients mapping` — verifies subdomain email routing via config

All existing tests pass.