### PR TITLE
fix(secrets): make file keyring filenames Windows-safe (#502)

### DIFF
--- a/internal/secrets/filename_safe.go
+++ b/internal/secrets/filename_safe.go
@@ -1,0 +1,276 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/99designs/keyring"
+)
+
+// isInvalidFilenameError reports whether err is the platform-specific signal
+// that the underlying filesystem rejected a path because the filename
+// contains characters it considers illegal (e.g. NTFS rejecting ":" via
+// ERROR_INVALID_NAME on Windows). Tests swap this to simulate other
+// platforms; the runtime default is wired up per-OS via
+// filename_safe_{windows,other}.go.
+var isInvalidFilenameError = defaultIsInvalidFilenameError
+
+// isNotFound treats keyring.ErrKeyNotFound, fs.ErrNotExist, and the
+// platform-specific "filename invalid" signal as "not found". The third case
+// matters on Windows: the 99designs/keyring file backend forwards
+// ERROR_INVALID_NAME from os.OpenFile/os.Remove rather than translating to
+// the keyring sentinel, so a raw-key fallback for a path with NTFS-illegal
+// characters would otherwise look like a hard error to callers branching on
+// ErrKeyNotFound.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+
+	return isInvalidFilenameError(err)
+}
+
+// safeFilenameMap lists characters that are illegal in NTFS / Windows
+// filenames plus "%" itself, so percent-style encoding is self-inverse. The
+// 99designs/keyring file backend already escapes "/" via percent.Encode, so
+// it is omitted.
+//
+// Order matters: "%" -> "%25" must run first on encode and last on decode.
+//
+// Not handled here, on purpose: Windows reserved device names (CON, PRN,
+// AUX, NUL, COM1-9, LPT1-9), trailing spaces / dots, and ASCII control
+// characters. The gogcli key namespace ("token:<client>:<email>",
+// "default_account[:<client>]") cannot produce any of those forms; if a
+// future caller wires arbitrary user input through SetSecret, this list is
+// the place to extend.
+var safeFilenameMap = []struct {
+	raw     string
+	encoded string
+}{
+	{`%`, "%25"},
+	{`:`, "%3A"},
+	{`<`, "%3C"},
+	{`>`, "%3E"},
+	{`"`, "%22"},
+	{`|`, "%7C"},
+	{`?`, "%3F"},
+	{`*`, "%2A"},
+	{`\`, "%5C"},
+}
+
+// encodedKeyPrefix marks item keys that fileSafeKeyring rewrote so Keys()
+// can distinguish wrapper-written entries from legacy raw-form files. Older
+// gogcli versions wrote keys directly (e.g. "token:default:foo@bar.com"),
+// none of which start with this sentinel.
+//
+// Choosing a printable, filesystem-safe sentinel (vs. percent-encoded NULs
+// or high-bit Unicode) keeps the on-disk filenames human-debuggable on every
+// platform.
+const encodedKeyPrefix = "_v1_"
+
+// needsFilenameEncoding reports whether s contains any character that the
+// file keyring backend would persist as an illegal NTFS filename byte, or
+// whether it collides with the encodedKeyPrefix sentinel and therefore must
+// be encoded to round-trip cleanly through Keys() / decodeFilenameKey.
+func needsFilenameEncoding(s string) bool {
+	if strings.HasPrefix(s, encodedKeyPrefix) {
+		return true
+	}
+
+	for _, p := range safeFilenameMap {
+		if strings.Contains(s, p.raw) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// encodeFilenameKey percent-encodes Windows-illegal characters in key and
+// prepends encodedKeyPrefix so fileSafeKeyring can recognise its own writes
+// later. Keys with no encodable character pass through unchanged so existing
+// macOS/Linux keyring directories remain readable without manual migration.
+func encodeFilenameKey(key string) string {
+	if !needsFilenameEncoding(key) {
+		return key
+	}
+
+	out := key
+	for _, p := range safeFilenameMap {
+		out = strings.ReplaceAll(out, p.raw, p.encoded)
+	}
+
+	return encodedKeyPrefix + out
+}
+
+// decodeFilenameKey reverses encodeFilenameKey. Names lacking
+// encodedKeyPrefix are treated as legacy raw-form keys and returned
+// unchanged, which avoids corrupting any pre-existing item whose key
+// happened to contain a literal "%XX" sequence.
+func decodeFilenameKey(name string) string {
+	if !strings.HasPrefix(name, encodedKeyPrefix) {
+		return name
+	}
+
+	out := strings.TrimPrefix(name, encodedKeyPrefix)
+
+	for i := len(safeFilenameMap) - 1; i >= 0; i-- {
+		p := safeFilenameMap[i]
+		out = strings.ReplaceAll(out, p.encoded, p.raw)
+	}
+
+	return out
+}
+
+// fileSafeKeyring wraps a keyring.Keyring (intended for the file backend) and
+// percent-encodes NTFS-illegal characters in item keys so filenames are
+// portable across operating systems.
+//
+// Reads fall back to the raw (un-encoded) key form so file-keyring directories
+// written by older gogcli versions on macOS/Linux keep working without a
+// manual migration. Writes opportunistically remove the legacy file once the
+// new encoded form has been persisted.
+type fileSafeKeyring struct {
+	inner keyring.Keyring
+}
+
+func newFileSafeKeyring(inner keyring.Keyring) *fileSafeKeyring {
+	return &fileSafeKeyring{inner: inner}
+}
+
+func (k *fileSafeKeyring) Get(key string) (keyring.Item, error) {
+	encoded := encodeFilenameKey(key)
+	if encoded != key {
+		if it, err := k.inner.Get(encoded); err == nil {
+			it.Key = key
+
+			return it, nil
+		} else if !isNotFound(err) {
+			return keyring.Item{}, fmt.Errorf("file keyring get: %w", err)
+		}
+	}
+
+	it, err := k.inner.Get(key)
+	if err != nil {
+		if isNotFound(err) {
+			return keyring.Item{}, keyring.ErrKeyNotFound
+		}
+
+		return keyring.Item{}, fmt.Errorf("file keyring get: %w", err)
+	}
+
+	it.Key = key
+
+	return it, nil
+}
+
+func (k *fileSafeKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	encoded := encodeFilenameKey(key)
+	if encoded != key {
+		if md, err := k.inner.GetMetadata(encoded); err == nil {
+			return md, nil
+		} else if !isNotFound(err) {
+			return keyring.Metadata{}, fmt.Errorf("file keyring metadata: %w", err)
+		}
+	}
+
+	md, err := k.inner.GetMetadata(key)
+	if err != nil {
+		if isNotFound(err) {
+			return keyring.Metadata{}, keyring.ErrKeyNotFound
+		}
+
+		return keyring.Metadata{}, fmt.Errorf("file keyring metadata: %w", err)
+	}
+
+	return md, nil
+}
+
+func (k *fileSafeKeyring) Set(item keyring.Item) error {
+	encoded := encodeFilenameKey(item.Key)
+
+	stored := item
+	stored.Key = encoded
+
+	if err := k.inner.Set(stored); err != nil {
+		return fmt.Errorf("file keyring set: %w", err)
+	}
+
+	// Best-effort: remove a legacy raw-key file written by older versions so
+	// Keys() does not return duplicates after the in-place migration. Failure
+	// is non-fatal — a subsequent Set/Remove will retry. isNotFound also
+	// classifies the platform's "filename invalid" error as not-found, so on
+	// Windows + file backend (where the legacy filename can't exist anyway)
+	// the call collapses harmlessly.
+	if encoded != item.Key {
+		if err := k.inner.Remove(item.Key); err != nil && !isNotFound(err) {
+			_ = err
+		}
+	}
+
+	return nil
+}
+
+func (k *fileSafeKeyring) Remove(key string) error {
+	encoded := encodeFilenameKey(key)
+
+	encErr := k.inner.Remove(encoded)
+	if encErr != nil && !isNotFound(encErr) {
+		return fmt.Errorf("file keyring remove: %w", encErr)
+	}
+
+	encMissing := isNotFound(encErr)
+
+	if encoded == key {
+		if encMissing {
+			return keyring.ErrKeyNotFound
+		}
+
+		return nil
+	}
+
+	// Try legacy raw-form cleanup. isNotFound treats both
+	// keyring.ErrKeyNotFound and the platform "filename invalid" signal
+	// (Windows ERROR_INVALID_NAME for NTFS-illegal paths) as "nothing to
+	// clean up", so this call collapses harmlessly when the legacy file
+	// could never have existed on the underlying filesystem.
+	rawErr := k.inner.Remove(key)
+	if rawErr != nil && !isNotFound(rawErr) {
+		return fmt.Errorf("file keyring remove: %w", rawErr)
+	}
+
+	if encMissing && isNotFound(rawErr) {
+		return keyring.ErrKeyNotFound
+	}
+
+	return nil
+}
+
+func (k *fileSafeKeyring) Keys() ([]string, error) {
+	raw, err := k.inner.Keys()
+	if err != nil {
+		return nil, fmt.Errorf("file keyring list: %w", err)
+	}
+
+	out := make([]string, 0, len(raw))
+	seen := make(map[string]struct{}, len(raw))
+
+	for _, name := range raw {
+		decoded := decodeFilenameKey(name)
+		if _, ok := seen[decoded]; ok {
+			continue
+		}
+
+		seen[decoded] = struct{}{}
+
+		out = append(out, decoded)
+	}
+
+	return out, nil
+}

--- a/internal/secrets/filename_safe_other.go
+++ b/internal/secrets/filename_safe_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package secrets
+
+// defaultIsInvalidFilenameError on non-Windows platforms always returns false:
+// no syscall.Errno equivalent of ERROR_INVALID_NAME exists, and the filesystem
+// rules that produce it (NTFS reserved characters) don't apply here.
+func defaultIsInvalidFilenameError(_ error) bool {
+	return false
+}

--- a/internal/secrets/filename_safe_other_test.go
+++ b/internal/secrets/filename_safe_other_test.go
@@ -1,0 +1,17 @@
+//go:build !windows
+
+package secrets
+
+import (
+	"testing"
+)
+
+func TestDefaultIsInvalidFilenameError_OnNonWindowsAlwaysFalse(t *testing.T) {
+	if defaultIsInvalidFilenameError(nil) {
+		t.Errorf("defaultIsInvalidFilenameError(nil) = true, want false")
+	}
+
+	if defaultIsInvalidFilenameError(errFakeInvalidName) {
+		t.Errorf("defaultIsInvalidFilenameError(errFakeInvalidName) = true, want false on non-Windows host")
+	}
+}

--- a/internal/secrets/filename_safe_test.go
+++ b/internal/secrets/filename_safe_test.go
@@ -1,0 +1,648 @@
+package secrets
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/99designs/keyring"
+)
+
+func TestEncodeFilenameKey_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+	}{
+		{"primary token key", "token:default:user@gmail.com"},
+		{"legacy single-colon", "token:user@gmail.com"},
+		{"default account scoped", "default_account:default"},
+		{"all illegal chars", `evil:<>"|?*key`},
+		{"already contains percent", "weird%key:value"},
+		{"plain ascii no encoding", "default_account"},
+		{"empty string", ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded := encodeFilenameKey(tc.raw)
+			decoded := decodeFilenameKey(encoded)
+
+			if decoded != tc.raw {
+				t.Fatalf("round-trip mismatch: raw=%q encoded=%q decoded=%q", tc.raw, encoded, decoded)
+			}
+		})
+	}
+}
+
+func TestEncodeFilenameKey_IsNoopForSafeKeys(t *testing.T) {
+	for _, key := range []string{"default_account", "token", "abcdef", ""} {
+		if got := encodeFilenameKey(key); got != key {
+			t.Fatalf("safe key %q was rewritten to %q; expected unchanged", key, got)
+		}
+	}
+}
+
+func TestEncodeFilenameKey_StripsAllIllegalChars(t *testing.T) {
+	raw := `token:default:foo|bar?baz*qux<x>y"z`
+	encoded := encodeFilenameKey(raw)
+
+	for _, ch := range []string{":", "<", ">", `"`, "|", "?", "*"} {
+		if strings.Contains(encoded, ch) {
+			t.Fatalf("encoded form %q still contains illegal char %q", encoded, ch)
+		}
+	}
+}
+
+func TestDecodeFilenameKey_PassesThroughLegacyNames(t *testing.T) {
+	// Older gogcli versions wrote raw keys directly to disk on Linux/macOS. The
+	// decoder must return them unchanged so existing keyring directories keep
+	// working without manual migration.
+	for _, name := range []string{"token:default:user@example.com", "default_account:default"} {
+		if got := decodeFilenameKey(name); got != name {
+			t.Fatalf("decode rewrote legacy raw filename %q to %q", name, got)
+		}
+	}
+}
+
+func TestNeedsFilenameEncoding(t *testing.T) {
+	cases := map[string]bool{
+		"":                               false,
+		"default_account":                false,
+		"token:user@example.com":         true,
+		"token:default:user@example.com": true,
+		`weird"key`:                      true,
+		"contains%already":               true,
+		`with\backslash`:                 true,
+	}
+
+	for input, want := range cases {
+		if got := needsFilenameEncoding(input); got != want {
+			t.Errorf("needsFilenameEncoding(%q) = %v, want %v", input, got, want)
+		}
+	}
+}
+
+func TestEncodeFilenameKey_PrefixesEncodedKeysOnly(t *testing.T) {
+	encoded := encodeFilenameKey("token:default:user@example.com")
+	if !strings.HasPrefix(encoded, encodedKeyPrefix) {
+		t.Errorf("expected encoded form to start with %q sentinel, got %q", encodedKeyPrefix, encoded)
+	}
+
+	plain := encodeFilenameKey("default_account")
+	if strings.HasPrefix(plain, encodedKeyPrefix) {
+		t.Errorf("plain key was prefixed with sentinel: %q", plain)
+	}
+}
+
+func TestDecodeFilenameKey_PreservesLegacyPercentTriplets(t *testing.T) {
+	// A pre-existing keyring item whose raw key happened to contain "%3A"
+	// must round-trip unchanged, since older gogcli wrote no prefix marker.
+	// Decoding the percent triplet would corrupt the key and stop the
+	// caller from finding the item.
+	legacy := "token:default:user%3Afoo@example.com"
+	if got := decodeFilenameKey(legacy); got != legacy {
+		t.Fatalf("decode rewrote legacy %%XX-bearing key %q to %q", legacy, got)
+	}
+}
+
+func TestEncodeFilenameKey_ReservesSentinelPrefix(t *testing.T) {
+	// A legitimate caller-supplied key that happens to start with
+	// encodedKeyPrefix must round-trip cleanly. If it passed through
+	// unchanged on Set, Keys() would mistakenly strip the prefix and corrupt
+	// the key on read.
+	raw := encodedKeyPrefix + "foo"
+
+	encoded := encodeFilenameKey(raw)
+	if encoded == raw {
+		t.Fatalf("key starting with sentinel %q was not encoded", raw)
+	}
+
+	if !strings.HasPrefix(encoded, encodedKeyPrefix) {
+		t.Fatalf("encoded form lost sentinel prefix: %q", encoded)
+	}
+
+	if got := decodeFilenameKey(encoded); got != raw {
+		t.Fatalf("sentinel-collision round-trip failed: %q -> %q -> %q", raw, encoded, got)
+	}
+}
+
+func TestEncodeFilenameKey_HandlesBackslash(t *testing.T) {
+	raw := `weird\path:thing`
+
+	encoded := encodeFilenameKey(raw)
+	if strings.ContainsAny(encoded, `\:`) {
+		t.Fatalf("encoded form %q still contains Windows-illegal chars", encoded)
+	}
+
+	decoded := decodeFilenameKey(encoded)
+	if decoded != raw {
+		t.Fatalf("backslash round-trip failed: %q -> %q -> %q", raw, encoded, decoded)
+	}
+}
+
+// fileSafeKeyringFixture spins up a real 99designs/keyring file backend backed
+// by a temp directory plus our wrapper. End-to-end tests use this fixture to
+// catch interactions between encoding, the underlying percent-escaping in the
+// upstream library, and on-disk filenames.
+func fileSafeKeyringFixture(t *testing.T) (*fileSafeKeyring, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	inner, err := keyring.Open(keyring.Config{
+		ServiceName:      "gogcli-filename-safe-test",
+		AllowedBackends:  []keyring.BackendType{keyring.FileBackend},
+		FileDir:          dir,
+		FilePasswordFunc: keyring.FixedStringPrompt("test-password"),
+	})
+	if err != nil {
+		t.Fatalf("open file keyring: %v", err)
+	}
+
+	return newFileSafeKeyring(inner), dir
+}
+
+func TestFileSafeKeyring_SetGetRoundTrip(t *testing.T) {
+	ring, dir := fileSafeKeyringFixture(t)
+
+	key := "token:default:user@example.com"
+	payload := []byte(`{"refresh_token":"abc"}`)
+
+	if err := ring.Set(keyring.Item{Key: key, Data: payload, Label: "gogcli"}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	got, err := ring.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if got.Key != key {
+		t.Errorf("returned key %q, want %q (wrapper must hide encoded form from callers)", got.Key, key)
+	}
+
+	if string(got.Data) != string(payload) {
+		t.Errorf("payload mismatch: got %q want %q", got.Data, payload)
+	}
+
+	// On-disk filename must contain no NTFS-illegal chars (the whole point).
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+
+	for _, e := range entries {
+		for _, ch := range []string{":", "<", ">", `"`, "|", "?", "*"} {
+			if strings.Contains(e.Name(), ch) {
+				t.Errorf("on-disk filename %q contains NTFS-illegal char %q", e.Name(), ch)
+			}
+		}
+	}
+}
+
+func TestFileSafeKeyring_KeysRoundTripsEncodedNames(t *testing.T) {
+	ring, _ := fileSafeKeyringFixture(t)
+
+	keys := []string{
+		"token:default:user@example.com",
+		"token:default:other@example.com",
+		"default_account",
+	}
+
+	for _, k := range keys {
+		if err := ring.Set(keyring.Item{Key: k, Data: []byte("x")}); err != nil {
+			t.Fatalf("Set %q: %v", k, err)
+		}
+	}
+
+	got, err := ring.Keys()
+	if err != nil {
+		t.Fatalf("Keys: %v", err)
+	}
+
+	sort.Strings(got)
+
+	wanted := append([]string(nil), keys...)
+	sort.Strings(wanted)
+
+	if strings.Join(got, "|") != strings.Join(wanted, "|") {
+		t.Fatalf("Keys() = %v, want %v", got, wanted)
+	}
+}
+
+func TestFileSafeKeyring_GetFallsBackToLegacyRawFile(t *testing.T) {
+	// Simulate a directory written by an older gogcli version that stored
+	// keys with raw colons. The wrapper must still find them via the
+	// fallback path so users do not have to re-authenticate.
+	ring, dir := fileSafeKeyringFixture(t)
+
+	legacyKey := "token:default:legacy@example.com"
+
+	// Drive the underlying keyring directly with the raw key so the on-disk
+	// filename matches the legacy format. (On NTFS this would already have
+	// failed; this test runs on the host's filesystem which accepts colons.)
+	if err := ring.inner.Set(keyring.Item{Key: legacyKey, Data: []byte("legacy-data")}); err != nil {
+		t.Fatalf("seed legacy item: %v", err)
+	}
+
+	// Verify the fixture really wrote a raw-form file (otherwise the test
+	// is vacuous).
+	if _, err := os.Stat(filepath.Join(dir, legacyKey)); err != nil {
+		t.Skipf("filesystem rejected legacy filename (likely Windows); fallback path is irrelevant here: %v", err)
+	}
+
+	got, err := ring.Get(legacyKey)
+	if err != nil {
+		t.Fatalf("Get legacy key: %v", err)
+	}
+
+	if string(got.Data) != "legacy-data" {
+		t.Errorf("legacy fallback returned %q, want %q", got.Data, "legacy-data")
+	}
+
+	if got.Key != legacyKey {
+		t.Errorf("returned key %q, want %q", got.Key, legacyKey)
+	}
+}
+
+func TestFileSafeKeyring_SetMigratesLegacyFile(t *testing.T) {
+	ring, dir := fileSafeKeyringFixture(t)
+
+	key := "token:default:migrate@example.com"
+
+	if err := ring.inner.Set(keyring.Item{Key: key, Data: []byte("old")}); err != nil {
+		t.Fatalf("seed legacy item: %v", err)
+	}
+
+	legacyPath := filepath.Join(dir, key)
+	if _, err := os.Stat(legacyPath); err != nil {
+		t.Skipf("filesystem rejected legacy filename; migration test is irrelevant: %v", err)
+	}
+
+	if err := ring.Set(keyring.Item{Key: key, Data: []byte("new")}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Errorf("legacy file %s still present after Set; expected best-effort cleanup. err=%v", legacyPath, err)
+	}
+
+	got, err := ring.Get(key)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	if string(got.Data) != "new" {
+		t.Errorf("post-migration payload = %q, want %q", got.Data, "new")
+	}
+}
+
+func TestFileSafeKeyring_RemoveEncodedAndLegacy(t *testing.T) {
+	ring, dir := fileSafeKeyringFixture(t)
+
+	key := "token:default:rm@example.com"
+
+	// Seed both a legacy raw file and a new encoded file for the same key,
+	// to exercise dual cleanup.
+	if err := ring.inner.Set(keyring.Item{Key: key, Data: []byte("legacy")}); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+
+	if err := ring.inner.Set(keyring.Item{Key: encodeFilenameKey(key), Data: []byte("new")}); err != nil {
+		t.Fatalf("seed encoded: %v", err)
+	}
+
+	if err := ring.Remove(key); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+
+	for _, e := range entries {
+		decoded := decodeFilenameKey(e.Name())
+		if decoded == key {
+			t.Errorf("file %q (decoded %q) still present after Remove", e.Name(), decoded)
+		}
+	}
+}
+
+func TestFileSafeKeyring_GetMetadataPrefersEncodedThenLegacy(t *testing.T) {
+	ring, dir := fileSafeKeyringFixture(t)
+
+	encodedKey := "token:default:meta@example.com"
+
+	if err := ring.Set(keyring.Item{Key: encodedKey, Data: []byte("x")}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	md, err := ring.GetMetadata(encodedKey)
+	if err != nil {
+		t.Fatalf("GetMetadata encoded: %v", err)
+	}
+
+	if md.ModificationTime.IsZero() {
+		t.Errorf("GetMetadata returned zero ModificationTime")
+	}
+
+	// Now seed a legacy-only key (raw filename, no wrapper Set) and confirm
+	// GetMetadata reaches it via the fallback branch.
+	legacyKey := "token:default:legacy-meta@example.com"
+	if err := ring.inner.Set(keyring.Item{Key: legacyKey, Data: []byte("y")}); err != nil {
+		t.Fatalf("seed legacy: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, legacyKey)); err != nil {
+		t.Skipf("filesystem rejected legacy filename; fallback path is irrelevant: %v", err)
+	}
+
+	if _, err := ring.GetMetadata(legacyKey); err != nil {
+		t.Fatalf("GetMetadata legacy fallback: %v", err)
+	}
+}
+
+func TestFileSafeKeyring_GetMetadataMissing(t *testing.T) {
+	ring, _ := fileSafeKeyringFixture(t)
+
+	_, err := ring.GetMetadata("token:default:does-not-exist@example.com")
+	if !errors.Is(err, keyring.ErrKeyNotFound) && !errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("GetMetadata of missing key: got %v, want ErrKeyNotFound or fs.ErrNotExist", err)
+	}
+}
+
+func TestFileSafeKeyring_RemoveMissingReturnsErrKeyNotFound(t *testing.T) {
+	ring, _ := fileSafeKeyringFixture(t)
+
+	err := ring.Remove("token:default:does-not-exist@example.com")
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("Remove of missing key: got %v, want ErrKeyNotFound", err)
+	}
+}
+
+func TestFileSafeKeyring_GetMissingReturnsErrKeyNotFound(t *testing.T) {
+	ring, _ := fileSafeKeyringFixture(t)
+
+	_, err := ring.Get("token:default:does-not-exist@example.com")
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("Get of missing key: got %v, want ErrKeyNotFound", err)
+	}
+}
+
+// errFakeInvalidName mimics Windows ERROR_INVALID_NAME so platform-behaviour
+// tests can drive fileSafeKeyring's "raw fallback would fail" code paths
+// without needing an actual NTFS volume.
+var errFakeInvalidName = errors.New("fake: filename invalid for backing filesystem")
+
+// windowsLikeIllegalRunes is the set of characters fakeInnerKeyring rejects,
+// matching the NTFS-illegal set fileSafeKeyring percent-encodes.
+const windowsLikeIllegalRunes = `:<>"|?*\`
+
+// fakeInnerKeyring stands in for the 99designs/keyring file backend during
+// platform-behaviour tests. Any key containing a rune in
+// windowsLikeIllegalRunes returns errFakeInvalidName from Get / GetMetadata /
+// Set / Remove, mimicking the way Windows surfaces ERROR_INVALID_NAME for
+// NTFS-illegal filenames.
+type fakeInnerKeyring struct {
+	store             map[string][]byte
+	removeAttemptKeys []string
+}
+
+func newFakeInnerKeyring() *fakeInnerKeyring {
+	return &fakeInnerKeyring{store: map[string][]byte{}}
+}
+
+func (f *fakeInnerKeyring) wouldReject(key string) bool {
+	return strings.ContainsAny(key, windowsLikeIllegalRunes)
+}
+
+func (f *fakeInnerKeyring) Get(key string) (keyring.Item, error) {
+	if f.wouldReject(key) {
+		return keyring.Item{}, errFakeInvalidName
+	}
+
+	data, ok := f.store[key]
+	if !ok {
+		return keyring.Item{}, keyring.ErrKeyNotFound
+	}
+
+	return keyring.Item{Key: key, Data: data}, nil
+}
+
+func (f *fakeInnerKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	if f.wouldReject(key) {
+		return keyring.Metadata{}, errFakeInvalidName
+	}
+
+	if _, ok := f.store[key]; !ok {
+		return keyring.Metadata{}, keyring.ErrKeyNotFound
+	}
+
+	return keyring.Metadata{}, nil
+}
+
+func (f *fakeInnerKeyring) Set(item keyring.Item) error {
+	if f.wouldReject(item.Key) {
+		return errFakeInvalidName
+	}
+
+	f.store[item.Key] = item.Data
+
+	return nil
+}
+
+func (f *fakeInnerKeyring) Remove(key string) error {
+	f.removeAttemptKeys = append(f.removeAttemptKeys, key)
+
+	if f.wouldReject(key) {
+		return errFakeInvalidName
+	}
+
+	if _, ok := f.store[key]; !ok {
+		return keyring.ErrKeyNotFound
+	}
+
+	delete(f.store, key)
+
+	return nil
+}
+
+func (f *fakeInnerKeyring) Keys() ([]string, error) {
+	out := make([]string, 0, len(f.store))
+	for k := range f.store {
+		out = append(out, k)
+	}
+
+	return out, nil
+}
+
+// withFakeInvalidFilenameClassifier swaps isInvalidFilenameError for one
+// that recognises errFakeInvalidName for the duration of the test. This
+// lets cross-platform CI exercise the Windows ERROR_INVALID_NAME branches
+// without needing an NTFS volume.
+func withFakeInvalidFilenameClassifier(t *testing.T) {
+	t.Helper()
+
+	previous := isInvalidFilenameError
+	isInvalidFilenameError = func(err error) bool {
+		return errors.Is(err, errFakeInvalidName)
+	}
+
+	t.Cleanup(func() { isInvalidFilenameError = previous })
+}
+
+func TestFileSafeKeyring_GetTranslatesInvalidFilenameToErrKeyNotFound(t *testing.T) {
+	withFakeInvalidFilenameClassifier(t)
+
+	inner := newFakeInnerKeyring()
+	ring := newFileSafeKeyring(inner)
+
+	_, err := ring.Get("token:default:does-not-exist@example.com")
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("Get with NTFS-illegal raw key: got %v, want ErrKeyNotFound", err)
+	}
+}
+
+func TestFileSafeKeyring_GetMetadataTranslatesInvalidFilenameToErrKeyNotFound(t *testing.T) {
+	withFakeInvalidFilenameClassifier(t)
+
+	inner := newFakeInnerKeyring()
+	ring := newFileSafeKeyring(inner)
+
+	_, err := ring.GetMetadata("token:default:does-not-exist@example.com")
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("GetMetadata with NTFS-illegal raw key: got %v, want ErrKeyNotFound", err)
+	}
+}
+
+func TestFileSafeKeyring_RemoveSurvivesInvalidFilenameLegacyCleanup(t *testing.T) {
+	withFakeInvalidFilenameClassifier(t)
+
+	inner := newFakeInnerKeyring()
+	ring := newFileSafeKeyring(inner)
+
+	key := "token:default:rm@example.com"
+	if err := ring.Set(keyring.Item{Key: key, Data: []byte("x")}); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+
+	// Remove must not surface the inner's invalid-filename error from the
+	// raw-form cleanup attempt as a failure: the encoded form was deleted
+	// successfully and the legacy form provably can't exist.
+	if err := ring.Remove(key); err != nil {
+		t.Fatalf("Remove with NTFS-illegal raw key: got %v, want nil", err)
+	}
+}
+
+func TestFileSafeKeyring_RemoveMissingTranslatesInvalidFilename(t *testing.T) {
+	withFakeInvalidFilenameClassifier(t)
+
+	inner := newFakeInnerKeyring()
+	ring := newFileSafeKeyring(inner)
+
+	err := ring.Remove("token:default:missing@example.com")
+	if !errors.Is(err, keyring.ErrKeyNotFound) {
+		t.Fatalf("Remove of missing key with NTFS-illegal raw key: got %v, want ErrKeyNotFound", err)
+	}
+}
+
+func TestFileSafeKeyring_SetSurvivesInvalidFilenameLegacyCleanup(t *testing.T) {
+	withFakeInvalidFilenameClassifier(t)
+
+	inner := newFakeInnerKeyring()
+	ring := newFileSafeKeyring(inner)
+
+	key := "token:default:setwin@example.com"
+	// Set must succeed even though the best-effort legacy cleanup of the
+	// raw-form key would surface invalid-filename from the inner backend.
+	if err := ring.Set(keyring.Item{Key: key, Data: []byte("x")}); err != nil {
+		t.Fatalf("Set with NTFS-illegal raw key: got %v, want nil", err)
+	}
+}
+
+// acceptingFakeKeyring stands in for backends like Windows WinCred that
+// store opaque strings and accept colon-bearing keys verbatim. It exists
+// to verify that fileSafeKeyring's raw-key fallback still finds legacy
+// items after the wrapper is layered on top of a non-file backend.
+type acceptingFakeKeyring struct {
+	store map[string][]byte
+}
+
+func newAcceptingFakeKeyring() *acceptingFakeKeyring {
+	return &acceptingFakeKeyring{store: map[string][]byte{}}
+}
+
+func (f *acceptingFakeKeyring) Get(key string) (keyring.Item, error) {
+	data, ok := f.store[key]
+	if !ok {
+		return keyring.Item{}, keyring.ErrKeyNotFound
+	}
+
+	return keyring.Item{Key: key, Data: data}, nil
+}
+
+func (f *acceptingFakeKeyring) GetMetadata(key string) (keyring.Metadata, error) {
+	if _, ok := f.store[key]; !ok {
+		return keyring.Metadata{}, keyring.ErrKeyNotFound
+	}
+
+	return keyring.Metadata{}, nil
+}
+
+func (f *acceptingFakeKeyring) Set(item keyring.Item) error {
+	f.store[item.Key] = item.Data
+
+	return nil
+}
+
+func (f *acceptingFakeKeyring) Remove(key string) error {
+	if _, ok := f.store[key]; !ok {
+		return keyring.ErrKeyNotFound
+	}
+
+	delete(f.store, key)
+
+	return nil
+}
+
+func (f *acceptingFakeKeyring) Keys() ([]string, error) {
+	out := make([]string, 0, len(f.store))
+	for k := range f.store {
+		out = append(out, k)
+	}
+
+	return out, nil
+}
+
+func TestFileSafeKeyring_LegacyKeysSurviveOnAcceptingBackend(t *testing.T) {
+	// Models the Windows WinCred upgrade scenario: existing tokens were
+	// written under raw colon-bearing keys before the shim landed. The
+	// wrapper must still find them via the raw-key fallback, otherwise
+	// upgrading users would silently lose every credential.
+	inner := newAcceptingFakeKeyring()
+
+	legacyKey := "token:default:legacy@example.com"
+	if err := inner.Set(keyring.Item{Key: legacyKey, Data: []byte("legacy")}); err != nil {
+		t.Fatalf("seed legacy item: %v", err)
+	}
+
+	ring := newFileSafeKeyring(inner)
+
+	got, err := ring.Get(legacyKey)
+	if err != nil {
+		t.Fatalf("Get legacy on accepting backend: %v", err)
+	}
+
+	if string(got.Data) != "legacy" {
+		t.Errorf("legacy fallback returned %q, want %q", got.Data, "legacy")
+	}
+
+	if got.Key != legacyKey {
+		t.Errorf("returned key %q, want %q", got.Key, legacyKey)
+	}
+}

--- a/internal/secrets/filename_safe_windows.go
+++ b/internal/secrets/filename_safe_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package secrets
+
+import (
+	"errors"
+	"io/fs"
+	"syscall"
+)
+
+// errorInvalidName is Windows ERROR_INVALID_NAME (0x7B). The 99designs/keyring
+// file backend surfaces it via *fs.PathError when os.OpenFile / os.Remove is
+// called with a path containing characters NTFS rejects (":", "<", etc.).
+const errorInvalidName = syscall.Errno(0x7B)
+
+func defaultIsInvalidFilenameError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var pathErr *fs.PathError
+	if !errors.As(err, &pathErr) {
+		return false
+	}
+
+	var errno syscall.Errno
+
+	return errors.As(pathErr.Err, &errno) && errno == errorInvalidName
+}

--- a/internal/secrets/filename_safe_windows_test.go
+++ b/internal/secrets/filename_safe_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package secrets
+
+import (
+	"errors"
+	"io/fs"
+	"syscall"
+	"testing"
+)
+
+func TestDefaultIsInvalidFilenameError_OnWindows(t *testing.T) {
+	if defaultIsInvalidFilenameError(nil) {
+		t.Errorf("defaultIsInvalidFilenameError(nil) = true, want false")
+	}
+
+	pathErr := &fs.PathError{Op: "open", Path: `C:\foo:bar`, Err: errorInvalidName}
+	if !defaultIsInvalidFilenameError(pathErr) {
+		t.Errorf("defaultIsInvalidFilenameError(ERROR_INVALID_NAME PathError) = false, want true")
+	}
+
+	wrapped := errors.New("wrap: " + pathErr.Error())
+	if defaultIsInvalidFilenameError(wrapped) {
+		t.Errorf("defaultIsInvalidFilenameError(non-PathError) = true, want false")
+	}
+
+	other := &fs.PathError{Op: "open", Path: "C:\\foo", Err: syscall.Errno(2)}
+	if defaultIsInvalidFilenameError(other) {
+		t.Errorf("defaultIsInvalidFilenameError(unrelated errno PathError) = true, want false")
+	}
+}

--- a/internal/secrets/store.go
+++ b/internal/secrets/store.go
@@ -211,7 +211,12 @@ func openKeyring() (keyring.Keyring, error) {
 	// is unresponsive (e.g., gnome-keyring installed but not running).
 	// Use a timeout as a safety net.
 	if shouldUseKeyringTimeout(runtime.GOOS, backendInfo, dbusAddr) {
-		return openKeyringWithTimeout(cfg, keyringOpenTimeout)
+		ring, openErr := openKeyringWithTimeout(cfg, keyringOpenTimeout)
+		if openErr != nil {
+			return nil, openErr
+		}
+
+		return newFileSafeKeyring(ring), nil
 	}
 
 	ring, err := keyringOpenFunc(cfg)
@@ -219,7 +224,14 @@ func openKeyring() (keyring.Keyring, error) {
 		return nil, fmt.Errorf("open keyring: %w", err)
 	}
 
-	return ring, nil
+	// Wrap unconditionally so we cover the auto-fallback case where the
+	// 99designs/keyring opener tries native backends in priority order and
+	// silently lands on the file backend (e.g. Windows + WinCred broken,
+	// Linux + secret-service+kwallet broken). For non-file backends the shim
+	// is effectively a no-op for keys without Windows-illegal characters and
+	// transparently migrates legacy raw-form items on first read/write. See
+	// issue #502.
+	return newFileSafeKeyring(ring), nil
 }
 
 type keyringResult struct {


### PR DESCRIPTION
Closes #502.

## Problem

The `99designs/keyring` file backend writes one file per item, escaping only `/` in filenames via `percent.Encode`. NTFS rejects `:`, `<`, `>`, `"`, `|`, `?`, `*`, and `\`, so token keys like `token:default:user@gmail.com` cannot be persisted on Windows. Any auth-requiring command exits with:

