### PR TITLE
fix(gmail): surface missing Message-ID on --reply-to-message-id (#512)

### DIFF
--- a/internal/cmd/execute_gmail_get_test.go
+++ b/internal/cmd/execute_gmail_get_test.go
@@ -87,6 +87,63 @@ func TestExecute_GmailGet_Metadata_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_GmailGet_Metadata_DefaultHeadersIncludeThreading(t *testing.T) {
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1") {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.URL.Query().Get("format"); got != "metadata" {
+			t.Errorf("format=%q", got)
+			http.Error(w, "bad format", http.StatusBadRequest)
+			return
+		}
+		gotHeaders := r.URL.Query()["metadataHeaders"]
+		want := []string{
+			"From", "To", "Cc", "Bcc", "Subject", "Date",
+			"Message-ID", "In-Reply-To", "References", "List-Unsubscribe",
+		}
+		if !containsAll(gotHeaders, want) {
+			t.Errorf("metadataHeaders=%#v missing one of %v", gotHeaders, want)
+			http.Error(w, "bad metadataHeaders", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m1",
+			"threadId": "t1",
+			"payload":  map[string]any{"headers": []map[string]any{}},
+		})
+	}))
+	defer srv.Close()
+
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"gmail", "get", "m1",
+				"--format", "metadata",
+			}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+}
+
 func containsAll(got []string, want []string) bool {
 	set := map[string]bool{}
 	for _, g := range got {

--- a/internal/cmd/gmail_get.go
+++ b/internal/cmd/gmail_get.go
@@ -54,7 +54,10 @@ func (c *GmailGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if format == gmailFormatMetadata {
 		headerList := splitCSV(c.Headers)
 		if len(headerList) == 0 {
-			headerList = []string{"From", "To", "Cc", "Bcc", "Subject", "Date"}
+			headerList = []string{
+				"From", "To", "Cc", "Bcc", "Subject", "Date",
+				"Message-ID", "In-Reply-To", "References",
+			}
 		}
 		if !hasHeaderName(headerList, "List-Unsubscribe") {
 			headerList = append(headerList, "List-Unsubscribe")

--- a/internal/cmd/gmail_send.go
+++ b/internal/cmd/gmail_send.go
@@ -451,7 +451,13 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 		if err != nil {
 			return nil, err
 		}
-		return replyInfoFromMessage(msg, includeQuoteBodies), nil
+
+		info := replyInfoFromMessage(msg, includeQuoteBodies)
+		if info.InReplyTo == "" {
+			return nil, fmt.Errorf("reply target message %s has no Message-ID header; cannot set In-Reply-To/References", replyToMessageID)
+		}
+
+		return info, nil
 	}
 
 	// For thread replies, we always need just headers to select the latest message.
@@ -481,6 +487,7 @@ func fetchReplyInfo(ctx context.Context, svc *gmail.Service, replyToMessageID st
 	if info.ThreadID == "" {
 		info.ThreadID = thread.Id
 	}
+
 	return info, nil
 }
 

--- a/internal/cmd/gmail_send_reply_test.go
+++ b/internal/cmd/gmail_send_reply_test.go
@@ -101,6 +101,102 @@ func TestFetchReplyInfoFromThread(t *testing.T) {
 	}
 }
 
+func TestFetchReplyInfo_NoMessageIDFails(t *testing.T) {
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages/m0" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m0",
+			"threadId": "t0",
+			"payload": map[string]any{
+				"headers": []map[string]any{
+					{"name": "From", "value": "a@example.com"},
+					{"name": "Subject", "value": "no message id here"},
+				},
+			},
+		})
+	})
+	defer cleanup()
+
+	_, err := fetchReplyInfo(context.Background(), svc, "m0", "", false)
+	if err == nil {
+		t.Fatalf("expected error when reply target lacks Message-ID, got nil")
+	}
+	if !strings.Contains(err.Error(), "Message-ID") {
+		t.Fatalf("expected error to mention Message-ID, got: %v", err)
+	}
+}
+
+func TestFetchReplyInfo_ParentWithoutReferences(t *testing.T) {
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages/m0" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m0",
+			"threadId": "t0",
+			"payload": map[string]any{
+				"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<orig@id>"},
+				},
+			},
+		})
+	})
+	defer cleanup()
+
+	info, err := fetchReplyInfo(context.Background(), svc, "m0", "", false)
+	if err != nil {
+		t.Fatalf("fetchReplyInfo: %v", err)
+	}
+	if info.InReplyTo != "<orig@id>" {
+		t.Fatalf("unexpected InReplyTo: %q", info.InReplyTo)
+	}
+	if info.References != "<orig@id>" {
+		t.Fatalf("expected References to equal parent Message-ID, got %q", info.References)
+	}
+}
+
+func TestFetchReplyInfo_ParentWithReferences(t *testing.T) {
+	svc, cleanup := newGmailServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/gmail/v1")
+		if r.Method != http.MethodGet || path != "/users/me/messages/m0" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "m0",
+			"threadId": "t0",
+			"payload": map[string]any{
+				"headers": []map[string]any{
+					{"name": "Message-ID", "value": "<orig@id>"},
+					{"name": "References", "value": "<grandparent@id> <parent@id>"},
+				},
+			},
+		})
+	})
+	defer cleanup()
+
+	info, err := fetchReplyInfo(context.Background(), svc, "m0", "", false)
+	if err != nil {
+		t.Fatalf("fetchReplyInfo: %v", err)
+	}
+	if info.InReplyTo != "<orig@id>" {
+		t.Fatalf("unexpected InReplyTo: %q", info.InReplyTo)
+	}
+	expected := "<grandparent@id> <parent@id> <orig@id>"
+	if info.References != expected {
+		t.Fatalf("expected References %q, got %q", expected, info.References)
+	}
+}
+
 func TestWriteSendResults_JSON(t *testing.T) {
 	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
 	if err != nil {


### PR DESCRIPTION
Fixes #512.

## Problem
When `gog gmail send --reply-to-message-id <id>` (and the `gmail drafts create`
equivalent) resolves to a message whose metadata fetch returns no `Message-ID`
header, `replyInfoFromMessage` silently produces empty `InReplyTo`/`References`,
and `buildRFC822` skips writing both threading headers because of its
`TrimSpace == ""` guards. The send proceeds with only `threadId` set, the CLI
reports success, the Gmail UI threads the reply, but recipients on non-Gmail
clients receive what looks like a brand-new message with no thread ancestry.

The reporter's repro inspects via `gog gmail get <id> --format metadata --json`,
but the default `--format metadata` allowlist only contained `From`, `To`, `Cc`,
`Bcc`, `Subject`, `Date` (plus `List-Unsubscribe`), so threading headers were
filtered out of the response regardless of whether they were actually set on
the wire. That made the bug genuinely silent end-to-end.

## Fix
1. `internal/cmd/gmail_send.go`: `fetchReplyInfo` now returns a clear error
   when the explicit `--reply-to-message-id` path resolves to a message
   without a `Message-ID` header. Scoped to the explicit message-id path so
   `drafts update`'s implicit thread-id continuity (which can legitimately
   include drafts in the lookback) is unaffected.
2. `internal/cmd/gmail_get.go`: default `metadataHeaders` for `--format
   metadata` now also include `Message-ID`, `In-Reply-To`, and `References`.
   Explicit `--headers` behavior is unchanged. JSON consumers reading
   `.message.payload.headers` will see up to three additional headers when
   present on the message.

## Tests
- `TestFetchReplyInfo_NoMessageIDFails` — explicit reply target with no
  `Message-ID` returns an error mentioning `Message-ID`.
- `TestFetchReplyInfo_ParentWithoutReferences` — parent has only `Message-ID`,
  child `References` equals parent MID, `In-Reply-To` equals parent MID.
- `TestFetchReplyInfo_ParentWithReferences` — parent has both `Message-ID` and
  `References`, child `References` equals parent References + parent MID,
  `In-Reply-To` equals parent MID.
- `TestExecute_GmailGet_Metadata_DefaultHeadersIncludeThreading` — asserts the
  three new headers ride along in the default metadata request.

## Verification
- `make fmt` clean, `make lint` reports `0 issues.`, `make test` green.
- `go test -race -count=1 -run "Gmail|Reply" ./internal/cmd/` clean.
- Codex review pass (two rounds): no merge-blocking findings; one acknowledged
  follow-up (same silent-failure class on `--thread-id`) intentionally left
  out of scope for a surgical fix.

## Note re #516
PR #516 also targets this issue but takes a different approach (using the
existing draft's own message ID as the reply target in `drafts update`).
Happy to defer if maintainers prefer that path; this PR addresses the
underlying silent-failure mode and the diagnostic gap.