### PR TITLE
feat(docs): add table cell update command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Sheets: add `--inherit-from-before` to `sheets insert` so callers can choose whether inserted rows/columns inherit formatting from the preceding or following neighbor. (#655, #658) — thanks @chrischall.
 - Auth: update stored OAuth scope metadata from observed granted scopes during refresh so `auth list` reflects newly usable services. (#649)
 - Docs: preserve paragraph-separating blank lines when replacing a single tab from Markdown. (#644)
+- Docs: add `docs cell-update` for non-destructive table-cell content replacement by table, row, and column. (#646)
 - Gmail: pause watch push Gmail API fetches per account while a 429 Retry-After circuit is open. (#643)
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -220,6 +220,7 @@ Generated from `gog schema --json`.
   - [`gog docs (doc) <command> [flags]`](commands/gog-docs.md) - Google Docs (export via Drive)
     - [`gog docs (doc) add-tab <docId> [flags]`](commands/gog-docs-add-tab.md) - Add a tab to a Google Doc
     - [`gog docs (doc) cat (text,read) <docId> [flags]`](commands/gog-docs-cat.md) - Print a Google Doc as plain text
+    - [`gog docs (doc) cell-update (update-cell) --row=INT --col=INT <docId> [flags]`](commands/gog-docs-cell-update.md) - Replace or append content inside a specific table cell
     - [`gog docs (doc) clear <docId>`](commands/gog-docs-clear.md) - Clear all content from a Google Doc
     - [`gog docs (doc) comments <command>`](commands/gog-docs-comments.md) - Manage comments on files
       - [`gog docs (doc) comments add (create,new) <docId> <content> [flags]`](commands/gog-docs-comments-add.md) - Add a comment to a Google Doc

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 572.
+Generated pages: 573.
 
 ## Top-level Commands
 
@@ -271,6 +271,7 @@ Generated pages: 572.
   - [gog docs](gog-docs.md) - Google Docs (export via Drive)
     - [gog docs add-tab](gog-docs-add-tab.md) - Add a tab to a Google Doc
     - [gog docs cat](gog-docs-cat.md) - Print a Google Doc as plain text
+    - [gog docs cell-update](gog-docs-cell-update.md) - Replace or append content inside a specific table cell
     - [gog docs clear](gog-docs-clear.md) - Clear all content from a Google Doc
     - [gog docs comments](gog-docs-comments.md) - Manage comments on files
       - [gog docs comments add](gog-docs-comments-add.md) - Add a comment to a Google Doc

--- a/docs/commands/gog-docs-cell-update.md
+++ b/docs/commands/gog-docs-cell-update.md
@@ -1,0 +1,52 @@
+# `gog docs cell-update`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Replace or append content inside a specific table cell
+
+## Usage
+
+```bash
+gog docs (doc) cell-update (update-cell) --row=INT --col=INT <docId> [flags]
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
+| `--append` | `bool` |  | Append inside the cell instead of replacing existing cell content |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int` |  | 1-based column number |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--content` | `string` |  | Replacement content (omit when using --content-file) |
+| `--content-file` | `string` |  | Read replacement content from a file |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled commands; dot paths allowed (restricts CLI) |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--format` | `string` | markdown | Content format: markdown\|plain |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int` |  | 1-based row number |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table-index` | `int` | 1 | 1-based table index in document order; negative indexes count from the end |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -18,6 +18,7 @@ gog docs (doc) <command> [flags]
 
 - [gog docs add-tab](gog-docs-add-tab.md) - Add a tab to a Google Doc
 - [gog docs cat](gog-docs-cat.md) - Print a Google Doc as plain text
+- [gog docs cell-update](gog-docs-cell-update.md) - Replace or append content inside a specific table cell
 - [gog docs clear](gog-docs-clear.md) - Clear all content from a Google Doc
 - [gog docs comments](gog-docs-comments.md) - Manage comments on files
 - [gog docs copy](gog-docs-copy.md) - Copy a Google Doc

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -118,9 +118,20 @@ to insert at a specific document index. Prefer this primitive when you want a
 guaranteed native table rather than relying on the Markdown writer's table
 rendering (see `gog docs write --markdown`).
 
+Update one existing table cell without round-tripping the surrounding document:
+
+```bash
+gog docs cell-update <docId> --table-index 1 --row 2 --col 3 \
+  --content "**Ready**" --format markdown
+```
+
+Coordinates are 1-based. `--tab` targets a specific tab, and `--append` inserts
+at the end of the cell instead of replacing its current content.
+
 Command page:
 
 - [`gog docs insert-table`](commands/gog-docs-insert-table.md)
+- [`gog docs cell-update`](commands/gog-docs-cell-update.md)
 
 ## Tabs
 

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -32,6 +32,7 @@ type DocsCmd struct {
 	Write           DocsWriteCmd           `cmd:"" name:"write" help:"Write content to a Google Doc"`
 	Insert          DocsInsertCmd          `cmd:"" name:"insert" help:"Insert text at a specific position"`
 	InsertTable     DocsInsertTableCmd     `cmd:"" name:"insert-table" help:"Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json"`
+	CellUpdate      DocsCellUpdateCmd      `cmd:"" name:"cell-update" aliases:"update-cell" help:"Replace or append content inside a specific table cell"`
 	InsertPageBreak DocsInsertPageBreakCmd `cmd:"" name:"insert-page-break" aliases:"page-break,pb" help:"Insert a page break at a specific position (or end-of-doc with --at-end)"`
 	Delete          DocsDeleteCmd          `cmd:"" name:"delete" help:"Delete text range from document"`
 	FindReplace     DocsFindReplaceCmd     `cmd:"" name:"find-replace" help:"Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence."`

--- a/internal/cmd/docs_cell_update.go
+++ b/internal/cmd/docs_cell_update.go
@@ -1,0 +1,246 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsCellUpdateCmd struct {
+	DocID       string `arg:"" name:"docId" help:"Doc ID"`
+	TableIndex  int    `name:"table-index" help:"1-based table index in document order; negative indexes count from the end" default:"1"`
+	Row         int    `name:"row" required:"" help:"1-based row number"`
+	Col         int    `name:"col" required:"" help:"1-based column number"`
+	Content     string `name:"content" help:"Replacement content (omit when using --content-file)"`
+	ContentFile string `name:"content-file" help:"Read replacement content from a file"`
+	Format      string `name:"format" help:"Content format: markdown|plain" default:"markdown" enum:"markdown,plain"`
+	Append      bool   `name:"append" help:"Append inside the cell instead of replacing existing cell content"`
+	Tab         string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID       string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+}
+
+func (c *DocsCellUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := strings.TrimSpace(c.DocID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if c.TableIndex == 0 {
+		return usage("--table-index cannot be 0")
+	}
+	if c.Row < 1 {
+		return usage("--row must be >= 1")
+	}
+	if c.Col < 1 {
+		return usage("--col must be >= 1")
+	}
+	content, err := c.resolveContent()
+	if err != nil {
+		return err
+	}
+	format := strings.ToLower(strings.TrimSpace(c.Format))
+	if format == "" {
+		format = docsContentFormatMarkdown
+	}
+	if format != docsContentFormatMarkdown && format != docsContentFormatPlain {
+		return usage("--format must be markdown or plain")
+	}
+	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
+	if tabErr != nil {
+		return tabErr
+	}
+	c.Tab = tab
+
+	if dryRunErr := dryRunExit(ctx, flags, "docs.cell-update", map[string]any{
+		"document_id": docID,
+		"table_index": c.TableIndex,
+		"row":         c.Row,
+		"col":         c.Col,
+		"format":      format,
+		"append":      c.Append,
+		"tab":         c.Tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, c.Tab)
+	if err != nil {
+		return err
+	}
+	c.Tab = loaded.tabID
+
+	ref := &tableCellRef{tableIndex: c.TableIndex, row: c.Row, col: c.Col}
+	cell, err := findTableCell(loaded.target, ref)
+	if err != nil {
+		return fmt.Errorf("find table cell: %w", err)
+	}
+	cellText, startIdx, endIdx := getCellText(cell)
+	if startIdx <= 0 || endIdx <= startIdx {
+		return fmt.Errorf("target cell has no editable text range")
+	}
+	writeEnd := endIdx
+	if strings.HasSuffix(cellText, "\n") {
+		writeEnd--
+	}
+	writeStart := startIdx
+	prefixBoundary := false
+	if c.Append {
+		writeStart = writeEnd
+		prefixBoundary = format == docsContentFormatMarkdown &&
+			strings.TrimSpace(strings.TrimSuffix(cellText, "\n")) != "" &&
+			markdownCellAppendNeedsBoundary(ParseMarkdown(content))
+	}
+
+	if err := updateDocsCellContent(ctx, svc, loaded.full, writeStart, writeEnd, content, format, c.Append, prefixBoundary, c.Tab); err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": docID,
+			"tableIndex": c.TableIndex,
+			"row":        c.Row,
+			"col":        c.Col,
+			"format":     format,
+			"append":     c.Append,
+			"updated":    true,
+		}
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+	u.Out().Linef("documentId\t%s", docID)
+	u.Out().Linef("table_index\t%d", c.TableIndex)
+	u.Out().Linef("row\t%d", c.Row)
+	u.Out().Linef("col\t%d", c.Col)
+	u.Out().Linef("updated\ttrue")
+	if c.Tab != "" {
+		u.Out().Linef("tabId\t%s", c.Tab)
+	}
+	return nil
+}
+
+func (c *DocsCellUpdateCmd) resolveContent() (string, error) {
+	if c.ContentFile != "" && c.Content != "" {
+		return "", usage("cannot use both --content and --content-file")
+	}
+	if c.ContentFile == "" {
+		return c.Content, nil
+	}
+	data, err := os.ReadFile(c.ContentFile)
+	if err != nil {
+		return "", fmt.Errorf("read content file: %w", err)
+	}
+	return string(data), nil
+}
+
+func updateDocsCellContent(ctx context.Context, svc *docs.Service, doc *docs.Document, startIdx, endIdx int64, content, format string, appendOnly bool, prefixBoundary bool, tabID string) error {
+	var requests []*docs.Request
+	if !appendOnly && startIdx < endIdx {
+		requests = append(requests, &docs.Request{
+			DeleteContentRange: &docs.DeleteContentRangeRequest{
+				Range: &docs.Range{StartIndex: startIdx, EndIndex: endIdx, TabId: tabID},
+			},
+		})
+	}
+	if content != "" {
+		if format == docsContentFormatMarkdown {
+			baseIndex := startIdx
+			prefix := ""
+			if prefixBoundary {
+				baseIndex++
+				prefix = "\n"
+			}
+			formatReqs, textToInsert, tables := MarkdownToDocsRequests(ParseMarkdown(content), baseIndex, tabID)
+			if len(tables) > 0 {
+				return usage("markdown tables are not supported inside table cells")
+			}
+			textToInsert = strings.TrimSuffix(textToInsert, "\n")
+			formatReqs = clampDocsCellFormatRequests(formatReqs, baseIndex+utf16Len(textToInsert))
+			if textToInsert != "" {
+				requests = append(requests, &docs.Request{
+					InsertText: &docs.InsertTextRequest{
+						Location: &docs.Location{Index: startIdx, TabId: tabID},
+						Text:     prefix + textToInsert,
+					},
+				})
+				requests = append(requests, formatReqs...)
+			}
+		} else {
+			requests = append(requests, &docs.Request{
+				InsertText: &docs.InsertTextRequest{
+					Location: &docs.Location{Index: startIdx, TabId: tabID},
+					Text:     content,
+				},
+			})
+		}
+	}
+	if len(requests) == 0 {
+		return nil
+	}
+	_, err := svc.Documents.BatchUpdate(doc.DocumentId, &docs.BatchUpdateDocumentRequest{
+		WriteControl: &docs.WriteControl{RequiredRevisionId: doc.RevisionId},
+		Requests:     requests,
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("cell update: %w", err)
+	}
+	return nil
+}
+
+func markdownCellAppendNeedsBoundary(elements []MarkdownElement) bool {
+	if len(elements) != 1 {
+		return len(elements) > 1
+	}
+	switch elements[0].Type {
+	case MDText, MDParagraph:
+		return false
+	default:
+		return true
+	}
+}
+
+func clampDocsCellFormatRequests(requests []*docs.Request, maxEnd int64) []*docs.Request {
+	out := requests[:0]
+	for _, req := range requests {
+		r := docsRequestRange(req)
+		if r == nil {
+			out = append(out, req)
+			continue
+		}
+		if r.EndIndex > maxEnd {
+			r.EndIndex = maxEnd
+		}
+		if r.StartIndex >= r.EndIndex {
+			continue
+		}
+		out = append(out, req)
+	}
+	return out
+}
+
+func docsRequestRange(req *docs.Request) *docs.Range {
+	switch {
+	case req.UpdateTextStyle != nil:
+		return req.UpdateTextStyle.Range
+	case req.UpdateParagraphStyle != nil:
+		return req.UpdateParagraphStyle.Range
+	case req.CreateParagraphBullets != nil:
+		return req.CreateParagraphBullets.Range
+	case req.DeleteParagraphBullets != nil:
+		return req.DeleteParagraphBullets.Range
+	default:
+		return nil
+	}
+}

--- a/internal/cmd/docs_cell_update_test.go
+++ b/internal/cmd/docs_cell_update_test.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsCellUpdate_ReplacesTargetCellOnly(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(cellUpdateTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--table-index", "1", "--row", "1", "--col", "2", "--content", "New", "--format", "plain"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("docs cell-update: %v", err)
+	}
+	if got.WriteControl == nil || got.WriteControl.RequiredRevisionId != "rev1" {
+		t.Fatalf("missing write control: %#v", got.WriteControl)
+	}
+	if len(got.Requests) != 2 {
+		t.Fatalf("expected delete+insert, got %d requests", len(got.Requests))
+	}
+	del := got.Requests[0].DeleteContentRange
+	if del == nil || del.Range.StartIndex != 10 || del.Range.EndIndex != 15 {
+		t.Fatalf("unexpected delete range: %#v", del)
+	}
+	ins := got.Requests[1].InsertText
+	if ins == nil || ins.Location.Index != 10 || ins.Text != "New" {
+		t.Fatalf("unexpected insert: %#v", ins)
+	}
+}
+
+func TestDocsCellUpdate_AppendMarkdownWithTab(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	var includeTabs bool
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			includeTabs = r.URL.Query().Get("includeTabsContent") == "true"
+			_ = json.NewEncoder(w).Encode(cellUpdateTabsTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--tab", "Second", "--row", "1", "--col", "1", "--content", " **bold**", "--append"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("docs cell-update append: %v", err)
+	}
+	if !includeTabs {
+		t.Fatalf("expected tab-aware GET")
+	}
+	if len(got.Requests) < 2 || got.Requests[0].DeleteContentRange != nil {
+		t.Fatalf("append should not delete, requests=%#v", got.Requests)
+	}
+	ins := got.Requests[0].InsertText
+	if ins == nil || ins.Location.Index != 8 || ins.Location.TabId != "t.second" || ins.Text != " bold" {
+		t.Fatalf("unexpected append insert: %#v", ins)
+	}
+	style := got.Requests[1].UpdateTextStyle
+	if style == nil || style.Range.TabId != "t.second" || !style.TextStyle.Bold {
+		t.Fatalf("missing bold style on tab: %#v", style)
+	}
+}
+
+func TestDocsCellUpdate_AppendBlockMarkdownStartsNewParagraph(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(cellUpdateTabsTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--tab", "Second", "--row", "1", "--col", "1", "--content", "# Ready", "--append"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("docs cell-update append heading: %v", err)
+	}
+	if len(got.Requests) < 2 || got.Requests[0].DeleteContentRange != nil {
+		t.Fatalf("append should not delete, requests=%#v", got.Requests)
+	}
+	ins := got.Requests[0].InsertText
+	if ins == nil || ins.Location.Index != 8 || ins.Text != "\nReady" {
+		t.Fatalf("unexpected append insert: %#v", ins)
+	}
+	para := got.Requests[1].UpdateParagraphStyle
+	if para == nil || para.Range.StartIndex != 9 || para.Range.EndIndex != 14 {
+		t.Fatalf("heading style should start after inserted boundary: %#v", para)
+	}
+}
+
+func cellUpdateTestDoc() *docs.Document {
+	return &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev1",
+		Body: &docs.Body{Content: []*docs.StructuralElement{
+			{
+				StartIndex: 1,
+				EndIndex:   20,
+				Table: &docs.Table{TableRows: []*docs.TableRow{
+					{TableCells: []*docs.TableCell{
+						cellUpdateTestCell(5, "Keep\n"),
+						cellUpdateTestCell(10, "Old B\n"),
+					}},
+				}},
+			},
+		}},
+	}
+}
+
+func cellUpdateTabsTestDoc() *docs.Document {
+	tabDoc := cellUpdateTestDoc()
+	tabDoc.Body.Content[0].Table.TableRows[0].TableCells[0] = cellUpdateTestCell(5, "Old\n")
+	return &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev1",
+		Tabs: []*docs.Tab{
+			{
+				TabProperties: &docs.TabProperties{TabId: "t.second", Title: "Second"},
+				DocumentTab:   &docs.DocumentTab{Body: tabDoc.Body},
+			},
+		},
+	}
+}
+
+func cellUpdateTestCell(start int64, text string) *docs.TableCell {
+	end := start + int64(len(text))
+	return &docs.TableCell{Content: []*docs.StructuralElement{
+		{
+			StartIndex: start,
+			EndIndex:   end,
+			Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{
+				{
+					StartIndex: start,
+					EndIndex:   end,
+					TextRun:    &docs.TextRun{Content: text},
+				},
+			}},
+		},
+	}}
+}


### PR DESCRIPTION
## Summary
- add `gog docs cell-update` / `update-cell` for table-cell content replacement by table index, row, and column
- support plain or markdown content, `--content-file`, `--append`, and tab targeting
- document the command and regenerate command reference pages

Fixes #646.

## Testing
- `go test ./internal/cmd -run 'TestDocsCellUpdate'`
- `go test ./internal/cmd -run 'TestDocsCellUpdate|TestDocsFindReplace|TestDocsInsertTable'`
- `make test`
- `make lint`
- `make docs-check`
- `autoreview --mode local` clean after addressing one accepted finding
- Live clawdbot e2e: created a disposable Doc with link paragraphs and a table, ran `docs cell-update` on one table cell, exported Markdown, verified both external links were preserved, verified the target cell changed to Ready and old text was removed, then trashed the Doc
