### PR TITLE
feat(docs): add Google Docs tab management commands

### DIFF
--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -24,6 +24,9 @@ type DocsCmd struct {
 	Copy        DocsCopyCmd        `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Doc"`
 	Cat         DocsCatCmd         `cmd:"" name:"cat" aliases:"text,read" help:"Print a Google Doc as plain text"`
 	Comments    DocsCommentsCmd    `cmd:"" name:"comments" help:"Manage comments on files"`
+	AddTab      DocsAddTabCmd      `cmd:"" name:"add-tab" help:"Add a tab to a Google Doc"`
+	RenameTab   DocsRenameTabCmd   `cmd:"" name:"rename-tab" help:"Rename a tab in a Google Doc"`
+	DeleteTab   DocsDeleteTabCmd   `cmd:"" name:"delete-tab" help:"Delete a tab from a Google Doc"`
 	ListTabs    DocsListTabsCmd    `cmd:"" name:"list-tabs" help:"List all tabs in a Google Doc"`
 	Write       DocsWriteCmd       `cmd:"" name:"write" help:"Write content to a Google Doc"`
 	Insert      DocsInsertCmd      `cmd:"" name:"insert" help:"Insert text at a specific position"`

--- a/internal/cmd/docs_tab_manage.go
+++ b/internal/cmd/docs_tab_manage.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsAddTabCmd struct {
+	DocID     string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	Title     string `name:"title" help:"User-visible tab title"`
+	Index     *int64 `name:"index" help:"Zero-based tab index within the parent"`
+	ParentTab string `name:"parent-tab" help:"Optional parent tab title or ID"`
+	IconEmoji string `name:"icon-emoji" help:"Optional tab emoji icon"`
+}
+
+func (c *DocsAddTabCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	props := &docs.TabProperties{}
+	if title := strings.TrimSpace(c.Title); title != "" {
+		props.Title = title
+	}
+	if c.Index != nil {
+		props.Index = *c.Index
+		props.ForceSendFields = append(props.ForceSendFields, "Index")
+	}
+	if emoji := strings.TrimSpace(c.IconEmoji); emoji != "" {
+		props.IconEmoji = emoji
+	}
+	if parent := strings.TrimSpace(c.ParentTab); parent != "" {
+		parentID, err := docsResolveTabID(ctx, svc, docID, parent)
+		if err != nil {
+			return err
+		}
+		props.ParentTabId = parentID
+	}
+
+	if err := dryRunExit(ctx, flags, "docs.add-tab", map[string]any{
+		"doc_id":      docID,
+		"title":       props.Title,
+		"index":       c.Index,
+		"parent_tab":  props.ParentTabId,
+		"icon_emoji":  props.IconEmoji,
+	}); err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{
+			AddDocumentTab: &docs.AddDocumentTabRequest{TabProperties: props},
+		}},
+	}).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return err
+	}
+	if resp == nil {
+		return errors.New("add tab failed")
+	}
+
+	var created *docs.TabProperties
+	if len(resp.Replies) > 0 && resp.Replies[0] != nil && resp.Replies[0].AddDocumentTab != nil {
+		created = resp.Replies[0].AddDocumentTab.TabProperties
+	}
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{"documentId": docID}
+		if created != nil {
+			payload["tab"] = tabPropertiesJSON(created)
+		}
+		if resp.WriteControl != nil {
+			payload["writeControl"] = resp.WriteControl
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+
+	u.Out().Printf("docId\t%s", docID)
+	if created != nil {
+		u.Out().Printf("tabId\t%s", created.TabId)
+		u.Out().Printf("title\t%s", created.Title)
+		u.Out().Printf("index\t%d", created.Index)
+		if created.ParentTabId != "" {
+			u.Out().Printf("parentTabId\t%s", created.ParentTabId)
+		}
+	}
+	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
+		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
+type DocsRenameTabCmd struct {
+	DocID string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	Tab   string `name:"tab" help:"Existing tab title or ID"`
+	Title string `name:"title" help:"New user-visible tab title"`
+}
+
+func (c *DocsRenameTabCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	tabQuery := strings.TrimSpace(c.Tab)
+	newTitle := strings.TrimSpace(c.Title)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if tabQuery == "" {
+		return usage("empty --tab")
+	}
+	if newTitle == "" {
+		return usage("empty --title")
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	resolved, err := docsResolveTab(ctx, svc, docID, tabQuery)
+	if err != nil {
+		return err
+	}
+
+	if err := dryRunExit(ctx, flags, "docs.rename-tab", map[string]any{
+		"doc_id":  docID,
+		"tab_id":  resolved.TabProperties.TabId,
+		"title":   newTitle,
+	}); err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{
+			UpdateDocumentTabProperties: &docs.UpdateDocumentTabPropertiesRequest{
+				Fields: "title",
+				TabProperties: &docs.TabProperties{
+					TabId: resolved.TabProperties.TabId,
+					Title: newTitle,
+				},
+			},
+		}},
+	}).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": docID,
+			"tab":        map[string]any{"id": resolved.TabProperties.TabId, "title": newTitle},
+		}
+		if resp != nil && resp.WriteControl != nil {
+			payload["writeControl"] = resp.WriteControl
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+
+	u.Out().Printf("docId\t%s", docID)
+	u.Out().Printf("tabId\t%s", resolved.TabProperties.TabId)
+	u.Out().Printf("title\t%s", newTitle)
+	if resp != nil && resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
+		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
+type DocsDeleteTabCmd struct {
+	DocID string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	Tab   string `name:"tab" help:"Existing tab title or ID"`
+}
+
+func (c *DocsDeleteTabCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	tabQuery := strings.TrimSpace(c.Tab)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if tabQuery == "" {
+		return usage("empty --tab")
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	resolved, err := docsResolveTab(ctx, svc, docID, tabQuery)
+	if err != nil {
+		return err
+	}
+
+	if confirmErr := confirmDestructive(ctx, flags, fmt.Sprintf("delete tab %s from doc %s", resolved.TabProperties.TabId, docID)); confirmErr != nil {
+		return confirmErr
+	}
+	if err := dryRunExit(ctx, flags, "docs.delete-tab", map[string]any{
+		"doc_id": docID,
+		"tab_id": resolved.TabProperties.TabId,
+	}); err != nil {
+		return err
+	}
+
+	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{
+			DeleteTab: &docs.DeleteTabRequest{TabId: resolved.TabProperties.TabId},
+		}},
+	}).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": docID,
+			"deleted":    true,
+			"tab":        map[string]any{"id": resolved.TabProperties.TabId, "title": resolved.TabProperties.Title},
+		}
+		if resp != nil && resp.WriteControl != nil {
+			payload["writeControl"] = resp.WriteControl
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+
+	u.Out().Printf("docId\t%s", docID)
+	u.Out().Printf("tabId\t%s", resolved.TabProperties.TabId)
+	u.Out().Printf("deleted\ttrue")
+	if resolved.TabProperties.Title != "" {
+		u.Out().Printf("title\t%s", resolved.TabProperties.Title)
+	}
+	if resp != nil && resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
+		u.Out().Printf("revision\t%s", resp.WriteControl.RequiredRevisionId)
+	}
+	return nil
+}
+
+func docsResolveTab(ctx context.Context, svc *docs.Service, docID, query string) (*docs.Tab, error) {
+	doc, err := svc.Documents.Get(docID).IncludeTabsContent(true).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return nil, fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return nil, err
+	}
+	if doc == nil {
+		return nil, errors.New("doc not found")
+	}
+	return findTab(flattenTabs(doc.Tabs), query)
+}
+
+func docsResolveTabID(ctx context.Context, svc *docs.Service, docID, query string) (string, error) {
+	tab, err := docsResolveTab(ctx, svc, docID, query)
+	if err != nil {
+		return "", err
+	}
+	if tab == nil || tab.TabProperties == nil || strings.TrimSpace(tab.TabProperties.TabId) == "" {
+		return "", fmt.Errorf("tab not found: %q", query)
+	}
+	return tab.TabProperties.TabId, nil
+}
+
+func tabPropertiesJSON(props *docs.TabProperties) map[string]any {
+	if props == nil {
+		return nil
+	}
+	payload := map[string]any{
+		"id":    props.TabId,
+		"title": props.Title,
+		"index": props.Index,
+	}
+	if props.ParentTabId != "" {
+		payload["parentTabId"] = props.ParentTabId
+	}
+	if props.IconEmoji != "" {
+		payload["iconEmoji"] = props.IconEmoji
+	}
+	if props.NestingLevel != 0 {
+		payload["nestingLevel"] = props.NestingLevel
+	}
+	return payload
+}

