### PR TITLE
docs(agent-skill): fix stale repo references

### DIFF
--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -112,14 +112,13 @@ gog schema <service> <command> --json
 
 Docs:
 
-- `docs/README.md`
+- `docs/index.md`
 - `docs/commands/README.md`
 - `docs/safety-profiles.md`
-- `README.md#security`
 
 Repo paths:
 
 - CLI entrypoint: `cmd/gog/`
 - Command implementations: `internal/cmd/`
-- OAuth/keyring: `internal/auth/`, `internal/secrets/`
+- OAuth/keyring: `internal/googleauth/`, `internal/authclient/`, `internal/secrets/`
 - Generated command docs: `docs/commands/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Docs: avoid infinite loops when local Markdown parsing ends on Thai, CJK, emoji, or other multi-byte runes. (#560 / #559) — thanks @ninyawee.
+- Agent skill: replace stale bundled `gog` skill paths with the current docs and auth package locations. (#558 / #557) — thanks @WadydX.
 
 ## 0.15.0 - 2026-05-05
 


### PR DESCRIPTION
## Summary
- replace dead `docs/README.md` skill reference with `docs/index.md`
- drop the stale `README.md#security` reference
- update auth-related repo paths to the current packages

## Why
The bundled `gog` agent skill currently points at repo paths that do not exist:
- `docs/README.md`
- `README.md#security`
- `internal/auth/`

This updates the skill to reference files/directories that exist in the current repo layout.

Closes #557
