### PR TITLE
refactor(cli): deprecate --tab-id in favor of --tab

### DIFF
--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -15,6 +15,23 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+// resolveTabArg returns the effective tab value from --tab or the deprecated
+// --tab-id flag. It rejects supplying both and emits a deprecation warning
+// when --tab-id is used.
+func resolveTabArg(ctx context.Context, tab, tabID string) (string, error) {
+	tab = strings.TrimSpace(tab)
+	tabID = strings.TrimSpace(tabID)
+	if tab != "" && tabID != "" {
+		return "", usage("--tab and --tab-id are mutually exclusive (--tab-id is deprecated; use --tab)")
+	}
+	if tabID != "" {
+		u := ui.FromContext(ctx)
+		u.Err().Printf("Warning: --tab-id is deprecated; use --tab instead")
+		return tabID, nil
+	}
+	return tab, nil
+}
+
 type DocsWriteCmd struct {
 	DocID    string `arg:"" name:"docId" help:"Doc ID"`
 	Text     string `name:"text" help:"Text to write"`
@@ -23,7 +40,8 @@ type DocsWriteCmd struct {
 	Markdown bool   `name:"markdown" help:"Convert markdown to Google Docs formatting (requires --replace)"`
 	Append   bool   `name:"append" help:"Append instead of replacing the document body"`
 	Pageless bool   `name:"pageless" help:"Set document to pageless mode"`
-	TabID    string `name:"tab-id" help:"Target a specific tab by ID (see docs list-tabs)"`
+	Tab      string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID    string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -39,6 +57,13 @@ func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootF
 	if c.Append && c.Replace {
 		return usage("--append cannot be combined with --replace")
 	}
+
+	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
+	if tabErr != nil {
+		return tabErr
+	}
+	c.Tab = tab
+
 	if c.Markdown {
 		return c.writeMarkdown(ctx, flags, id, text)
 	}
@@ -66,7 +91,7 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, flags *RootFlags, doc
 		return err
 	}
 
-	endIndex, err := docsTargetEndIndex(ctx, svc, docID, c.TabID)
+	endIndex, err := docsTargetEndIndex(ctx, svc, docID, c.Tab)
 	if err != nil {
 		return err
 	}
@@ -97,14 +122,14 @@ func (c *DocsWriteCmd) buildPlainWriteRequests(endIndex, insertIndex int64, text
 		if deleteEnd > 1 {
 			reqs = append(reqs, &docs.Request{
 				DeleteContentRange: &docs.DeleteContentRangeRequest{
-					Range: &docs.Range{StartIndex: 1, EndIndex: deleteEnd, TabId: c.TabID},
+					Range: &docs.Range{StartIndex: 1, EndIndex: deleteEnd, TabId: c.Tab},
 				},
 			})
 		}
 	}
 	reqs = append(reqs, &docs.Request{
 		InsertText: &docs.InsertTextRequest{
-			Location: &docs.Location{Index: insertIndex, TabId: c.TabID},
+			Location: &docs.Location{Index: insertIndex, TabId: c.Tab},
 			Text:     text,
 		},
 	})
@@ -130,8 +155,8 @@ func (c *DocsWriteCmd) writePlainTextResult(ctx context.Context, resp *docs.Batc
 			"append":     c.Append,
 			"index":      insertIndex,
 		}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		if resp.WriteControl != nil {
 			payload["writeControl"] = resp.WriteControl
@@ -143,8 +168,8 @@ func (c *DocsWriteCmd) writePlainTextResult(ctx context.Context, resp *docs.Batc
 	u.Out().Printf("requests\t%d", requestCount)
 	u.Out().Printf("append\t%t", c.Append)
 	u.Out().Printf("index\t%d", insertIndex)
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
 		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
@@ -161,8 +186,8 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 	if c.Append {
 		return usage("--markdown cannot be combined with --append")
 	}
-	if c.TabID != "" {
-		return usage("--markdown cannot be combined with --tab-id")
+	if c.Tab != "" {
+		return usage("--markdown cannot be combined with --tab")
 	}
 
 	_, driveSvc, err := requireDriveService(ctx, flags)
@@ -221,7 +246,8 @@ type DocsUpdateCmd struct {
 	File     string `name:"file" help:"Text file path ('-' for stdin)"`
 	Index    int64  `name:"index" help:"Insert index (default: end of document)"`
 	Pageless bool   `name:"pageless" help:"Set document to pageless mode"`
-	TabID    string `name:"tab-id" help:"Target a specific tab by ID (see docs list-tabs)"`
+	Tab      string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID    string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -245,6 +271,12 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return usage("invalid --index (must be >= 1)")
 	}
 
+	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
+	if tabErr != nil {
+		return tabErr
+	}
+	c.Tab = tab
+
 	svc, err := requireDocsService(ctx, flags)
 	if err != nil {
 		return err
@@ -252,7 +284,7 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 
 	insertIndex := c.Index
 	if insertIndex <= 0 {
-		endIndex, endErr := docsTargetEndIndex(ctx, svc, id, c.TabID)
+		endIndex, endErr := docsTargetEndIndex(ctx, svc, id, c.Tab)
 		if endErr != nil {
 			return endErr
 		}
@@ -261,7 +293,7 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 
 	reqs := []*docs.Request{{
 		InsertText: &docs.InsertTextRequest{
-			Location: &docs.Location{Index: insertIndex, TabId: c.TabID},
+			Location: &docs.Location{Index: insertIndex, TabId: c.Tab},
 			Text:     text,
 		},
 	}}
@@ -285,8 +317,8 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 			"requests":   len(reqs),
 			"index":      insertIndex,
 		}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		if resp.WriteControl != nil {
 			payload["writeControl"] = resp.WriteControl
@@ -297,8 +329,8 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	u.Out().Printf("id\t%s", resp.DocumentId)
 	u.Out().Printf("requests\t%d", len(reqs))
 	u.Out().Printf("index\t%d", insertIndex)
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
 		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
@@ -311,7 +343,8 @@ type DocsInsertCmd struct {
 	Content string `arg:"" optional:"" name:"content" help:"Text to insert (or use --file / stdin)"`
 	Index   int64  `name:"index" help:"Character index to insert at (1 = beginning)" default:"1"`
 	File    string `name:"file" short:"f" help:"Read content from file (use - for stdin)"`
-	TabID   string `name:"tab-id" help:"Target a specific tab by ID (see docs list-tabs)"`
+	Tab     string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID   string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -331,6 +364,12 @@ func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("--index must be >= 1 (index 0 is reserved)")
 	}
 
+	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
+	if tabErr != nil {
+		return tabErr
+	}
+	c.Tab = tab
+
 	svc, err := requireDocsService(ctx, flags)
 	if err != nil {
 		return err
@@ -342,7 +381,7 @@ func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Text: content,
 				Location: &docs.Location{
 					Index: c.Index,
-					TabId: c.TabID,
+					TabId: c.Tab,
 				},
 			},
 		}},
@@ -353,8 +392,8 @@ func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	if outfmt.IsJSON(ctx) {
 		payload := map[string]any{"documentId": result.DocumentId, "inserted": len(content), "atIndex": c.Index}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		return outfmt.WriteJSON(ctx, os.Stdout, payload)
 	}
@@ -362,8 +401,8 @@ func (c *DocsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u.Out().Printf("documentId\t%s", result.DocumentId)
 	u.Out().Printf("inserted\t%d bytes", len(content))
 	u.Out().Printf("atIndex\t%d", c.Index)
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	return nil
 }
@@ -372,7 +411,8 @@ type DocsDeleteCmd struct {
 	DocID string `arg:"" name:"docId" help:"Doc ID"`
 	Start int64  `name:"start" required:"" help:"Start index (>= 1)"`
 	End   int64  `name:"end" required:"" help:"End index (> start)"`
-	TabID string `name:"tab-id" help:"Target a specific tab by ID (see docs list-tabs)"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -388,6 +428,12 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("--end must be greater than --start")
 	}
 
+	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
+	if tabErr != nil {
+		return tabErr
+	}
+	c.Tab = tab
+
 	svc, err := requireDocsService(ctx, flags)
 	if err != nil {
 		return err
@@ -396,7 +442,7 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	result, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 		Requests: []*docs.Request{{
 			DeleteContentRange: &docs.DeleteContentRangeRequest{
-				Range: &docs.Range{StartIndex: c.Start, EndIndex: c.End, TabId: c.TabID},
+				Range: &docs.Range{StartIndex: c.Start, EndIndex: c.End, TabId: c.Tab},
 			},
 		}},
 	}).Context(ctx).Do()
@@ -411,8 +457,8 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"startIndex": c.Start,
 			"endIndex":   c.End,
 		}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		return outfmt.WriteJSON(ctx, os.Stdout, payload)
 	}
@@ -420,8 +466,8 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u.Out().Printf("documentId\t%s", result.DocumentId)
 	u.Out().Printf("deleted\t%d characters", c.End-c.Start)
 	u.Out().Printf("range\t%d-%d", c.Start, c.End)
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	return nil
 }
@@ -446,7 +492,8 @@ type DocsFindReplaceCmd struct {
 	MatchCase   bool   `name:"match-case" help:"Case-sensitive matching"`
 	Format      string `name:"format" help:"Replacement format: plain|markdown. Markdown converts formatting, tables, and inline images; local images must be under --content-file's directory (or use remote URLs)." default:"plain" enum:"plain,markdown"`
 	First       bool   `name:"first" help:"Replace only the first occurrence instead of all."`
-	TabID       string `name:"tab-id" help:"Target a specific tab by ID (see docs list-tabs)"`
+	Tab         string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID       string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 type DocsEditCmd struct {
@@ -484,8 +531,15 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if format == "" {
 		format = docsContentFormatPlain
 	}
-	if c.TabID != "" && format == docsContentFormatMarkdown {
-		return usage("--tab-id is not yet supported with --format markdown")
+
+	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
+	if tabErr != nil {
+		return tabErr
+	}
+	c.Tab = tab
+
+	if c.Tab != "" && format == docsContentFormatMarkdown {
+		return usage("--tab is not yet supported with --format markdown")
 	}
 
 	account, err := requireAccount(flags)
@@ -502,7 +556,7 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return c.runReplaceAll(ctx, u, svc, docID, replaceText)
 	}
 
-	loaded, err := loadDocsTargetDocument(ctx, svc, docID, c.TabID)
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, c.Tab)
 	if err != nil {
 		return err
 	}
@@ -533,7 +587,7 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if i == 0 {
 			continue
 		}
-		loaded, err = loadDocsTargetDocument(ctx, svc, docID, c.TabID)
+		loaded, err = loadDocsTargetDocument(ctx, svc, docID, c.Tab)
 		if err != nil {
 			return fmt.Errorf("re-reading document: %w", err)
 		}
@@ -547,8 +601,8 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"replace":      replaceText,
 			"replacements": len(matches),
 		}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		return outfmt.WriteJSON(ctx, os.Stdout, payload)
 	}
@@ -557,14 +611,14 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u.Out().Printf("find\t%s", c.Find)
 	u.Out().Printf("replace\t%s", replaceText)
 	u.Out().Printf("replacements\t%d", len(matches))
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	return nil
 }
 
 func (c *DocsFindReplaceCmd) runReplaceAll(ctx context.Context, u *ui.UI, svc *docs.Service, docID, replaceText string) error {
-	documentID, replacements, err := runDocsReplaceAll(ctx, svc, docID, c.Find, replaceText, c.MatchCase, c.TabID)
+	documentID, replacements, err := runDocsReplaceAll(ctx, svc, docID, c.Find, replaceText, c.MatchCase, c.Tab)
 	if err != nil {
 		return err
 	}
@@ -576,8 +630,8 @@ func (c *DocsFindReplaceCmd) runReplaceAll(ctx context.Context, u *ui.UI, svc *d
 			"replace":      replaceText,
 			"replacements": replacements,
 		}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		return outfmt.WriteJSON(ctx, os.Stdout, payload)
 	}
@@ -586,14 +640,14 @@ func (c *DocsFindReplaceCmd) runReplaceAll(ctx context.Context, u *ui.UI, svc *d
 	u.Out().Printf("find\t%s", c.Find)
 	u.Out().Printf("replace\t%s", replaceText)
 	u.Out().Printf("replacements\t%d", replacements)
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	return nil
 }
 
 func (c *DocsFindReplaceCmd) runPlain(ctx context.Context, svc *docs.Service, doc *docs.Document, startIdx, endIdx int64, replaceText string) error {
-	return replaceDocsTextRange(ctx, svc, doc, startIdx, endIdx, replaceText, c.TabID)
+	return replaceDocsTextRange(ctx, svc, doc, startIdx, endIdx, replaceText, c.Tab)
 }
 
 func (c *DocsFindReplaceCmd) runMarkdown(ctx context.Context, svc *docs.Service, account string, doc *docs.Document, startIdx, endIdx int64, replaceText string) error {
@@ -612,8 +666,8 @@ func (c *DocsFindReplaceCmd) printFirstResult(ctx context.Context, u *ui.UI, doc
 			"replacements": replacements,
 			"remaining":    total - replacements,
 		}
-		if c.TabID != "" {
-			payload["tabId"] = c.TabID
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
 		}
 		return outfmt.WriteJSON(ctx, os.Stdout, payload)
 	}
@@ -625,8 +679,8 @@ func (c *DocsFindReplaceCmd) printFirstResult(ctx context.Context, u *ui.UI, doc
 	if remaining := total - replacements; remaining > 0 {
 		u.Out().Printf("remaining\t%d", remaining)
 	}
-	if c.TabID != "" {
-		u.Out().Printf("tabId\t%s", c.TabID)
+	if c.Tab != "" {
+		u.Out().Printf("tabId\t%s", c.Tab)
 	}
 	return nil
 }

--- a/internal/cmd/docs_helpers.go
+++ b/internal/cmd/docs_helpers.go
@@ -114,16 +114,6 @@ func docsDocumentEndIndex(doc *docs.Document) int64 {
 	return end
 }
 
-func findTabByID(tabs []*docs.Tab, tabID string) *docs.Tab {
-	tabID = strings.TrimSpace(tabID)
-	for _, tab := range tabs {
-		if tab != nil && tab.TabProperties != nil && tab.TabProperties.TabId == tabID {
-			return tab
-		}
-	}
-	return nil
-}
-
 func docsTabEndIndex(tab *docs.Tab) int64 {
 	if tab == nil || tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
 		return 1
@@ -162,7 +152,7 @@ func docsTargetEndIndex(ctx context.Context, svc *docs.Service, docID, tabID str
 		return docsDocumentEndIndex(doc), nil
 	}
 
-	tab := findTabByID(flattenTabs(doc.Tabs), tabID)
+	tab := findTab(flattenTabs(doc.Tabs), tabID)
 	if tab == nil {
 		return 0, fmt.Errorf("tab not found: %s", tabID)
 	}

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -39,7 +39,7 @@ func loadDocsTargetDocument(ctx context.Context, svc *docs.Service, docID, tabID
 		return &docsLoadedTarget{full: doc, target: doc}, nil
 	}
 
-	tab := findTabByID(flattenTabs(doc.Tabs), tabID)
+	tab := findTab(flattenTabs(doc.Tabs), tabID)
 	if tab == nil {
 		return nil, fmt.Errorf("tab not found: %s", tabID)
 	}

--- a/internal/cmd/docs_tab_edit_test.go
+++ b/internal/cmd/docs_tab_edit_test.go
@@ -1,13 +1,17 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/ui"
 )
 
 func tabsDocWithEndIndex() map[string]any {
@@ -39,7 +43,7 @@ func tabsDocWithEndIndex() map[string]any {
 	}
 }
 
-func TestDocsWriteUpdate_WithTabID(t *testing.T) {
+func TestDocsWriteUpdate_WithTab(t *testing.T) {
 	origDocs := newDocsService
 	t.Cleanup(func() { newDocsService = origDocs })
 
@@ -77,7 +81,7 @@ func TestDocsWriteUpdate_WithTabID(t *testing.T) {
 	flags := &RootFlags{Account: "a@b.com"}
 	ctx := newDocsCmdContext(t)
 
-	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--tab-id", "t.second"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--tab", "t.second"}, ctx, flags); err != nil {
 		t.Fatalf("write replace: %v", err)
 	}
 	if got := batchRequests[0]; len(got) != 2 || got[0].DeleteContentRange == nil || got[1].InsertText == nil {
@@ -90,21 +94,21 @@ func TestDocsWriteUpdate_WithTabID(t *testing.T) {
 		t.Fatalf("unexpected write insert location: %#v", got)
 	}
 
-	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "world", "--append", "--tab-id", "t.second"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "world", "--append", "--tab", "t.second"}, ctx, flags); err != nil {
 		t.Fatalf("write append: %v", err)
 	}
 	if got := batchRequests[1][0].InsertText.Location; got.TabId != "t.second" || got.Index != 19 {
 		t.Fatalf("unexpected append insert location: %#v", got)
 	}
 
-	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "!", "--tab-id", "t.second"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "!", "--tab", "t.second"}, ctx, flags); err != nil {
 		t.Fatalf("update append: %v", err)
 	}
 	if got := batchRequests[2][0].InsertText.Location; got.TabId != "t.second" || got.Index != 19 {
 		t.Fatalf("unexpected update insert location: %#v", got)
 	}
 
-	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "?", "--index", "5", "--tab-id", "t.second"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "?", "--index", "5", "--tab", "t.second"}, ctx, flags); err != nil {
 		t.Fatalf("update explicit index: %v", err)
 	}
 	if got := batchRequests[3][0].InsertText.Location; got.TabId != "t.second" || got.Index != 5 {
@@ -116,7 +120,7 @@ func TestDocsWriteUpdate_WithTabID(t *testing.T) {
 	}
 }
 
-func TestDocsWriteUpdate_WithTabID_TabNotFound(t *testing.T) {
+func TestDocsWriteUpdate_WithTab_TabNotFound(t *testing.T) {
 	origDocs := newDocsService
 	t.Cleanup(func() { newDocsService = origDocs })
 
@@ -130,18 +134,18 @@ func TestDocsWriteUpdate_WithTabID_TabNotFound(t *testing.T) {
 	flags := &RootFlags{Account: "a@b.com"}
 	ctx := newDocsCmdContext(t)
 
-	err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--tab-id", "t.missing"}, ctx, flags)
+	err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--tab", "t.missing"}, ctx, flags)
 	if err == nil || !strings.Contains(err.Error(), "tab not found: t.missing") {
 		t.Fatalf("unexpected write error: %v", err)
 	}
 
-	err = runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "hello", "--tab-id", "t.missing"}, ctx, flags)
+	err = runKong(t, &DocsUpdateCmd{}, []string{"doc1", "--text", "hello", "--tab", "t.missing"}, ctx, flags)
 	if err == nil || !strings.Contains(err.Error(), "tab not found: t.missing") {
 		t.Fatalf("unexpected update error: %v", err)
 	}
 }
 
-func TestDocsEditingCommands_WithTabID(t *testing.T) {
+func TestDocsEditingCommands_WithTab(t *testing.T) {
 	origDocs := newDocsService
 	t.Cleanup(func() { newDocsService = origDocs })
 
@@ -169,25 +173,62 @@ func TestDocsEditingCommands_WithTabID(t *testing.T) {
 	flags := &RootFlags{Account: "a@b.com"}
 	ctx := newDocsCmdContext(t)
 
-	if err := runKong(t, &DocsInsertCmd{}, []string{"doc1", "hello", "--index", "5", "--tab-id", "t.abc"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsInsertCmd{}, []string{"doc1", "hello", "--index", "5", "--tab", "t.abc"}, ctx, flags); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
 	if got := batchRequests[0][0].InsertText.Location; got.TabId != "t.abc" || got.Index != 5 {
 		t.Fatalf("unexpected insert location: %#v", got)
 	}
 
-	if err := runKong(t, &DocsDeleteCmd{}, []string{"doc1", "--start", "2", "--end", "7", "--tab-id", "t.abc"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsDeleteCmd{}, []string{"doc1", "--start", "2", "--end", "7", "--tab", "t.abc"}, ctx, flags); err != nil {
 		t.Fatalf("delete: %v", err)
 	}
 	if got := batchRequests[1][0].DeleteContentRange.Range; got.TabId != "t.abc" || got.StartIndex != 2 || got.EndIndex != 7 {
 		t.Fatalf("unexpected delete range: %#v", got)
 	}
 
-	if err := runKong(t, &DocsFindReplaceCmd{}, []string{"doc1", "old", "new", "--tab-id", "t.abc"}, ctx, flags); err != nil {
+	if err := runKong(t, &DocsFindReplaceCmd{}, []string{"doc1", "old", "new", "--tab", "t.abc"}, ctx, flags); err != nil {
 		t.Fatalf("find-replace: %v", err)
 	}
 	req := batchRequests[2][0].ReplaceAllText
 	if req == nil || req.TabsCriteria == nil || len(req.TabsCriteria.TabIds) != 1 || req.TabsCriteria.TabIds[0] != "t.abc" {
 		t.Fatalf("unexpected tabs criteria: %#v", req)
+	}
+}
+
+func TestDocsWriteCmd_DeprecatedTabIDFlag(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(path, ":batchUpdate"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		case r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderrBuf bytes.Buffer
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: &stderrBuf, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	if err := runKong(t, &DocsWriteCmd{}, []string{"doc1", "--text", "hello", "--tab-id", "t.second"}, ctx, flags); err != nil {
+		t.Fatalf("write with --tab-id: %v", err)
+	}
+	if !strings.Contains(stderrBuf.String(), "--tab-id is deprecated") {
+		t.Errorf("expected deprecation warning in stderr, got: %q", stderrBuf.String())
 	}
 }

--- a/internal/cmd/help_snapshot_test.go
+++ b/internal/cmd/help_snapshot_test.go
@@ -38,7 +38,7 @@ func TestHelpSnapshot_Auth(t *testing.T) {
 func TestHelpSnapshot_DocsUpdate(t *testing.T) {
 	out := captureHelpOutput(t, "docs", "update", "--help")
 	requireHelpContains(t, out,
-		"--tab-id",
+		"--tab",
 		"--text",
 		"--file",
 		"--index",


### PR DESCRIPTION

### Summary

The docs editing commands (`write`, `update`, `insert`, `delete`, `find-replace`) used `--tab-id` (ID only), while the read commands (`cat`, `structure`, `sed`) already used `--tab` (title or ID). 

- Renames `--tab-id` to `--tab` on all 5 editing commands, accepting both tab titles (case-insensitive) and tab IDs
- Keeps `--tab-id` as a hidden flag that still works but emits a deprecation warning to stderr
- Rejects passing both `--tab` and `--tab-id` simultaneously with a clear error
- Switches internal helpers (`docsTargetEndIndex`, `loadDocsTargetDocument`) from the ID-only `findTabByID` to the title-aware `findTab`, so title resolution actually works for mutations — not just reads
- Removes the now-unused `findTabByID`

### Test plan

- Existing tab editing tests updated to use `--tab` and still pass
- New `TestDocsWriteCmd_DeprecatedTabIDFlag` verifies `--tab-id` still works and emits the deprecation warning
- Help snapshot test updated to check for `--tab` in `docs update --help` output
- `make test` passes
