### PR TITLE
ci(docker): Add Dockerfile and configure GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,3 +56,34 @@ jobs:
           args: release --clean --config /tmp/.goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lowercase variables
+        run: |
+          echo "GITHUB_REPOSITORY_LC=${GITHUB_REPOSITORY,,}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/${{ env.GITHUB_REPOSITORY_LC }}:${{ github.ref_name || inputs.tag }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM golang:1.26-alpine
+
+RUN apk add --no-cache make bash git
+
+WORKDIR /app
+
+COPY . .
+
+RUN go mod tidy
+
+RUN make build
+
+FROM busybox
+
+COPY --from=0 /app/bin/gog /bin/
+
+CMD ["/bin/gog"]


### PR DESCRIPTION
This PR adds support for containerizing the project and automated CI image building:
﻿
- Add a valid Dockerfile for building gogcli container image
- Configure GitHub Actions workflow to automatically build and push Docker images to GHCR on code update