### PR TITLE
feat(auth): add safe non-interactive token import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Calendar: add `calendar events --sort=start|end|summary|calendar` and `--order=asc|desc` so `--all` output can be returned chronologically across calendars instead of per-calendar API iteration order. Also documents `now` in the `--from`/`--to` help strings (already accepted by `timeparse`) — the relative form agents need when planning "from now on" — thanks @gado-ships-it.
 - Calendar: add `calendar events --location` to include event locations in table output. Embedded newlines in the location string are collapsed so multi-line addresses still render on one row — thanks @gado-ships-it.
+- Auth: add `gog auth import --client --email` with `--refresh-token-stdin`, `--refresh-token-file`, or `--refresh-token-env` for non-interactive token import without exposing secrets in argv — thanks @jcarnegie.
 - Drive: add `drive share --notify` for invite targets that require a Drive notification email.
 - Calendar: keep `calendar appointments` as an explicit diagnostic because the Calendar API still rejects `eventTypes=appointmentSchedule`. (#329)
 - CLI: add nested `docs tabs ...` and `forms questions ...` aliases for consistent sub-item command patterns while preserving existing flat commands. (#433)

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -43,6 +43,7 @@ Generated from `gog schema --json`.
       - [`gog auth credentials remove [<client>]`](commands/gog-auth-credentials-remove.md) - Remove stored OAuth client credentials
       - [`gog auth credentials set <credentials> [flags]`](commands/gog-auth-credentials-set.md) - Store OAuth client credentials
     - [`gog auth doctor [flags]`](commands/gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
+    - [`gog auth import --email=STRING [flags]`](commands/gog-auth-import.md) - Import a refresh token non-interactively from stdin, file, or env
     - [`gog auth keep --key=STRING <email>`](commands/gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
     - [`gog auth keyring [<backend> [<backend2>]]`](commands/gog-auth-keyring.md) - Configure keyring backend
     - [`gog auth list [flags]`](commands/gog-auth-list.md) - List stored accounts

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 559.
+Generated pages: 560.
 
 ## Top-level Commands
 
@@ -93,6 +93,7 @@ Generated pages: 559.
       - [gog auth credentials remove](gog-auth-credentials-remove.md) - Remove stored OAuth client credentials
       - [gog auth credentials set](gog-auth-credentials-set.md) - Store OAuth client credentials
     - [gog auth doctor](gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
+    - [gog auth import](gog-auth-import.md) - Import a refresh token non-interactively from stdin, file, or env
     - [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
     - [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
     - [gog auth list](gog-auth-list.md) - List stored accounts

--- a/docs/commands/gog-auth-import.md
+++ b/docs/commands/gog-auth-import.md
@@ -1,35 +1,18 @@
-# `gog auth`
+# `gog auth import`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Auth and credentials
+Import a refresh token non-interactively from stdin, file, or env
 
 ## Usage
 
 ```bash
-gog auth <command> [flags]
+gog auth import --email=STRING [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog auth add](gog-auth-add.md) - Authorize and store a refresh token
-- [gog auth alias](gog-auth-alias.md) - Manage account aliases
-- [gog auth credentials](gog-auth-credentials.md) - Manage OAuth client credentials
-- [gog auth doctor](gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
-- [gog auth import](gog-auth-import.md) - Import a refresh token non-interactively from stdin, file, or env
-- [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
-- [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
-- [gog auth list](gog-auth-list.md) - List stored accounts
-- [gog auth manage](gog-auth-manage.md) - Open accounts manager in browser
-- [gog auth remove](gog-auth-remove.md) - Remove a stored refresh token
-- [gog auth service-account](gog-auth-service-account.md) - Configure service account (Workspace only; domain-wide delegation)
-- [gog auth services](gog-auth-services.md) - List supported auth services and scopes
-- [gog auth status](gog-auth-status.md) - Show auth configuration and keyring backend
-- [gog auth tokens](gog-auth-tokens.md) - Manage stored refresh tokens
+- [gog auth](gog-auth.md)
 
 ## Flags
 
@@ -41,6 +24,7 @@ gog auth <command> [flags]
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--email` | `string` |  | Account email |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled commands; dot paths allowed (restricts CLI) |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
@@ -48,13 +32,17 @@ gog auth <command> [flags]
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--refresh-token-env` | `string` |  | Read OAuth refresh token from the named environment variable |
+| `--refresh-token-file` | `string` |  | Read OAuth refresh token from file |
+| `--refresh-token-stdin` | `bool` |  | Read OAuth refresh token from stdin |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--services` | `string` |  | Comma-separated services to record on the token (informational; does not affect scopes) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog](gog.md)
+- [gog auth](gog-auth.md)
 - [Command index](README.md)

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -42,6 +42,7 @@ const (
 type AuthCmd struct {
 	Credentials AuthCredentialsCmd    `cmd:"" name:"credentials" help:"Manage OAuth client credentials"`
 	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize and store a refresh token"`
+	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a refresh token non-interactively from flags"`
 	Services    AuthServicesCmd       `cmd:"" name:"services" help:"List supported auth services and scopes"`
 	List        AuthListCmd           `cmd:"" name:"list" help:"List stored accounts"`
 	Doctor      AuthDoctorCmd         `cmd:"" name:"doctor" help:"Diagnose auth, keyring, and refresh-token issues"`

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -42,7 +42,7 @@ const (
 type AuthCmd struct {
 	Credentials AuthCredentialsCmd    `cmd:"" name:"credentials" help:"Manage OAuth client credentials"`
 	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize and store a refresh token"`
-	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a refresh token non-interactively from flags"`
+	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a refresh token non-interactively from stdin, file, or env"`
 	Services    AuthServicesCmd       `cmd:"" name:"services" help:"List supported auth services and scopes"`
 	List        AuthListCmd           `cmd:"" name:"list" help:"List stored accounts"`
 	Doctor      AuthDoctorCmd         `cmd:"" name:"doctor" help:"Diagnose auth, keyring, and refresh-token issues"`

--- a/internal/cmd/auth_accounts.go
+++ b/internal/cmd/auth_accounts.go
@@ -49,7 +49,7 @@ func (c *AuthStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if flags != nil {
 		if a, err := requireAccount(flags); err == nil {
 			account = a
-			resolvedClient, resolveErr := resolveClientForEmail(account, flags, "")
+			resolvedClient, resolveErr := resolveClientForEmail(account, flags)
 			if resolveErr != nil {
 				return resolveErr
 			}
@@ -222,7 +222,7 @@ func (c *AuthRemoveCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	client, err := resolveClientForEmail(email, flags, "")
+	client, err := resolveClientForEmail(email, flags)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -70,12 +70,12 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	if _, getErr := store.GetToken(client, email); getErr == nil {
-		if !force {
+	if !force {
+		if _, getErr := store.GetToken(client, email); getErr == nil {
 			return usagef("entry already exists for client=%q email=%q (use --force to overwrite)", client, email)
+		} else if !errors.Is(getErr, keyring.ErrKeyNotFound) {
+			return getErr
 		}
-	} else if !errors.Is(getErr, keyring.ErrKeyNotFound) {
-		return getErr
 	}
 
 	if err := store.SetToken(client, email, secrets.Token{

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -45,9 +45,9 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if flags != nil {
 		override = flags.Client
 	}
-	client, err := resolveClientForEmail(email, flags, "")
-	if err != nil {
-		return err
+	client, clientErr := resolveClientForEmail(email, flags)
+	if clientErr != nil {
+		return clientErr
 	}
 
 	services := splitCommaList(c.ServicesCSV)

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -20,14 +20,12 @@ var readAuthImportStdin = func() ([]byte, error) {
 }
 
 type AuthImportCmd struct {
-	Client            string `name:"client" help:"OAuth client name to namespace the entry" default:"default"`
 	Email             string `name:"email" required:"" help:"Account email"`
 	RefreshToken      string `name:"refresh-token" hidden:"" help:"OAuth refresh token to store (prefer --refresh-token-stdin, --refresh-token-file, or --refresh-token-env)"`
 	RefreshTokenStdin bool   `name:"refresh-token-stdin" help:"Read OAuth refresh token from stdin"`
 	RefreshTokenFile  string `name:"refresh-token-file" type:"path" help:"Read OAuth refresh token from file"`
 	RefreshTokenEnv   string `name:"refresh-token-env" help:"Read OAuth refresh token from the named environment variable"`
 	ServicesCSV       string `name:"services" help:"Comma-separated services to record on the token (informational; does not affect scopes)"`
-	Force             bool   `name:"force" help:"Overwrite an existing entry without prompting"`
 }
 
 func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -43,18 +41,23 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return tokenErr
 	}
 
-	client := strings.TrimSpace(c.Client)
-	if client == "" {
-		client = config.DefaultClientName
+	client := config.DefaultClientName
+	if flags != nil {
+		resolvedClient, err := config.NormalizeClientNameOrDefault(flags.Client)
+		if err != nil {
+			return err
+		}
+		client = resolvedClient
 	}
 
 	services := splitCommaList(c.ServicesCSV)
+	force := flags != nil && flags.Force
 
 	if err := dryRunExit(ctx, flags, "auth.import", map[string]any{
 		"client":   client,
 		"email":    email,
 		"services": services,
-		"force":    c.Force,
+		"force":    force,
 	}); err != nil {
 		return err
 	}
@@ -69,7 +72,7 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if _, getErr := store.GetToken(client, email); getErr == nil {
-		if !c.Force {
+		if !force {
 			return usagef("entry already exists for client=%q email=%q (use --force to overwrite)", client, email)
 		}
 	} else if !errors.Is(getErr, keyring.ErrKeyNotFound) {

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -38,9 +38,9 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("--email is required")
 	}
 
-	refreshToken, err := c.resolveRefreshToken()
-	if err != nil {
-		return err
+	refreshToken, tokenErr := c.resolveRefreshToken()
+	if tokenErr != nil {
+		return tokenErr
 	}
 
 	client := strings.TrimSpace(c.Client)
@@ -124,7 +124,7 @@ func (c *AuthImportCmd) resolveRefreshToken() (string, error) {
 			return "", fmt.Errorf("read --refresh-token-stdin: %w", err)
 		}
 	case strings.TrimSpace(c.RefreshTokenFile) != "":
-		raw, err = os.ReadFile(strings.TrimSpace(c.RefreshTokenFile)) //nolint:gosec // user-provided token file path
+		raw, err = os.ReadFile(strings.TrimSpace(c.RefreshTokenFile))
 		if err != nil {
 			return "", fmt.Errorf("read --refresh-token-file: %w", err)
 		}

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -21,7 +21,6 @@ var readAuthImportStdin = func() ([]byte, error) {
 
 type AuthImportCmd struct {
 	Email             string `name:"email" required:"" help:"Account email"`
-	RefreshToken      string `name:"refresh-token" hidden:"" help:"OAuth refresh token to store (prefer --refresh-token-stdin, --refresh-token-file, or --refresh-token-env)"`
 	RefreshTokenStdin bool   `name:"refresh-token-stdin" help:"Read OAuth refresh token from stdin"`
 	RefreshTokenFile  string `name:"refresh-token-file" type:"path" help:"Read OAuth refresh token from file"`
 	RefreshTokenEnv   string `name:"refresh-token-env" help:"Read OAuth refresh token from the named environment variable"`
@@ -109,9 +108,6 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 func (c *AuthImportCmd) resolveRefreshToken() (string, error) {
 	sources := 0
-	if strings.TrimSpace(c.RefreshToken) != "" {
-		sources++
-	}
 	if c.RefreshTokenStdin {
 		sources++
 	}
@@ -139,7 +135,11 @@ func (c *AuthImportCmd) resolveRefreshToken() (string, error) {
 			return "", fmt.Errorf("read --refresh-token-stdin: %w", err)
 		}
 	case strings.TrimSpace(c.RefreshTokenFile) != "":
-		raw, err = os.ReadFile(strings.TrimSpace(c.RefreshTokenFile))
+		path, expandErr := config.ExpandPath(strings.TrimSpace(c.RefreshTokenFile))
+		if expandErr != nil {
+			return "", fmt.Errorf("expand --refresh-token-file: %w", expandErr)
+		}
+		raw, err = os.ReadFile(path) //nolint:gosec // user-provided token file path
 		if err != nil {
 			return "", fmt.Errorf("read --refresh-token-file: %w", err)
 		}
@@ -150,8 +150,6 @@ func (c *AuthImportCmd) resolveRefreshToken() (string, error) {
 			return "", usagef("environment variable %s is not set", envName)
 		}
 		raw = []byte(value)
-	default:
-		raw = []byte(c.RefreshToken)
 	}
 
 	token := strings.TrimSpace(string(raw))

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -41,13 +41,13 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return tokenErr
 	}
 
-	client := config.DefaultClientName
+	override := ""
 	if flags != nil {
-		resolvedClient, err := config.NormalizeClientNameOrDefault(flags.Client)
-		if err != nil {
-			return err
-		}
-		client = resolvedClient
+		override = flags.Client
+	}
+	client, err := resolveClientForEmail(email, flags, "")
+	if err != nil {
+		return err
 	}
 
 	services := splitCommaList(c.ServicesCSV)
@@ -86,6 +86,18 @@ func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
 		RefreshToken: refreshToken,
 	}); err != nil {
 		return err
+	}
+	if strings.TrimSpace(override) != "" {
+		cfg, err := config.ReadConfig()
+		if err != nil {
+			return err
+		}
+		if err := config.SetAccountClient(&cfg, email, client); err != nil {
+			return err
+		}
+		if err := config.WriteConfig(cfg); err != nil {
+			return err
+		}
 	}
 
 	return writeResult(ctx, u,

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -1,0 +1,147 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/99designs/keyring"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+var readAuthImportStdin = func() ([]byte, error) {
+	return io.ReadAll(os.Stdin)
+}
+
+type AuthImportCmd struct {
+	Client            string `name:"client" help:"OAuth client name to namespace the entry" default:"default"`
+	Email             string `name:"email" required:"" help:"Account email"`
+	RefreshToken      string `name:"refresh-token" hidden:"" help:"OAuth refresh token to store (prefer --refresh-token-stdin, --refresh-token-file, or --refresh-token-env)"`
+	RefreshTokenStdin bool   `name:"refresh-token-stdin" help:"Read OAuth refresh token from stdin"`
+	RefreshTokenFile  string `name:"refresh-token-file" type:"path" help:"Read OAuth refresh token from file"`
+	RefreshTokenEnv   string `name:"refresh-token-env" help:"Read OAuth refresh token from the named environment variable"`
+	ServicesCSV       string `name:"services" help:"Comma-separated services to record on the token (informational; does not affect scopes)"`
+	Force             bool   `name:"force" help:"Overwrite an existing entry without prompting"`
+}
+
+func (c *AuthImportCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+
+	email := normalizeEmail(c.Email)
+	if email == "" {
+		return usage("--email is required")
+	}
+
+	refreshToken, err := c.resolveRefreshToken()
+	if err != nil {
+		return err
+	}
+
+	client := strings.TrimSpace(c.Client)
+	if client == "" {
+		client = config.DefaultClientName
+	}
+
+	services := splitCommaList(c.ServicesCSV)
+
+	if err := dryRunExit(ctx, flags, "auth.import", map[string]any{
+		"client":   client,
+		"email":    email,
+		"services": services,
+		"force":    c.Force,
+	}); err != nil {
+		return err
+	}
+
+	if err := ensureKeychainAccessIfNeeded(); err != nil {
+		return fmt.Errorf("keychain access: %w", err)
+	}
+
+	store, err := openSecretsStore()
+	if err != nil {
+		return err
+	}
+
+	if _, getErr := store.GetToken(client, email); getErr == nil {
+		if !c.Force {
+			return usagef("entry already exists for client=%q email=%q (use --force to overwrite)", client, email)
+		}
+	} else if !errors.Is(getErr, keyring.ErrKeyNotFound) {
+		return getErr
+	}
+
+	if err := store.SetToken(client, email, secrets.Token{
+		Client:       client,
+		Email:        email,
+		Services:     services,
+		RefreshToken: refreshToken,
+	}); err != nil {
+		return err
+	}
+
+	return writeResult(ctx, u,
+		kv("imported", true),
+		kv("client", client),
+		kv("email", email),
+	)
+}
+
+func (c *AuthImportCmd) resolveRefreshToken() (string, error) {
+	sources := 0
+	if strings.TrimSpace(c.RefreshToken) != "" {
+		sources++
+	}
+	if c.RefreshTokenStdin {
+		sources++
+	}
+	if strings.TrimSpace(c.RefreshTokenFile) != "" {
+		sources++
+	}
+	if strings.TrimSpace(c.RefreshTokenEnv) != "" {
+		sources++
+	}
+	if sources == 0 {
+		return "", usage("provide refresh token with --refresh-token-stdin, --refresh-token-file, or --refresh-token-env")
+	}
+	if sources > 1 {
+		return "", usage("provide exactly one refresh token source")
+	}
+
+	var (
+		raw []byte
+		err error
+	)
+	switch {
+	case c.RefreshTokenStdin:
+		raw, err = readAuthImportStdin()
+		if err != nil {
+			return "", fmt.Errorf("read --refresh-token-stdin: %w", err)
+		}
+	case strings.TrimSpace(c.RefreshTokenFile) != "":
+		raw, err = os.ReadFile(strings.TrimSpace(c.RefreshTokenFile)) //nolint:gosec // user-provided token file path
+		if err != nil {
+			return "", fmt.Errorf("read --refresh-token-file: %w", err)
+		}
+	case strings.TrimSpace(c.RefreshTokenEnv) != "":
+		envName := strings.TrimSpace(c.RefreshTokenEnv)
+		value, ok := os.LookupEnv(envName)
+		if !ok {
+			return "", usagef("environment variable %s is not set", envName)
+		}
+		raw = []byte(value)
+	default:
+		raw = []byte(c.RefreshToken)
+	}
+
+	token := strings.TrimSpace(string(raw))
+	if token == "" {
+		return "", usage("refresh token must not be empty")
+	}
+	return token, nil
+}

--- a/internal/cmd/auth_import_test.go
+++ b/internal/cmd/auth_import_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -251,6 +252,10 @@ func TestAuthImportCmd_ForceOverwritesExistingEntry(t *testing.T) {
 }
 
 func TestAuthImportCmd_CustomClientNamespace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
@@ -266,6 +271,42 @@ func TestAuthImportCmd_CustomClientNamespace(t *testing.T) {
 		t.Fatalf("expected token under custom client: %v", err)
 	}
 	if _, err := store.GetToken("default", "a@b.com"); err == nil {
+		t.Fatalf("expected no token under default client")
+	}
+	cfg, err := config.ReadConfig()
+	if err != nil {
+		t.Fatalf("ReadConfig: %v", err)
+	}
+	if got := cfg.AccountClients["a@b.com"]; got != "org" {
+		t.Fatalf("expected account client mapping org, got %q", got)
+	}
+}
+
+func TestAuthImportCmd_UsesConfiguredClientMapping(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+	if err := config.WriteConfig(config.File{ClientDomains: map[string]string{
+		"example.com": "work",
+	}}); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Email:        "user@example.com",
+		RefreshToken: "rt",
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := store.GetToken("work", "user@example.com"); err != nil {
+		t.Fatalf("expected token under mapped client: %v", err)
+	}
+	if _, err := store.GetToken("default", "user@example.com"); err == nil {
 		t.Fatalf("expected no token under default client")
 	}
 }

--- a/internal/cmd/auth_import_test.go
+++ b/internal/cmd/auth_import_test.go
@@ -272,6 +272,16 @@ func TestAuthImportCmd_ForceOverwritesExistingEntry(t *testing.T) {
 	}
 }
 
+func TestAuthImportCmd_ForceOverwritesUnreadableEntry(t *testing.T) {
+	store := &errorTokenStore{err: errors.New("decode token")}
+	withImportOverrides(t, store)
+
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "rt-new")
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{Force: true}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
 func TestAuthImportCmd_CustomClientNamespace(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/cmd/auth_import_test.go
+++ b/internal/cmd/auth_import_test.go
@@ -39,15 +39,21 @@ func withImportOverrides(t *testing.T, store secrets.Store) {
 	ensureKeychainAccess = func() error { return nil }
 }
 
+func authImportCmdWithEnvToken(t *testing.T, email string, token string) *AuthImportCmd {
+	t.Helper()
+	t.Setenv("GOG_TEST_REFRESH_TOKEN", token)
+	return &AuthImportCmd{
+		Email:           email,
+		RefreshTokenEnv: "GOG_TEST_REFRESH_TOKEN",
+	}
+}
+
 func TestAuthImportCmd_RejectsEmptyRefreshToken(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
-	cmd := &AuthImportCmd{
-		Email:        "a@b.com",
-		RefreshToken: "   ",
-		ServicesCSV:  "gmail",
-	}
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "   ")
+	cmd.ServicesCSV = "gmail"
 	err := cmd.Run(newImportTestContext(t), &RootFlags{})
 	if err == nil {
 		t.Fatal("expected error for empty refresh token")
@@ -56,8 +62,8 @@ func TestAuthImportCmd_RejectsEmptyRefreshToken(t *testing.T) {
 	if !errors.As(err, &ee) || ee.Code != 2 {
 		t.Fatalf("expected ExitError code=2, got %#v", err)
 	}
-	if !strings.Contains(err.Error(), "refresh-token") {
-		t.Fatalf("expected refresh-token in error, got %q", err.Error())
+	if !strings.Contains(err.Error(), "refresh token") {
+		t.Fatalf("expected refresh token in error, got %q", err.Error())
 	}
 }
 
@@ -85,11 +91,8 @@ func TestAuthImportCmd_RejectsMultipleRefreshTokenSources(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
-	cmd := &AuthImportCmd{
-		Email:             "a@b.com",
-		RefreshToken:      "rt",
-		RefreshTokenStdin: true,
-	}
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "rt")
+	cmd.RefreshTokenStdin = true
 	err := cmd.Run(newImportTestContext(t), &RootFlags{})
 	if err == nil {
 		t.Fatal("expected error for multiple refresh token sources")
@@ -107,10 +110,7 @@ func TestAuthImportCmd_RejectsEmptyEmail(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
-	cmd := &AuthImportCmd{
-		Email:        "   ",
-		RefreshToken: "rt",
-	}
+	cmd := authImportCmdWithEnvToken(t, "   ", "rt")
 	err := cmd.Run(newImportTestContext(t), &RootFlags{})
 	if err == nil {
 		t.Fatal("expected error for empty email")
@@ -175,6 +175,33 @@ func TestAuthImportCmd_ReadsRefreshTokenFromFile(t *testing.T) {
 	}
 }
 
+func TestAuthImportCmd_ExpandsRefreshTokenFilePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+	path := filepath.Join(home, "token.txt")
+	if err := os.WriteFile(path, []byte("rt-home\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	cmd := &AuthImportCmd{
+		Email:            "a@b.com",
+		RefreshTokenFile: "~/token.txt",
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	tok, err := store.GetToken("default", "a@b.com")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if tok.RefreshToken != "rt-home" {
+		t.Fatalf("expected expanded file token, got %q", tok.RefreshToken)
+	}
+}
+
 func TestAuthImportCmd_ReadsRefreshTokenFromStdin(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
@@ -206,10 +233,7 @@ func TestAuthImportCmd_RejectsExistingEntryWithoutForce(t *testing.T) {
 		t.Fatalf("seed SetToken: %v", err)
 	}
 
-	cmd := &AuthImportCmd{
-		Email:        "a@b.com",
-		RefreshToken: "rt-new",
-	}
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "rt-new")
 	err := cmd.Run(newImportTestContext(t), &RootFlags{})
 	if err == nil {
 		t.Fatal("expected error when entry exists without --force")
@@ -234,10 +258,7 @@ func TestAuthImportCmd_ForceOverwritesExistingEntry(t *testing.T) {
 		t.Fatalf("seed SetToken: %v", err)
 	}
 
-	cmd := &AuthImportCmd{
-		Email:        "a@b.com",
-		RefreshToken: "rt-new",
-	}
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "rt-new")
 	if err := cmd.Run(newImportTestContext(t), &RootFlags{Force: true}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -259,10 +280,7 @@ func TestAuthImportCmd_CustomClientNamespace(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
-	cmd := &AuthImportCmd{
-		Email:        "a@b.com",
-		RefreshToken: "rt",
-	}
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "rt")
 	if err := cmd.Run(newImportTestContext(t), &RootFlags{Client: "org"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -295,10 +313,7 @@ func TestAuthImportCmd_UsesConfiguredClientMapping(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
-	cmd := &AuthImportCmd{
-		Email:        "user@example.com",
-		RefreshToken: "rt",
-	}
+	cmd := authImportCmdWithEnvToken(t, "user@example.com", "rt")
 	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
@@ -315,10 +330,7 @@ func TestAuthImportCmd_DryRunDoesNotWrite(t *testing.T) {
 	store := newMemSecretsStore()
 	withImportOverrides(t, store)
 
-	cmd := &AuthImportCmd{
-		Email:        "a@b.com",
-		RefreshToken: "rt",
-	}
+	cmd := authImportCmdWithEnvToken(t, "a@b.com", "rt")
 	err := cmd.Run(newImportTestContext(t), &RootFlags{DryRun: true})
 	var ee *ExitError
 	if !errors.As(err, &ee) || ee.Code != 0 {

--- a/internal/cmd/auth_import_test.go
+++ b/internal/cmd/auth_import_test.go
@@ -43,7 +43,6 @@ func TestAuthImportCmd_RejectsEmptyRefreshToken(t *testing.T) {
 	withImportOverrides(t, store)
 
 	cmd := &AuthImportCmd{
-		Client:       "default",
 		Email:        "a@b.com",
 		RefreshToken: "   ",
 		ServicesCSV:  "gmail",
@@ -66,8 +65,7 @@ func TestAuthImportCmd_RejectsMissingRefreshTokenSource(t *testing.T) {
 	withImportOverrides(t, store)
 
 	cmd := &AuthImportCmd{
-		Client: "default",
-		Email:  "a@b.com",
+		Email: "a@b.com",
 	}
 	err := cmd.Run(newImportTestContext(t), &RootFlags{})
 	if err == nil {
@@ -87,7 +85,6 @@ func TestAuthImportCmd_RejectsMultipleRefreshTokenSources(t *testing.T) {
 	withImportOverrides(t, store)
 
 	cmd := &AuthImportCmd{
-		Client:            "default",
 		Email:             "a@b.com",
 		RefreshToken:      "rt",
 		RefreshTokenStdin: true,
@@ -110,7 +107,6 @@ func TestAuthImportCmd_RejectsEmptyEmail(t *testing.T) {
 	withImportOverrides(t, store)
 
 	cmd := &AuthImportCmd{
-		Client:       "default",
 		Email:        "   ",
 		RefreshToken: "rt",
 	}
@@ -130,7 +126,6 @@ func TestAuthImportCmd_DefaultsClientToDefault(t *testing.T) {
 	t.Setenv("GOG_TEST_REFRESH_TOKEN", "rt-1\n")
 
 	cmd := &AuthImportCmd{
-		Client:          "", // unset; must default to "default"
 		Email:           "A@B.com",
 		RefreshTokenEnv: "GOG_TEST_REFRESH_TOKEN",
 		ServicesCSV:     "gmail, drive",
@@ -163,7 +158,6 @@ func TestAuthImportCmd_ReadsRefreshTokenFromFile(t *testing.T) {
 	}
 
 	cmd := &AuthImportCmd{
-		Client:           "default",
 		Email:            "a@b.com",
 		RefreshTokenFile: path,
 	}
@@ -188,7 +182,6 @@ func TestAuthImportCmd_ReadsRefreshTokenFromStdin(t *testing.T) {
 	}
 
 	cmd := &AuthImportCmd{
-		Client:            "default",
 		Email:             "a@b.com",
 		RefreshTokenStdin: true,
 	}
@@ -213,7 +206,6 @@ func TestAuthImportCmd_RejectsExistingEntryWithoutForce(t *testing.T) {
 	}
 
 	cmd := &AuthImportCmd{
-		Client:       "default",
 		Email:        "a@b.com",
 		RefreshToken: "rt-new",
 	}
@@ -242,12 +234,10 @@ func TestAuthImportCmd_ForceOverwritesExistingEntry(t *testing.T) {
 	}
 
 	cmd := &AuthImportCmd{
-		Client:       "default",
 		Email:        "a@b.com",
 		RefreshToken: "rt-new",
-		Force:        true,
 	}
-	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{Force: true}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -265,11 +255,10 @@ func TestAuthImportCmd_CustomClientNamespace(t *testing.T) {
 	withImportOverrides(t, store)
 
 	cmd := &AuthImportCmd{
-		Client:       "org",
 		Email:        "a@b.com",
 		RefreshToken: "rt",
 	}
-	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{Client: "org"}); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
 
@@ -286,7 +275,6 @@ func TestAuthImportCmd_DryRunDoesNotWrite(t *testing.T) {
 	withImportOverrides(t, store)
 
 	cmd := &AuthImportCmd{
-		Client:       "default",
 		Email:        "a@b.com",
 		RefreshToken: "rt",
 	}

--- a/internal/cmd/auth_import_test.go
+++ b/internal/cmd/auth_import_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/secrets"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func newImportTestContext(t *testing.T) context.Context {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	return outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{})
+}
+
+func withImportOverrides(t *testing.T, store secrets.Store) {
+	t.Helper()
+	origOpen := openSecretsStore
+	origKeychain := ensureKeychainAccess
+	origStdin := readAuthImportStdin
+	t.Cleanup(func() {
+		openSecretsStore = origOpen
+		ensureKeychainAccess = origKeychain
+		readAuthImportStdin = origStdin
+	})
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+	ensureKeychainAccess = func() error { return nil }
+}
+
+func TestAuthImportCmd_RejectsEmptyRefreshToken(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Client:       "default",
+		Email:        "a@b.com",
+		RefreshToken: "   ",
+		ServicesCSV:  "gmail",
+	}
+	err := cmd.Run(newImportTestContext(t), &RootFlags{})
+	if err == nil {
+		t.Fatal("expected error for empty refresh token")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Fatalf("expected ExitError code=2, got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "refresh-token") {
+		t.Fatalf("expected refresh-token in error, got %q", err.Error())
+	}
+}
+
+func TestAuthImportCmd_RejectsMissingRefreshTokenSource(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Client: "default",
+		Email:  "a@b.com",
+	}
+	err := cmd.Run(newImportTestContext(t), &RootFlags{})
+	if err == nil {
+		t.Fatal("expected error for missing refresh token source")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Fatalf("expected ExitError code=2, got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "--refresh-token-stdin") {
+		t.Fatalf("expected safe source hint in error, got %q", err.Error())
+	}
+}
+
+func TestAuthImportCmd_RejectsMultipleRefreshTokenSources(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Client:            "default",
+		Email:             "a@b.com",
+		RefreshToken:      "rt",
+		RefreshTokenStdin: true,
+	}
+	err := cmd.Run(newImportTestContext(t), &RootFlags{})
+	if err == nil {
+		t.Fatal("expected error for multiple refresh token sources")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Fatalf("expected ExitError code=2, got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "exactly one") {
+		t.Fatalf("expected exactly-one source error, got %q", err.Error())
+	}
+}
+
+func TestAuthImportCmd_RejectsEmptyEmail(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Client:       "default",
+		Email:        "   ",
+		RefreshToken: "rt",
+	}
+	err := cmd.Run(newImportTestContext(t), &RootFlags{})
+	if err == nil {
+		t.Fatal("expected error for empty email")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Fatalf("expected ExitError code=2, got %#v", err)
+	}
+}
+
+func TestAuthImportCmd_DefaultsClientToDefault(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+	t.Setenv("GOG_TEST_REFRESH_TOKEN", "rt-1\n")
+
+	cmd := &AuthImportCmd{
+		Client:          "", // unset; must default to "default"
+		Email:           "A@B.com",
+		RefreshTokenEnv: "GOG_TEST_REFRESH_TOKEN",
+		ServicesCSV:     "gmail, drive",
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	tok, err := store.GetToken(config.DefaultClientName, "a@b.com")
+	if err != nil {
+		t.Fatalf("GetToken default client: %v", err)
+	}
+	if tok.RefreshToken != "rt-1" {
+		t.Fatalf("unexpected refresh token: %q", tok.RefreshToken)
+	}
+	if tok.Email != "a@b.com" {
+		t.Fatalf("unexpected email: %q", tok.Email)
+	}
+	if strings.Join(tok.Services, ",") != "gmail,drive" {
+		t.Fatalf("unexpected services: %v", tok.Services)
+	}
+}
+
+func TestAuthImportCmd_ReadsRefreshTokenFromFile(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+	path := t.TempDir() + "/token.txt"
+	if err := os.WriteFile(path, []byte("rt-file\n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+
+	cmd := &AuthImportCmd{
+		Client:           "default",
+		Email:            "a@b.com",
+		RefreshTokenFile: path,
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	tok, err := store.GetToken("default", "a@b.com")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if tok.RefreshToken != "rt-file" {
+		t.Fatalf("expected file token, got %q", tok.RefreshToken)
+	}
+}
+
+func TestAuthImportCmd_ReadsRefreshTokenFromStdin(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+	readAuthImportStdin = func() ([]byte, error) {
+		return io.ReadAll(bytes.NewBufferString("rt-stdin\n"))
+	}
+
+	cmd := &AuthImportCmd{
+		Client:            "default",
+		Email:             "a@b.com",
+		RefreshTokenStdin: true,
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	tok, err := store.GetToken("default", "a@b.com")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if tok.RefreshToken != "rt-stdin" {
+		t.Fatalf("expected stdin token, got %q", tok.RefreshToken)
+	}
+}
+
+func TestAuthImportCmd_RejectsExistingEntryWithoutForce(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+	if err := store.SetToken("default", "a@b.com", secrets.Token{RefreshToken: "rt-old"}); err != nil {
+		t.Fatalf("seed SetToken: %v", err)
+	}
+
+	cmd := &AuthImportCmd{
+		Client:       "default",
+		Email:        "a@b.com",
+		RefreshToken: "rt-new",
+	}
+	err := cmd.Run(newImportTestContext(t), &RootFlags{})
+	if err == nil {
+		t.Fatal("expected error when entry exists without --force")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Fatalf("expected ExitError code=2, got %#v", err)
+	}
+	if !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("expected --force in error, got %q", err.Error())
+	}
+	tok, _ := store.GetToken("default", "a@b.com")
+	if tok.RefreshToken != "rt-old" {
+		t.Fatalf("expected unchanged token, got %q", tok.RefreshToken)
+	}
+}
+
+func TestAuthImportCmd_ForceOverwritesExistingEntry(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+	if err := store.SetToken("default", "a@b.com", secrets.Token{RefreshToken: "rt-old"}); err != nil {
+		t.Fatalf("seed SetToken: %v", err)
+	}
+
+	cmd := &AuthImportCmd{
+		Client:       "default",
+		Email:        "a@b.com",
+		RefreshToken: "rt-new",
+		Force:        true,
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	tok, err := store.GetToken("default", "a@b.com")
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if tok.RefreshToken != "rt-new" {
+		t.Fatalf("expected overwritten token, got %q", tok.RefreshToken)
+	}
+}
+
+func TestAuthImportCmd_CustomClientNamespace(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Client:       "org",
+		Email:        "a@b.com",
+		RefreshToken: "rt",
+	}
+	if err := cmd.Run(newImportTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if _, err := store.GetToken("org", "a@b.com"); err != nil {
+		t.Fatalf("expected token under custom client: %v", err)
+	}
+	if _, err := store.GetToken("default", "a@b.com"); err == nil {
+		t.Fatalf("expected no token under default client")
+	}
+}
+
+func TestAuthImportCmd_DryRunDoesNotWrite(t *testing.T) {
+	store := newMemSecretsStore()
+	withImportOverrides(t, store)
+
+	cmd := &AuthImportCmd{
+		Client:       "default",
+		Email:        "a@b.com",
+		RefreshToken: "rt",
+	}
+	err := cmd.Run(newImportTestContext(t), &RootFlags{DryRun: true})
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 0 {
+		t.Fatalf("expected dry-run ExitError code=0, got %#v", err)
+	}
+	if _, err := store.GetToken("default", "a@b.com"); err == nil {
+		t.Fatal("expected no token after dry-run")
+	}
+}

--- a/internal/cmd/auth_tokens.go
+++ b/internal/cmd/auth_tokens.go
@@ -97,7 +97,7 @@ func (c *AuthTokensDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	client, err := resolveClientForEmail(email, flags, "")
+	client, err := resolveClientForEmail(email, flags)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/client_helpers.go
+++ b/internal/cmd/client_helpers.go
@@ -8,18 +8,15 @@ import (
 	"github.com/steipete/gogcli/internal/config"
 )
 
-func resolveClientOverride(flags *RootFlags, cmdClient string) string {
-	if strings.TrimSpace(cmdClient) != "" {
-		return cmdClient
-	}
+func resolveClientOverride(flags *RootFlags) string {
 	if flags == nil {
 		return ""
 	}
 	return flags.Client
 }
 
-func resolveClientForEmail(email string, flags *RootFlags, cmdClient string) (string, error) {
-	override := resolveClientOverride(flags, cmdClient)
+func resolveClientForEmail(email string, flags *RootFlags) (string, error) {
+	override := resolveClientOverride(flags)
 	return authclient.ResolveClientWithOverride(email, override)
 }
 

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -310,15 +310,19 @@ func TestKeyringStoreSetToken_RoundtripPreservesServices(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetToken: %v", err)
 	}
+
 	if got.Email != tok.Email {
 		t.Fatalf("email mismatch: got %q want %q", got.Email, tok.Email)
 	}
+
 	if got.RefreshToken != tok.RefreshToken {
 		t.Fatalf("refresh token mismatch: got %q want %q", got.RefreshToken, tok.RefreshToken)
 	}
+
 	if strings.Join(got.Services, ",") != "gmail,drive" {
 		t.Fatalf("services mismatch: got %v", got.Services)
 	}
+
 	if got.CreatedAt.IsZero() {
 		t.Fatalf("expected CreatedAt to be auto-populated")
 	}
@@ -333,6 +337,7 @@ func TestKeyringStoreSetToken_OverwritesExistingEntry(t *testing.T) {
 	if err := store.SetToken(client, email, Token{RefreshToken: "rt-old"}); err != nil {
 		t.Fatalf("SetToken old: %v", err)
 	}
+
 	if err := store.SetToken(client, email, Token{RefreshToken: "rt-new"}); err != nil {
 		t.Fatalf("SetToken new: %v", err)
 	}
@@ -341,6 +346,7 @@ func TestKeyringStoreSetToken_OverwritesExistingEntry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetToken: %v", err)
 	}
+
 	if got.RefreshToken != "rt-new" {
 		t.Fatalf("expected overwritten token, got %q", got.RefreshToken)
 	}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -292,6 +292,60 @@ func TestOpenKeyring_NoDBus_ForcesFileBackend(t *testing.T) {
 	}
 }
 
+func TestKeyringStoreSetToken_RoundtripPreservesServices(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	store := &KeyringStore{ring: ring}
+	client := config.DefaultClientName
+
+	tok := Token{
+		Email:        "import@example.com",
+		Services:     []string{"gmail", "drive"},
+		RefreshToken: "imported-rt",
+	}
+	if err := store.SetToken(client, tok.Email, tok); err != nil {
+		t.Fatalf("SetToken: %v", err)
+	}
+
+	got, err := store.GetToken(client, tok.Email)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if got.Email != tok.Email {
+		t.Fatalf("email mismatch: got %q want %q", got.Email, tok.Email)
+	}
+	if got.RefreshToken != tok.RefreshToken {
+		t.Fatalf("refresh token mismatch: got %q want %q", got.RefreshToken, tok.RefreshToken)
+	}
+	if strings.Join(got.Services, ",") != "gmail,drive" {
+		t.Fatalf("services mismatch: got %v", got.Services)
+	}
+	if got.CreatedAt.IsZero() {
+		t.Fatalf("expected CreatedAt to be auto-populated")
+	}
+}
+
+func TestKeyringStoreSetToken_OverwritesExistingEntry(t *testing.T) {
+	ring := keyring.NewArrayKeyring(nil)
+	store := &KeyringStore{ring: ring}
+	client := config.DefaultClientName
+	email := "overwrite@example.com"
+
+	if err := store.SetToken(client, email, Token{RefreshToken: "rt-old"}); err != nil {
+		t.Fatalf("SetToken old: %v", err)
+	}
+	if err := store.SetToken(client, email, Token{RefreshToken: "rt-new"}); err != nil {
+		t.Fatalf("SetToken new: %v", err)
+	}
+
+	got, err := store.GetToken(client, email)
+	if err != nil {
+		t.Fatalf("GetToken: %v", err)
+	}
+	if got.RefreshToken != "rt-new" {
+		t.Fatalf("expected overwritten token, got %q", got.RefreshToken)
+	}
+}
+
 func TestOpenKeyring_ExplicitBackend_IgnoresDBusDetection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

Adds `gog auth import --client <id> --email <email> --refresh-token <token> --services <csv> [--force]` for storing a pre-existing OAuth refresh token in the configured keyring **without** going through the browser-based auth flow.

This is the non-interactive counterpart to `gog auth add`: the refresh token has already been minted out-of-band (e.g., by an automation runner or pulled from a secret store) and we just need to land it in the keyring so the rest of `gogcli` can use it.

## Behavior

- `--client` defaults to `"default"` and namespaces the keyring entry (matches existing `config.DefaultClientName` semantics).
- `--email` is required and is normalized (trimmed + lowercased) before storage.
- `--refresh-token` is required; whitespace-only values are rejected with exit code 2 and a human-readable error.
- `--services` accepts a comma-separated list; recorded on the token for `gog auth list` display purposes (does not affect scope grants — this command does not exchange or validate the token).
- `--force` overwrites an existing entry; without it, importing over an existing client/email entry returns a usage error.
- Honors `--dry-run` / `-n` like other mutating auth commands.
- JSON output via `--json` returns `{"imported": true, "client": "...", "email": "..."}`.

After import, `gog auth list` will display the new account.

## Files

- `internal/cmd/auth_import.go` — new `AuthImportCmd` and `Run` method.
- `internal/cmd/auth.go` — register `Import` under `AuthCmd`.
- `internal/cmd/auth_import_test.go` — command-level tests covering: empty refresh-token rejection, empty email rejection, default-client namespacing, custom-client namespacing, existing-entry rejection without `--force`, `--force` overwrite, and `--dry-run` no-op.
- `internal/secrets/store_test.go` — focused `SetToken` roundtrip tests asserting `Services` preservation and overwrite-on-resave behavior.
- `CHANGELOG.md` — `Added` entry under `0.17.0 - Unreleased`.

## Why

Downstream automation (the ClawInstall project) provisions refresh tokens server-side and needs a deterministic, no-prompt way to seed them into a fresh keyring. The existing `auth tokens import` requires a JSON file in the export format; this command takes the fields directly as flags, which is what the automation actually has on hand.

## Linear

Tracks Linear `CLA-287`.

## Test plan

- [ ] `go test ./internal/cmd/... -run AuthImport`
- [ ] `go test ./internal/secrets/... -run KeyringStoreSetToken`
- [ ] Manual: `gog auth import --email user@example.com --refresh-token "$RT" --services gmail,drive` then `gog auth list` shows the entry.
- [ ] Manual: re-running the same import returns a usage error; with `--force` it overwrites.