### PR TITLE
refactor(googleapi): extract authenticatedTransport and add NewHTTPCl…

### DIFF
--- a/internal/cmd/docs_testutil_test.go
+++ b/internal/cmd/docs_testutil_test.go
@@ -19,16 +19,16 @@ func newDocsServiceForTest(t *testing.T, h http.HandlerFunc) (*docs.Service, fun
 	t.Helper()
 
 	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
 	docSvc, err := docs.NewService(context.Background(),
 		option.WithoutAuthentication(),
 		option.WithHTTPClient(srv.Client()),
 		option.WithEndpoint(srv.URL+"/"),
 	)
 	if err != nil {
-		srv.Close()
 		t.Fatalf("NewDocsService: %v", err)
 	}
-	return docSvc, srv.Close
+	return docSvc, func() {} // retained for call-site compat; cleanup is via t.Cleanup
 }
 
 func newDocsCmdContext(t *testing.T) context.Context {

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -50,9 +50,7 @@ func IsADCMode() bool {
 	return os.Getenv("GOG_AUTH_MODE") == "adc"
 }
 
-func optionsForAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
-	slog.Debug("creating client options with custom scopes", "serviceLabel", serviceLabel, "email", email)
-
+func authenticatedTransport(ctx context.Context, serviceLabel string, email string, scopes []string) (http.RoundTripper, error) {
 	var ts oauth2.TokenSource
 
 	if IsADCMode() {
@@ -73,13 +71,22 @@ func optionsForAccountScopes(ctx context.Context, serviceLabel string, email str
 		}
 	}
 
-	baseTransport := newBaseTransport()
-	retryTransport := NewRetryTransport(&oauth2.Transport{
+	return NewRetryTransport(&oauth2.Transport{
 		Source: ts,
-		Base:   baseTransport,
-	})
+		Base:   newBaseTransport(),
+	}), nil
+}
+
+func optionsForAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
+	slog.Debug("creating client options with custom scopes", "serviceLabel", serviceLabel, "email", email)
+
+	transport, err := authenticatedTransport(ctx, serviceLabel, email, scopes)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &http.Client{
-		Transport: retryTransport,
+		Transport: transport,
 		// No Timeout set: large file downloads (Drive videos, etc.) must not
 		// be cut short. Server responsiveness is guarded by the transport's
 		// ResponseHeaderTimeout instead.
@@ -88,6 +95,23 @@ func optionsForAccountScopes(ctx context.Context, serviceLabel string, email str
 	slog.Debug("client options with custom scopes created successfully", "serviceLabel", serviceLabel, "email", email)
 
 	return []option.ClientOption{option.WithHTTPClient(c)}, nil
+}
+
+// NewHTTPClient returns a raw *http.Client authenticated for the given service
+// and account. The caller may set CheckRedirect or other policies on the
+// returned client.
+func NewHTTPClient(ctx context.Context, service googleauth.Service, email string) (*http.Client, error) {
+	scopes, err := googleauth.Scopes(service)
+	if err != nil {
+		return nil, fmt.Errorf("resolve scopes: %w", err)
+	}
+
+	transport, err := authenticatedTransport(ctx, string(service), email, scopes)
+	if err != nil {
+		return nil, err
+	}
+
+	return &http.Client{Transport: transport}, nil
 }
 
 func newBaseTransport() *http.Transport {

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -549,3 +549,33 @@ func TestOptionsForAccountScopes_NoClientTimeout(t *testing.T) {
 		t.Fatalf("expected ResponseHeaderTimeout to be set on transport")
 	}
 }
+
+func TestNewHTTPClient_NoRedirectPolicy(t *testing.T) {
+	origRead := readClientCredentials
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() {
+		readClientCredentials = origRead
+		openSecretsStore = origOpen
+	})
+
+	readClientCredentials = func(string) (config.ClientCredentials, error) {
+		return config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}, nil
+	}
+	openSecretsStore = func() (secrets.Store, error) {
+		return &stubStore{tok: secrets.Token{Email: "a@b.com", RefreshToken: "rt"}}, nil
+	}
+
+	client, err := NewHTTPClient(context.Background(), googleauth.ServiceDocs, "a@b.com")
+	if err != nil {
+		t.Fatalf("NewHTTPClient: %v", err)
+	}
+
+	if client.Transport == nil {
+		t.Fatal("expected Transport to be set on client")
+	}
+
+	if client.CheckRedirect != nil {
+		t.Fatal("expected no CheckRedirect on bare client")
+	}
+}


### PR DESCRIPTION
refactor(googleapi): extract authenticatedTransport and add NewHTTPClient

> Dependency for https://github.com/steipete/gogcli/pull/535  ⚠️ only merge this if you plan to merge #535 ⚠️ 

### Summary

- Extracts the OAuth transport setup from `optionsForAccountScopes` into a reusable `authenticatedTransport` helper, removing duplication between the existing google-api-go client path and callers that need a raw `*http.Client`
- Adds `NewHTTPClient(ctx, service, email)` for callers that need to set their own policies (e.g. custom `CheckRedirect`) on the HTTP client rather than going through `option.WithHTTPClient`
- Minor test cleanup: switches `newDocsServiceForTest` to use `t.Cleanup` instead of returning a manual close func

### Test plan

- `TestNewHTTPClient_NoRedirectPolicy` verifies the returned client has no redirect policy set (callers can add their own)
- `TestOptionsForAccountScopes_NoClientTimeout` continues to pass, confirming no regression in the existing path
- `make test` passes