```
store token: open C:\Users\<user>\AppData\Roaming\gogcli\keyring\token:default:<email>: The filename, directory name, or volume label syntax is incorrect.
```

## Fix

Wrap the keyring with a new `fileSafeKeyring` shim that:

- Percent-encodes Windows-illegal characters (`:`, `<`, `>`, `"`, `|`, `?`, `*`, `\`, plus `%` for self-inverse encoding) in item keys before they reach the on-disk filename builder.
- Prepends a `_v1_` sentinel to encoded keys so `Keys()` can unambiguously distinguish wrapper-written entries from legacy raw-form files. Avoids corrupting any pre-existing item whose key happened to contain a literal `%XX` triplet.
- Falls back to the raw key form on read so existing `~/.local/share/gogcli/keyring/` directories on macOS/Linux keep working without manual migration.
- Best-effort removes the legacy raw file once the new encoded form is persisted, so `Keys()` does not return duplicates.
- Translates the platform's "filename invalid" error (`ERROR_INVALID_NAME` on Windows, surfaced as a `*fs.PathError` wrapping `syscall.Errno(0x7B)`) to `keyring.ErrKeyNotFound`. Detection is build-tagged: `filename_safe_windows.go` for the real check, `filename_safe_other.go` returning `false` everywhere else. This is what lets the raw-form fallback safely run on every platform without leaking a confusing error from a path the underlying filesystem could never have stored.

The shim is applied unconditionally rather than only when the file backend is explicitly selected. That covers two cases at once:

1. **Auto-fallback to file backend** — `99designs/keyring`'s opener tries native backends in priority order and silently lands on the file backend when they fail (e.g. Windows + WinCred unavailable, Linux + secret-service+kwallet unavailable). The wrapper now catches those too.
2. **Native backends with legacy raw keys** — for example Windows WinCred, which stores opaque credential targets and has always accepted colon-bearing keys. The raw-key fallback finds those, so existing credentials survive the upgrade. (For non-file backends the encoder is a near no-op for keys without Windows-illegal characters.)

## Tests

`internal/secrets/filename_safe_test.go`, `_other_test.go`, `_windows_test.go` add 25 tests:

**Encoder unit tests**

- Round-trip across primary, legacy single-colon, scoped, all-illegal-chars, percent-bearing, plain, and empty inputs.
- Fast path: keys with no encodable character pass through unchanged.
- Sentinel reservation: keys legitimately starting with `_v1_` are still encoded, preserving the round trip.
- Backslash is handled.
- `decodeFilenameKey` does not corrupt legacy `%XX`-bearing names (no `_v1_` prefix → returned as-is).

**End-to-end fixture against a real `99designs/keyring` file backend in a temp dir**

- On-disk filenames contain no NTFS-illegal characters.
- `Keys()` returns the original (decoded) key set with duplicates collapsed.
- `Get` falls back to legacy raw-form files (`Skipf`-guarded for filesystems that reject the legacy filename, so the test stays portable).
- `Set` migrates a legacy raw file to the encoded form.
- `Remove` cleans both encoded and legacy forms.
- `Get`, `GetMetadata`, `Remove` of missing keys return `keyring.ErrKeyNotFound`.

**Cross-platform error-translation behaviour via a `fakeInnerKeyring` plus a swappable `isInvalidFilenameError`**

- `Get` / `GetMetadata` / `Remove` translate the simulated "invalid filename" error to `keyring.ErrKeyNotFound`.
- `Set` and `Remove` survive the inner backend rejecting the raw-form cleanup attempt with that error.
- `acceptingFakeKeyring` covers the WinCred upgrade scenario: a non-file backend that accepts colon-bearing keys still serves legacy items via the raw-key fallback.

**Platform-specific defaults**

- `filename_safe_windows_test.go` (build-tagged `windows`) verifies `defaultIsInvalidFilenameError` matches a `*fs.PathError` wrapping `syscall.Errno(0x7B)` and rejects unrelated errnos.
- `filename_safe_other_test.go` (build-tagged `!windows`) verifies the default returns `false`.

## Verification

- `make fmt` clean, `make lint` 0 issues, `make test` green across all packages including `cmd/gog` and `internal/cmd`.
- `-race` clean on the 25 new tests. (The pre-existing race in `TestOpenKeyringWithTimeout_Timeout` is upstream/main behaviour, untouched here.)
- Cross-compile: `GOOS=windows GOARCH=amd64` and `GOOS=darwin GOARCH=arm64` both build the package and tests cleanly.
- Coverage: 100% on `encodeFilenameKey` / `decodeFilenameKey` / `needsFilenameEncoding` / `isNotFound`; 79.5% package overall.

## Notes

Out of scope on purpose, called out in a comment on `safeFilenameMap` so a future contributor knows where to extend:

- Windows reserved device names (`CON`, `PRN`, `AUX`, `NUL`, `COM1-9`, `LPT1-9`).
- Trailing spaces / dots.
- ASCII control characters.

The current gogcli key namespace (`token:<client>:<email>` and `default_account[:<client>]`) cannot produce any of those forms.

Distinct from #395 (CI test skips on Windows). This is the runtime crash path for real user machines whether they explicitly set `keyring_backend: file` or auto-fall through to it.