### PR TITLE
feat(sheets): add copy-paste (fill) command mapping to CopyPasteRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Gmail: keep label IDs case-sensitive during label resolution and duplicate-name checks while still matching label names case-insensitively.
 - Gmail: clarify that `gmail drafts delete` permanently deletes drafts and cannot be recovered. (#656, #659) — thanks @chrischall.
 - Sheets: add `--inherit-from-before` to `sheets insert` so callers can choose whether inserted rows/columns inherit formatting from the preceding or following neighbor. (#655, #658) — thanks @chrischall.
+- Sheets: add `sheets copy-paste` / `fill` for range-level CopyPasteRequest fills of values, formulas, formatting, and related paste types. (#661, #663) — thanks @chrischall.
 - Auth: update stored OAuth scope metadata from observed granted scopes during refresh so `auth list` reflects newly usable services. (#649)
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -483,6 +483,7 @@ Generated from `gog schema --json`.
       - [`gog sheets (sheet) conditional-format (cf,conditional-formats) clear (delete,rm,remove) --sheet=STRING <spreadsheetId> [flags]`](commands/gog-sheets-conditional-format-clear.md) - Remove conditional formatting rules
       - [`gog sheets (sheet) conditional-format (cf,conditional-formats) list <spreadsheetId> [flags]`](commands/gog-sheets-conditional-format-list.md) - List conditional formatting rules
     - [`gog sheets (sheet) copy (cp,duplicate) <spreadsheetId> <title> [flags]`](commands/gog-sheets-copy.md) - Copy a Google Sheet
+    - [`gog sheets (sheet) copy-paste (fill,copy-range) <spreadsheetId> <source> <dest> [flags]`](commands/gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
     - [`gog sheets (sheet) create (new) <title> [flags]`](commands/gog-sheets-create.md) - Create a new spreadsheet
     - [`gog sheets (sheet) delete-tab (delete-sheet) <spreadsheetId> <tabName>`](commands/gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
     - [`gog sheets (sheet) export (download,dl) <spreadsheetId> [flags]`](commands/gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 573.
+Generated pages: 574.
 
 ## Top-level Commands
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 572.
+Generated pages: 573.
 
 ## Top-level Commands
 
@@ -534,6 +534,7 @@ Generated pages: 572.
       - [gog sheets conditional-format clear](gog-sheets-conditional-format-clear.md) - Remove conditional formatting rules
       - [gog sheets conditional-format list](gog-sheets-conditional-format-list.md) - List conditional formatting rules
     - [gog sheets copy](gog-sheets-copy.md) - Copy a Google Sheet
+    - [gog sheets copy-paste](gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
     - [gog sheets create](gog-sheets-create.md) - Create a new spreadsheet
     - [gog sheets delete-tab](gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
     - [gog sheets export](gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive

--- a/docs/commands/gog-sheets-copy-paste.md
+++ b/docs/commands/gog-sheets-copy-paste.md
@@ -1,0 +1,46 @@
+# `gog sheets copy-paste`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Copy a range's values/formulas/format to another range (tiles to fill down/across)
+
+## Usage
+
+```bash
+gog sheets (sheet) copy-paste (fill,copy-range) <spreadsheetId> <source> <dest> [flags]
+```
+
+## Parent
+
+- [gog sheets](gog-sheets.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled commands; dot paths allowed (restricts CLI) |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--transpose` | `bool` |  | Paste transposed (swap rows and columns) |
+| `--type` | `string` | NORMAL | Paste type: NORMAL, VALUES, FORMAT, FORMULA, NO_BORDERS, DATA_VALIDATION, CONDITIONAL_FORMATTING |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog sheets](gog-sheets.md)
+- [Command index](README.md)

--- a/docs/commands/gog-sheets.md
+++ b/docs/commands/gog-sheets.md
@@ -24,6 +24,7 @@ gog sheets (sheet) <command> [flags]
 - [gog sheets clear](gog-sheets-clear.md) - Clear values in a range
 - [gog sheets conditional-format](gog-sheets-conditional-format.md) - Manage conditional formatting rules
 - [gog sheets copy](gog-sheets-copy.md) - Copy a Google Sheet
+- [gog sheets copy-paste](gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
 - [gog sheets create](gog-sheets-create.md) - Create a new spreadsheet
 - [gog sheets delete-tab](gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
 - [gog sheets export](gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -37,6 +37,7 @@ type SheetsCmd struct {
 	Banding       SheetsBandingCmd       `cmd:"" name:"banding" aliases:"banded-ranges" help:"Manage alternating color banding"`
 	Merge         SheetsMergeCmd         `cmd:"" name:"merge" help:"Merge cells in a range"`
 	Unmerge       SheetsUnmergeCmd       `cmd:"" name:"unmerge" help:"Unmerge cells in a range"`
+	CopyPaste     SheetsCopyPasteCmd     `cmd:"" name:"copy-paste" aliases:"fill,copy-range" help:"Copy a range's values/formulas/format to another range (tiles to fill down/across)"`
 	NumberFormat  SheetsNumberFormatCmd  `cmd:"" name:"number-format" help:"Apply number format to a range"`
 	Freeze        SheetsFreezeCmd        `cmd:"" name:"freeze" help:"Freeze rows and columns on a sheet"`
 	ResizeColumns SheetsResizeColumnsCmd `cmd:"" name:"resize-columns" help:"Resize sheet columns"`

--- a/internal/cmd/sheets_copy_paste.go
+++ b/internal/cmd/sheets_copy_paste.go
@@ -1,0 +1,108 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/sheets/v4"
+)
+
+// pasteNormal is the default paste type / orientation keyword shared by the
+// struct default, orientation fallback, and the type allow-list.
+const pasteNormal = "NORMAL"
+
+type SheetsCopyPasteCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	Source        string `arg:"" name:"source" help:"Source range (eg. Sheet1!A2:H71)"`
+	Dest          string `arg:"" name:"dest" help:"Destination range (eg. Sheet1!A2:H120). A destination larger than the source tiles the source to fill it — use this to fill formulas down or across with relative references adjusted."`
+	Type          string `name:"type" help:"Paste type: NORMAL, VALUES, FORMAT, FORMULA, NO_BORDERS, DATA_VALIDATION, CONDITIONAL_FORMATTING" default:"NORMAL"`
+	Transpose     bool   `name:"transpose" help:"Paste transposed (swap rows and columns)"`
+}
+
+func (c *SheetsCopyPasteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	source := cleanRange(c.Source)
+	dest := cleanRange(c.Dest)
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+	if strings.TrimSpace(source) == "" {
+		return usage("empty source range")
+	}
+	if strings.TrimSpace(dest) == "" {
+		return usage("empty dest range")
+	}
+
+	pasteType, err := normalizePasteType(c.Type)
+	if err != nil {
+		return err
+	}
+	orientation := pasteNormal
+	if c.Transpose {
+		orientation = "TRANSPOSE"
+	}
+
+	srcInfo, err := parseSheetRange(source, "copy-paste source")
+	if err != nil {
+		return err
+	}
+	dstInfo, err := parseSheetRange(dest, "copy-paste dest")
+	if err != nil {
+		return err
+	}
+
+	return runSheetsMutation(ctx, flags, "sheets.copy-paste", map[string]any{
+		"spreadsheet_id": spreadsheetID,
+		"source":         source,
+		"dest":           dest,
+		"type":           pasteType,
+		"orientation":    orientation,
+	}, func(ctx context.Context, svc *sheets.Service) (map[string]any, string, error) {
+		sheetIDs, err := fetchSheetIDMap(ctx, svc, spreadsheetID)
+		if err != nil {
+			return nil, "", err
+		}
+		srcGrid, err := gridRangeFromMap(srcInfo, sheetIDs, "copy-paste source")
+		if err != nil {
+			return nil, "", err
+		}
+		dstGrid, err := gridRangeFromMap(dstInfo, sheetIDs, "copy-paste dest")
+		if err != nil {
+			return nil, "", err
+		}
+		req := &sheets.BatchUpdateSpreadsheetRequest{
+			Requests: []*sheets.Request{{
+				CopyPaste: &sheets.CopyPasteRequest{
+					Source:           srcGrid,
+					Destination:      dstGrid,
+					PasteType:        pasteType,
+					PasteOrientation: orientation,
+				},
+			}},
+		}
+		if err := applySheetsBatchUpdate(ctx, svc, spreadsheetID, req); err != nil {
+			return nil, "", err
+		}
+		return map[string]any{
+			"source":      source,
+			"dest":        dest,
+			"type":        pasteType,
+			"orientation": orientation,
+		}, fmt.Sprintf("Copied %s → %s (%s)", source, dest, pasteType), nil
+	})
+}
+
+func normalizePasteType(raw string) (string, error) {
+	v := strings.ToUpper(strings.TrimSpace(raw))
+	if v == "" {
+		v = pasteNormal
+	}
+	v = strings.TrimPrefix(v, "PASTE_")
+	switch v {
+	case pasteNormal, "VALUES", "FORMAT", "NO_BORDERS", "FORMULA", "DATA_VALIDATION", "CONDITIONAL_FORMATTING":
+		return "PASTE_" + v, nil
+	default:
+		return "", fmt.Errorf("invalid --type %q (expected NORMAL, VALUES, FORMAT, FORMULA, NO_BORDERS, DATA_VALIDATION, or CONDITIONAL_FORMATTING)", raw)
+	}
+}

--- a/internal/cmd/sheets_copy_paste_test.go
+++ b/internal/cmd/sheets_copy_paste_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestSheetsCopyPasteCmd(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	var gotRequest *sheets.Request
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(strings.TrimPrefix(r.URL.Path, "/sheets/v4"), "/v4")
+		switch {
+		case strings.HasPrefix(path, "/spreadsheets/s1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"sheets": []map[string]any{
+					{"properties": map[string]any{"sheetId": 9, "title": "Sheet1"}},
+				},
+			})
+		case strings.Contains(path, "/spreadsheets/s1:batchUpdate") && r.Method == http.MethodPost:
+			var req sheets.BatchUpdateSpreadsheetRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			if len(req.Requests) != 1 {
+				t.Fatalf("expected one request, got %#v", req.Requests)
+			}
+			gotRequest = req.Requests[0]
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+
+	t.Run("fill formulas down (formula paste type)", func(t *testing.T) {
+		gotRequest = nil
+		cmd := &SheetsCopyPasteCmd{}
+		if err := runKong(t, cmd, []string{
+			"s1", "Sheet1!A2:H71", "Sheet1!A2:H120", "--type", "FORMULA",
+		}, ctx, flags); err != nil {
+			t.Fatalf("copy-paste: %v", err)
+		}
+		if gotRequest == nil || gotRequest.CopyPaste == nil {
+			t.Fatalf("expected copyPaste request, got %#v", gotRequest)
+		}
+		cp := gotRequest.CopyPaste
+		if cp.PasteType != "PASTE_FORMULA" {
+			t.Fatalf("unexpected paste type: %s", cp.PasteType)
+		}
+		if cp.PasteOrientation != "NORMAL" {
+			t.Fatalf("unexpected orientation: %s", cp.PasteOrientation)
+		}
+		if cp.Source.SheetId != 9 || cp.Destination.SheetId != 9 {
+			t.Fatalf("unexpected sheet ids: src=%d dst=%d", cp.Source.SheetId, cp.Destination.SheetId)
+		}
+		// A2:H71 -> rows [1,71); A2:H120 -> rows [1,120). Destination is taller (fill-down).
+		if cp.Source.StartRowIndex != 1 || cp.Source.EndRowIndex != 71 {
+			t.Fatalf("unexpected source rows: %#v", cp.Source)
+		}
+		if cp.Destination.StartRowIndex != 1 || cp.Destination.EndRowIndex != 120 {
+			t.Fatalf("unexpected dest rows: %#v", cp.Destination)
+		}
+	})
+
+	t.Run("default type is PASTE_NORMAL", func(t *testing.T) {
+		gotRequest = nil
+		cmd := &SheetsCopyPasteCmd{}
+		if err := runKong(t, cmd, []string{"s1", "Sheet1!A1:B2", "Sheet1!D1:E2"}, ctx, flags); err != nil {
+			t.Fatalf("copy-paste: %v", err)
+		}
+		if gotRequest == nil || gotRequest.CopyPaste == nil {
+			t.Fatal("expected copyPaste request")
+		}
+		if gotRequest.CopyPaste.PasteType != "PASTE_NORMAL" {
+			t.Fatalf("unexpected paste type: %s", gotRequest.CopyPaste.PasteType)
+		}
+	})
+
+	t.Run("transpose sets orientation", func(t *testing.T) {
+		gotRequest = nil
+		cmd := &SheetsCopyPasteCmd{}
+		if err := runKong(t, cmd, []string{"s1", "Sheet1!A1:B3", "Sheet1!D1:F2", "--transpose"}, ctx, flags); err != nil {
+			t.Fatalf("copy-paste: %v", err)
+		}
+		if gotRequest == nil || gotRequest.CopyPaste == nil {
+			t.Fatal("expected copyPaste request")
+		}
+		if gotRequest.CopyPaste.PasteOrientation != "TRANSPOSE" {
+			t.Fatalf("unexpected orientation: %s", gotRequest.CopyPaste.PasteOrientation)
+		}
+	})
+
+	t.Run("invalid paste type", func(t *testing.T) {
+		gotRequest = nil
+		cmd := &SheetsCopyPasteCmd{}
+		err := runKong(t, cmd, []string{"s1", "Sheet1!A1:B2", "Sheet1!D1:E2", "--type", "BOGUS"}, ctx, flags)
+		if err == nil {
+			t.Fatal("expected error for invalid type")
+		}
+		if !strings.Contains(err.Error(), "invalid --type") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if gotRequest != nil {
+			t.Fatal("did not expect an API request")
+		}
+	})
+
+	t.Run("empty source range", func(t *testing.T) {
+		cmd := &SheetsCopyPasteCmd{}
+		err := runKong(t, cmd, []string{"s1", "  ", "Sheet1!A1"}, ctx, flags)
+		if err == nil || !strings.Contains(err.Error(), "empty source range") {
+			t.Fatalf("expected empty source error, got %v", err)
+		}
+	})
+
+	t.Run("empty dest range", func(t *testing.T) {
+		cmd := &SheetsCopyPasteCmd{}
+		err := runKong(t, cmd, []string{"s1", "Sheet1!A1", "  "}, ctx, flags)
+		if err == nil || !strings.Contains(err.Error(), "empty dest range") {
+			t.Fatalf("expected empty dest error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Fixes #661.

## Problem
There's no primitive to copy a range's formulas/format down or across with relative-reference adjustment. `sheets copy` is sheet-level, `sheets raw` is read-only (`Spreadsheets.Get`), and `sheets batch-update` only writes value ranges. Filling per-row formulas down a column currently means inlining every fully-spelled-out formula via large value writes — high-token and error-prone.

## Change
`gog sheets copy-paste <spreadsheetId> <source> <dest> [--type=NORMAL|VALUES|FORMAT|FORMULA|NO_BORDERS|DATA_VALIDATION|CONDITIONAL_FORMATTING] [--transpose]` (aliases `fill`, `copy-range`), mapping to `spreadsheets.batchUpdate` `CopyPasteRequest`. A destination larger than the source tiles it, so a fill-down is one call. Built on the existing `parseSheetRange`/`gridRangeFromMap`/`runSheetsMutation`/`applySheetsBatchUpdate` helpers (same shape as `sheets merge`). Command reference regenerated via `make docs-commands`; no CHANGELOG edit (release-owned).

## Real-behavior proof (built from this branch)

**`gog sheets copy-paste --help`**:
```
Usage: gog sheets (sheet) copy-paste (fill,copy-range) <spreadsheetId> <source> <dest> [flags]

Copy a range's values/formulas/format to another range (tiles to fill down/across)
```

**`--dry-run` (fill formulas down a buffer)**:
```json
$ gog sheets copy-paste s1 'Sheet1!A2:H71' 'Sheet1!A2:H120' --type FORMULA --dry-run --json
{ "dry_run": true, "op": "sheets.copy-paste",
  "request": { "source": "Sheet1!A2:H71", "dest": "Sheet1!A2:H120",
               "type": "PASTE_FORMULA", "orientation": "NORMAL", "spreadsheet_id": "s1" } }
```

## Tests
`internal/cmd/sheets_copy_paste_test.go` over the existing `httptest` Sheets stub: asserts the wire-level `CopyPasteRequest` (paste type incl. `PASTE_FORMULA`, transpose → `TRANSPOSE` orientation, source/dest GridRanges with a taller destination for fill-down), invalid-type rejection, and empty-range guards. `make fmt` + `make lint` (0 issues) + `go test ./internal/cmd/` green.