### PR TITLE
build(macos): auto self-sign local builds to stabilize keychain trust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := build
 
 .PHONY: build build-safe gog gogcli gog-help gogcli-help help fmt fmt-check lint test ci tools docs-commands docs-site docs-check
-.PHONY: worker-ci
+.PHONY: worker-ci codesign-local codesign-bootstrap
 
 BIN_DIR := $(CURDIR)/bin
 BIN := $(BIN_DIR)/gog
@@ -37,6 +37,13 @@ endif
 build:
 	@mkdir -p $(BIN_DIR)
 	@go build -ldflags "$(LDFLAGS)" -o $(BIN) $(CMD)
+	@./scripts/codesign-macos-local.sh $(BIN)
+
+codesign-local: build
+	@./scripts/codesign-macos-local.sh $(BIN)
+
+codesign-bootstrap:
+	@./scripts/codesign-macos-bootstrap.sh
 
 build-safe:
 	@./build-safe.sh $${PROFILE:-safety-profiles/agent-safe.yaml} -o $${OUTPUT:-$(BIN_DIR)/gog-safe}

--- a/scripts/codesign-macos-bootstrap.sh
+++ b/scripts/codesign-macos-bootstrap.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# scripts/codesign-macos-bootstrap.sh
+#
+# One-time bootstrap of a self-signed code signing identity for local
+# `gog` builds. Idempotent: safe to re-run.
+#
+# Output state:
+#   ~/Library/Keychains/gog-codesign.keychain-db   — dedicated keychain
+#   ~/.gog-codesign-keychain-pass                  — keychain unlock password (mode 600)
+#   identity CN: gog-codesign-local-<hostname>
+#   private key allowed for: /usr/bin/codesign, /usr/bin/security
+#
+# Why a dedicated keychain instead of the login keychain
+#   `security import` into login.keychain-db over a non-GUI shell raises
+#   "User interaction is not allowed" because there is no auth context
+#   to prompt the user. A dedicated keychain that the script creates and
+#   unlocks itself sidesteps this entirely.
+#
+# Why a self-signed cert is OK here
+#   This identity is local-only and never used to distribute software.
+#   Its purpose is purely to give `gog` a STABLE designated requirement
+#   so the user's macOS Keychain ACL (for the gogcli token entries) can
+#   anchor a persistent trust decision.
+
+set -euo pipefail
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "codesign-bootstrap: not macOS, nothing to do" >&2
+  exit 0
+fi
+
+CERT_NAME="gog-codesign-local-$(hostname -s)"
+KEYCHAIN="$HOME/Library/Keychains/gog-codesign.keychain-db"
+PASS_FILE="$HOME/.gog-codesign-keychain-pass"
+
+# If keychain and identity already exist, we're done.
+if [[ -f "$KEYCHAIN" ]] \
+  && security find-identity -v "$KEYCHAIN" 2>/dev/null | grep -q "$CERT_NAME"; then
+  echo "codesign-bootstrap: identity '$CERT_NAME' already present, skipping" >&2
+  exit 0
+fi
+
+WORKDIR="$(mktemp -d -t gog-codesign-bootstrap)"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+P12_PASS="$(openssl rand -hex 16)"
+KEYCHAIN_PASS="$(openssl rand -hex 16)"
+
+KEY="$WORKDIR/key.pem"
+CSR_CONF="$WORKDIR/csr.cnf"
+CERT="$WORKDIR/cert.pem"
+P12="$WORKDIR/identity.p12"
+
+cat > "$CSR_CONF" <<EOF
+[ req ]
+distinguished_name = req_dn
+prompt = no
+x509_extensions = v3_ext
+
+[ req_dn ]
+CN = $CERT_NAME
+
+[ v3_ext ]
+basicConstraints = critical,CA:FALSE
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+subjectKeyIdentifier = hash
+EOF
+
+echo "codesign-bootstrap: generating RSA-2048 keypair" >&2
+openssl genrsa -out "$KEY" 2048 2>/dev/null
+
+echo "codesign-bootstrap: self-signing certificate (10 years)" >&2
+openssl req -new -x509 -key "$KEY" -out "$CERT" -days 3650 -config "$CSR_CONF" 2>/dev/null
+
+echo "codesign-bootstrap: bundling into legacy PKCS12 for security import" >&2
+openssl pkcs12 -export -legacy -in "$CERT" -inkey "$KEY" \
+  -out "$P12" -name "$CERT_NAME" \
+  -passout "pass:$P12_PASS"
+
+if [[ -f "$KEYCHAIN" ]]; then
+  echo "codesign-bootstrap: removing pre-existing keychain for clean state" >&2
+  security delete-keychain "$KEYCHAIN" 2>/dev/null || true
+fi
+
+echo "codesign-bootstrap: creating dedicated keychain" >&2
+security create-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+security set-keychain-settings -lut 21600 "$KEYCHAIN"
+security unlock-keychain -p "$KEYCHAIN_PASS" "$KEYCHAIN"
+
+echo "codesign-bootstrap: adding to user keychain search list" >&2
+EXISTING_LIST="$(security list-keychains -d user \
+  | sed 's/"//g' | tr -s ' ' '\n' | grep -v '^$' | grep -v "$KEYCHAIN" | tr '\n' ' ')"
+# shellcheck disable=SC2086
+security list-keychains -d user -s "$KEYCHAIN" $EXISTING_LIST
+
+echo "codesign-bootstrap: importing identity" >&2
+security import "$P12" \
+  -k "$KEYCHAIN" \
+  -P "$P12_PASS" \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security
+
+echo "codesign-bootstrap: setting key partition list (allow codesign without prompts)" >&2
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign:,security: \
+  -s -k "$KEYCHAIN_PASS" \
+  "$KEYCHAIN"
+
+echo "codesign-bootstrap: saving keychain unlock password to $PASS_FILE (mode 600)" >&2
+printf '%s' "$KEYCHAIN_PASS" > "$PASS_FILE"
+chmod 600 "$PASS_FILE"
+
+echo "codesign-bootstrap: done. identity = '$CERT_NAME'" >&2

