### PR TITLE
fix(docs): markdown empty-header tables leak last row after the table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Release: update the Homebrew handoff to publish through `openclaw/tap`.
 - Version: `gog --version` now reports an informative fallback (for example, `v0.17.0-dev`) when built from source with plain `go build` instead of returning `dev`.
 - Docs: `gog docs insert` now defaults to end-of-doc when `--index` is omitted, instead of always inserting at position 1 (which silently reversed iterative inserts across multiple calls). Pass `--index 1` explicitly to keep the previous behaviour. (#606)
+- Docs: markdown empty-header table rows (e.g. `|   |   |`) no longer collide with the separator detection — previously `docs write --append --markdown` swallowed both the empty header and the real `|---|---|` separator, leaving the last data row re-parsed as a literal pipe paragraph after the table. (#609)
 
 ## 0.17.0 - 2026-05-15
 

--- a/internal/cmd/docs_markdown.go
+++ b/internal/cmd/docs_markdown.go
@@ -218,6 +218,12 @@ func isTableSeparator(line string) bool {
 	inner := strings.Trim(trimmed, "|")
 	// Split by | and check each segment
 	segments := strings.Split(inner, "|")
+	// A genuine separator must have at least one segment that actually contains
+	// dashes. Without this guard a row of empty pipe cells (e.g. an empty
+	// markdown table header `|     |     |`) would be misclassified as a
+	// separator because every segment hits the `continue` and never trips the
+	// dash check — see #609.
+	sawDashSegment := false
 	for _, seg := range segments {
 		seg = strings.TrimSpace(seg)
 		if seg == "" {
@@ -237,8 +243,9 @@ func isTableSeparator(line string) bool {
 		if strings.Count(seg, "-") == 0 {
 			return false
 		}
+		sawDashSegment = true
 	}
-	return len(segments) > 1
+	return sawDashSegment && len(segments) > 1
 }
 
 // parseMarkdownTable parses a markdown table into rows of cells

--- a/internal/cmd/docs_markdown_test.go
+++ b/internal/cmd/docs_markdown_test.go
@@ -335,3 +335,52 @@ func TestParseMarkdown_TableDoesNotSkipFollowingLine(t *testing.T) {
 		t.Fatalf("second element = %#v, want paragraph 'After table'", got[1])
 	}
 }
+
+func TestIsTableSeparator_EmptyPipeRowRejected(t *testing.T) {
+	// Regression for #609: a row of empty pipe cells (e.g. an empty markdown
+	// table header) must not be classified as a separator line. Otherwise the
+	// outer parser drops a row from the table and re-parses the next data line
+	// as a literal pipe paragraph.
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"empty cells", "|     |     |", false},
+		{"empty cells tight", "||", false},
+		{"empty cells three cols", "|   |   |   |", false},
+		{"normal separator", "|---|---|", true},
+		{"spaced separator", "| --- | --- |", true},
+		{"left align", "|:---|---|", true},
+		{"center align", "|:---:|---:|", true},
+		{"mixed empty+dashes still valid", "|---|   |", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTableSeparator(tt.line); got != tt.want {
+				t.Errorf("isTableSeparator(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseMarkdown_EmptyHeaderTableKeepsAllDataRows(t *testing.T) {
+	// Regression for #609: an empty-header table previously had its last data
+	// row re-parsed as a literal pipe paragraph (because the empty pipe row
+	// matched isTableSeparator and the outer loop advanced too far).
+	input := "|     |     |\n|-----|-----|\n| Label A | Value A |\n| Label B | Value B |"
+	got := ParseMarkdown(input)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 element (table only), got %d: %#v", len(got), got)
+	}
+	if got[0].Type != MDTable {
+		t.Fatalf("element type = %v, want MDTable", got[0].Type)
+	}
+	if len(got[0].TableCells) != 3 {
+		t.Fatalf("expected 3 rows (empty header + 2 data), got %d: %#v", len(got[0].TableCells), got[0].TableCells)
+	}
+	last := got[0].TableCells[2]
+	if len(last) != 2 || last[0] != "Label B" || last[1] != "Value B" {
+		t.Fatalf("last row = %#v, want [Label B, Value B]", last)
+	}
+}


### PR DESCRIPTION
Closes #609.

## Root cause

`isTableSeparator` accepted rows of empty pipe cells like `|     |     |` as separators because the per-segment loop hit `continue` for empty segments and never tripped the *"must have at least one dash"* check at the end of the loop body. Concretely:

```go
for _, seg := range segments {
    seg = strings.TrimSpace(seg)
    if seg == "" {
        continue          // ← skips the dash check
    }
    // … dash-only check + must-have-a-dash check …
}
return len(segments) > 1
```

With input

```
|     |     |       ← row 0 (empty header) — also matched isTableSeparator
|-----|-----|       ← row 1 (real separator)
| Label A | Value A |
| Label B | Value B |
```

`parseMarkdownTable` then skipped *both* row 0 (false separator) and row 1, returning only 2 data rows. The outer parser advanced `i += len(tableCells)` = 2, putting the next iteration on row 3, where `| Label B | Value B |` was re-parsed as a literal pipe paragraph.

## Fix

Track `sawDashSegment` in `isTableSeparator` and require at least one non-empty, dash-containing segment. `||` is still rejected by the existing `len(segments) > 1` guard, so this change is strictly additive.

## Tests

- `TestIsTableSeparator_EmptyPipeRowRejected` — table-driven cases covering empty-cell forms, normal separators, and alignment variants.
- `TestParseMarkdown_EmptyHeaderTableKeepsAllDataRows` — full `ParseMarkdown` regression that exercises the exact repro from the issue and asserts there is exactly one `MDTable` element with all three rows intact.

`go test ./internal/cmd/ -count=1` → ok 23.5s.