### PR TITLE
feat(docs): add --tab flag for per-tab Google Doc export

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -18,7 +18,7 @@ import (
 var newDocsService = googleapi.NewDocs
 
 type DocsCmd struct {
-	Export      DocsExportCmd      `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Doc (pdf|docx|txt|md)"`
+	Export      DocsExportCmd      `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Doc (pdf|docx|txt|md|html)"`
 	Info        DocsInfoCmd        `cmd:"" name:"info" aliases:"get,show" help:"Get Google Doc metadata"`
 	Create      DocsCreateCmd      `cmd:"" name:"create" aliases:"add,new" help:"Create a Google Doc"`
 	Copy        DocsCopyCmd        `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Doc"`
@@ -40,9 +40,18 @@ type DocsExportCmd struct {
 	DocID  string         `arg:"" name:"docId" help:"Doc ID"`
 	Output OutputPathFlag `embed:""`
 	Format string         `name:"format" help:"Export format: pdf|docx|txt|md|html" default:"pdf"`
+	Tab    string         `name:"tab" help:"(experimental) Export a specific tab by title or ID (see 'gog docs list-tabs')"`
 }
 
 func (c *DocsExportCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if tab := strings.TrimSpace(c.Tab); tab != "" {
+		return runDocsTabExport(ctx, flags, tabExportParams{
+			DocID:    c.DocID,
+			OutFlag:  c.Output.Path,
+			Format:   c.Format,
+			TabQuery: tab,
+		})
+	}
 	return exportViaDrive(ctx, flags, exportViaDriveOptions{
 		ArgName:       "docId",
 		ExpectedMime:  "application/vnd.google-apps.document",

--- a/internal/cmd/docs_paragraphs.go
+++ b/internal/cmd/docs_paragraphs.go
@@ -44,9 +44,9 @@ func buildParagraphMap(doc *docs.Document, tabID string) (*paragraphMap, error) 
 
 	if tabID != "" && len(doc.Tabs) > 0 {
 		tabs := flattenTabs(doc.Tabs)
-		tab := findTab(tabs, tabID)
-		if tab == nil {
-			return nil, fmt.Errorf("tab not found: %s", tabID)
+		tab, tabErr := findTab(tabs, tabID)
+		if tabErr != nil {
+			return nil, tabErr
 		}
 		if tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
 			return nil, fmt.Errorf("tab has no content: %s", tabID)

--- a/internal/cmd/docs_read.go
+++ b/internal/cmd/docs_read.go
@@ -103,9 +103,9 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 
 	tabs := flattenTabs(doc.Tabs)
 	if c.Tab != "" {
-		tab := findTab(tabs, c.Tab)
-		if tab == nil {
-			return fmt.Errorf("tab not found: %s", c.Tab)
+		tab, tabErr := findTab(tabs, c.Tab)
+		if tabErr != nil {
+			return tabErr
 		}
 		if c.Numbered {
 			return c.printNumbered(ctx, doc, c.Tab)
@@ -363,20 +363,29 @@ func flattenTabs(tabs []*docs.Tab) []*docs.Tab {
 	return result
 }
 
-func findTab(tabs []*docs.Tab, query string) *docs.Tab {
+func findTab(tabs []*docs.Tab, query string) (*docs.Tab, error) {
 	query = strings.TrimSpace(query)
 	for _, tab := range tabs {
 		if tab.TabProperties != nil && tab.TabProperties.TabId == query {
-			return tab
+			return tab, nil
 		}
 	}
 	lower := strings.ToLower(query)
 	for _, tab := range tabs {
 		if tab.TabProperties != nil && strings.ToLower(tab.TabProperties.Title) == lower {
-			return tab
+			return tab, nil
 		}
 	}
-	return nil
+	names := make([]string, 0, len(tabs))
+	for _, t := range tabs {
+		if t.TabProperties != nil {
+			names = append(names, fmt.Sprintf("%q", t.TabProperties.Title))
+		}
+	}
+	if len(names) > 0 {
+		return nil, fmt.Errorf("tab not found: %q (available: %s)", query, strings.Join(names, ", "))
+	}
+	return nil, fmt.Errorf("tab not found: %q (no tabs returned by API)", query)
 }
 
 func tabTitle(tab *docs.Tab) string {

--- a/internal/cmd/docs_tab_export.go
+++ b/internal/cmd/docs_tab_export.go
@@ -1,0 +1,245 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// UNSTABLE: docsTabExportBaseURL is the base for the undocumented per-tab
+// export endpoint. If Google changes or removes it, callers will see an HTTP
+// 302 redirect to a login page or an HTTP 404.
+const docsTabExportBaseURL = "https://docs.google.com/document/d"
+
+// maxRedirects matches net/http.defaultCheckRedirect (10 hops).
+const maxRedirects = 10
+
+// newDocsHTTPClient is swapped in tests to avoid real auth.
+var newDocsHTTPClient = func(ctx context.Context, email string) (*http.Client, error) {
+	return googleapi.NewHTTPClient(ctx, googleauth.ServiceDocs, email)
+}
+
+// googleExportRedirectPolicy allows redirects within Google's serving
+// infrastructure (*.google.com, *.googleusercontent.com, *.googleapis.com)
+// but rejects redirects to unrecognised domains, which typically indicate
+// an auth-wall redirect.
+func googleExportRedirectPolicy(req *http.Request, via []*http.Request) error {
+	if len(via) >= maxRedirects {
+		return errors.New("too many redirects")
+	}
+	if len(via) > 0 && !isGoogleHost(req.URL.Host) {
+		return fmt.Errorf("refusing redirect from %s to non-Google host %s (possible auth redirect; try re-authenticating)", via[0].URL.Host, req.URL.Host)
+	}
+	return nil
+}
+
+func isGoogleHost(host string) bool {
+	for _, suffix := range []string{".google.com", ".googleusercontent.com", ".googleapis.com"} {
+		if host == suffix[1:] || strings.HasSuffix(host, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+type tabExportParams struct {
+	DocID    string
+	OutFlag  string
+	Format   string
+	TabQuery string
+}
+
+// sanitizeFilenameComponent replaces characters unsafe for filenames with
+// underscores, collapsing runs. Only ASCII word chars ([0-9A-Za-z_]), dots,
+// @, and hyphens are kept; non-ASCII characters are replaced.
+var unsafeFilenameChars = regexp.MustCompile(`[^\w.@-]+`)
+
+func sanitizeFilenameComponent(s string) string {
+	return unsafeFilenameChars.ReplaceAllString(s, "_")
+}
+
+const formatHTML = "html"
+
+func tabExportFormatParam(format string) (string, error) {
+	switch format {
+	case "pdf", "docx", "txt", formatHTML:
+		return format, nil
+	case "md":
+		return "markdown", nil
+	default:
+		return "", fmt.Errorf("--tab export does not support format %q (supported: pdf|docx|txt|md|"+formatHTML+")", format)
+	}
+}
+
+func docsTabExportURL(docID, format, tabID string) string {
+	v := url.Values{}
+	v.Set("format", format)
+	v.Set("tab", tabID)
+	return fmt.Sprintf("%s/%s/export?%s", docsTabExportBaseURL, url.PathEscape(docID), v.Encode())
+}
+
+func resolveTabID(ctx context.Context, docsSvc *docs.Service, docID, tabQuery string) (string, error) {
+	doc, err := docsSvc.Documents.Get(docID).
+		Fields("tabs(tabProperties(tabId,title,index),childTabs)").
+		Context(ctx).
+		Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return "", fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return "", fmt.Errorf("resolve tab: %w", err)
+	}
+
+	tabs := flattenTabs(doc.Tabs)
+	tab, err := findTab(tabs, tabQuery)
+	if err != nil {
+		return "", err
+	}
+	return tab.TabProperties.TabId, nil
+}
+
+func tabExportOutPath(outFlag, docID, tabQuery, format string) (string, error) {
+	defaultBase := docID + "_" + sanitizeFilenameComponent(tabQuery) + "." + format
+
+	outPath := strings.TrimSpace(outFlag)
+	if outPath != "" {
+		expanded, err := config.ExpandPath(outPath)
+		if err != nil {
+			return "", err
+		}
+		if st, statErr := os.Stat(expanded); statErr == nil && st.IsDir() {
+			return filepath.Join(expanded, defaultBase), nil
+		}
+		return expanded, nil
+	}
+	dir, err := config.EnsureDriveDownloadsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, defaultBase), nil
+}
+
+// runDocsTabExport performs a per-tab export using the undocumented Docs export
+// URL. It resolves the tab, downloads the content, and writes it to a file.
+func runDocsTabExport(ctx context.Context, flags *RootFlags, p tabExportParams) error {
+	u := ui.FromContext(ctx)
+
+	p.DocID = normalizeGoogleID(strings.TrimSpace(p.DocID))
+	if p.DocID == "" {
+		return usage("empty docId")
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	format := p.Format
+	if format == "" || format == formatAuto {
+		format = "pdf"
+	}
+
+	formatParam, fmtErr := tabExportFormatParam(format)
+	if fmtErr != nil {
+		return fmtErr
+	}
+
+	outPath, pathErr := tabExportOutPath(p.OutFlag, p.DocID, p.TabQuery, format)
+	if pathErr != nil {
+		return pathErr
+	}
+
+	if dryErr := dryRunExit(ctx, flags, "docs.tab-export", map[string]any{
+		"docID":  p.DocID,
+		"tab":    p.TabQuery,
+		"format": format,
+		"out":    outPath,
+	}); dryErr != nil {
+		return dryErr
+	}
+
+	docsSvc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	u.Err().Printf("Resolving tab %q…", p.TabQuery)
+	tabID, err := resolveTabID(ctx, docsSvc, p.DocID, p.TabQuery)
+	if err != nil {
+		return err
+	}
+
+	httpClient, err := newDocsHTTPClient(ctx, account)
+	if err != nil {
+		return err
+	}
+	httpClient.CheckRedirect = googleExportRedirectPolicy
+
+	u.Err().Printf("Exporting tab %q as %s…", p.TabQuery, format)
+	exportURL := docsTabExportURL(p.DocID, formatParam, tabID)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, exportURL, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if checkErr := checkTabExportResponse(resp, format); checkErr != nil {
+		return checkErr
+	}
+
+	f, outPath, writeErr := createUserOutputFile(outPath)
+	if writeErr != nil {
+		return writeErr
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"path": outPath, "size": n})
+	}
+	u.Out().Printf("path\t%s", outPath)
+	u.Out().Printf("size\t%s", formatDriveSize(n))
+	return nil
+}
+
+func checkTabExportResponse(resp *http.Response, format string) error {
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if ct := resp.Header.Get("Content-Type"); format != formatHTML && strings.HasPrefix(ct, "text/html") {
+			snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			return fmt.Errorf("tab export returned unexpected text/html (possible auth redirect; try 'gog auth login'): %s", strings.TrimSpace(string(snippet)))
+		}
+		return nil
+	}
+
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	body := strings.TrimSpace(string(snippet))
+	if resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("tab export failed: %s: %s (check sharing settings or re-authenticate with 'gog auth login')", resp.Status, body)
+	}
+	return fmt.Errorf("tab export failed: %s: %s (undocumented endpoint may have changed)", resp.Status, body)
+}

--- a/internal/cmd/docs_tab_export_test.go
+++ b/internal/cmd/docs_tab_export_test.go
@@ -1,0 +1,480 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/option"
+)
+
+func tabExportDocResponse() map[string]any {
+	return map[string]any{
+		"documentId": "doc1",
+		"title":      "Multi-Tab Doc",
+		"tabs": []any{
+			map[string]any{
+				"tabProperties": map[string]any{"tabId": "t.abc", "title": "First Tab", "index": 0},
+			},
+			map[string]any{
+				"tabProperties": map[string]any{"tabId": "t.def", "title": "Second Tab", "index": 1},
+			},
+		},
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
+
+func stubTabExportDeps(t *testing.T, exportHandler http.Handler) {
+	t.Helper()
+
+	origDocs := newDocsService
+	origHTTP := newDocsHTTPClient
+	t.Cleanup(func() {
+		newDocsService = origDocs
+		newDocsHTTPClient = origHTTP
+	})
+
+	docsSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tabExportDocResponse())
+	}))
+	t.Cleanup(docsSrv.Close)
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(docsSrv.Client()),
+		option.WithEndpoint(docsSrv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+	newDocsService = func(_ context.Context, _ string) (*docs.Service, error) {
+		return docSvc, nil
+	}
+
+	newDocsHTTPClient = func(_ context.Context, _ string) (*http.Client, error) {
+		return &http.Client{
+			Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				rec := httptest.NewRecorder()
+				exportHandler.ServeHTTP(rec, req)
+				return rec.Result(), nil
+			}),
+		}, nil
+	}
+}
+
+func TestTabExportFormatParam(t *testing.T) {
+	tests := []struct {
+		format  string
+		want    string
+		wantErr bool
+	}{
+		{"pdf", "pdf", false},
+		{"docx", "docx", false},
+		{"txt", "txt", false},
+		{"md", "markdown", false},
+		{"html", "html", false},
+		{"csv", "", true},
+		{"xlsx", "", true},
+	}
+	for _, tt := range tests {
+		got, err := tabExportFormatParam(tt.format)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("tabExportFormatParam(%q): expected error", tt.format)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("tabExportFormatParam(%q): %v", tt.format, err)
+		} else if got != tt.want {
+			t.Errorf("tabExportFormatParam(%q) = %q, want %q", tt.format, got, tt.want)
+		}
+	}
+}
+
+func TestGoogleExportRedirectPolicy(t *testing.T) {
+	ctx := context.Background()
+	origReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://docs.google.com/export", nil)
+
+	tests := []struct {
+		name    string
+		target  string
+		wantErr string
+	}{
+		{"same host", "https://docs.google.com/other", ""},
+		{"googleusercontent", "https://doc-04-0k-docstext.googleusercontent.com/export/abc", ""},
+		{"googleapis", "https://storage.googleapis.com/bucket/file", ""},
+		{"non-google host", "https://evil.example.com/steal", "non-Google host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, tt.target, nil)
+			err := googleExportRedirectPolicy(req, []*http.Request{origReq})
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected success, got: %v", err)
+				}
+			} else {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+
+	via := make([]*http.Request, 10)
+	for i := range via {
+		via[i], _ = http.NewRequestWithContext(ctx, http.MethodGet, "https://docs.google.com/r", nil)
+	}
+	nextReq, _ := http.NewRequestWithContext(ctx, http.MethodGet, "https://docs.google.com/r", nil)
+	err := googleExportRedirectPolicy(nextReq, via)
+	if err == nil || !strings.Contains(err.Error(), "too many redirects") {
+		t.Errorf("expected too many redirects error, got: %v", err)
+	}
+}
+
+func TestDocsTabExportURL(t *testing.T) {
+	got := docsTabExportURL("DOC123", "pdf", "t.abc")
+	want := "https://docs.google.com/document/d/DOC123/export?format=pdf&tab=t.abc"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestSanitizeFilenameComponent(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"t.abc", "t.abc"},
+		{"My Budget Sheet", "My_Budget_Sheet"},
+		{"tab/with\\bad:chars", "tab_with_bad_chars"},
+	}
+	for _, tt := range tests {
+		if got := sanitizeFilenameComponent(tt.in); got != tt.want {
+			t.Errorf("sanitizeFilenameComponent(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestResolveTabID(t *testing.T) {
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tabExportDocResponse())
+	}))
+	defer cleanup()
+
+	tests := []struct {
+		query   string
+		wantID  string
+		wantErr string
+	}{
+		{"Second Tab", "t.def", ""},
+		{"t.abc", "t.abc", ""},
+		{"Nonexistent", "", "tab not found"},
+	}
+	for _, tt := range tests {
+		tabID, err := resolveTabID(context.Background(), docSvc, "doc1", tt.query)
+		if tt.wantErr != "" {
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("resolveTabID(%q): got err=%v, want containing %q", tt.query, err, tt.wantErr)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("resolveTabID(%q): %v", tt.query, err)
+		} else if tabID != tt.wantID {
+			t.Errorf("resolveTabID(%q) = %q, want %q", tt.query, tabID, tt.wantID)
+		}
+	}
+}
+
+func TestRunDocsTabExport(t *testing.T) {
+	tests := []struct {
+		name     string
+		format   string
+		tabQuery string
+		respCT   string
+		respBody string
+		wantBody string
+		wantErr  string
+	}{
+		{
+			name:     "pdf success",
+			format:   "pdf",
+			tabQuery: "First Tab",
+			respCT:   "application/pdf",
+			respBody: "exported PDF content",
+			wantBody: "exported PDF content",
+		},
+		{
+			name:     "markdown format",
+			format:   "md",
+			tabQuery: "t.abc",
+			respCT:   "text/markdown",
+			respBody: "# Markdown",
+			wantBody: "# Markdown",
+		},
+		{
+			name:     "unsupported format",
+			format:   "csv",
+			tabQuery: "t.abc",
+			wantErr:  "does not support format",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.wantErr == "" {
+				stubTabExportDeps(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", tt.respCT)
+					_, _ = w.Write([]byte(tt.respBody))
+				}))
+			}
+
+			outPath := filepath.Join(t.TempDir(), "output."+tt.format)
+			ctx := newDocsCmdContext(t)
+			flags := &RootFlags{Account: "test@example.com"}
+
+			err := runDocsTabExport(ctx, flags, tabExportParams{
+				DocID:    "doc1",
+				OutFlag:  outPath,
+				Format:   tt.format,
+				TabQuery: tt.tabQuery,
+			})
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("runDocsTabExport: %v", err)
+			}
+			if tt.wantBody != "" {
+				data, readErr := os.ReadFile(outPath)
+				if readErr != nil {
+					t.Fatalf("read output: %v", readErr)
+				}
+				if string(data) != tt.wantBody {
+					t.Errorf("output = %q, want %q", string(data), tt.wantBody)
+				}
+			}
+		})
+	}
+}
+
+func TestRunDocsTabExport_HTMLRedirectGuard(t *testing.T) {
+	stubTabExportDeps(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte("<html>Sign in</html>"))
+	}))
+
+	ctx := newDocsCmdContext(t)
+	err := runDocsTabExport(ctx, &RootFlags{Account: "test@example.com"}, tabExportParams{
+		DocID:    "doc1",
+		OutFlag:  filepath.Join(t.TempDir(), "out.pdf"),
+		Format:   "pdf",
+		TabQuery: "First Tab",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unexpected text/html") {
+		t.Fatalf("expected HTML redirect error, got: %v", err)
+	}
+}
+
+func TestRunDocsTabExport_HTTPErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		status  int
+		wantErr string
+	}{
+		{"forbidden", http.StatusForbidden, "tab export failed"},
+		{"unauthorized", http.StatusUnauthorized, "re-authenticate"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubTabExportDeps(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+				_, _ = w.Write([]byte("error body"))
+			}))
+
+			ctx := newDocsCmdContext(t)
+			err := runDocsTabExport(ctx, &RootFlags{Account: "test@example.com"}, tabExportParams{
+				DocID:    "doc1",
+				OutFlag:  filepath.Join(t.TempDir(), "out.pdf"),
+				Format:   "pdf",
+				TabQuery: "First Tab",
+			})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("expected error containing %q, got: %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestRunDocsTabExport_JSONOutput(t *testing.T) {
+	stubTabExportDeps(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte("pdf bytes"))
+	}))
+
+	outPath := filepath.Join(t.TempDir(), "output.pdf")
+	ctx := newDocsJSONContext(t)
+
+	raw := captureStdout(t, func() {
+		err := runDocsTabExport(ctx, &RootFlags{Account: "test@example.com"}, tabExportParams{
+			DocID:    "doc1",
+			OutFlag:  outPath,
+			Format:   "pdf",
+			TabQuery: "First Tab",
+		})
+		if err != nil {
+			t.Fatalf("runDocsTabExport: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		t.Fatalf("json decode: %v (raw=%q)", err, raw)
+	}
+	if _, ok := result["path"]; !ok {
+		t.Errorf("JSON output missing 'path' key: %v", result)
+	}
+}
+
+func TestDocsExportCmd_TabRouting(t *testing.T) {
+	stubTabExportDeps(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/pdf")
+		_, _ = w.Write([]byte("tab pdf"))
+	}))
+
+	outPath := filepath.Join(t.TempDir(), "out.pdf")
+	ctx := newDocsCmdContext(t)
+
+	cmd := &DocsExportCmd{
+		DocID:  "doc1",
+		Format: "pdf",
+		Tab:    "Second Tab",
+		Output: OutputPathFlag{Path: outPath},
+	}
+
+	if err := cmd.Run(ctx, &RootFlags{Account: "test@example.com"}); err != nil {
+		t.Fatalf("DocsExportCmd.Run: %v", err)
+	}
+
+	data, _ := os.ReadFile(outPath)
+	if string(data) != "tab pdf" {
+		t.Errorf("output = %q, want %q", string(data), "tab pdf")
+	}
+}
+
+func TestDocsExportCmd_TabEmptyDocID(t *testing.T) {
+	ctx := newDocsCmdContext(t)
+	cmd := &DocsExportCmd{DocID: "", Tab: "some-tab"}
+	err := cmd.Run(ctx, &RootFlags{Account: "test@example.com"})
+	if err == nil || !strings.Contains(err.Error(), "empty docId") {
+		t.Fatalf("expected empty docId error, got: %v", err)
+	}
+}
+
+func TestTabExportOutPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		outFlag  string
+		docID    string
+		tabQuery string
+		format   string
+		wantBase string
+	}{
+		{"tab ID in filename", "", "doc123", "t.abc", "pdf", "doc123_t.abc.pdf"},
+		{"markdown extension", "", "doc1", "t.xyz", "md", "doc1_t.xyz.md"},
+		{"tab title sanitized", "", "doc1", "My Budget Sheet", "pdf", "doc1_My_Budget_Sheet.pdf"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			path, err := tabExportOutPath(tt.outFlag, tt.docID, tt.tabQuery, tt.format)
+			if err != nil {
+				t.Fatalf("tabExportOutPath: %v", err)
+			}
+			if got := filepath.Base(path); got != tt.wantBase {
+				t.Errorf("base = %q, want %q", got, tt.wantBase)
+			}
+		})
+	}
+}
+
+func TestTabExportOutPath_ExplicitPath(t *testing.T) {
+	outPath := filepath.Join(t.TempDir(), "custom.pdf")
+	path, err := tabExportOutPath(outPath, "doc1", "t.abc", "pdf")
+	if err != nil {
+		t.Fatalf("tabExportOutPath: %v", err)
+	}
+	if path != outPath {
+		t.Errorf("got %q, want %q", path, outPath)
+	}
+}
+
+func TestTabExportOutPath_DirectoryOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+	path, err := tabExportOutPath(tmpDir, "doc1", "t.abc", "pdf")
+	if err != nil {
+		t.Fatalf("tabExportOutPath: %v", err)
+	}
+	if filepath.Dir(path) != tmpDir {
+		t.Errorf("expected file in %q, got %q", tmpDir, filepath.Dir(path))
+	}
+}
+
+func TestDriveDownloadCmd_TabRouting(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+	}{
+		{"explicit format", "pdf"},
+		{"defaults to pdf", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubTabExportDeps(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/pdf")
+				_, _ = w.Write([]byte("tab pdf"))
+			}))
+
+			ctx := newDocsCmdContext(t)
+			cmd := &DriveDownloadCmd{
+				FileID: "doc1",
+				Tab:    "First Tab",
+				Format: tt.format,
+				Output: OutputPathFlag{Path: filepath.Join(t.TempDir(), "out.pdf")},
+			}
+
+			if err := cmd.Run(ctx, &RootFlags{Account: "test@example.com"}); err != nil {
+				t.Fatalf("DriveDownloadCmd.Run: %v", err)
+			}
+		})
+	}
+}
+
+func TestDriveDownloadCmd_TabUnsupportedFormat(t *testing.T) {
+	ctx := newDocsCmdContext(t)
+	cmd := &DriveDownloadCmd{
+		FileID: "doc1",
+		Tab:    "First Tab",
+		Format: "csv",
+		Output: OutputPathFlag{Path: filepath.Join(t.TempDir(), "out.csv")},
+	}
+
+	err := cmd.Run(ctx, &RootFlags{Account: "test@example.com"})
+	if err == nil || !strings.Contains(err.Error(), "--tab limits export formats") {
+		t.Fatalf("expected --tab format restriction error, got: %v", err)
+	}
+}

