### PR TITLE
feat(docs): add --tab support for markdown find-replace and append

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -221,7 +221,7 @@ func (c *DocsCreateCmd) insertImages(ctx context.Context, account string, docID 
 	if err != nil {
 		return err
 	}
-	return insertImagesIntoDocs(ctx, svc, docID, images)
+	return insertImagesIntoDocs(ctx, svc, docID, images, "")
 }
 
 type DocsCopyCmd struct {

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -187,8 +187,10 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 	if !c.Replace {
 		return usage("--markdown requires --replace or --append")
 	}
+	// Tab support for markdown replace is limited because Drive's markdown
+	// converter doesn't support tab-specific updates, so we skip tab support here.
 	if c.Tab != "" {
-		return usage("--markdown cannot be combined with --tab")
+		return usage("--markdown with --replace does not support --tab (Drive's markdown converter operates on entire documents)")
 	}
 
 	cleaned, images := extractMarkdownImages(content)
@@ -217,8 +219,8 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 		}
 	}
 	if len(images) > 0 {
-		if err := insertImagesIntoDocs(ctx, docsSvc, docID, images); err != nil {
-			cleanupDocsImagePlaceholders(ctx, docsSvc, docID, images)
+		if err := insertImagesIntoDocs(ctx, docsSvc, docID, images, ""); err != nil {
+			cleanupDocsImagePlaceholders(ctx, docsSvc, docID, images, "")
 			return fmt.Errorf("insert images: %w", err)
 		}
 	}
@@ -254,22 +256,18 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 }
 
 func (c *DocsWriteCmd) appendMarkdown(ctx context.Context, flags *RootFlags, docID, content string) error {
-	if c.Tab != "" {
-		return usage("--markdown cannot be combined with --tab")
-	}
-
 	svc, err := requireDocsService(ctx, flags)
 	if err != nil {
 		return err
 	}
 
-	endIndex, _, err := docsTargetEndIndexAndTabID(ctx, svc, docID, "")
+	endIndex, _, err := docsTargetEndIndexAndTabID(ctx, svc, docID, c.Tab)
 	if err != nil {
 		return err
 	}
 	insertIndex := docsAppendIndex(endIndex)
 
-	requestCount, inserted, err := insertDocsMarkdownAt(ctx, svc, docID, insertIndex, content)
+	requestCount, inserted, err := insertDocsMarkdownAt(ctx, svc, docID, insertIndex, content, c.Tab)
 	if err != nil {
 		if isDocsNotFound(err) {
 			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
@@ -627,7 +625,7 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 	c.Tab = tab
 
 	if c.Tab != "" && format == docsContentFormatMarkdown {
-		return usage("--tab is not yet supported with --format markdown")
+		// allow markdown find-replace in specific tab
 	}
 
 	svc, err := requireDocsService(ctx, flags)
@@ -635,15 +633,20 @@ func (c *DocsFindReplaceCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if !c.First && format == docsContentFormatPlain {
-		if c.Tab != "" {
-			tabID, tabErr := resolveDocsTabID(ctx, svc, docID, c.Tab)
-			if tabErr != nil {
-				return tabErr
-			}
-			c.Tab = tabID
+	if c.Tab != "" {
+		tabID, tabErr := resolveDocsTabID(ctx, svc, docID, c.Tab)
+		if tabErr != nil {
+			return tabErr
 		}
-		return c.runReplaceAll(ctx, u, svc, docID, replaceText)
+		c.Tab = tabID
+	}
+	
+	if !c.First {
+		if format == docsContentFormatPlain {
+			return c.runReplaceAll(ctx, u, svc, docID, replaceText)
+		} else {
+			// for markdown, runReplaceAll is not supported yet (native docs batch update only does plain text). We will fall through to iterative replacements.
+		}
 	}
 
 	loaded, err := loadDocsTargetDocument(ctx, svc, docID, c.Tab)
@@ -742,7 +745,7 @@ func (c *DocsFindReplaceCmd) runPlain(ctx context.Context, svc *docs.Service, do
 }
 
 func (c *DocsFindReplaceCmd) runMarkdown(ctx context.Context, svc *docs.Service, doc *docs.Document, startIdx, endIdx int64, replaceText string) error {
-	return replaceDocsMarkdownRange(ctx, svc, doc, startIdx, endIdx, replaceText)
+	return replaceDocsMarkdownRange(ctx, svc, doc, startIdx, endIdx, replaceText, c.Tab)
 }
 
 func (c *DocsFindReplaceCmd) printFirstResult(ctx context.Context, u *ui.UI, docID, replaceText string, replacements, total int) error {

--- a/internal/cmd/docs_formatter.go
+++ b/internal/cmd/docs_formatter.go
@@ -19,7 +19,7 @@ type TableData struct {
 // MarkdownToDocsRequests converts parsed markdown elements to Google Docs batch
 // update requests. baseIndex is the insertion location in the document.
 // Returns: requests, plainText, tableData (for native table insertion)
-func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*docs.Request, string, []TableData) {
+func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64, tabID string) ([]*docs.Request, string, []TableData) {
 	var requests []*docs.Request
 	var plainText strings.Builder
 	var tables []TableData
@@ -59,6 +59,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 					Range: &docs.Range{
 						StartIndex: startOffset,
 						EndIndex:   charOffset,
+						TabId:      tabID,
 					},
 					ParagraphStyle: &docs.ParagraphStyle{
 						NamedStyleType: headingStyle,
@@ -69,7 +70,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 
 			// Apply inline text styles
 			for _, style := range styles {
-				textStyleReq := buildTextStyleRequest(style, startOffset)
+				textStyleReq := buildTextStyleRequest(style, startOffset, tabID)
 				if textStyleReq != nil {
 					if debugMarkdown {
 						fmt.Printf("  Style request: [%d, %d]\n",
@@ -92,6 +93,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 					Range: &docs.Range{
 						StartIndex: startOffset,
 						EndIndex:   charOffset,
+						TabId:      tabID,
 					},
 					TextStyle: &docs.TextStyle{
 						WeightedFontFamily: &docs.WeightedFontFamily{
@@ -131,6 +133,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 					Range: &docs.Range{
 						StartIndex: startOffset,
 						EndIndex:   charOffset,
+						TabId:      tabID,
 					},
 					ParagraphStyle: &docs.ParagraphStyle{
 						IndentStart: &docs.Dimension{
@@ -144,7 +147,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 
 			// Apply inline text styles
 			for _, style := range styles {
-				textStyleReq := buildTextStyleRequest(style, startOffset)
+				textStyleReq := buildTextStyleRequest(style, startOffset, tabID)
 				if textStyleReq != nil {
 					if debugMarkdown {
 						fmt.Printf("  Style request: [%d, %d] (base=%d, style=[%d,%d])\n",
@@ -177,7 +180,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 
 			// Apply inline text styles (offset by prefix length)
 			for _, style := range styles {
-				textStyleReq := buildTextStyleRequest(style, startOffset+prefixLen)
+				textStyleReq := buildTextStyleRequest(style, startOffset+prefixLen, tabID)
 				if textStyleReq != nil {
 					requests = append(requests, textStyleReq)
 				}
@@ -212,7 +215,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 
 			// Apply inline text styles
 			for _, style := range styles {
-				textStyleReq := buildTextStyleRequest(style, startOffset)
+				textStyleReq := buildTextStyleRequest(style, startOffset, tabID)
 				if textStyleReq != nil {
 					if debugMarkdown {
 						fmt.Printf("  Style request: [%d, %d]\n",
@@ -268,7 +271,7 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64) ([]*doc
 }
 
 // buildTextStyleRequest creates a text style update request from a TextStyle
-func buildTextStyleRequest(style TextStyle, baseOffset int64) *docs.Request {
+func buildTextStyleRequest(style TextStyle, baseOffset int64, tabID string) *docs.Request {
 	// Validate indices
 	if style.Start < 0 || style.End < 0 || style.End <= style.Start {
 		return nil
@@ -308,6 +311,7 @@ func buildTextStyleRequest(style TextStyle, baseOffset int64) *docs.Request {
 			Range: &docs.Range{
 				StartIndex: baseOffset + int64(style.Start),
 				EndIndex:   baseOffset + int64(style.End),
+				TabId:      tabID,
 			},
 			TextStyle: textStyle,
 			Fields:    strings.Join(fields, ","),

--- a/internal/cmd/docs_formatter_test.go
+++ b/internal/cmd/docs_formatter_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestMarkdownToDocsRequests_BaseIndex(t *testing.T) {
 	elements := []MarkdownElement{{Type: MDParagraph, Content: "**bold**"}}
-	requests, text, tables := MarkdownToDocsRequests(elements, 42)
+	requests, text, tables := MarkdownToDocsRequests(elements, 42, "")
 
 	if text != "bold\n" {
 		t.Fatalf("unexpected text: %q", text)
@@ -27,7 +27,7 @@ func TestMarkdownToDocsRequests_TableStartIndexUsesBase(t *testing.T) {
 		{Type: MDParagraph, Content: "A"},
 		{Type: MDTable, TableCells: [][]string{{"h1", "h2"}, {"v1", "v2"}}},
 	}
-	_, text, tables := MarkdownToDocsRequests(elements, 10)
+	_, text, tables := MarkdownToDocsRequests(elements, 10, "")
 
 	if text != "A\n\n" {
 		t.Fatalf("unexpected text: %q", text)

--- a/internal/cmd/docs_import.go
+++ b/internal/cmd/docs_import.go
@@ -217,7 +217,7 @@ func searchParagraph(para *docs.Paragraph, placeholders []string, result map[str
 // insertImagesIntoDocs reads back a Google Doc to find <<IMG_token_N>> placeholders,
 // resolves image URLs (remote URLs used directly; local files are rejected),
 // and replaces the placeholders with inline images via BatchUpdate.
-func insertImagesIntoDocs(ctx context.Context, svc *docs.Service, docID string, images []markdownImage) error {
+func insertImagesIntoDocs(ctx context.Context, svc *docs.Service, docID string, images []markdownImage, tabID string) error {
 	// Read back the document to find placeholder positions.
 	doc, err := svc.Documents.Get(docID).Context(ctx).Do()
 	if err != nil {
@@ -244,7 +244,7 @@ func insertImagesIntoDocs(ctx context.Context, svc *docs.Service, docID string, 
 		return fmt.Errorf("local markdown image %q cannot be inserted automatically; Google Docs image insertion requires a public HTTPS image URL, so upload the image to a public host and use that URL", img.originalRef)
 	}
 
-	reqs := buildImageInsertRequests(placeholders, images, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, images, imageURLs, tabID)
 	if len(reqs) == 0 {
 		return nil
 	}
@@ -315,7 +315,7 @@ const defaultImageMaxWidthPt = 468.0
 // buildImageInsertRequests creates the Docs API batch update requests to replace
 // placeholder text with inline images. Requests are ordered in reverse index order
 // so earlier positions are not invalidated as the document is modified.
-func buildImageInsertRequests(placeholders map[string]docRange, images []markdownImage, imageURLs map[int]string) []*docs.Request {
+func buildImageInsertRequests(placeholders map[string]docRange, images []markdownImage, imageURLs map[int]string, tabID string) []*docs.Request {
 	// Collect entries sorted by start index descending.
 	type entry struct {
 		image markdownImage
@@ -349,6 +349,7 @@ func buildImageInsertRequests(placeholders map[string]docRange, images []markdow
 				Range: &docs.Range{
 					StartIndex: e.dr.startIndex,
 					EndIndex:   e.dr.endIndex,
+					TabId:      tabID,
 				},
 			},
 		})
@@ -370,6 +371,7 @@ func buildImageInsertRequests(placeholders map[string]docRange, images []markdow
 				Uri: e.url,
 				Location: &docs.Location{
 					Index: e.dr.startIndex,
+					TabId: tabID,
 				},
 				ObjectSize: objSize,
 			},

--- a/internal/cmd/docs_import_test.go
+++ b/internal/cmd/docs_import_test.go
@@ -547,7 +547,7 @@ func TestFindPlaceholderIndices_SkipsNilTextRun(t *testing.T) {
 
 func TestBuildImageInsertRequests_EmptyInputs(t *testing.T) {
 	// All empty
-	reqs := buildImageInsertRequests(nil, nil, nil)
+	reqs := buildImageInsertRequests(nil, nil, nil, "")
 	if len(reqs) != 0 {
 		t.Fatalf("expected 0 requests for nil inputs, got %d", len(reqs))
 	}
@@ -557,6 +557,7 @@ func TestBuildImageInsertRequests_EmptyInputs(t *testing.T) {
 		make(map[string]docRange),
 		[]markdownImage{},
 		make(map[int]string),
+		"",
 	)
 	if len(reqs) != 0 {
 		t.Fatalf("expected 0 requests for empty inputs, got %d", len(reqs))
@@ -572,7 +573,7 @@ func TestBuildImageInsertRequests_SingleImage(t *testing.T) {
 		0: "https://example.com/img.png",
 	}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests (delete + insert), got %d", len(reqs))
 	}
@@ -619,7 +620,7 @@ func TestBuildImageInsertRequests_MultipleImages_ReverseOrder(t *testing.T) {
 		2: "https://example.com/c.png",
 	}
 
-	reqs := buildImageInsertRequests(placeholders, images, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, images, imageURLs, "")
 	// 3 images * 2 requests each = 6
 	if len(reqs) != 6 {
 		t.Fatalf("expected 6 requests, got %d", len(reqs))
@@ -657,7 +658,7 @@ func TestBuildImageInsertRequests_MissingPlaceholder(t *testing.T) {
 		0: "https://example.com/img.png",
 	}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 0 {
 		t.Fatalf("expected 0 requests when placeholder missing, got %d", len(reqs))
 	}
@@ -671,7 +672,7 @@ func TestBuildImageInsertRequests_MissingURL(t *testing.T) {
 	}
 	imageURLs := map[int]string{} // empty — URL not resolved
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 0 {
 		t.Fatalf("expected 0 requests when URL missing, got %d", len(reqs))
 	}
@@ -692,7 +693,7 @@ func TestBuildImageInsertRequests_PartialMissing(t *testing.T) {
 		// 1 is intentionally missing
 	}
 
-	reqs := buildImageInsertRequests(placeholders, images, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, images, imageURLs, "")
 	// Only 1 image produces requests (2 = delete + insert)
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
@@ -711,7 +712,7 @@ func TestBuildImageInsertRequests_DeleteRangeMatchesPlaceholder(t *testing.T) {
 	}
 	imageURLs := map[int]string{0: "https://x.com/a.png"}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
 	}
@@ -729,7 +730,7 @@ func TestBuildImageInsertRequests_InsertLocationMatchesStart(t *testing.T) {
 	}
 	imageURLs := map[int]string{0: "https://x.com/a.png"}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
 	}
@@ -793,7 +794,7 @@ func TestExtractAndFindPlaceholders_RoundTrip(t *testing.T) {
 		0: "https://example.com/a.png",
 		1: "https://example.com/b.jpg",
 	}
-	reqs := buildImageInsertRequests(placeholders, images, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, images, imageURLs, "")
 	if len(reqs) != 4 {
 		t.Fatalf("expected 4 requests, got %d", len(reqs))
 	}
@@ -1118,7 +1119,7 @@ func TestBuildImageInsertRequests_CustomWidth(t *testing.T) {
 	}
 	imageURLs := map[int]string{0: "https://x.com/a.png"}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
 	}
@@ -1138,7 +1139,7 @@ func TestBuildImageInsertRequests_CustomBothDimensions(t *testing.T) {
 	}
 	imageURLs := map[int]string{0: "https://x.com/a.png"}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
 	}
@@ -1158,7 +1159,7 @@ func TestBuildImageInsertRequests_CustomHeightOnly(t *testing.T) {
 	}
 	imageURLs := map[int]string{0: "https://x.com/a.png"}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
 	}
@@ -1178,7 +1179,7 @@ func TestBuildImageInsertRequests_DefaultWidth(t *testing.T) {
 	}
 	imageURLs := map[int]string{0: "https://x.com/a.png"}
 
-	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs)
+	reqs := buildImageInsertRequests(placeholders, []markdownImage{img}, imageURLs, "")
 	if len(reqs) != 2 {
 		t.Fatalf("expected 2 requests, got %d", len(reqs))
 	}

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -112,21 +112,36 @@ func replaceDocsTextRange(ctx context.Context, svc *docs.Service, doc *docs.Docu
 	return nil
 }
 
-func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.Document, startIdx, endIdx int64, replaceText string) error {
+func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.Document, startIdx, endIdx int64, replaceText string, tabID string) error {
 	cleaned, images := extractMarkdownImages(replaceText)
 	elements := ParseMarkdown(cleaned)
-	formattingRequests, textToInsert, tables := MarkdownToDocsRequests(elements, startIdx)
+	formattingRequests, textToInsert, tables := MarkdownToDocsRequests(elements, startIdx, tabID)
+
+	for _, req := range formattingRequests {
+		if req.UpdateTextStyle != nil && req.UpdateTextStyle.Range != nil {
+			req.UpdateTextStyle.Range.TabId = tabID
+		}
+		if req.UpdateParagraphStyle != nil && req.UpdateParagraphStyle.Range != nil {
+			req.UpdateParagraphStyle.Range.TabId = tabID
+		}
+		if req.CreateParagraphBullets != nil && req.CreateParagraphBullets.Range != nil {
+			req.CreateParagraphBullets.Range.TabId = tabID
+		}
+		if req.DeleteParagraphBullets != nil && req.DeleteParagraphBullets.Range != nil {
+			req.DeleteParagraphBullets.Range.TabId = tabID
+		}
+	}
 
 	requests := make([]*docs.Request, 0, 2+len(formattingRequests))
 	requests = append(requests,
 		&docs.Request{
 			DeleteContentRange: &docs.DeleteContentRangeRequest{
-				Range: &docs.Range{StartIndex: startIdx, EndIndex: endIdx},
+				Range: &docs.Range{StartIndex: startIdx, EndIndex: endIdx, TabId: tabID},
 			},
 		},
 		&docs.Request{
 			InsertText: &docs.InsertTextRequest{
-				Location: &docs.Location{Index: startIdx},
+				Location: &docs.Location{Index: startIdx, TabId: tabID},
 				Text:     textToInsert,
 			},
 		},
@@ -146,7 +161,7 @@ func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.
 		tableOffset := int64(0)
 		for _, table := range tables {
 			tableIndex := table.StartIndex + tableOffset
-			tableEnd, tableErr := tableInserter.InsertNativeTable(ctx, tableIndex, table.Cells)
+			tableEnd, tableErr := tableInserter.InsertNativeTable(ctx, tableIndex, table.Cells, tabID)
 			if tableErr != nil {
 				return fmt.Errorf("insert native table: %w", tableErr)
 			}
@@ -157,8 +172,8 @@ func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.
 	}
 
 	if len(images) > 0 {
-		imgErr := insertImagesIntoDocs(ctx, svc, doc.DocumentId, images)
-		cleanupDocsImagePlaceholders(ctx, svc, doc.DocumentId, images)
+		imgErr := insertImagesIntoDocs(ctx, svc, doc.DocumentId, images, tabID)
+		cleanupDocsImagePlaceholders(ctx, svc, doc.DocumentId, images, tabID)
 		if imgErr != nil {
 			return fmt.Errorf("insert images: %w", imgErr)
 		}
@@ -167,18 +182,33 @@ func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.
 	return nil
 }
 
-func insertDocsMarkdownAt(ctx context.Context, svc *docs.Service, docID string, insertIdx int64, content string) (requestCount int, inserted int, err error) {
+func insertDocsMarkdownAt(ctx context.Context, svc *docs.Service, docID string, insertIdx int64, content string, tabID string) (requestCount int, inserted int, err error) {
 	cleaned, images := extractMarkdownImages(content)
 	elements := ParseMarkdown(cleaned)
-	formattingRequests, textToInsert, tables := MarkdownToDocsRequests(elements, insertIdx)
+	formattingRequests, textToInsert, tables := MarkdownToDocsRequests(elements, insertIdx, tabID)
 	if textToInsert == "" {
 		return 0, 0, nil
+	}
+
+	for _, req := range formattingRequests {
+		if req.UpdateTextStyle != nil && req.UpdateTextStyle.Range != nil {
+			req.UpdateTextStyle.Range.TabId = tabID
+		}
+		if req.UpdateParagraphStyle != nil && req.UpdateParagraphStyle.Range != nil {
+			req.UpdateParagraphStyle.Range.TabId = tabID
+		}
+		if req.CreateParagraphBullets != nil && req.CreateParagraphBullets.Range != nil {
+			req.CreateParagraphBullets.Range.TabId = tabID
+		}
+		if req.DeleteParagraphBullets != nil && req.DeleteParagraphBullets.Range != nil {
+			req.DeleteParagraphBullets.Range.TabId = tabID
+		}
 	}
 
 	requests := make([]*docs.Request, 0, 1+len(formattingRequests))
 	requests = append(requests, &docs.Request{
 		InsertText: &docs.InsertTextRequest{
-			Location: &docs.Location{Index: insertIdx},
+			Location: &docs.Location{Index: insertIdx, TabId: tabID},
 			Text:     textToInsert,
 		},
 	})
@@ -196,7 +226,7 @@ func insertDocsMarkdownAt(ctx context.Context, svc *docs.Service, docID string, 
 		tableOffset := int64(0)
 		for _, table := range tables {
 			tableIndex := table.StartIndex + tableOffset
-			tableEnd, tableErr := tableInserter.InsertNativeTable(ctx, tableIndex, table.Cells)
+			tableEnd, tableErr := tableInserter.InsertNativeTable(ctx, tableIndex, table.Cells, tabID)
 			if tableErr != nil {
 				return len(requests), len(textToInsert), fmt.Errorf("insert native table: %w", tableErr)
 			}
@@ -207,8 +237,8 @@ func insertDocsMarkdownAt(ctx context.Context, svc *docs.Service, docID string, 
 	}
 
 	if len(images) > 0 {
-		imgErr := insertImagesIntoDocs(ctx, svc, docID, images)
-		cleanupDocsImagePlaceholders(ctx, svc, docID, images)
+		imgErr := insertImagesIntoDocs(ctx, svc, docID, images, tabID)
+		cleanupDocsImagePlaceholders(ctx, svc, docID, images, tabID)
 		if imgErr != nil {
 			return len(requests), len(textToInsert), fmt.Errorf("insert images: %w", imgErr)
 		}
@@ -217,10 +247,10 @@ func insertDocsMarkdownAt(ctx context.Context, svc *docs.Service, docID string, 
 	return len(requests), len(textToInsert), nil
 }
 
-func cleanupDocsImagePlaceholders(ctx context.Context, svc *docs.Service, docID string, images []markdownImage) {
+func cleanupDocsImagePlaceholders(ctx context.Context, svc *docs.Service, docID string, images []markdownImage, tabID string) {
 	reqs := make([]*docs.Request, 0, len(images))
 	for _, img := range images {
-		reqs = append(reqs, &docs.Request{
+		req := &docs.Request{
 			ReplaceAllText: &docs.ReplaceAllTextRequest{
 				ContainsText: &docs.SubstringMatchCriteria{
 					Text:      img.placeholder(),
@@ -228,7 +258,11 @@ func cleanupDocsImagePlaceholders(ctx context.Context, svc *docs.Service, docID 
 				},
 				ReplaceText: "",
 			},
-		})
+		}
+		if tabID != "" {
+			req.ReplaceAllText.TabsCriteria = &docs.TabsCriteria{TabIds: []string{tabID}}
+		}
+		reqs = append(reqs, req)
 	}
 	_, _ = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 		Requests: reqs,

--- a/internal/cmd/docs_tab_edit_test.go
+++ b/internal/cmd/docs_tab_edit_test.go
@@ -199,6 +199,10 @@ func TestDocsEditingCommands_WithTab(t *testing.T) {
 	if req == nil || req.TabsCriteria == nil || len(req.TabsCriteria.TabIds) != 1 || req.TabsCriteria.TabIds[0] != "t.second" {
 		t.Fatalf("unexpected tabs criteria: %#v", req)
 	}
+
+	if err := runKong(t, &DocsFindReplaceCmd{}, []string{"doc1", "old", "**new**", "--format", "markdown", "--tab", "Second"}, ctx, flags); err != nil {
+		t.Fatalf("find-replace markdown tab: %v", err)
+	}
 }
 
 func TestDocsWriteCmd_DeprecatedTabIDFlag(t *testing.T) {

--- a/internal/cmd/docs_table_inserter.go
+++ b/internal/cmd/docs_table_inserter.go
@@ -22,7 +22,7 @@ func NewTableInserter(svc *docs.Service, docID string) *TableInserter {
 
 // InsertNativeTable inserts a native Google Docs table and populates it with content
 // Returns the end index of the table after insertion
-func (ti *TableInserter) InsertNativeTable(ctx context.Context, tableIndex int64, cells [][]string) (int64, error) {
+func (ti *TableInserter) InsertNativeTable(ctx context.Context, tableIndex int64, cells [][]string, tabID string) (int64, error) {
 	if len(cells) == 0 || len(cells[0]) == 0 {
 		return tableIndex, nil
 	}
@@ -37,6 +37,7 @@ func (ti *TableInserter) InsertNativeTable(ctx context.Context, tableIndex int64
 			Columns: cols,
 			Location: &docs.Location{
 				Index: tableIndex,
+				TabId: tabID,
 			},
 		},
 	}


### PR DESCRIPTION
Enables `gog docs find-replace --format markdown --tab <TAB_ID>` to render markdown into specific tabs of multi-tab Google Docs, addressing the automation workflow requested in #537.

Changes:
- Remove blocking error preventing --tab with --format markdown
- Propagate tabID through markdown rendering pipeline:
  - replaceDocsMarkdownRange, insertDocsMarkdownAt
  - MarkdownToDocsRequests, buildTextStyleRequest
  - InsertNativeTable, buildImageInsertRequests
  - insertImagesIntoDocs, cleanupDocsImagePlaceholders
- Add TabId to all Range and Location objects in formatting requests
- Enable --tab with --markdown --append for docs write
- Add test coverage in docs_tab_edit_test.go

Note: update --markdown --replace --tab remains unsupported by design, as Drive's markdown converter API operates on entire documents and doesn't support tab-specific updates (Google API limitation).

Fixes #537