### PR TITLE
fix(gmail): circuit-break watch rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Sheets: add `--inherit-from-before` to `sheets insert` so callers can choose whether inserted rows/columns inherit formatting from the preceding or following neighbor. (#655, #658) — thanks @chrischall.
 - Auth: update stored OAuth scope metadata from observed granted scopes during refresh so `auth list` reflects newly usable services. (#649)
 - Docs: preserve paragraph-separating blank lines when replacing a single tab from Markdown. (#644)
+- Gmail: pause watch push Gmail API fetches per account while a 429 Retry-After circuit is open. (#643)
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 
 ## 0.19.0 - 2026-05-22

--- a/internal/cmd/gmail_watch_cmds.go
+++ b/internal/cmd/gmail_watch_cmds.go
@@ -448,6 +448,9 @@ func writeWatchState(ctx context.Context, state gmailWatchState, showSecrets boo
 	if state.LastPushMessageID != "" {
 		u.Out().Linef("last_push_message_id\t%s", state.LastPushMessageID)
 	}
+	if state.RateLimitedUntilMs > 0 {
+		u.Out().Linef("rate_limited_until\t%s", formatUnixMillis(state.RateLimitedUntilMs))
+	}
 	return nil
 }
 

--- a/internal/cmd/gmail_watch_rate_limit_test.go
+++ b/internal/cmd/gmail_watch_rate_limit_test.go
@@ -1,0 +1,222 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/option"
+)
+
+func TestGmailWatchServer_History429OpensAccountCircuit(t *testing.T) {
+	setWatchTestConfigHome(t)
+
+	store := newRateLimitWatchStore(t)
+	var historyCalls int
+	gsvc := newRateLimitGmailService(t, func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/gmail/v1/users/me/history") {
+			historyCalls++
+			writeGmail429(t, w, "120")
+			return
+		}
+		http.NotFound(w, r)
+	})
+
+	var serviceCalls int
+	server := &gmailWatchServer{
+		cfg:        gmailWatchServeConfig{Account: "a@b.com", HistoryMax: 10},
+		store:      store,
+		newService: func(context.Context, string) (*gmail.Service, error) { serviceCalls++; return gsvc, nil },
+		logf:       func(string, ...any) {},
+		warnf:      func(string, ...any) {},
+	}
+
+	_, err := server.handlePush(context.Background(), gmailPushPayload{EmailAddress: "a@b.com", HistoryID: "200"})
+	var rateErr *gmailWatchRateLimitError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("expected rate limit error, got %v", err)
+	}
+	if historyCalls != 1 || serviceCalls != 1 {
+		t.Fatalf("expected one Gmail call, got history=%d service=%d", historyCalls, serviceCalls)
+	}
+	state := store.Get()
+	if state.RateLimitedUntilMs <= time.Now().UnixMilli() {
+		t.Fatalf("expected future rate limit timestamp, got %d", state.RateLimitedUntilMs)
+	}
+	if state.HistoryID != "100" {
+		t.Fatalf("history advanced under rate limit: %q", state.HistoryID)
+	}
+
+	_, err = server.handlePush(context.Background(), gmailPushPayload{EmailAddress: "a@b.com", HistoryID: "201"})
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("expected open circuit error, got %v", err)
+	}
+	if historyCalls != 1 || serviceCalls != 1 {
+		t.Fatalf("open circuit made Gmail calls: history=%d service=%d", historyCalls, serviceCalls)
+	}
+}
+
+func TestGmailWatchServer_Message429OpensAccountCircuit(t *testing.T) {
+	setWatchTestConfigHome(t)
+
+	store := newRateLimitWatchStore(t)
+	var historyCalls, messageCalls int
+	gsvc := newRateLimitGmailService(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/history"):
+			historyCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"historyId": "200",
+				"history": []map[string]any{
+					{"messagesAdded": []map[string]any{{"message": map[string]any{"id": "m1"}}}},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/m1"):
+			messageCalls++
+			writeGmail429(t, w, "60")
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	server := &gmailWatchServer{
+		cfg:        gmailWatchServeConfig{Account: "a@b.com", HistoryMax: 10},
+		store:      store,
+		newService: func(context.Context, string) (*gmail.Service, error) { return gsvc, nil },
+		logf:       func(string, ...any) {},
+		warnf:      func(string, ...any) {},
+	}
+
+	_, err := server.handlePush(context.Background(), gmailPushPayload{EmailAddress: "a@b.com", HistoryID: "200"})
+	var rateErr *gmailWatchRateLimitError
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("expected rate limit error, got %v", err)
+	}
+	state := store.Get()
+	if state.RateLimitedUntilMs <= time.Now().UnixMilli() {
+		t.Fatalf("expected future rate limit timestamp, got %d", state.RateLimitedUntilMs)
+	}
+	if state.HistoryID != "100" {
+		t.Fatalf("history advanced under rate limit: %q", state.HistoryID)
+	}
+
+	_, err = server.handlePush(context.Background(), gmailPushPayload{EmailAddress: "a@b.com", HistoryID: "201"})
+	if !errors.As(err, &rateErr) {
+		t.Fatalf("expected open circuit error, got %v", err)
+	}
+	if historyCalls != 1 || messageCalls != 1 {
+		t.Fatalf("open circuit made Gmail calls: history=%d message=%d", historyCalls, messageCalls)
+	}
+}
+
+func TestGmailWatchServer_OpenCircuitReturnsRetryAfter(t *testing.T) {
+	setWatchTestConfigHome(t)
+
+	store := newRateLimitWatchStore(t)
+	until := time.Now().Add(90 * time.Second).UnixMilli()
+	if err := store.Update(func(s *gmailWatchState) error {
+		s.RateLimitedUntilMs = until
+		return nil
+	}); err != nil {
+		t.Fatalf("store update: %v", err)
+	}
+
+	serviceCalls := 0
+	server := &gmailWatchServer{
+		cfg:   gmailWatchServeConfig{Account: "a@b.com", Path: "/hook"},
+		store: store,
+		newService: func(context.Context, string) (*gmail.Service, error) {
+			serviceCalls++
+			return nil, errors.New("unexpected Gmail service call")
+		},
+		logf:  func(string, ...any) {},
+		warnf: func(string, ...any) {},
+	}
+
+	push := pubsubPushEnvelope{}
+	push.Message.Data = base64.StdEncoding.EncodeToString([]byte(`{"emailAddress":"a@b.com","historyId":"200"}`))
+	body, _ := json.Marshal(push)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/hook", bytes.NewReader(body))
+	server.ServeHTTP(rr, req)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status: %d", rr.Code)
+	}
+	if rr.Header().Get("Retry-After") == "" {
+		t.Fatalf("expected Retry-After header")
+	}
+	if serviceCalls != 0 {
+		t.Fatalf("open circuit created Gmail service")
+	}
+}
+
+func TestUpdateStateAfterHistoryKeepsConcurrentRateLimitCircuit(t *testing.T) {
+	until := time.Now().Add(time.Minute).UnixMilli()
+	state := gmailWatchState{HistoryID: "100", RateLimitedUntilMs: until}
+	if err := updateStateAfterHistory(&state, "200", "push1"); err != nil {
+		t.Fatalf("update state: %v", err)
+	}
+	if state.RateLimitedUntilMs != until {
+		t.Fatalf("rate limit circuit changed: got %d want %d", state.RateLimitedUntilMs, until)
+	}
+	if state.HistoryID != "200" {
+		t.Fatalf("history not updated: %q", state.HistoryID)
+	}
+}
+
+func newRateLimitWatchStore(t *testing.T) *gmailWatchStore {
+	t.Helper()
+	store, err := newGmailWatchStore("a@b.com")
+	if err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	if err := store.Update(func(s *gmailWatchState) error {
+		s.Account = "a@b.com"
+		s.HistoryID = "100"
+		return nil
+	}); err != nil {
+		t.Fatalf("store update: %v", err)
+	}
+	return store
+}
+
+func newRateLimitGmailService(t *testing.T, handler http.HandlerFunc) *gmail.Service {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	gsvc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return gsvc
+}
+
+func writeGmail429(t *testing.T, w http.ResponseWriter, retryAfter string) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Retry-After", retryAfter)
+	w.WriteHeader(http.StatusTooManyRequests)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"code":    http.StatusTooManyRequests,
+			"message": "User-rate limit exceeded",
+			"errors": []map[string]any{
+				{"reason": "rateLimitExceeded", "message": "User-rate limit exceeded"},
+			},
+		},
+	})
+}

