### PR TITLE
fix: use generic dev version fallback

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	version = "0.13.0-dev"
+	version = "dev"
 	commit  = ""
 	date    = ""
 )


### PR DESCRIPTION
## Summary

This changes the built-in fallback version from a stale release-like value (`0.13.0-dev`) to a neutral `dev` value.

Release builds already inject the real version, commit, and date through GoReleaser `ldflags`, so this does not change the published release artifact behavior. It only affects binaries built without those linker flags, such as plain `go build` or `go install github.com/steipete/gogcli/cmd/gog@<version>`.

## Why

The hardcoded fallback can drift after releases. When it does, source-installed binaries from a newer tag can report an older dev version, which makes support diagnostics and packaging verification misleading.

For example, a binary built from a tagged module version should not look like a stale `0.13.0-dev` build simply because it was not built through GoReleaser.

## Why This Change

Using `dev` is the lowest-blast-radius fix:

- It preserves the existing GoReleaser workflow and release metadata injection.
- It avoids requiring release automation changes.
- It avoids a future maintenance burden of updating a hardcoded fallback every release.
- It makes non-release builds clearly identify as unversioned development/source builds instead of masquerading as a stale pre-release.

A more complete future improvement could infer the module version from `runtime/debug.ReadBuildInfo()` for `go install module@version`, but this one-line change fixes the misleading output without changing release behavior.

## Verification

- `go test ./internal/cmd`
- `go test ./cmd/gog`
- `go build -o /tmp/gog-dev ./cmd/gog && /tmp/gog-dev --version` prints `dev`
- `go build -ldflags \"-X github.com/steipete/gogcli/internal/cmd.version=v9.9.9 -X github.com/steipete/gogcli/internal/cmd.commit=abc123 -X github.com/steipete/gogcli/internal/cmd.date=2026-05-01T00:00:00Z\" -o /tmp/gog-release ./cmd/gog && /tmp/gog-release --version` prints `v9.9.9 (abc123 2026-05-01T00:00:00Z)`