### PR TITLE
fix(docs): unblock markdown --append on Thai/CJK/emoji content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16.0 - Unreleased
 
+### Fixed
+
+- Docs: avoid infinite loops when local Markdown parsing ends on Thai, CJK, emoji, or other multi-byte runes. (#560 / #559) — thanks @ninyawee.
+
 ## 0.15.0 - 2026-05-05
 
 ### Added

--- a/internal/cmd/docs_markdown.go
+++ b/internal/cmd/docs_markdown.go
@@ -5,6 +5,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode/utf16"
+	"unicode/utf8"
 )
 
 const (
@@ -455,18 +456,16 @@ func ParseInlineFormatting(text string) ([]TextStyle, string) {
 	return styles, strippedText
 }
 
-// nextRune returns the first rune and its byte size from a string
+// nextRune returns the first rune and its byte size from a string.
+// For a string consisting of a single multi-byte rune (e.g. Thai or other
+// non-ASCII text), the previous range-based implementation returned size 0,
+// which caused callers like ParseInlineFormatting to spin in an infinite loop.
 func nextRune(s string) (string, int) {
-	for i, r := range s {
-		if i > 0 {
-			return s[:i], i
-		}
-		if len(s) == 1 {
-			return s, 1
-		}
-		_ = r
+	if s == "" {
+		return "", 0
 	}
-	return "", 0
+	_, size := utf8.DecodeRuneInString(s)
+	return s[:size], size
 }
 
 func parseHeading(line string) (int, string) {

--- a/internal/cmd/docs_markdown_thai_test.go
+++ b/internal/cmd/docs_markdown_thai_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+// withTimeout runs fn in a goroutine and fails the test if it does not return
+// within d. Used to catch infinite loops without blocking the whole test run.
+func withTimeout(t *testing.T, d time.Duration, name string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("%s: timed out after %s (suspected infinite loop)", name, d)
+	}
+}
+
+// TestNextRune_SingleMultiByteRune is the direct unit-level regression test for
+// the bug that caused `gog docs write --markdown --append` to hang on any
+// content ending in a non-ASCII rune. The previous range-based nextRune
+// returned size=0 for a string that contained exactly one multi-byte rune
+// (e.g. a single Thai character), and ParseInlineFormatting then advanced
+// currentByte by 0, looping forever.
+func TestNextRune_SingleMultiByteRune(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantStr  string
+		wantSize int
+	}{
+		{name: "empty", in: "", wantStr: "", wantSize: 0},
+		{name: "single ascii", in: "a", wantStr: "a", wantSize: 1},
+		{name: "two ascii", in: "ab", wantStr: "a", wantSize: 1},
+		{name: "single thai (3 bytes)", in: "ก", wantStr: "ก", wantSize: 3},
+		{name: "single emoji (4 bytes)", in: "😀", wantStr: "😀", wantSize: 4},
+		{name: "two thai", in: "กข", wantStr: "ก", wantSize: 3},
+		{name: "thai then ascii", in: "กa", wantStr: "ก", wantSize: 3},
+		{name: "ascii then thai", in: "aก", wantStr: "a", wantSize: 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStr, gotSize := nextRune(tc.in)
+			if gotStr != tc.wantStr || gotSize != tc.wantSize {
+				t.Fatalf("nextRune(%q) = (%q, %d), want (%q, %d)",
+					tc.in, gotStr, gotSize, tc.wantStr, tc.wantSize)
+			}
+		})
+	}
+}
+
+// TestParseInlineFormatting_Thai ensures the parser returns in finite time on
+// Thai content. With the buggy nextRune this hung forever; we cap each call at
+// 2 seconds via withTimeout to keep the test suite fast even on regression.
+func TestParseInlineFormatting_Thai(t *testing.T) {
+	inputs := []string{
+		"ก",         // single Thai rune
+		"ส่วนคำถาม", // common heading text from the bug report
+		"คำถามที่พบบ่อย",                 // FAQ heading
+		"**ตัวหนา** ปกติ *เอียง* `code`", // bold/italic/code mixed with Thai
+		"พิมพ์ภาษาไทย 😀",                 // emoji at the end (4-byte rune)
+	}
+	for _, in := range inputs {
+		in := in
+		t.Run(in, func(t *testing.T) {
+			withTimeout(t, 2*time.Second, "ParseInlineFormatting", func() {
+				styles, stripped := ParseInlineFormatting(in)
+				_ = styles
+				if stripped == "" {
+					t.Fatalf("ParseInlineFormatting(%q) returned empty stripped text", in)
+				}
+			})
+		})
+	}
+}
+
+// TestMarkdownToDocsRequests_ThaiAppend exercises the full path used by
+// `gog docs write --markdown --append <thai-md>`: parse markdown, then convert
+// to Docs API requests at a non-zero base index. Each input ends in a Thai
+// rune, which is the trigger condition for the original hang.
+func TestMarkdownToDocsRequests_ThaiAppend(t *testing.T) {
+	const sample = `## ส่วนคำถาม
+
+คำถามที่พบบ่อยของลูกค้า
+
+- ราคาเท่าไหร่
+- ส่งของเมื่อไหร่
+
+> ติดต่อสอบถามเพิ่มเติม
+`
+	withTimeout(t, 5*time.Second, "MarkdownToDocsRequests", func() {
+		elements := ParseMarkdown(sample)
+		if len(elements) == 0 {
+			t.Fatal("ParseMarkdown returned no elements for Thai sample")
+		}
+		// baseIndex = 100 mimics appending at the tail of an existing doc.
+		reqs, plain, _ := MarkdownToDocsRequests(elements, 100, "")
+		if plain == "" {
+			t.Fatal("MarkdownToDocsRequests returned empty plain text for Thai sample")
+		}
+		if len(reqs) == 0 {
+			t.Fatal("MarkdownToDocsRequests returned no requests for Thai sample")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #559 — `gog docs write --markdown --append` hung indefinitely (CPU-bound infinite loop) on any markdown content ending in a non-ASCII rune. Thai content reliably triggered it because Thai paragraphs/headings naturally end with multi-byte runes; the same bug applies to CJK and emoji content.

The hang was in `nextRune` (`internal/cmd/docs_markdown.go`). For a string containing exactly one multi-byte rune, the previous range-based implementation:

```go
for i, r := range s {
    if i > 0 { return s[:i], i }   // never fires (only one iteration)
    if len(s) == 1 { return s, 1 } // false: len() is bytes, not runes
    _ = r
}
return "", 0   // ← falls through here
```

returned size 0, and the caller in `ParseInlineFormatting` advanced `currentByte += 0` forever inside its `for currentByte < len(text)` loop.

`--markdown --replace` is unaffected because that path uploads to Drive's server-side markdown converter (`Media(strings.NewReader(cleaned), ContentType(mimeTextMarkdown))` in `docs_edit.go`). Only `--append` and the find-replace/sed paths invoke the local parser, so this issue affects:

- `docs write --markdown --append`
- `docs find-replace --format markdown` (when replacement text ends in a multi-byte rune)
- `docs sed` family commands using markdown replacement content

## Fix

Replace the hand-rolled rune iteration with `utf8.DecodeRuneInString`. It handles every case correctly — empty input, ASCII, multi-byte runes, and invalid UTF-8 (`RuneError` with its byte size).

## Test plan

- [x] Added unit tests for `nextRune` covering the previously-broken paths (single Thai rune, single emoji, empty input, mixed strings).
- [x] Added timeout-guarded tests for `ParseInlineFormatting` on Thai headings, FAQ-style mixed text, bold/italic/code mixed with Thai, and trailing emoji. Each call is wrapped in a 2s timeout so any future infinite-loop regression fails fast in CI rather than stalling it.
- [x] Added an end-to-end test `TestMarkdownToDocsRequests_ThaiAppend` exercising the exact path used by `docs write --markdown --append` — `ParseMarkdown` → `MarkdownToDocsRequests` at a non-zero base index — on a multi-element Thai sample (heading + paragraph + bullet list + blockquote).
- [x] Verified the new tests **fail on `main` HEAD** (each times out and the goroutine stack confirms it's stuck inside `ParseInlineFormatting` at line 434) and **pass with the fix**.
- [x] `make lint` clean. Full `go test ./internal/cmd/...` passes apart from a pre-existing failure in `TestRequireAccount_Missing` that is unrelated to this change (also fails on stock `main`).
- [x] Verified end-to-end against the live Google Docs API:
  - The repro case (`--markdown --append` on a single-line Thai heading) used to time out at 30s; now completes in ~1.4s.
  - A 14 KB Thai markdown doc with 136 generated batch-update requests now appends in ~1.7s.

## Notes

- Issue #559 was filed by me from the same investigation; closing it on merge.
- I am running gogcli via `mise` (`github:steipete/gogcli@0.14.0`); the bug reproduces identically on current `main` (`56755e9`) which is what this branch targets.