### PR TITLE
docs(gmail): clarify that drafts delete is permanent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Gmail: keep label IDs case-sensitive during label resolution and duplicate-name checks while still matching label names case-insensitively.
+- Gmail: clarify that `gmail drafts delete` permanently deletes drafts and cannot be recovered. (#656, #659) — thanks @chrischall.
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 
 ## 0.19.0 - 2026-05-22

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -335,7 +335,7 @@ Generated from `gog schema --json`.
       - [`gog gmail (mail,email) batch modify (update,edit,set) <messageId> ... [flags]`](commands/gog-gmail-batch-modify.md) - Modify labels on multiple messages
     - [`gog gmail (mail,email) drafts (draft) <command>`](commands/gog-gmail-drafts.md) - Draft operations
       - [`gog gmail (mail,email) drafts (draft) create (add,new) [flags]`](commands/gog-gmail-drafts-create.md) - Create a draft
-      - [`gog gmail (mail,email) drafts (draft) delete (rm,del,remove) <draftId>`](commands/gog-gmail-drafts-delete.md) - Delete a draft
+      - [`gog gmail (mail,email) drafts (draft) delete (rm,del,remove) <draftId>`](commands/gog-gmail-drafts-delete.md) - Permanently delete a draft (not recoverable; drafts are not moved to Trash)
       - [`gog gmail (mail,email) drafts (draft) get (info,show) <draftId> [flags]`](commands/gog-gmail-drafts-get.md) - Get draft details
       - [`gog gmail (mail,email) drafts (draft) list (ls) [flags]`](commands/gog-gmail-drafts-list.md) - List drafts
       - [`gog gmail (mail,email) drafts (draft) send (post) <draftId>`](commands/gog-gmail-drafts-send.md) - Send a draft

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -386,7 +386,7 @@ Generated pages: 572.
       - [gog gmail batch modify](gog-gmail-batch-modify.md) - Modify labels on multiple messages
     - [gog gmail drafts](gog-gmail-drafts.md) - Draft operations
       - [gog gmail drafts create](gog-gmail-drafts-create.md) - Create a draft
-      - [gog gmail drafts delete](gog-gmail-drafts-delete.md) - Delete a draft
+      - [gog gmail drafts delete](gog-gmail-drafts-delete.md) - Permanently delete a draft (not recoverable; drafts are not moved to Trash)
       - [gog gmail drafts get](gog-gmail-drafts-get.md) - Get draft details
       - [gog gmail drafts list](gog-gmail-drafts-list.md) - List drafts
       - [gog gmail drafts send](gog-gmail-drafts-send.md) - Send a draft

--- a/docs/commands/gog-gmail-drafts-delete.md
+++ b/docs/commands/gog-gmail-drafts-delete.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Delete a draft
+Permanently delete a draft (not recoverable; drafts are not moved to Trash)
 
 ## Usage
 

--- a/docs/commands/gog-gmail-drafts.md
+++ b/docs/commands/gog-gmail-drafts.md
@@ -17,7 +17,7 @@ gog gmail (mail,email) drafts (draft) <command>
 ## Subcommands
 
 - [gog gmail drafts create](gog-gmail-drafts-create.md) - Create a draft
-- [gog gmail drafts delete](gog-gmail-drafts-delete.md) - Delete a draft
+- [gog gmail drafts delete](gog-gmail-drafts-delete.md) - Permanently delete a draft (not recoverable; drafts are not moved to Trash)
 - [gog gmail drafts get](gog-gmail-drafts-get.md) - Get draft details
 - [gog gmail drafts list](gog-gmail-drafts-list.md) - List drafts
 - [gog gmail drafts send](gog-gmail-drafts-send.md) - Send a draft

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -16,7 +16,7 @@ import (
 type GmailDraftsCmd struct {
 	List   GmailDraftsListCmd   `cmd:"" name:"list" aliases:"ls" help:"List drafts"`
 	Get    GmailDraftsGetCmd    `cmd:"" name:"get" aliases:"info,show" help:"Get draft details"`
-	Delete GmailDraftsDeleteCmd `cmd:"" name:"delete" aliases:"rm,del,remove" help:"Delete a draft"`
+	Delete GmailDraftsDeleteCmd `cmd:"" name:"delete" aliases:"rm,del,remove" help:"Permanently delete a draft (not recoverable; drafts are not moved to Trash)"`
 	Send   GmailDraftsSendCmd   `cmd:"" name:"send" aliases:"post" help:"Send a draft"`
 	Create GmailDraftsCreateCmd `cmd:"" name:"create" aliases:"add,new" help:"Create a draft"`
 	Update GmailDraftsUpdateCmd `cmd:"" name:"update" aliases:"edit,set" help:"Update a draft"`
@@ -178,6 +178,9 @@ func (c *GmailDraftsGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return nil
 }
 
+// GmailDraftsDeleteCmd permanently deletes a draft. The Gmail API's
+// users.drafts.delete is irreversible — drafts are not moved to Trash and have
+// no untrash path — so this cannot be undone.
 type GmailDraftsDeleteCmd struct {
 	DraftID string `arg:"" name:"draftId" help:"Draft ID"`
 }
@@ -191,7 +194,7 @@ func (c *GmailDraftsDeleteCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 	if confirmErr := dryRunAndConfirmDestructive(ctx, flags, "gmail.drafts.delete", map[string]any{
 		"draft_id": draftID,
-	}, fmt.Sprintf("delete gmail draft %s", draftID)); confirmErr != nil {
+	}, fmt.Sprintf("permanently delete gmail draft %s (not recoverable; drafts are not moved to Trash)", draftID)); confirmErr != nil {
 		return confirmErr
 	}
 


### PR DESCRIPTION
Fixes #656.

## Problem
`gog gmail drafts delete` is **permanent and irreversible** — the Gmail API's `users.drafts.delete` deletes the draft outright; drafts are not moved to Trash and there's no untrash path (`gog gmail trash` operates on message IDs only). But the command's help (`"Delete a draft"`) and confirmation prompt (`"delete gmail draft <id>"`) read like an ordinary, recoverable delete, so the irreversibility wasn't surfaced before confirming.

## Change
- Command help → `Permanently delete a draft (not recoverable; drafts are not moved to Trash)`.
- Destructive-confirmation/refusal wording → `permanently delete gmail draft <id> (not recoverable; drafts are not moved to Trash)`.
- Doc comment on `GmailDraftsDeleteCmd` explaining why it's irreversible.
- Regenerated the command reference (`make docs-commands`) so the published docs match.

No behavioural change — same API call, same `dryRunAndConfirmDestructive` guard; only the wording is clarified.

## Real-behavior proof (built from this branch)

**`gog gmail drafts --help`** (parent listing):
```
  delete (rm,del,remove) <draftId>
    Permanently delete a draft (not recoverable; drafts are not moved to Trash)
```

**`gog gmail drafts delete --help`**:
```
Usage: gog gmail (mail,email) drafts (draft) delete (rm,del,remove) <draftId>

Permanently delete a draft (not recoverable; drafts are not moved to Trash)
```

**Destructive confirmation/refusal** (`gog gmail drafts delete <id>`, no `--force`):
```
refusing to permanently delete gmail draft demo-draft-id-12345 (not recoverable; drafts are not moved to Trash) without --force (non-interactive)
```

**`--dry-run` intended action**:
```json
{ "dry_run": true, "op": "gmail.drafts.delete", "request": { "draft_id": "demo-draft-id-12345" } }
```

## Review follow-ups addressed
- **[P1] proof** — added above (redacted terminal output of the updated help + confirmation prompt).
- **[P2] generated docs** — ran `make docs-commands`; `docs/commands/gog-gmail-drafts-delete.md`, `gog-gmail-drafts.md`, `commands.generated.md`, and `commands/README.md` now carry the permanent-delete wording (no stale `Delete a draft`).
- **[P3] CHANGELOG** — dropped the contributor CHANGELOG edit; release notes are release-owned.

`make fmt` + `go test ./internal/cmd/` green.