--- a/internal/cmd/docs_tab_manage_test.go
+++ b/internal/cmd/docs_tab_manage_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsAddRenameDeleteTab(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var batchRequests [][]*docs.Request
+	var includeTabsCalls int
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(path, "/v1/documents/"):
+			if strings.Contains(r.URL.RawQuery, "includeTabsContent=true") {
+				includeTabsCalls++
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+			return
+		case r.Method == http.MethodPost && strings.Contains(path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			batchRequests = append(batchRequests, req.Requests)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies": []any{
+					map[string]any{
+						"addDocumentTab": map[string]any{
+							"tabProperties": map[string]any{"tabId": "t.third", "title": "Third", "index": 2},
+						},
+					},
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	}))
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com", Force: true}
+	ctx := newDocsCmdContext(t)
+
+	idx := int64(2)
+	if err := runKong(t, &DocsAddTabCmd{}, []string{"doc1", "--title", "Third", "--index", "2"}, ctx, flags); err != nil {
+		t.Fatalf("add-tab: %v", err)
+	}
+	addReq := batchRequests[0][0].AddDocumentTab
+	if addReq == nil || addReq.TabProperties == nil {
+		t.Fatalf("unexpected add request: %#v", batchRequests[0][0])
+	}
+	if addReq.TabProperties.Title != "Third" || addReq.TabProperties.Index != idx {
+		t.Fatalf("unexpected add props: %#v", addReq.TabProperties)
+	}
+
+	if err := runKong(t, &DocsRenameTabCmd{}, []string{"doc1", "--tab", "Second", "--title", "TWO"}, ctx, flags); err != nil {
+		t.Fatalf("rename-tab: %v", err)
+	}
+	renameReq := batchRequests[1][0].UpdateDocumentTabProperties
+	if renameReq == nil || renameReq.TabProperties == nil {
+		t.Fatalf("unexpected rename request: %#v", batchRequests[1][0])
+	}
+	if renameReq.Fields != "title" || renameReq.TabProperties.TabId != "t.second" || renameReq.TabProperties.Title != "TWO" {
+		t.Fatalf("unexpected rename props: %#v", renameReq)
+	}
+
+	if err := runKong(t, &DocsDeleteTabCmd{}, []string{"doc1", "--tab", "Second"}, ctx, flags); err != nil {
+		t.Fatalf("delete-tab: %v", err)
+	}
+	deleteReq := batchRequests[2][0].DeleteTab
+	if deleteReq == nil || deleteReq.TabId != "t.second" {
+		t.Fatalf("unexpected delete request: %#v", batchRequests[2][0])
+	}
+
+	if includeTabsCalls != 2 {
+		t.Fatalf("expected 2 tab-aware GET calls, got %d", includeTabsCalls)
+	}
+}
+
+func TestDocsRenameDeleteTab_NotFound(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(tabsDocWithEndIndex())
+	}))
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	flags := &RootFlags{Account: "a@b.com", Force: true}
+	ctx := newDocsCmdContext(t)
+
+	err := runKong(t, &DocsRenameTabCmd{}, []string{"doc1", "--tab", "Missing", "--title", "X"}, ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), `tab not found: "Missing"`) {
+		t.Fatalf("unexpected rename error: %v", err)
+	}
+
+	err = runKong(t, &DocsDeleteTabCmd{}, []string{"doc1", "--tab", "Missing"}, ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), `tab not found: "Missing"`) {
+		t.Fatalf("unexpected delete error: %v", err)
+	}
+}


