### PR TITLE
fix(drive): include driveId in field masks for list/search/get

### DIFF
--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -123,7 +123,7 @@ func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	f, err := svc.Files.Get(fileID).
 		SupportsAllDrives(true).
-		Fields("id, name, mimeType, size, modifiedTime, createdTime, parents, webViewLink, description, starred").
+		Fields("id, name, mimeType, size, modifiedTime, createdTime, parents, webViewLink, description, starred, driveId").
 		Context(ctx).
 		Do()
 	if err != nil {

--- a/internal/cmd/drive_driveid_field_test.go
+++ b/internal/cmd/drive_driveid_field_test.go
@@ -1,0 +1,17 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDriveFileListFields_IncludesDriveId guards against future regressions
+// where driveId gets removed from the shared field mask. Without driveId
+// in the mask, the Drive API will not return it in responses, making it
+// impossible for callers to distinguish My Drive files from Shared Drive
+// files in gog JSON output.
+func TestDriveFileListFields_IncludesDriveId(t *testing.T) {
+	if !strings.Contains(driveFileListFields, "driveId") {
+		t.Fatalf("driveFileListFields must include driveId; got %q", driveFileListFields)
+	}
+}

--- a/internal/cmd/drive_listing.go
+++ b/internal/cmd/drive_listing.go
@@ -12,7 +12,7 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
-const driveFileListFields = "nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink, owners(emailAddress))"
+const driveFileListFields = "nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink, owners(emailAddress), driveId)"
 
 type driveFileListOptions struct {
 	query     string


### PR DESCRIPTION
## Summary
- Adds `driveId` to the shared field mask in `driveFileListFields` (drives `drive ls`, `drive search`) and to the inline `Fields(...)` call in `DriveGetCmd.Run` (`drive get`).
- The Drive API only returns fields explicitly requested in `fields`; with `driveId` omitted, JSON output never included it even for files living in a Shared Drive, making it impossible to distinguish My Drive vs. Shared Drive files from `gog` output alone.
- For My Drive files the API omits the field, so existing consumers are unaffected. Shared Drive files now carry `driveId` through.
- Adds `internal/cmd/drive_driveid_field_test.go` pinning `driveId` in the shared mask constant.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./internal/cmd/... -count=1 -timeout 60s`
- [x] `go test ./internal/cmd/... -run TestDriveFileListFields -count=1 -v` (new test passes)
- [x] Manual spot check: `gog drive ls --all-drives --format=json` on an account with Shared Drive access shows `driveId` for Shared Drive files and omits it for My Drive files
- [x] Manual spot check: `gog drive get <sharedDriveFileId> --format=json` includes `driveId`