--- a/scripts/codesign-macos-local.sh
+++ b/scripts/codesign-macos-local.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# scripts/codesign-macos-local.sh
+#
+# Local-build code signing for `gog` on macOS.
+#
+# Why this exists
+#   When `gog` reads/writes a token in the user's macOS Keychain (via the
+#   keyring backend), securityd evaluates the requesting binary against each
+#   keychain item's ACL. If `gog` is unsigned (or only ad-hoc signed via
+#   `go build`'s default linker-signed mode), securityd cannot anchor a
+#   stable trust decision — every invocation re-prompts the user even after
+#   "Always Allow" is clicked.
+#
+#   Giving every local build a STABLE designated requirement (via a real
+#   signing identity, even a self-signed one) lets the keychain ACL store
+#   a persistent trust binding. The first prompt sticks across rebuilds.
+#
+# Two modes
+#   1) Identity provided: if GOG_CODESIGN_IDENTITY (or CODESIGN_IDENTITY) is
+#      set, sign with that identity. This is the same env var the existing
+#      `scripts/codesign-macos.sh` uses for the goreleaser release flow, so
+#      a developer with a real Apple Developer ID set up will get the same
+#      signing for both local and release builds.
+#
+#   2) Auto self-signed fallback: if no identity is provided, bootstrap (on
+#      first run) and use a self-signed identity stored in a dedicated
+#      keychain at ~/Library/Keychains/gog-codesign.keychain-db. The cert
+#      is added to the user's keychain search list with codesign access.
+#
+# No-ops on non-Darwin. Skip with GOG_SKIP_LOCAL_CODESIGN=1.
+#
+# Usage: scripts/codesign-macos-local.sh <path-to-binary>
+
+set -euo pipefail
+
+BIN="${1:-}"
+if [[ -z "$BIN" ]]; then
+  echo "usage: $0 <path-to-binary>" >&2
+  exit 2
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  exit 0
+fi
+
+if [[ -n "${GOG_SKIP_LOCAL_CODESIGN:-}" ]]; then
+  echo "codesign-local: skipped (GOG_SKIP_LOCAL_CODESIGN set)" >&2
+  exit 0
+fi
+
+if ! [[ -f "$BIN" ]]; then
+  echo "codesign-local: binary not found: $BIN" >&2
+  exit 1
+fi
+
+BUNDLE_ID="com.openclaw.gogcli.gog"
+
+# Mode 1: real signing identity (Developer ID, etc.) provided.
+IDENTITY="${GOG_CODESIGN_IDENTITY:-${CODESIGN_IDENTITY:-}}"
+if [[ -n "$IDENTITY" ]]; then
+  codesign --force --sign "$IDENTITY" --timestamp --options runtime \
+    --identifier "$BUNDLE_ID" "$BIN"
+  codesign --verify --strict --verbose=2 "$BIN" >/dev/null
+  echo "codesign-local: signed with identity '$IDENTITY'" >&2
+  exit 0
+fi
+
+# Mode 2: auto-self-signed identity in dedicated keychain.
+LOCAL_KEYCHAIN="$HOME/Library/Keychains/gog-codesign.keychain-db"
+LOCAL_IDENTITY_NAME="gog-codesign-local-$(hostname -s)"
+LOCAL_PASS_FILE="$HOME/.gog-codesign-keychain-pass"
+
+# Bootstrap if keychain or identity is missing.
+need_bootstrap=0
+if [[ ! -f "$LOCAL_KEYCHAIN" ]]; then
+  need_bootstrap=1
+elif ! security find-identity -v "$LOCAL_KEYCHAIN" 2>/dev/null | grep -q "$LOCAL_IDENTITY_NAME"; then
+  need_bootstrap=1
+fi
+
+if [[ "$need_bootstrap" == "1" ]]; then
+  echo "codesign-local: bootstrapping self-signed identity '$LOCAL_IDENTITY_NAME'..." >&2
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  "$script_dir/codesign-macos-bootstrap.sh"
+fi
+
+# Unlock dedicated keychain (idempotent).
+if [[ -f "$LOCAL_PASS_FILE" ]]; then
+  KEYCHAIN_PASS="$(cat "$LOCAL_PASS_FILE")"
+  security unlock-keychain -p "$KEYCHAIN_PASS" "$LOCAL_KEYCHAIN" >/dev/null 2>&1 || true
+fi
+
+codesign --force --sign "$LOCAL_IDENTITY_NAME" \
+  --identifier "$BUNDLE_ID" \
+  --keychain "$LOCAL_KEYCHAIN" \
+  "$BIN"
+
+codesign --verify --strict --verbose=2 "$BIN" >/dev/null
+echo "codesign-local: signed with self-signed identity '$LOCAL_IDENTITY_NAME'" >&2


