### PR TITLE
fix: infer module version for source builds

### DIFF
--- a/internal/cmd/version.go
+++ b/internal/cmd/version.go
@@ -4,22 +4,39 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"strings"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 )
 
 var (
-	version = "0.13.0-dev"
-	commit  = ""
-	date    = ""
+	version       = "dev"
+	commit        = ""
+	date          = ""
+	readBuildInfo = debug.ReadBuildInfo
 )
 
-func VersionString() string {
+func resolvedVersion() string {
 	v := strings.TrimSpace(version)
-	if v == "" {
-		v = "dev"
+	if v != "" && v != "dev" && !strings.HasSuffix(v, "-dev") {
+		return v
 	}
+	info, ok := readBuildInfo()
+	if ok {
+		moduleVersion := strings.TrimSpace(info.Main.Version)
+		if moduleVersion != "" && moduleVersion != "(devel)" {
+			return moduleVersion
+		}
+	}
+	if v == "" {
+		return "dev"
+	}
+	return v
+}
+
+func VersionString() string {
+	v := resolvedVersion()
 	if strings.TrimSpace(commit) == "" && strings.TrimSpace(date) == "" {
 		return v
 	}
@@ -37,7 +54,7 @@ type VersionCmd struct{}
 func (c *VersionCmd) Run(ctx context.Context) error {
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
-			"version": strings.TrimSpace(version),
+			"version": resolvedVersion(),
 			"commit":  strings.TrimSpace(commit),
 			"date":    strings.TrimSpace(date),
 		})

--- a/internal/cmd/version_test.go
+++ b/internal/cmd/version_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"runtime/debug"
 	"testing"
 
 	"github.com/steipete/gogcli/internal/outfmt"
@@ -11,8 +12,9 @@ import (
 )
 
 func TestVersionStringVariants(t *testing.T) {
-	origVersion, origCommit, origDate := version, commit, date
-	t.Cleanup(func() { version, commit, date = origVersion, origCommit, origDate })
+	origVersion, origCommit, origDate, origReadBuildInfo := version, commit, date, readBuildInfo
+	t.Cleanup(func() { version, commit, date, readBuildInfo = origVersion, origCommit, origDate, origReadBuildInfo })
+	readBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
 
 	version, commit, date = "v1", "", ""
 	if got := VersionString(); got != "v1" {
@@ -32,9 +34,38 @@ func TestVersionStringVariants(t *testing.T) {
 	}
 }
 
+func TestVersionStringUsesModuleVersionFallback(t *testing.T) {
+	origVersion, origCommit, origDate, origReadBuildInfo := version, commit, date, readBuildInfo
+	t.Cleanup(func() { version, commit, date, readBuildInfo = origVersion, origCommit, origDate, origReadBuildInfo })
+
+	version, commit, date = "dev", "", ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "v1.2.3"}}, true
+	}
+
+	if got := VersionString(); got != "v1.2.3" {
+		t.Fatalf("unexpected: %q", got)
+	}
+}
+
+func TestVersionStringPrefersInjectedVersion(t *testing.T) {
+	origVersion, origCommit, origDate, origReadBuildInfo := version, commit, date, readBuildInfo
+	t.Cleanup(func() { version, commit, date, readBuildInfo = origVersion, origCommit, origDate, origReadBuildInfo })
+
+	version, commit, date = "v9.9.9", "", ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "v1.2.3"}}, true
+	}
+
+	if got := VersionString(); got != "v9.9.9" {
+		t.Fatalf("unexpected: %q", got)
+	}
+}
+
 func TestVersionCmd_JSON(t *testing.T) {
-	origVersion, origCommit, origDate := version, commit, date
-	t.Cleanup(func() { version, commit, date = origVersion, origCommit, origDate })
+	origVersion, origCommit, origDate, origReadBuildInfo := version, commit, date, readBuildInfo
+	t.Cleanup(func() { version, commit, date, readBuildInfo = origVersion, origCommit, origDate, origReadBuildInfo })
+	readBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
 	version, commit, date = "v2", "c1", "d1"
 
 	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})


### PR DESCRIPTION
## Summary

This makes version reporting use Go build metadata as a fallback when release metadata has not been injected by linker flags.

Release builds still work the same way: GoReleaser injects `version`, `commit`, and `date` with `-ldflags`, and those injected values remain authoritative. For source/module builds without those linker flags, `gog` now falls back to `debug.ReadBuildInfo()` and reports the main module version when Go provides one.

## Why

`go install github.com/steipete/gogcli/cmd/gog@v0.14.0` does not run through GoReleaser, so it does not receive the release workflow's `-ldflags`. Before this change, those builds fell back to the hardcoded source value (`0.13.0-dev`), which made a binary built from a newer tag look like an older development build.

That is misleading for diagnostics, support reports, and packaging verification.

## Why This Change

This keeps the release workflow and GoReleaser config unchanged while improving source-build behavior:

- GoReleaser artifacts keep their rich injected output, e.g. `v0.14.0 (commit date)`.
- `go install module@version` can report the module version from Go's build info.
- Plain local development builds still fall back to `dev` when no useful module version is available.
- Stale hardcoded release-like fallback values are removed.

## Verification

- `go test ./internal/cmd`
- `go test ./cmd/gog`
- `go build -o /tmp/gog-dev ./cmd/gog && /tmp/gog-dev --version` prints the local module/VCS-derived build version
- `go build -ldflags \"-X github.com/steipete/gogcli/internal/cmd.version=v9.9.9 -X github.com/steipete/gogcli/internal/cmd.commit=abc123 -X github.com/steipete/gogcli/internal/cmd.date=2026-05-01T00:00:00Z\" -o /tmp/gog-release ./cmd/gog && /tmp/gog-release --version` prints `v9.9.9 (abc123 2026-05-01T00:00:00Z)`

Related issue: https://github.com/steipete/gogcli/issues/544