--- a/internal/cmd/gmail_watch_server.go
+++ b/internal/cmd/gmail_watch_server.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,7 +24,24 @@ var errNoNewMessages = errors.New("no new messages")
 const (
 	gmailWatchFormatMetadata  = "metadata"
 	gmailWatchStatusHTTPError = "http_error"
+	gmailWatchStatusRateLimit = "rate_limited"
 )
+
+type gmailWatchRateLimitError struct {
+	Until time.Time
+	Cause error
+}
+
+func (e *gmailWatchRateLimitError) Error() string {
+	if e.Until.IsZero() {
+		return "gmail watch rate limited"
+	}
+	return fmt.Sprintf("gmail watch rate limited until %s", e.Until.Format(time.RFC3339))
+}
+
+func (e *gmailWatchRateLimitError) Unwrap() error {
+	return e.Cause
+}
 
 type gmailWatchServer struct {
 	cfg             gmailWatchServeConfig
@@ -74,6 +92,15 @@ func (s *gmailWatchServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if errors.Is(err, errNoNewMessages) {
 			w.WriteHeader(http.StatusAccepted)
+			return
+		}
+		var rateErr *gmailWatchRateLimitError
+		if errors.As(err, &rateErr) {
+			if !rateErr.Until.IsZero() {
+				w.Header().Set("Retry-After", retryAfterSeconds(time.Now(), rateErr.Until))
+			}
+			s.warnf("watch: Gmail rate limit circuit open: %v", err)
+			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
 		s.warnf("watch: handle push failed: %v", err)
@@ -156,6 +183,9 @@ func (s *gmailWatchServer) handlePush(ctx context.Context, payload gmailPushPayl
 			return nil, errNoNewMessages
 		}
 	}
+	if err := s.checkRateLimitCircuit(time.Now()); err != nil {
+		return nil, err
+	}
 	startID, err := store.StartHistoryID(payload.HistoryID)
 	if err != nil {
 		return nil, err
@@ -192,7 +222,7 @@ func (s *gmailWatchServer) handlePush(ctx context.Context, payload gmailPushPayl
 		if isStaleHistoryError(err) {
 			return s.resyncHistory(ctx, svc, payload.HistoryID, payload.MessageID)
 		}
-		return nil, err
+		return nil, s.openRateLimitCircuitIfNeeded(err)
 	}
 
 	nextHistoryID := payload.HistoryID
@@ -211,7 +241,7 @@ func (s *gmailWatchServer) handlePush(ctx context.Context, payload gmailPushPayl
 	historyIDs := collectHistoryMessageIDs(historyResp)
 	msgs, excluded, err := s.fetchMessages(ctx, svc, historyIDs.FetchIDs)
 	if err != nil {
-		return nil, err
+		return nil, s.openRateLimitCircuitIfNeeded(err)
 	}
 	if err := store.Update(func(state *gmailWatchState) error {
 		return updateStateAfterHistory(state, nextHistoryID, payload.MessageID)
@@ -238,7 +268,7 @@ func (s *gmailWatchServer) handlePush(ctx context.Context, payload gmailPushPayl
 func (s *gmailWatchServer) resyncHistory(ctx context.Context, svc *gmail.Service, historyID string, messageID string) (*gmailHookPayload, error) {
 	list, err := svc.Users.Messages.List("me").MaxResults(s.cfg.ResyncMax).Do()
 	if err != nil {
-		return nil, err
+		return nil, s.openRateLimitCircuitIfNeeded(err)
 	}
 	ids := make([]string, 0, len(list.Messages))
 	for _, m := range list.Messages {
@@ -248,7 +278,7 @@ func (s *gmailWatchServer) resyncHistory(ctx context.Context, svc *gmail.Service
 	}
 	msgs, excluded, err := s.fetchMessages(ctx, svc, ids)
 	if err != nil {
-		return nil, err
+		return nil, s.openRateLimitCircuitIfNeeded(err)
 	}
 
 	if err := s.store.Update(func(state *gmailWatchState) error {
@@ -338,6 +368,53 @@ func (s *gmailWatchServer) fetchMessages(ctx context.Context, svc *gmail.Service
 		messages = append(messages, item)
 	}
 	return messages, excluded, nil
+}
+
+func (s *gmailWatchServer) checkRateLimitCircuit(now time.Time) error {
+	if s.store == nil {
+		return nil
+	}
+	state := s.store.Get()
+	if state.RateLimitedUntilMs <= 0 {
+		return nil
+	}
+	if state.RateLimitedUntilMs > now.UnixMilli() {
+		return &gmailWatchRateLimitError{Until: time.UnixMilli(state.RateLimitedUntilMs)}
+	}
+	if err := s.store.Update(func(state *gmailWatchState) error {
+		if state.RateLimitedUntilMs > 0 && state.RateLimitedUntilMs <= now.UnixMilli() {
+			state.RateLimitedUntilMs = 0
+			if state.LastDeliveryStatus == gmailWatchStatusRateLimit {
+				state.LastDeliveryStatusNote = ""
+			}
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (s *gmailWatchServer) openRateLimitCircuitIfNeeded(err error) error {
+	until, ok := gmailWatchRateLimitUntil(err, time.Now())
+	if !ok {
+		return err
+	}
+	if s.store != nil {
+		if updateErr := s.store.Update(func(state *gmailWatchState) error {
+			untilMs := until.UnixMilli()
+			if untilMs > state.RateLimitedUntilMs {
+				state.RateLimitedUntilMs = untilMs
+			}
+			state.LastDeliveryStatus = gmailWatchStatusRateLimit
+			state.LastDeliveryAtMs = time.Now().UnixMilli()
+			state.LastDeliveryStatusNote = err.Error()
+			return nil
+		}); updateErr != nil {
+			s.warnf("watch: failed to update rate limit state: %v", updateErr)
+		}
+	}
+	return &gmailWatchRateLimitError{Until: until, Cause: err}
 }
 
 func (s *gmailWatchServer) isExcludedLabel(labelIDs []string) bool {
@@ -538,6 +615,48 @@ func isNotFoundAPIError(err error) bool {
 		return gerr.Code == http.StatusNotFound
 	}
 	return false
+}
+
+func gmailWatchRateLimitUntil(err error, now time.Time) (time.Time, bool) {
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) || gerr.Code != http.StatusTooManyRequests {
+		return time.Time{}, false
+	}
+	if until, ok := parseRetryAfterUntil(gerr.Header.Get("Retry-After"), now); ok {
+		return until, true
+	}
+	return now.Add(time.Minute), true
+}
+
+func parseRetryAfterUntil(raw string, now time.Time) (time.Time, bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return time.Time{}, false
+	}
+	if seconds, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
+		if seconds < 0 {
+			seconds = 0
+		}
+		return now.Add(time.Duration(seconds) * time.Second), true
+	}
+	if parsed, err := http.ParseTime(trimmed); err == nil {
+		return parsed, true
+	}
+	if parsed, err := time.Parse(time.RFC3339, trimmed); err == nil {
+		return parsed, true
+	}
+	return time.Time{}, false
+}
+
+func retryAfterSeconds(now, until time.Time) string {
+	if now.IsZero() {
+		now = time.Now()
+	}
+	seconds := int64(until.Sub(now).Seconds())
+	if seconds < 1 {
+		seconds = 1
+	}
+	return strconv.FormatInt(seconds, 10)
 }
 
 // historyMessageIDs holds the result of collecting message IDs from history.

--- a/internal/cmd/gmail_watch_types.go
+++ b/internal/cmd/gmail_watch_types.go
@@ -38,6 +38,7 @@ type gmailWatchState struct {
 	LastDeliveryAtMs       int64           `json:"lastDeliveryAtMs,omitempty"`
 	LastDeliveryStatusNote string          `json:"lastDeliveryStatusNote,omitempty"`
 	LastPushMessageID      string          `json:"lastPushMessageId,omitempty"`
+	RateLimitedUntilMs     int64           `json:"rateLimitedUntilMs,omitempty"`
 }
 
 type gmailWatchServeConfig struct {


### PR DESCRIPTION
## Summary
- persist a per-account Gmail watch `rateLimitedUntilMs` circuit when Gmail push handling hits 429
- skip Gmail API fetches while the circuit is open and return 503 with `Retry-After`
- surface the circuit timestamp in `gmail watch status` and add regression coverage for history/message 429s

Fixes #643.

## Testing
- `go test ./internal/cmd -run 'GmailWatchServer_(History429|Message429|OpenCircuit)|UpdateStateAfterHistoryKeepsConcurrentRateLimitCircuit'`
- `go test ./internal/cmd -run 'GmailWatchServer_(History429|Message429|OpenCircuit)'`
- `go test ./internal/cmd -run 'GmailWatch(Server|RateLimit|WatchState|ServeHTTP)'`
- `go test ./internal/cmd ./internal/googleapi`
- `make test`
- `make lint`
- `autoreview --mode local` clean
- Live clawdbot smoke: `gmail watch status` returned stored watch state and real `gmail labels list` returned 16 labels