### PR DESCRIPTION
## Problem

`make build` produces a `gog` binary that is only ad-hoc / linker-signed (Go's default).
When `gog` reads or writes a token in the user's macOS Keychain, `securityd` cannot
anchor a stable trust decision against an ad-hoc binary, so:

- The "Allow / Always Allow / Deny" prompt **re-appears on every invocation**, even
  after the user clicks "Always Allow".
- The dialog shows only the keychain item description (`gogcli`), with no path or
  signing identity, making it impossible for the user to understand that each
  build looks like "a different app" to macOS.
- For long-running gog processes that poll keychain (~every 10s on this user's
  setup), this becomes a continuous prompt loop.

The issue is reproducible on macOS 26.4 against tokens stored by the gogcli keyring
backend. `securityd` log confirms: `code requirement check failed (-67050), client
is not Apple-signed` plus `AMFI: '<gog path>' has no CMS blob`.

## Fix

Give every local build a **stable designated requirement** by signing it post-`go build`.

Two modes:

1. **Real signing identity (preferred):** if `GOG_CODESIGN_IDENTITY` (or
   `CODESIGN_IDENTITY`) is set — same env var the existing
   `scripts/codesign-macos.sh` (goreleaser hook) uses — the binary is signed with
   that identity. A developer with an Apple Developer ID gets unified signing for
   both local and release builds.

2. **Auto self-signed fallback:** if no identity is provided, a one-time bootstrap
   creates a self-signed identity in a dedicated keychain at
   `~/Library/Keychains/gog-codesign.keychain-db`. The cert is local-only (never
   used to distribute software) — its sole purpose is to give `gog` a stable
   `designated requirement` so the user's macOS Keychain ACL can persist
   "Always Allow" trust across rebuilds.

## Changes

- `scripts/codesign-macos-local.sh` — post-build signing hook (idempotent).
- `scripts/codesign-macos-bootstrap.sh` — one-time self-signed identity creation.
- `Makefile` — `build` target invokes `codesign-macos-local.sh` after `go build`.
  New explicit `codesign-local` and `codesign-bootstrap` targets.

## Behavior matrix

| Platform / Setting | Effect |
|---|---|
| Linux / Windows | No-op (script exits 0 on non-Darwin) |
| macOS, no env var | Bootstraps self-signed identity on first build, signs every build with it |
| macOS, `GOG_CODESIGN_IDENTITY` set | Signs with that identity (same as goreleaser hook) |
| macOS, `GOG_SKIP_LOCAL_CODESIGN=1` | No-op (opt-out for users who don't want it) |

## Untouched

- `.goreleaser.yaml` — release flow unchanged.
- `scripts/codesign-macos.sh` — release goreleaser hook unchanged.
- All existing CI workflows — unaffected (no Linux runner reaches this code path).
- Tests — none added; the script is tooling-only and shells out to `codesign` /
  `security` which can't be unit-tested in a useful way without elevated CI privs.

## Verification

Tested on macOS 26.4 against a real gogcli installation that was hitting the
prompt loop. After signing with the auto-bootstrapped self-signed identity,
`codesign --verify --strict` passes and the binary's designated requirement is:

```
identifier "com.openclaw.gogcli.gog" and certificate leaf = H"<sha1>"
```

This is stable across rebuilds (depends only on bundle id + cert leaf hash, not
CDHash), so the keychain ACL anchors "Always Allow" persistently.

## Carried patch

This change is also tracked as a carried patch in a downstream CPQ-managed fork.

Carried patch: patch-feat-pr568

---

Co-Authored-By: Oz <oz-agent@warp.dev>