--- a/internal/cmd/docs_testutil_test.go
+++ b/internal/cmd/docs_testutil_test.go
@@ -19,16 +19,16 @@ func newDocsServiceForTest(t *testing.T, h http.HandlerFunc) (*docs.Service, fun
 	t.Helper()
 
 	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
 	docSvc, err := docs.NewService(context.Background(),
 		option.WithoutAuthentication(),
 		option.WithHTTPClient(srv.Client()),
 		option.WithEndpoint(srv.URL+"/"),
 	)
 	if err != nil {
-		srv.Close()
 		t.Fatalf("NewDocsService: %v", err)
 	}
-	return docSvc, srv.Close
+	return docSvc, func() {} // retained for call-site compat; cleanup is via t.Cleanup
 }
 
 func newDocsCmdContext(t *testing.T) context.Context {

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -154,19 +154,35 @@ type DriveDownloadCmd struct {
 	FileID string         `arg:"" name:"fileId" help:"File ID"`
 	Output OutputPathFlag `embed:""`
 	Format string         `name:"format" help:"Export format for Google Docs files: pdf|csv|xlsx|pptx|txt|png|docx|md (default: inferred)"`
+	Tab    string         `name:"tab" help:"(experimental) Export a specific tab by title or ID (Google Docs only; see 'gog docs list-tabs')"`
 }
 
 func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
-	u := ui.FromContext(ctx)
 	account, err := requireAccount(flags)
 	if err != nil {
 		return err
 	}
 
-	fileID := strings.TrimSpace(c.FileID)
+	fileID := normalizeGoogleID(strings.TrimSpace(c.FileID))
 	if fileID == "" {
 		return usage("empty fileId")
 	}
+
+	if tab := strings.TrimSpace(c.Tab); tab != "" {
+		if f := c.Format; f != "" && f != formatAuto {
+			if _, fmtErr := tabExportFormatParam(f); fmtErr != nil {
+				return fmt.Errorf("--tab limits export formats (pdf|docx|txt|md|html); %q is not supported with --tab", f)
+			}
+		}
+		return runDocsTabExport(ctx, flags, tabExportParams{
+			DocID:    fileID,
+			OutFlag:  c.Output.Path,
+			Format:   c.Format,
+			TabQuery: tab,
+		})
+	}
+
+	u := ui.FromContext(ctx)
 	if formatErr := validateDriveDownloadFormatFlag(c.Format); formatErr != nil {
 		return formatErr
 	}

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -50,9 +50,7 @@ func IsADCMode() bool {
 	return os.Getenv("GOG_AUTH_MODE") == "adc"
 }
 
-func optionsForAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
-	slog.Debug("creating client options with custom scopes", "serviceLabel", serviceLabel, "email", email)
-
+func authenticatedTransport(ctx context.Context, serviceLabel string, email string, scopes []string) (http.RoundTripper, error) {
 	var ts oauth2.TokenSource
 
 	if IsADCMode() {
@@ -73,13 +71,22 @@ func optionsForAccountScopes(ctx context.Context, serviceLabel string, email str
 		}
 	}
 
-	baseTransport := newBaseTransport()
-	retryTransport := NewRetryTransport(&oauth2.Transport{
+	return NewRetryTransport(&oauth2.Transport{
 		Source: ts,
-		Base:   baseTransport,
-	})
+		Base:   newBaseTransport(),
+	}), nil
+}
+
+func optionsForAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
+	slog.Debug("creating client options with custom scopes", "serviceLabel", serviceLabel, "email", email)
+
+	transport, err := authenticatedTransport(ctx, serviceLabel, email, scopes)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &http.Client{
-		Transport: retryTransport,
+		Transport: transport,
 		// No Timeout set: large file downloads (Drive videos, etc.) must not
 		// be cut short. Server responsiveness is guarded by the transport's
 		// ResponseHeaderTimeout instead.
@@ -88,6 +95,23 @@ func optionsForAccountScopes(ctx context.Context, serviceLabel string, email str
 	slog.Debug("client options with custom scopes created successfully", "serviceLabel", serviceLabel, "email", email)
 
 	return []option.ClientOption{option.WithHTTPClient(c)}, nil
+}
+
+// NewHTTPClient returns a raw *http.Client authenticated for the given service
+// and account. The caller may set CheckRedirect or other policies on the
+// returned client.
+func NewHTTPClient(ctx context.Context, service googleauth.Service, email string) (*http.Client, error) {
+	scopes, err := googleauth.Scopes(service)
+	if err != nil {
+		return nil, fmt.Errorf("resolve scopes: %w", err)
+	}
+
+	transport, err := authenticatedTransport(ctx, string(service), email, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{Transport: transport}, nil
 }
 
 func newBaseTransport() *http.Transport {

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -549,3 +549,29 @@ func TestOptionsForAccountScopes_NoClientTimeout(t *testing.T) {
 		t.Fatalf("expected ResponseHeaderTimeout to be set on transport")
 	}
 }
+
+func TestNewHTTPClient_NoRedirectPolicy(t *testing.T) {
+	origRead := readClientCredentials
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() {
+		readClientCredentials = origRead
+		openSecretsStore = origOpen
+	})
+
+	readClientCredentials = func(string) (config.ClientCredentials, error) {
+		return config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}, nil
+	}
+	openSecretsStore = func() (secrets.Store, error) {
+		return &stubStore{tok: secrets.Token{Email: "a@b.com", RefreshToken: "rt"}}, nil
+	}
+
+	client, err := NewHTTPClient(context.Background(), googleauth.ServiceDocs, "a@b.com")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+
+	if client.CheckRedirect != nil {
+		t.Fatal("expected no CheckRedirect on bare client")
+	}
+}


### PR DESCRIPTION
## Add `--tab` flag for per-tab Google Doc export

Adds `--tab` to `gog docs export` and `gog drive download` to export a single tab by title or ID:

```bash
gog docs export <docId> --tab "New Tab" --format md
gog drive download <docId> --tab "New Tab" --format pdf
```

- Supports `pdf`, `docx`, `txt`, `md`, and `html`.
- :warning: 
   - Uses an undocumented per-tab export endpoint (flagged as `(experimental)`) since per-tab is not supported in the stable docs API. 
      -  Note: with redirect detection for auth failures.
   - Export uses `--tab` (title or ID); write commands use `--tab-id` (ID only, passed directly to the API). Different names reflect different behavior. 

### Other changes

- Extracted `authenticatedTransport` in `googleapi/client.go` and added `NewHTTPClient` to support raw HTTP requests with OAuth credentials.
   - The new HTTP client is used for the experimental tabs endpoint
- `findTab` now returns `(*docs.Tab, error)` with a helpful "available tabs" message, benefiting all existing call sites.
- `runDocsTabExport` owns its own docID normalization/validation.
- `DriveDownloadCmd` now runs `normalizeGoogleID` on file IDs (supports pasted URLs).

### Test plan

- Unit tests for format mapping, URL construction, output paths, error messages, redirect policy, content-type sniffing, JSON output
- Routing tests for both `docs export --tab` and `drive download --tab`
- `make test` passes across all packages

```bash
# FULL TEST PLAN

# 1. Create doc
gog docs create "tab-test" --json
# →grab $DOC_ID

# 2. Add a second tab and some copy in the UI. 

# 3. Get the new tab's ID
gog docs list-tabs $DOC_ID --json
# → grab $TAB_ID for "New Tab"

# 4. Write content into the new tab
gog docs write $DOC_ID --tab-id $TAB_ID --text "Hello from the New Tab"

# 5. Export by title (pdf)
gog docs export $DOC_ID --tab "New Tab" --format pdf --out /tmp/new-tab.pdf

# 6. Export by title (txt) — should contain "Hello from the New Tab"
gog docs export $DOC_ID --tab "New Tab" --format txt --out /tmp/new-tab.txt

# 7. Export via drive download
gog drive download $DOC_ID --tab "New Tab" --format pdf --out /tmp/new-tab-drive.pdf

# 8. Bad tab name (should fail with available tabs list)
gog docs export $DOC_ID --tab "NoSuchTab" --format pdf --out /tmp/bad.pdf

# 9. Cleanup
gog drive delete DOC_ID --force
