### PR TITLE
fix(auth): reconcile observed OAuth scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Gmail: keep label IDs case-sensitive during label resolution and duplicate-name checks while still matching label names case-insensitively.
 - Gmail: clarify that `gmail drafts delete` permanently deletes drafts and cannot be recovered. (#656, #659) — thanks @chrischall.
 - Sheets: add `--inherit-from-before` to `sheets insert` so callers can choose whether inserted rows/columns inherit formatting from the preceding or following neighbor. (#655, #658) — thanks @chrischall.
+- Auth: update stored OAuth scope metadata from observed granted scopes during refresh so `auth list` reflects newly usable services. (#649)
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 
 ## 0.19.0 - 2026-05-22

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 
@@ -30,6 +31,10 @@ type persistingTokenSource struct {
 	store  secrets.Store
 	client string
 	email  string
+	// Metadata repair uses only scopes returned by the OAuth server, not the
+	// requested set. serviceLabel is added only when the observed grant covers
+	// the canonical scope set for that service.
+	serviceLabel string
 
 	mu  sync.Mutex
 	tok secrets.Token
@@ -39,13 +44,14 @@ type tokenAliasDeleter interface {
 	DeleteTokenAlias(client string, email string) error
 }
 
-func newPersistingTokenSource(base oauth2.TokenSource, store secrets.Store, client string, email string, tok secrets.Token) oauth2.TokenSource {
+func newPersistingTokenSource(base oauth2.TokenSource, store secrets.Store, client string, email string, tok secrets.Token, serviceLabel string) oauth2.TokenSource {
 	return &persistingTokenSource{
-		base:   base,
-		store:  store,
-		client: client,
-		email:  email,
-		tok:    tok,
+		base:         base,
+		store:        store,
+		client:       client,
+		email:        email,
+		serviceLabel: strings.TrimSpace(serviceLabel),
+		tok:          tok,
 	}
 }
 
@@ -77,6 +83,22 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 	if !t.Expiry.IsZero() && !t.Expiry.Equal(p.tok.AccessTokenExpiresAt) {
 		updated.AccessTokenExpiresAt = t.Expiry
 		changed = true
+	}
+
+	if grantedScopes := tokenGrantedScopes(t); len(grantedScopes) > 0 {
+		if mergedScopes := mergeStringSet(updated.Scopes, grantedScopes); !stringSlicesEqual(updated.Scopes, mergedScopes) {
+			updated.Scopes = mergedScopes
+			changed = true
+		}
+
+		if p.serviceLabel != "" {
+			if canonicalScopes, serviceErr := googleauth.Scopes(googleauth.Service(p.serviceLabel)); serviceErr == nil && scopesContainAll(grantedScopes, canonicalScopes) {
+				if mergedServices := mergeStringSet(updated.Services, []string{p.serviceLabel}); !stringSlicesEqual(updated.Services, mergedServices) {
+					updated.Services = mergedServices
+					changed = true
+				}
+			}
+		}
 	}
 
 	if rawIDToken, ok := t.Extra("id_token").(string); ok && strings.TrimSpace(rawIDToken) != "" {
@@ -223,5 +245,80 @@ func tokenSourceForAccountScopes(ctx context.Context, serviceLabel string, email
 		Expiry:       tok.AccessTokenExpiresAt,
 	})
 
-	return newPersistingTokenSource(baseSource, store, client, email, tok), nil
+	return newPersistingTokenSource(baseSource, store, client, email, tok, serviceLabel), nil
+}
+
+func tokenGrantedScopes(t *oauth2.Token) []string {
+	if t == nil {
+		return nil
+	}
+
+	switch raw := t.Extra("scope").(type) {
+	case string:
+		return normalizeScopeList(strings.Fields(raw))
+	case []string:
+		return normalizeScopeList(raw)
+	case []any:
+		scopes := make([]string, 0, len(raw))
+		for _, item := range raw {
+			if s, ok := item.(string); ok {
+				scopes = append(scopes, s)
+			}
+		}
+		return normalizeScopeList(scopes)
+	default:
+		return nil
+	}
+}
+
+func normalizeScopeList(scopes []string) []string {
+	set := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		scope = strings.TrimSpace(scope)
+		if scope == "" {
+			continue
+		}
+		set[scope] = struct{}{}
+	}
+
+	out := make([]string, 0, len(set))
+	for scope := range set {
+		out = append(out, scope)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mergeStringSet(a []string, b []string) []string {
+	return normalizeScopeList(append(append([]string(nil), a...), b...))
+}
+
+func scopesContainAll(haystack []string, needles []string) bool {
+	if len(needles) == 0 {
+		return false
+	}
+
+	set := make(map[string]struct{}, len(haystack))
+	for _, scope := range normalizeScopeList(haystack) {
+		set[scope] = struct{}{}
+	}
+
+	for _, scope := range normalizeScopeList(needles) {
+		if _, ok := set[scope]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+func stringSlicesEqual(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -265,6 +265,7 @@ func tokenGrantedScopes(t *oauth2.Token) []string {
 				scopes = append(scopes, s)
 			}
 		}
+
 		return normalizeScopeList(scopes)
 	default:
 		return nil
@@ -285,7 +286,9 @@ func normalizeScopeList(scopes []string) []string {
 	for scope := range set {
 		out = append(out, scope)
 	}
+
 	sort.Strings(out)
+
 	return out
 }
 
@@ -308,6 +311,7 @@ func scopesContainAll(haystack []string, needles []string) bool {
 			return false
 		}
 	}
+
 	return true
 }
 
@@ -315,10 +319,12 @@ func stringSlicesEqual(a []string, b []string) bool {
 	if len(a) != len(b) {
 		return false
 	}
+
 	for i := range a {
 		if a[i] != b[i] {
 			return false
 		}
 	}
+
 	return true
 }

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -197,7 +197,7 @@ func TestPersistingTokenSource_PersistsRotatedRefreshToken(t *testing.T) {
 
 	store := &stubStore{tok: stored}
 	base := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access", RefreshToken: "new-refresh-token"})
-	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "A@B.COM", stored)
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "A@B.COM", stored, "")
 
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
@@ -246,7 +246,7 @@ func TestPersistingTokenSource_PersistsAccessToken(t *testing.T) {
 		RefreshToken: "refresh-token",
 		Expiry:       expires,
 	})
-	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored)
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "")
 
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
@@ -279,7 +279,118 @@ func TestPersistingTokenSource_NoRotationDoesNotPersist(t *testing.T) {
 	}
 	store := &stubStore{tok: stored}
 	base := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access", RefreshToken: "same-token", Expiry: expires})
-	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored)
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "")
+
+	if _, err := ts.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	if store.setCalls != 0 {
+		t.Fatalf("expected no SetToken calls, got %d", store.setCalls)
+	}
+}
+
+func TestPersistingTokenSource_PersistsObservedGrantedScopeUpgrade(t *testing.T) {
+	gmailScopes, err := googleauth.Scopes(googleauth.ServiceGmail)
+	if err != nil {
+		t.Fatalf("gmail scopes: %v", err)
+	}
+	grantedScopes := normalizeScopeList(append([]string{
+		"https://www.googleapis.com/auth/calendar",
+		"openid",
+	}, gmailScopes...))
+	stored := secrets.Token{
+		Email:        "a@b.com",
+		RefreshToken: "same-token",
+		Services:     []string{"calendar"},
+		Scopes: []string{
+			"https://www.googleapis.com/auth/calendar",
+			"openid",
+		},
+	}
+	store := &stubStore{tok: stored}
+	base := oauth2.StaticTokenSource((&oauth2.Token{
+		AccessToken:  "access",
+		RefreshToken: "same-token",
+	}).WithExtra(map[string]any{
+		"scope": strings.Join(grantedScopes, " "),
+	}))
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "gmail")
+
+	if _, err := ts.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	if store.setCalls != 1 {
+		t.Fatalf("expected 1 SetToken call, got %d", store.setCalls)
+	}
+
+	wantServices := []string{"calendar", "gmail"}
+	if !reflect.DeepEqual(store.lastSet.Services, wantServices) {
+		t.Fatalf("services=%#v want %#v", store.lastSet.Services, wantServices)
+	}
+
+	wantScopes := grantedScopes
+	if !reflect.DeepEqual(store.lastSet.Scopes, wantScopes) {
+		t.Fatalf("scopes=%#v want %#v", store.lastSet.Scopes, wantScopes)
+	}
+}
+
+func TestPersistingTokenSource_DoesNotAddServiceForPartialObservedGrant(t *testing.T) {
+	stored := secrets.Token{
+		Email:        "a@b.com",
+		RefreshToken: "same-token",
+		AccessToken:  "access",
+		Services:     []string{"calendar"},
+		Scopes:       []string{"https://www.googleapis.com/auth/calendar"},
+	}
+	store := &stubStore{tok: stored}
+	base := oauth2.StaticTokenSource((&oauth2.Token{
+		AccessToken:  "access",
+		RefreshToken: "same-token",
+	}).WithExtra(map[string]any{
+		"scope": "https://www.googleapis.com/auth/calendar https://www.googleapis.com/auth/directory.readonly",
+	}))
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "contacts")
+
+	if _, err := ts.Token(); err != nil {
+		t.Fatalf("Token: %v", err)
+	}
+
+	if store.setCalls != 1 {
+		t.Fatalf("expected 1 SetToken call, got %d", store.setCalls)
+	}
+
+	wantServices := []string{"calendar"}
+	if !reflect.DeepEqual(store.lastSet.Services, wantServices) {
+		t.Fatalf("services=%#v want %#v", store.lastSet.Services, wantServices)
+	}
+
+	wantScopes := []string{
+		"https://www.googleapis.com/auth/calendar",
+		"https://www.googleapis.com/auth/directory.readonly",
+	}
+	if !reflect.DeepEqual(store.lastSet.Scopes, wantScopes) {
+		t.Fatalf("scopes=%#v want %#v", store.lastSet.Scopes, wantScopes)
+	}
+}
+
+func TestPersistingTokenSource_DoesNotPersistRequestedScopeWithoutObservedGrant(t *testing.T) {
+	stored := secrets.Token{
+		Email:        "a@b.com",
+		RefreshToken: "same-token",
+		AccessToken:  "access",
+		Services:     []string{"calendar"},
+		Scopes:       []string{"https://www.googleapis.com/auth/calendar"},
+	}
+	store := &stubStore{tok: stored}
+	base := oauth2.StaticTokenSource((&oauth2.Token{
+		AccessToken:  "access",
+		RefreshToken: "same-token",
+	}).WithExtra(map[string]any{
+		"scope": "https://www.googleapis.com/auth/calendar",
+	}))
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "gmail")
 
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
@@ -299,7 +410,7 @@ func TestPersistingTokenSource_BackfillsSubjectFromIDToken(t *testing.T) {
 	}).WithExtra(map[string]any{
 		"id_token": unsignedIDTokenForTest(t, "sub-123", "a@b.com"),
 	}))
