### PR TITLE
refactor(docs): improve findTab error messages with available tab names

### DIFF
--- a/internal/cmd/docs_paragraphs.go
+++ b/internal/cmd/docs_paragraphs.go
@@ -44,9 +44,9 @@ func buildParagraphMap(doc *docs.Document, tabID string) (*paragraphMap, error) 
 
 	if tabID != "" && len(doc.Tabs) > 0 {
 		tabs := flattenTabs(doc.Tabs)
-		tab := findTab(tabs, tabID)
-		if tab == nil {
-			return nil, fmt.Errorf("tab not found: %s", tabID)
+		tab, tabErr := findTab(tabs, tabID)
+		if tabErr != nil {
+			return nil, tabErr
 		}
 		if tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
 			return nil, fmt.Errorf("tab has no content: %s", tabID)

--- a/internal/cmd/docs_read.go
+++ b/internal/cmd/docs_read.go
@@ -103,9 +103,9 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 
 	tabs := flattenTabs(doc.Tabs)
 	if c.Tab != "" {
-		tab := findTab(tabs, c.Tab)
-		if tab == nil {
-			return fmt.Errorf("tab not found: %s", c.Tab)
+		tab, tabErr := findTab(tabs, c.Tab)
+		if tabErr != nil {
+			return tabErr
 		}
 		if c.Numbered {
 			return c.printNumbered(ctx, doc, c.Tab)
@@ -363,20 +363,29 @@ func flattenTabs(tabs []*docs.Tab) []*docs.Tab {
 	return result
 }
 
-func findTab(tabs []*docs.Tab, query string) *docs.Tab {
+func findTab(tabs []*docs.Tab, query string) (*docs.Tab, error) {
 	query = strings.TrimSpace(query)
 	for _, tab := range tabs {
 		if tab.TabProperties != nil && tab.TabProperties.TabId == query {
-			return tab
+			return tab, nil
 		}
 	}
 	lower := strings.ToLower(query)
 	for _, tab := range tabs {
 		if tab.TabProperties != nil && strings.ToLower(tab.TabProperties.Title) == lower {
-			return tab
+			return tab, nil
 		}
 	}
-	return nil
+	names := make([]string, 0, len(tabs))
+	for _, t := range tabs {
+		if t.TabProperties != nil {
+			names = append(names, fmt.Sprintf("%q", t.TabProperties.Title))
+		}
+	}
+	if len(names) > 0 {
+		return nil, fmt.Errorf("tab not found: %q (available: %s)", query, strings.Join(names, ", "))
+	}
+	return nil, fmt.Errorf("tab not found: %q (no tabs returned by API)", query)
 }
 
 func tabTitle(tab *docs.Tab) string {


### PR DESCRIPTION
refactor(docs): improve `findTab` error messages with available tab names

## Summary

- `findTab` now resolves tabs by exact ID first, then by case-insensitive title match, so users can pass either a tab ID or a human-readable name
- When no match is found, the error now lists available tab titles (e.g. `tab not found: "Shopping List" (available: "Inventory", "Markets")`) instead of a bare "tab not found" message
- `findTab` returns `(*docs.Tab, error)` instead of `*docs.Tab` so callers get structured errors
- Covers both call sites: `docs cat --tab` and `docs structure --tab` (via `buildParagraphMap`)

## Test plan

- Existing `TestDocsCat_TabNotFound` and `TestBuildParagraphMap_TabNotFound` exercise the updated error paths
- No new flags or user-facing behavior changes beyond improved error text
