### PR TITLE
feat(sheets): add --inherit-from-before to sheets insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Gmail: keep label IDs case-sensitive during label resolution and duplicate-name checks while still matching label names case-insensitively.
 - Gmail: clarify that `gmail drafts delete` permanently deletes drafts and cannot be recovered. (#656, #659) — thanks @chrischall.
+- Sheets: add `--inherit-from-before` to `sheets insert` so callers can choose whether inserted rows/columns inherit formatting from the preceding or following neighbor. (#655, #658) — thanks @chrischall.
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 
 ## 0.19.0 - 2026-05-22

--- a/docs/commands/gog-sheets-insert.md
+++ b/docs/commands/gog-sheets-insert.md
@@ -31,7 +31,7 @@ gog sheets (sheet) insert <spreadsheetId> <sheet> <dimension> <start> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--inherit-from-before` | `*bool` |  | Inherit number format / styling from the adjacent row/column. Defaults to true with --after, false otherwise; set to false to insert with plain formatting. |
+| `--inherit-from-before` | `*bool` |  | Inherit number format / styling from the row/column before the insertion. Defaults to true with --after, false otherwise; false inherits from the row/column after the insertion. |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |

--- a/docs/commands/gog-sheets-insert.md
+++ b/docs/commands/gog-sheets-insert.md
@@ -31,6 +31,7 @@ gog sheets (sheet) insert <spreadsheetId> <sheet> <dimension> <start> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--inherit-from-before` | `*bool` |  | Inherit number format / styling from the adjacent row/column. Defaults to true with --after, false otherwise; set to false to insert with plain formatting. |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |

--- a/internal/cmd/sheets_insert.go
+++ b/internal/cmd/sheets_insert.go
@@ -20,7 +20,7 @@ type SheetsInsertCmd struct {
 	After         bool   `name:"after" help:"Insert after the position instead of before"`
 	// *bool so an unset flag keeps the historical default (inherit only when
 	// --after); passing --inherit-from-before[=false] overrides it explicitly.
-	InheritFromBefore *bool `name:"inherit-from-before" help:"Inherit number format / styling from the adjacent row/column. Defaults to true with --after, false otherwise; set to false to insert with plain formatting."`
+	InheritFromBefore *bool `name:"inherit-from-before" help:"Inherit number format / styling from the row/column before the insertion. Defaults to true with --after, false otherwise; false inherits from the row/column after the insertion."`
 }
 
 func (c *SheetsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -66,6 +66,9 @@ func (c *SheetsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 	inheritFromBefore := c.After
 	if c.InheritFromBefore != nil {
 		inheritFromBefore = *c.InheritFromBefore
+	}
+	if inheritFromBefore && startIndex == 0 {
+		return usagef("cannot inherit from the previous %s when inserting at position 1", dimLabel)
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "sheets.insert", map[string]any{

--- a/internal/cmd/sheets_insert.go
+++ b/internal/cmd/sheets_insert.go
@@ -18,6 +18,9 @@ type SheetsInsertCmd struct {
 	Start         int64  `arg:"" name:"start" help:"Position before which to insert (1-based; for cols 1=A, 2=B)"`
 	Count         int64  `name:"count" help:"Number of rows/columns to insert" default:"1"`
 	After         bool   `name:"after" help:"Insert after the position instead of before"`
+	// *bool so an unset flag keeps the historical default (inherit only when
+	// --after); passing --inherit-from-before[=false] overrides it explicitly.
+	InheritFromBefore *bool `name:"inherit-from-before" help:"Inherit number format / styling from the adjacent row/column. Defaults to true with --after, false otherwise; set to false to insert with plain formatting."`
 }
 
 func (c *SheetsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -58,7 +61,12 @@ func (c *SheetsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 		startIndex = c.Start
 	}
 	endIndex := startIndex + c.Count
+	// Default: inherit formatting only when inserting after an existing line.
+	// An explicit --inherit-from-before[=false] overrides that default.
 	inheritFromBefore := c.After
+	if c.InheritFromBefore != nil {
+		inheritFromBefore = *c.InheritFromBefore
+	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "sheets.insert", map[string]any{
 		"spreadsheet_id":      spreadsheetID,

--- a/internal/cmd/sheets_insert_test.go
+++ b/internal/cmd/sheets_insert_test.go
@@ -124,7 +124,7 @@ func TestSheetsInsertCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("insert after without inheriting formatting", func(t *testing.T) {
+	t.Run("insert after inheriting from following dimension", func(t *testing.T) {
 		gotInsert = nil
 		cmd := &SheetsInsertCmd{}
 		if err := runKong(t, cmd, []string{
@@ -135,7 +135,8 @@ func TestSheetsInsertCmd(t *testing.T) {
 		if gotInsert == nil {
 			t.Fatal("expected insertDimension request")
 		}
-		// --after would default inheritFromBefore=true; the explicit flag overrides it.
+		// --after would default inheritFromBefore=true; the explicit flag overrides it
+		// so the API inherits from the following adjacent row/column instead.
 		if gotInsert.InheritFromBefore {
 			t.Fatal("expected inheritFromBefore=false when --inherit-from-before=false overrides --after")
 		}
@@ -155,6 +156,23 @@ func TestSheetsInsertCmd(t *testing.T) {
 		// before-insert defaults inheritFromBefore=false; the explicit flag overrides it.
 		if !gotInsert.InheritFromBefore {
 			t.Fatal("expected inheritFromBefore=true when --inherit-from-before is set")
+		}
+	})
+
+	t.Run("reject inherit from before at first row", func(t *testing.T) {
+		gotInsert = nil
+		cmd := &SheetsInsertCmd{}
+		err := runKong(t, cmd, []string{
+			"s1", "Data", "rows", "1", "--inherit-from-before",
+		}, ctx, flags)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "cannot inherit from the previous row") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotInsert != nil {
+			t.Fatal("did not expect API request")
 		}
 	})
 

--- a/internal/cmd/sheets_insert_test.go
+++ b/internal/cmd/sheets_insert_test.go
@@ -124,6 +124,40 @@ func TestSheetsInsertCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("insert after without inheriting formatting", func(t *testing.T) {
+		gotInsert = nil
+		cmd := &SheetsInsertCmd{}
+		if err := runKong(t, cmd, []string{
+			"s1", "Data", "rows", "2", "--count", "1", "--after", "--inherit-from-before=false",
+		}, ctx, flags); err != nil {
+			t.Fatalf("insert rows: %v", err)
+		}
+		if gotInsert == nil {
+			t.Fatal("expected insertDimension request")
+		}
+		// --after would default inheritFromBefore=true; the explicit flag overrides it.
+		if gotInsert.InheritFromBefore {
+			t.Fatal("expected inheritFromBefore=false when --inherit-from-before=false overrides --after")
+		}
+	})
+
+	t.Run("insert before with explicit inherit", func(t *testing.T) {
+		gotInsert = nil
+		cmd := &SheetsInsertCmd{}
+		if err := runKong(t, cmd, []string{
+			"s1", "Data", "rows", "2", "--count", "1", "--inherit-from-before",
+		}, ctx, flags); err != nil {
+			t.Fatalf("insert rows: %v", err)
+		}
+		if gotInsert == nil {
+			t.Fatal("expected insertDimension request")
+		}
+		// before-insert defaults inheritFromBefore=false; the explicit flag overrides it.
+		if !gotInsert.InheritFromBefore {
+			t.Fatal("expected inheritFromBefore=true when --inherit-from-before is set")
+		}
+	})
+
 	t.Run("insert cols before", func(t *testing.T) {
 		gotInsert = nil
 		cmd := &SheetsInsertCmd{}


### PR DESCRIPTION
Fixes #655.

## Problem
`gog sheets insert` always derived `InsertDimensionRequest.inheritFromBefore` from `--after`:
```go
inheritFromBefore := c.After
```
So there was no way to insert rows/columns with **plain** formatting next to a formatted neighbour — the reported case: plain 0–100 score columns inserted immediately after a currency-formatted column rendered as currency until the format was manually cleared.

## Change
Add a tri-state `--inherit-from-before` flag (`*bool`):
- **omitted** — unchanged behaviour: inherit only when `--after` is set;
- `--inherit-from-before=false` — force plain formatting (the reported need);
- `--inherit-from-before` — force inheritance even on a before-insert.

Maps straight through to `InsertDimensionRequest.inheritFromBefore`. Command reference regenerated via `make docs-commands`.

## Real-behavior proof (built from this branch)

**`gog sheets insert --help`**:
```
      --inherit-from-before    Inherit number format / styling from the adjacent
                               row/column. Defaults to true with --after, false
                               otherwise; set to false to insert with plain formatting.
```

**`--dry-run` shows the flag controlling `inherit_from_before` (no API call):**
```
# default with --after  → inherits
$ gog sheets insert SHEET_ID Sheet1 rows 2 --after --dry-run --json
  → inherit_from_before: true

# explicit override: --after but DON'T inherit
$ gog sheets insert SHEET_ID Sheet1 rows 2 --after --inherit-from-before=false --dry-run --json
  → inherit_from_before: false

# explicit override: force inherit on a before-insert
$ gog sheets insert SHEET_ID Sheet1 rows 2 --inherit-from-before --dry-run --json
  → inherit_from_before: true
```

## Review follow-ups addressed
- **proof** — added above (help + dry-run output showing the tri-state behaviour).
- **generated docs** — ran `make docs-commands`; `docs/commands/gog-sheets-insert.md` now lists the flag.
- **CHANGELOG** — no CHANGELOG edit in this PR (release notes are release-owned).

Tests: added two subtests over the existing httptest Sheets stub asserting wire-level `InheritFromBefore` for both override directions. `make fmt` + `make lint` + `go test ./internal/cmd/` green.