### PR TITLE
feat(forms): add publish settings command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.16.0 - Unreleased
 
+### Added
+
+- Forms: add `forms publish` to publish/unpublish existing forms and return the responder URL for automated form creation flows. (#565 / #564) — thanks @bogdanovich.
+
 ### Fixed
 
 - Auth: list one row per OAuth client when the same account is authorized under multiple clients, and let `auth list --client` filter that token bucket. (#563) — thanks @UnPractical91.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ gog sheets banding set <spreadsheetId> 'Sheet1!A1:D100'
 ```bash
 gog slides create-from-markdown "Weekly update" --content-file slides.md
 gog slides insert-text <presentationId> <objectId> "New text"
+gog forms publish <formId>
 gog forms responses list <formId> --json
 gog forms raw <formId> --pretty
 ```

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -268,6 +268,7 @@ Generated from `gog schema --json`.
     - [`gog forms (form) delete-question (delete-q,dq,rm-q) <formId> <index>`](commands/gog-forms-delete-question.md) - Delete a question by index
     - [`gog forms (form) get (info,show) <formId>`](commands/gog-forms-get.md) - Get a form
     - [`gog forms (form) move-question (move-q,mq) <formId> <oldIndex> <newIndex>`](commands/gog-forms-move-question.md) - Move a question to a new position
+    - [`gog forms (form) publish <formId> [flags]`](commands/gog-forms-publish.md) - Publish or unpublish a form
     - [`gog forms (form) raw <formId> [flags]`](commands/gog-forms-raw.md) - Dump raw Google Forms API response as JSON (Forms.Get; lossless; for scripting and LLM consumption)
     - [`gog forms (form) responses <command>`](commands/gog-forms-responses.md) - Form responses
       - [`gog forms (form) responses get (info,show) <formId> <responseId>`](commands/gog-forms-responses-get.md) - Get a form response

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 470.
+Generated pages: 471.
 
 ## Top-level Commands
 
@@ -311,6 +311,7 @@ Generated pages: 470.
     - [gog forms delete-question](gog-forms-delete-question.md) - Delete a question by index
     - [gog forms get](gog-forms-get.md) - Get a form
     - [gog forms move-question](gog-forms-move-question.md) - Move a question to a new position
+    - [gog forms publish](gog-forms-publish.md) - Publish or unpublish a form
     - [gog forms raw](gog-forms-raw.md) - Dump raw Google Forms API response as JSON (Forms.Get; lossless; for scripting and LLM consumption)
     - [gog forms responses](gog-forms-responses.md) - Form responses
       - [gog forms responses get](gog-forms-responses-get.md) - Get a form response

--- a/docs/commands/gog-forms-publish.md
+++ b/docs/commands/gog-forms-publish.md
@@ -1,36 +1,24 @@
-# `gog forms`
+# `gog forms publish`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Forms
+Publish or unpublish a form
 
 ## Usage
 
 ```bash
-gog forms (form) <command> [flags]
+gog forms (form) publish <formId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog forms add-question](gog-forms-add-question.md) - Add a question to a form
-- [gog forms create](gog-forms-create.md) - Create a form
-- [gog forms delete-question](gog-forms-delete-question.md) - Delete a question by index
-- [gog forms get](gog-forms-get.md) - Get a form
-- [gog forms move-question](gog-forms-move-question.md) - Move a question to a new position
-- [gog forms publish](gog-forms-publish.md) - Publish or unpublish a form
-- [gog forms raw](gog-forms-raw.md) - Dump raw Google Forms API response as JSON (Forms.Get; lossless; for scripting and LLM consumption)
-- [gog forms responses](gog-forms-responses.md) - Form responses
-- [gog forms update](gog-forms-update.md) - Update form title, description, or settings
-- [gog forms watch](gog-forms-watch.md) - Response watches (push notifications)
+- [gog forms](gog-forms.md)
 
 ## Flags
 
 | Flag | Type | Default | Help |
 | --- | --- | --- | --- |
+| `--accepting-responses` | `bool` | true | Whether a published form accepts responses |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/docs/slides/contacts/tasks/people/sheets/forms/appscript/ads) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
@@ -46,10 +34,11 @@ gog forms (form) <command> [flags]
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--unpublish` | `bool` |  | Unpublish the form instead of publishing it |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 
 ## See Also
 
-- [gog](gog.md)
+- [gog forms](gog-forms.md)
 - [Command index](README.md)

--- a/internal/cmd/auth_keyring.go
+++ b/internal/cmd/auth_keyring.go
@@ -62,7 +62,7 @@ func (c *AuthKeyringCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usagef("too many args: %q %q", c.Backend, c.Backend2)
 	}
 
-	if backend == "default" {
+	if backend == literalDefault {
 		backend = literalAuto
 	}
 

--- a/internal/cmd/auth_list_helpers.go
+++ b/internal/cmd/auth_list_helpers.go
@@ -142,7 +142,7 @@ func authListServiceAccountKey(email string) string {
 func authListCanonicalClient(client string) string {
 	client = strings.TrimSpace(client)
 	if client == "" {
-		return "default"
+		return literalDefault
 	}
 	return client
 }

--- a/internal/cmd/forms.go
+++ b/internal/cmd/forms.go
@@ -19,6 +19,7 @@ type FormsCmd struct {
 	Get            FormsGetCmd            `cmd:"" name:"get" aliases:"info,show" help:"Get a form"`
 	Create         FormsCreateCmd         `cmd:"" name:"create" aliases:"new" help:"Create a form"`
 	Update         FormsUpdateCmd         `cmd:"" name:"update" aliases:"edit" help:"Update form title, description, or settings"`
+	Publish        FormsPublishCmd        `cmd:"" name:"publish" help:"Publish or unpublish a form"`
 	AddQuestion    FormsAddQuestionCmd    `cmd:"" name:"add-question" aliases:"add-q,aq" help:"Add a question to a form"`
 	DeleteQuestion FormsDeleteQuestionCmd `cmd:"" name:"delete-question" aliases:"delete-q,dq,rm-q" help:"Delete a question by index"`
 	MoveQuestion   FormsMoveQuestionCmd   `cmd:"" name:"move-question" aliases:"move-q,mq" help:"Move a question to a new position"`

--- a/internal/cmd/forms_publish.go
+++ b/internal/cmd/forms_publish.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	formsapi "google.golang.org/api/forms/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// FormsPublishCmd publishes a form via forms.setPublishSettings.
+type FormsPublishCmd struct {
+	FormID             string `arg:"" name:"formId" help:"Form ID"`
+	Unpublish          bool   `name:"unpublish" help:"Unpublish the form instead of publishing it"`
+	AcceptingResponses bool   `name:"accepting-responses" help:"Whether a published form accepts responses" default:"true"`
+}
+
+func (c *FormsPublishCmd) Run(ctx context.Context, flags *RootFlags) error {
+	published := !c.Unpublish
+	acceptingResponses := c.AcceptingResponses
+	if !published {
+		acceptingResponses = false
+	}
+	operation := "forms.publish"
+	if !published {
+		operation = "forms.unpublish"
+	}
+
+	return setFormPublishState(ctx, flags, formPublishStateRequest{
+		FormID:             c.FormID,
+		Published:          published,
+		AcceptingResponses: acceptingResponses,
+		Operation:          operation,
+	})
+}
+
+type formPublishStateRequest struct {
+	FormID             string
+	Published          bool
+	AcceptingResponses bool
+	Operation          string
+}
+
+func setFormPublishState(ctx context.Context, flags *RootFlags, publishReq formPublishStateRequest) error {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	formID := strings.TrimSpace(normalizeGoogleID(publishReq.FormID))
+	if formID == "" {
+		return usage("empty formId")
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, publishReq.Operation, map[string]any{
+		"form_id":             formID,
+		"published":           publishReq.Published,
+		"accepting_responses": publishReq.AcceptingResponses,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := newFormsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	req := &formsapi.SetPublishSettingsRequest{
+		UpdateMask: "publish_state",
+		PublishSettings: &formsapi.PublishSettings{
+			PublishState: &formsapi.PublishState{
+				IsPublished:          publishReq.Published,
+				IsAcceptingResponses: publishReq.AcceptingResponses,
+				ForceSendFields:      []string{"IsPublished", "IsAcceptingResponses"},
+			},
+		},
+	}
+	resp, err := svc.Forms.SetPublishSettings(formID, req).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	form, err := svc.Forms.Get(formID).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+
+	responderURI := strings.TrimSpace(form.ResponderUri)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"published":           publishReq.Published,
+			"accepting_responses": publishReq.AcceptingResponses,
+			"form_id":             formID,
+			"responder_uri":       responderURI,
+			"edit_url":            formEditURL(formID),
+			"publish_settings":    resp.PublishSettings,
+			"form":                form,
+		})
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Printf("published\t%t", publishReq.Published)
+	u.Out().Printf("accepting_responses\t%t", publishReq.AcceptingResponses)
+	u.Out().Printf("form_id\t%s", formID)
+	if responderURI != "" {
+		u.Out().Printf("responder_uri\t%s", responderURI)
+	}
+	u.Out().Printf("edit_url\t%s", formEditURL(formID))
+	return nil
+}

--- a/internal/cmd/forms_publish_test.go
+++ b/internal/cmd/forms_publish_test.go
@@ -1,0 +1,283 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	formsapi "google.golang.org/api/forms/v1"
+)
+
+func TestFormsPublishCmd(t *testing.T) {
+	origNew := newFormsService
+	t.Cleanup(func() { newFormsService = origNew })
+
+	var gotPublish formsapi.SetPublishSettingsRequest
+	var gotPublishJSON map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/v1/forms/form1:setPublishSettings"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read setPublishSettings: %v", err)
+			}
+			if err := json.Unmarshal(body, &gotPublish); err != nil {
+				t.Fatalf("decode setPublishSettings: %v", err)
+			}
+			if err := json.Unmarshal(body, &gotPublishJSON); err != nil {
+				t.Fatalf("decode setPublishSettings JSON: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"publishSettings": map[string]any{
+					"publishState": map[string]any{
+						"isPublished":          true,
+						"isAcceptingResponses": true,
+					},
+				},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/v1/forms/form1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"formId":       "form1",
+				"responderUri": "https://docs.google.com/forms/d/e/form1/viewform",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	newFormsService = func(ctx context.Context, account string) (*formsapi.Service, error) {
+		return newFormsTestService(t, ctx, srv), nil
+	}
+
+	err := runKong(t, &FormsPublishCmd{}, []string{"form1"}, newQuietUIContext(t), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	if gotPublish.UpdateMask != "publish_state" {
+		t.Fatalf("UpdateMask = %q, want publish_state", gotPublish.UpdateMask)
+	}
+	if gotPublish.PublishSettings == nil || gotPublish.PublishSettings.PublishState == nil {
+		t.Fatalf("missing publish state: %#v", gotPublish.PublishSettings)
+	}
+	state := gotPublish.PublishSettings.PublishState
+	if !state.IsPublished || !state.IsAcceptingResponses {
+		t.Fatalf("unexpected publish state: %#v", state)
+	}
+	assertPublishStateJSON(t, gotPublishJSON, true, true)
+}
+
+func TestFormsPublishCmdUnpublish(t *testing.T) {
+	origNew := newFormsService
+	t.Cleanup(func() { newFormsService = origNew })
+
+	var gotPublish formsapi.SetPublishSettingsRequest
+	var gotPublishJSON map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/v1/forms/form1:setPublishSettings"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read setPublishSettings: %v", err)
+			}
+			if err := json.Unmarshal(body, &gotPublish); err != nil {
+				t.Fatalf("decode setPublishSettings: %v", err)
+			}
+			if err := json.Unmarshal(body, &gotPublishJSON); err != nil {
+				t.Fatalf("decode setPublishSettings JSON: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"publishSettings": map[string]any{
+					"publishState": map[string]any{
+						"isPublished":          false,
+						"isAcceptingResponses": false,
+					},
+				},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/v1/forms/form1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"formId": "form1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	newFormsService = func(ctx context.Context, account string) (*formsapi.Service, error) {
+		return newFormsTestService(t, ctx, srv), nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{"--json", "--account", "a@b.com", "forms", "publish", "form1", "--unpublish"})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if gotPublish.UpdateMask != "publish_state" {
+		t.Fatalf("UpdateMask = %q, want publish_state", gotPublish.UpdateMask)
+	}
+	if gotPublish.PublishSettings == nil || gotPublish.PublishSettings.PublishState == nil {
+		t.Fatalf("missing publish state: %#v", gotPublish.PublishSettings)
+	}
+	state := gotPublish.PublishSettings.PublishState
+	if state.IsPublished || state.IsAcceptingResponses {
+		t.Fatalf("unexpected publish state: %#v", state)
+	}
+	assertPublishStateJSON(t, gotPublishJSON, false, false)
+
+	var parsed struct {
+		Published          bool   `json:"published"`
+		AcceptingResponses bool   `json:"accepting_responses"`
+		FormID             string `json:"form_id"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if parsed.Published || parsed.AcceptingResponses || parsed.FormID != "form1" {
+		t.Fatalf("unexpected JSON payload: %#v", parsed)
+	}
+}
+
+func TestFormsPublishCmdAcceptingResponsesFalseJSON(t *testing.T) {
+	origNew := newFormsService
+	t.Cleanup(func() { newFormsService = origNew })
+
+	var gotPublish formsapi.SetPublishSettingsRequest
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/v1/forms/form1:setPublishSettings"):
+			if err := json.NewDecoder(r.Body).Decode(&gotPublish); err != nil {
+				t.Fatalf("decode setPublishSettings: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"publishSettings": map[string]any{
+					"publishState": map[string]any{
+						"isPublished":          true,
+						"isAcceptingResponses": false,
+					},
+				},
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/v1/forms/form1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"formId":       "form1",
+				"responderUri": "https://docs.google.com/forms/d/e/form1/viewform",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	newFormsService = func(ctx context.Context, account string) (*formsapi.Service, error) {
+		return newFormsTestService(t, ctx, srv), nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{
+				"--json",
+				"--account", "a@b.com",
+				"forms", "publish", "form1",
+				"--accepting-responses=false",
+			})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if gotPublish.PublishSettings == nil ||
+		gotPublish.PublishSettings.PublishState == nil ||
+		!gotPublish.PublishSettings.PublishState.IsPublished ||
+		gotPublish.PublishSettings.PublishState.IsAcceptingResponses {
+		t.Fatalf("unexpected publish state: %#v", gotPublish.PublishSettings)
+	}
+
+	var parsed struct {
+		Published          bool   `json:"published"`
+		AcceptingResponses bool   `json:"accepting_responses"`
+		FormID             string `json:"form_id"`
+		ResponderURI       string `json:"responder_uri"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if !parsed.Published || parsed.AcceptingResponses || parsed.FormID != "form1" {
+		t.Fatalf("unexpected JSON payload: %#v", parsed)
+	}
+	if parsed.ResponderURI != "https://docs.google.com/forms/d/e/form1/viewform" {
+		t.Fatalf("responder_uri = %q", parsed.ResponderURI)
+	}
+}
+
+func TestFormsPublishCmdDryRun(t *testing.T) {
+	origNew := newFormsService
+	t.Cleanup(func() { newFormsService = origNew })
+	newFormsService = func(context.Context, string) (*formsapi.Service, error) {
+		t.Fatalf("dry-run should not create forms service")
+		return nil, nil
+	}
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			err := Execute([]string{
+				"--json",
+				"--dry-run",
+				"--account", "a@b.com",
+				"forms", "publish", "form1",
+			})
+			if err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	var parsed struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			FormID             string `json:"form_id"`
+			Published          bool   `json:"published"`
+			AcceptingResponses bool   `json:"accepting_responses"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if !parsed.DryRun || parsed.Op != "forms.publish" {
+		t.Fatalf("unexpected dry-run payload: %#v", parsed)
+	}
+	if parsed.Request.FormID != "form1" || !parsed.Request.Published || !parsed.Request.AcceptingResponses {
+		t.Fatalf("unexpected request payload: %#v", parsed.Request)
+	}
+}
+
+func assertPublishStateJSON(t *testing.T, payload map[string]any, wantPublished, wantAccepting bool) {
+	t.Helper()
+	settings, _ := payload["publishSettings"].(map[string]any)
+	state, _ := settings["publishState"].(map[string]any)
+	if got, ok := state["isPublished"].(bool); !ok || got != wantPublished {
+		t.Fatalf("JSON isPublished = %v (%t), want %t; payload=%#v", state["isPublished"], ok, wantPublished, payload)
+	}
+	if got, ok := state["isAcceptingResponses"].(bool); !ok || got != wantAccepting {
+		t.Fatalf("JSON isAcceptingResponses = %v (%t), want %t; payload=%#v", state["isAcceptingResponses"], ok, wantAccepting, payload)
+	}
+}

--- a/internal/cmd/forms_publish_test.go
+++ b/internal/cmd/forms_publish_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -233,7 +234,7 @@ func TestFormsPublishCmdDryRun(t *testing.T) {
 	t.Cleanup(func() { newFormsService = origNew })
 	newFormsService = func(context.Context, string) (*formsapi.Service, error) {
 		t.Fatalf("dry-run should not create forms service")
-		return nil, nil
+		return nil, errors.New("unexpected forms service call")
 	}
 
 	out := captureStdout(t, func() {

--- a/internal/cmd/literals.go
+++ b/internal/cmd/literals.go
@@ -6,9 +6,10 @@ package cmd
 // literals across the package; keeping them in one place avoids accidental
 // coupling to unrelated semantic constants.
 const (
-	literalAll   = "all"
-	literalAuto  = "auto"
-	literalError = "error"
+	literalAll     = "all"
+	literalAuto    = "auto"
+	literalDefault = "default"
+	literalError   = "error"
 
 	// literalMarkdownTripleDash is the three-dash token used for YAML
 	// frontmatter delimiters, horizontal rules, and slide separators.

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -230,6 +230,7 @@ forms:
   get: true
   create: false
   update: false
+  publish: false
   add-question: false
   delete-question: false
   move-question: true

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -235,6 +235,7 @@ forms:
   get: true
   create: false
   update: false
+  publish: false
   add-question: false
   delete-question: false
   move-question: false


### PR DESCRIPTION
## Summary
- add `gog forms publish <formId>` for Google Forms publish settings
- support `--unpublish` and `--accepting-responses=false`
- return the form responder URI after publishing and include JSON output for scripting
- keep the command disabled in readonly and agent-safe safety profiles
- update generated command docs

Closes #564

## Tests
- `go test ./internal/cmd -run 'FormsPublish|Forms.*Publish|Execute_Forms'`
- `go test ./internal/cmd -run 'Safety|Enabled|Schema|Help'`
- `XDG_CONFIG_HOME=$(mktemp -d) GOG_KEYRING_BACKEND=file go test ./internal/cmd`
- `make build`
- `make docs-check`