### PR DESCRIPTION
## feat(docs): add Google Docs tab management commands

Adds first-class Google Docs tab management to `gog docs`, covering the missing operations supported by the official Google Docs API but not yet exposed by the CLI.

### New commands

- `gog docs add-tab <docId> [--title ...] [--index N] [--parent-tab <title|id>] [--icon-emoji 😀]`
- `gog docs rename-tab <docId> --tab <title|id> --title <new-title>`
- `gog docs delete-tab <docId> --tab <title|id>`

### Why

`gog docs` already supports:
- listing tabs
- reading tabs
- writing to an existing tab

But it was still missing the lifecycle operations needed for full tab automation:
- create a new tab
- rename a tab
- delete a tab

The official Google Docs API supports all three via `documents.batchUpdate` requests:
- `addDocumentTab`
- `updateDocumentTabProperties`
- `deleteTab`

### Implementation notes

- Reuses the existing Docs service and tab-resolution helpers/patterns.
- `rename-tab` and `delete-tab` resolve `--tab` by title or tab ID.
- `add-tab` optionally resolves `--parent-tab` by title or tab ID.
- `delete-tab` uses the existing destructive confirmation flow.
- JSON output includes the affected tab metadata when available.

### Files changed

- `internal/cmd/docs.go`
- `internal/cmd/docs_tab_manage.go`
- `internal/cmd/docs_tab_manage_test.go`

### Test coverage added

New tests cover:
- add / rename / delete tab request generation
- tab resolution by title
- not-found failures for rename/delete

### Caveat

This patch was prepared in a constrained environment without `go`, `gofmt`, or `gh` installed, so I could not run the normal local validation (`make fmt`, `make test`, `make ci`) before opening the PR.

### References

Official Google Docs API references used for this change:
- https://developers.google.com/workspace/docs/api/reference/rest/v1/documents/request
- https://developers.google.com/workspace/docs/api/how-tos/tabs