-	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored)
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "")
 
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
@@ -343,7 +454,7 @@ func TestPersistingTokenSource_MigratesRenamedEmailFromIDToken(t *testing.T) {
 	}).WithExtra(map[string]any{
 		"id_token": unsignedIDTokenForTest(t, "sub-123", "new@example.com"),
 	}))
-	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "old@example.com", stored)
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "old@example.com", stored, "")
 
 	if _, err := ts.Token(); err != nil {
 		t.Fatalf("Token: %v", err)
@@ -400,7 +511,7 @@ func TestPersistingTokenSource_PersistFailureIsNonFatal(t *testing.T) {
 	stored := secrets.Token{Email: "a@b.com", RefreshToken: "old-token"}
 	store := &stubStore{tok: stored, setErr: errBoom}
 	base := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "access", RefreshToken: "new-token"})
-	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored)
+	ts := newPersistingTokenSource(base, store, config.DefaultClientName, "a@b.com", stored, "")
 
 	tok, err := ts.Token()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Reconcile stored OAuth scope metadata from scopes observed in successful token refresh responses.
- Add the service label only when the observed grant covers that service's canonical scope set.
- Add regression coverage for observed scope upgrades and partial-scope service over-reporting.

Fixes #649.

## Testing
- `go test ./internal/googleapi -run 'TestPersistingTokenSource|TestTokenSourceForAccountScopes'`
- `go test ./internal/googleapi ./internal/googleauth ./internal/cmd`
- `make test`
- Live clawdbot smoke: `gmail labels list` returned 16 labels; post-refresh `auth list` reported Gmail service and 47 scopes.
- Autoreview: clean.
