### PR TITLE
test: run docs-check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
+      - name: Docs check
+        run: make docs-check
 
   worker:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Docs: avoid infinite loops when local Markdown parsing ends on Thai, CJK, emoji, or other multi-byte runes. (#560 / #559) — thanks @ninyawee.
 - Agent skill: replace stale bundled `gog` skill paths with the current docs and auth package locations. (#558 / #557) — thanks @WadydX.
+- CI: run the docs validation gate in GitHub Actions and the local `make ci` target. (#562 / #561) — thanks @WadydX.
 
 ## 0.15.0 - 2026-05-05
 

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ pnpm-gate:
 test:
 	@go test $(GO_TEST_FLAGS) $(TEST_FLAGS) $(TEST_PKGS)
 
-ci: pnpm-gate fmt-check lint test
+ci: pnpm-gate fmt-check lint test docs-check
 
 worker-ci:
 	@pnpm -C internal/tracking/worker lint


### PR DESCRIPTION
## Summary
- run `make docs-check` in the main CI test job

## Why
Issue #561 points out that the repo already has a docs validation target, but the main CI workflow does not run it. This keeps the existing docs coverage/link gate on the normal PR path.

## Test plan
- reviewed the workflow diff to confirm the change only adds one CI step in `.github/workflows/ci.yml`
- local `make docs-check` could not be executed in this shell because `go` is not available on PATH

Fixes #561.
