### PR TITLE
Add binary install entries for Windows, Linux, macOS to gog skill

### DIFF
--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -1,6 +1,79 @@
 ---
 name: gog
 description: "gog CLI: safe Google Workspace automation, JSON, auth, scoped reads/writes."
+metadata:
+  openclaw:
+    requires:
+      bins:
+        - gog
+    install:
+      - id: darwin-arm64
+        kind: binary
+        os:
+          - darwin
+        arch:
+          - arm64
+        url: https://github.com/openclaw/gogcli/releases/download/{{version}}/gogcli_{{version}}_darwin_arm64.tar.gz
+        bins:
+          - gog
+        label: Install gog (macOS arm64)
+      - id: darwin-amd64
+        kind: binary
+        os:
+          - darwin
+        arch:
+          - amd64
+        url: https://github.com/openclaw/gogcli/releases/download/{{version}}/gogcli_{{version}}_darwin_amd64.tar.gz
+        bins:
+          - gog
+        label: Install gog (macOS amd64)
+      - id: linux-arm64
+        kind: binary
+        os:
+          - linux
+        arch:
+          - arm64
+        url: https://github.com/openclaw/gogcli/releases/download/{{version}}/gogcli_{{version}}_linux_arm64.tar.gz
+        bins:
+          - gog
+        label: Install gog (Linux arm64)
+      - id: linux-amd64
+        kind: binary
+        os:
+          - linux
+        arch:
+          - amd64
+        url: https://github.com/openclaw/gogcli/releases/download/{{version}}/gogcli_{{version}}_linux_amd64.tar.gz
+        bins:
+          - gog
+        label: Install gog (Linux amd64)
+      - id: windows-arm64
+        kind: binary
+        os:
+          - windows
+        arch:
+          - arm64
+        url: https://github.com/openclaw/gogcli/releases/download/{{version}}/gogcli_{{version}}_windows_arm64.zip
+        bins:
+          - gog.exe
+        label: Install gog (Windows arm64)
+      - id: windows-amd64
+        kind: binary
+        os:
+          - windows
+        arch:
+          - amd64
+        url: https://github.com/openclaw/gogcli/releases/download/{{version}}/gogcli_{{version}}_windows_amd64.zip
+        bins:
+          - gog.exe
+        label: Install gog (Windows amd64)
+      - id: brew
+        kind: brew
+        os:
+          - darwin
+          - linux
+        formula: steipete/tap/gogcli
+        label: Install gog (brew)
 ---
 
 # gog


### PR DESCRIPTION
## Summary

The gog skill on ClawHub only declared a rew install path, which doesn't work on Windows. This PR adds kind: binary install entries for all platforms so OpenClaw can auto-install gog on any OS.

## Changes

- Adds kind: binary install entries for: Windows (amd64, arm64), Linux (amd64, arm64), macOS (amd64, arm64)
- OpenClaw auto-detects OS + arch and picks the correct entry
- Retains rew as an alternative for macOS/Linux
- Binary URLs point to the existing GitHub Releases assets

## Why

Users on Windows who tried to install gog via the skill got no valid install path. The brew-only metadata was incomplete — gog has always supported Windows via GitHub Releases ZIPs.

## Testing

- gog v0.17.0 installed and verified working on Windows (manually tested)
- Calendar and Gmail queries returned valid results
- Auth doctor check passed