### PR TITLE
fix(youtube): honor account auth for list reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Docs: preserve paragraph-separating blank lines when replacing a single tab from Markdown. (#644)
 - Docs: add `docs cell-update` for non-destructive table-cell content replacement by table, row, and column. (#646)
 - Gmail: pause watch push Gmail API fetches per account while a 429 Retry-After circuit is open. (#643)
+- YouTube: let `videos list` and `comments list` use OAuth when `--account` is supplied, preserving the API-key fallback for unauthenticated public reads. (#664)
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 
 ## 0.19.0 - 2026-05-22

--- a/internal/cmd/youtube.go
+++ b/internal/cmd/youtube.go
@@ -8,9 +8,12 @@ import (
 
 	youtube "google.golang.org/api/youtube/v3"
 
+	"github.com/steipete/gogcli/internal/errfmt"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
+
+const youtubeCommentsOAuthScope = "https://www.googleapis.com/auth/youtube.force-ssl"
 
 type YouTubeCmd struct {
 	Activities YouTubeActivitiesCmd `cmd:"" name:"activities" aliases:"activity" help:"List channel activities"`
@@ -133,7 +136,7 @@ func (c *YouTubeVideosListCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return usage("--chart mostPopular requires --region (e.g. US)")
 	}
 
-	svc, err := getYouTubeServiceWithAPIKey(ctx)
+	svc, err := getYouTubeReadService(ctx, flags)
 	if err != nil {
 		return err
 	}
@@ -289,7 +292,7 @@ func (c *YouTubeCommentsListCmd) Run(ctx context.Context, flags *RootFlags) erro
 		return usage("use either --video-id or --channel-id, not both")
 	}
 
-	svc, err := getYouTubeServiceWithAPIKey(ctx)
+	svc, err := getYouTubeCommentsService(ctx, flags)
 	if err != nil {
 		return err
 	}
@@ -304,7 +307,7 @@ func (c *YouTubeCommentsListCmd) Run(ctx context.Context, flags *RootFlags) erro
 	}
 	resp, err := call.Do()
 	if err != nil {
-		return err
+		return wrapYouTubeCommentsError(err, flags)
 	}
 
 	if outfmt.IsJSON(ctx) {
@@ -433,4 +436,53 @@ func validateYouTubeMax(limit int64) error {
 		return usage("--max must be between 1 and 50")
 	}
 	return nil
+}
+
+func getYouTubeReadService(ctx context.Context, flags *RootFlags) (*youtube.Service, error) {
+	if youtubeAccountSelectorPresent(flags) {
+		account, err := requireAccount(flags)
+		if err != nil {
+			return nil, err
+		}
+		return getYouTubeServiceForAccount(ctx, account)
+	}
+	return getYouTubeServiceWithAPIKey(ctx)
+}
+
+func getYouTubeCommentsService(ctx context.Context, flags *RootFlags) (*youtube.Service, error) {
+	if youtubeAccountSelectorPresent(flags) {
+		account, err := requireAccount(flags)
+		if err != nil {
+			return nil, err
+		}
+		return getYouTubeCommentsServiceForAccount(ctx, account)
+	}
+	return getYouTubeServiceWithAPIKey(ctx)
+}
+
+func youtubeAccountSelectorPresent(flags *RootFlags) bool {
+	return flagAccount(flags) != "" || strings.TrimSpace(os.Getenv("GOG_ACCOUNT")) != "" || hasDirectAccessToken(flags)
+}
+
+func wrapYouTubeCommentsError(err error, flags *RootFlags) error {
+	if err == nil {
+		return nil
+	}
+	errText := err.Error()
+	if !strings.Contains(errText, "insufficientPermissions") &&
+		!strings.Contains(errText, "insufficient authentication scopes") &&
+		!strings.Contains(errText, "ACCESS_TOKEN_SCOPE_INSUFFICIENT") {
+		return err
+	}
+	if !youtubeAccountSelectorPresent(flags) {
+		return err
+	}
+	account, accountErr := requireAccount(flags)
+	if accountErr != nil {
+		return err
+	}
+	return errfmt.NewUserFacingError(
+		fmt.Sprintf("youtube comments OAuth requires %s; re-authenticate with: gog auth add %s --services youtube --extra-scopes %s --force-consent", youtubeCommentsOAuthScope, account, youtubeCommentsOAuthScope),
+		err,
+	)
 }

--- a/internal/cmd/youtube_services.go
+++ b/internal/cmd/youtube_services.go
@@ -10,8 +10,9 @@ import (
 )
 
 var (
-	newYouTubeWithAPIKey = googleapi.NewYouTubeWithAPIKey
-	newYouTubeForAccount = googleapi.NewYouTubeForAccount
+	newYouTubeWithAPIKey         = googleapi.NewYouTubeWithAPIKey
+	newYouTubeForAccount         = googleapi.NewYouTubeForAccount
+	newYouTubeCommentsForAccount = googleapi.NewYouTubeCommentsForAccount
 )
 
 func getYouTubeAPIKey() (string, error) {
@@ -36,4 +37,8 @@ func getYouTubeServiceWithAPIKey(ctx context.Context) (*youtube.Service, error) 
 
 func getYouTubeServiceForAccount(ctx context.Context, account string) (*youtube.Service, error) {
 	return newYouTubeForAccount(ctx, account)
+}
+
+func getYouTubeCommentsServiceForAccount(ctx context.Context, account string) (*youtube.Service, error) {
+	return newYouTubeCommentsForAccount(ctx, account)
 }

--- a/internal/cmd/youtube_test.go
+++ b/internal/cmd/youtube_test.go
@@ -4,12 +4,15 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	youtube "google.golang.org/api/youtube/v3"
+
+	"github.com/steipete/gogcli/internal/secrets"
 )
 
 func TestYouTubeChannelsListWithAPIKey(t *testing.T) {
@@ -98,6 +101,125 @@ func TestYouTubeMineUsesOAuthService(t *testing.T) {
 		t.Fatalf("runKong: %v", err)
 	}
 	if gotAccount != "me@example.com" {
+		t.Fatalf("account = %q", gotAccount)
+	}
+}
+
+func TestYouTubeVideosListWithAccountUsesOAuthService(t *testing.T) {
+	origOAuth := newYouTubeForAccount
+	origAPIKey := newYouTubeWithAPIKey
+	t.Cleanup(func() {
+		newYouTubeForAccount = origOAuth
+		newYouTubeWithAPIKey = origAPIKey
+	})
+
+	var gotAccount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/youtube/v3/videos" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("id"); got != "dQw4w9WgXcQ" {
+			t.Fatalf("id = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	newYouTubeForAccount = func(_ context.Context, account string) (*youtube.Service, error) {
+		gotAccount = account
+		return svc, nil
+	}
+	newYouTubeWithAPIKey = func(context.Context, string) (*youtube.Service, error) {
+		t.Fatal("API key service should not be used when account is configured")
+		return nil, errors.New("unexpected API key service")
+	}
+
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "dQw4w9WgXcQ", "--max", "1"}, newQuietUIContext(t), &RootFlags{Account: "me@example.com"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	if gotAccount != "me@example.com" {
+		t.Fatalf("account = %q", gotAccount)
+	}
+}
+
+func TestYouTubeCommentsListWithAccountUsesOAuthService(t *testing.T) {
+	origOAuth := newYouTubeCommentsForAccount
+	origAPIKey := newYouTubeWithAPIKey
+	t.Cleanup(func() {
+		newYouTubeCommentsForAccount = origOAuth
+		newYouTubeWithAPIKey = origAPIKey
+	})
+
+	var gotAccount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/youtube/v3/commentThreads" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("videoId"); got != "dQw4w9WgXcQ" {
+			t.Fatalf("videoId = %q", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	newYouTubeCommentsForAccount = func(_ context.Context, account string) (*youtube.Service, error) {
+		gotAccount = account
+		return svc, nil
+	}
+	newYouTubeWithAPIKey = func(context.Context, string) (*youtube.Service, error) {
+		t.Fatal("API key service should not be used when account is configured")
+		return nil, errors.New("unexpected API key service")
+	}
+
+	err := runKong(t, &YouTubeCommentsListCmd{}, []string{"--video-id", "dQw4w9WgXcQ", "--max", "1"}, newQuietUIContext(t), &RootFlags{Account: "me@example.com"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	if gotAccount != "me@example.com" {
+		t.Fatalf("account = %q", gotAccount)
+	}
+}
+
+func TestYouTubeVideosListWithAutoAccountUsesOAuthService(t *testing.T) {
+	origOAuth := newYouTubeForAccount
+	origAPIKey := newYouTubeWithAPIKey
+	origStore := openSecretsStoreForAccount
+	t.Cleanup(func() {
+		newYouTubeForAccount = origOAuth
+		newYouTubeWithAPIKey = origAPIKey
+		openSecretsStoreForAccount = origStore
+	})
+	openSecretsStoreForAccount = func() (secrets.Store, error) {
+		return &fakeSecretsStore{defaultAccount: "default@example.com"}, nil
+	}
+
+	var gotAccount string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/youtube/v3/videos" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	newYouTubeForAccount = func(_ context.Context, account string) (*youtube.Service, error) {
+		gotAccount = account
+		return svc, nil
+	}
+	newYouTubeWithAPIKey = func(context.Context, string) (*youtube.Service, error) {
+		t.Fatal("API key service should not be used when --account auto is configured")
+		return nil, errors.New("unexpected API key service")
+	}
+
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "dQw4w9WgXcQ", "--max", "1"}, newQuietUIContext(t), &RootFlags{Account: "auto"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	if gotAccount != "default@example.com" {
 		t.Fatalf("account = %q", gotAccount)
 	}
 }

--- a/internal/googleapi/youtube.go
+++ b/internal/googleapi/youtube.go
@@ -15,6 +15,8 @@ import (
 
 var errYouTubeAPIKeyRequired = errors.New("youtube: API key required (config set youtube_api_key KEY or GOG_YOUTUBE_API_KEY)")
 
+const scopeYouTubeForceSSL = "https://www.googleapis.com/auth/youtube.force-ssl"
+
 // NewYouTubeWithAPIKey creates a YouTube Data API v3 service client using an API key.
 // Use for public data: list by channelId, videoId, playlistId, etc.
 // API key can be set via config (youtube_api_key) or GOG_YOUTUBE_API_KEY.
@@ -56,6 +58,22 @@ func NewYouTubeForAccount(ctx context.Context, email string) (*youtube.Service, 
 	svc, err := youtube.NewService(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("youtube service for account: %w", err)
+	}
+
+	return svc, nil
+}
+
+// NewYouTubeCommentsForAccount creates a YouTube Data API v3 client for comment reads.
+// Google requires youtube.force-ssl for commentThreads.list; youtube.readonly is insufficient.
+func NewYouTubeCommentsForAccount(ctx context.Context, email string) (*youtube.Service, error) {
+	opts, err := optionsForAccountScopes(ctx, string(googleauth.ServiceYouTube), email, []string{scopeYouTubeForceSSL})
+	if err != nil {
+		return nil, fmt.Errorf("youtube comments OAuth options: %w", err)
+	}
+
+	svc, err := youtube.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("youtube comments service for account: %w", err)
 	}
 
 	return svc, nil


### PR DESCRIPTION
## Summary
- honor configured YouTube OAuth accounts for `youtube videos list` and `youtube comments list`
- keep the existing API-key fallback when no account selector is supplied
- route `comments list` through the Google-required `youtube.force-ssl` scope and surface a reauth hint when the stored token lacks it

Closes #664.

## Tests
- `go test ./internal/cmd -run 'TestYouTube'`
- `go test ./internal/cmd ./internal/googleapi -run 'TestYouTube'`
- `make ci`
- autoreview: `/Users/steipete/Projects/agent-scripts/skills/autoreview/scripts/autoreview --mode local --parallel-tests "make ci"` clean

## Live proof
- `clawdbot@gmail.com`, with `GOG_YOUTUBE_API_KEY=definitely-invalid`: `yt videos list --id dQw4w9WgXcQ --max 1` returned one video via OAuth.
- `clawdbot@gmail.com`, comments path: reached OAuth and now returns the new `youtube.force-ssl` reauth hint because the stored token lacks that scope.
