### PR TITLE
feat(docs): add document shaping helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
 - Gmail: pause watch push Gmail API fetches per account while a 429 Retry-After circuit is open. (#643)
 - YouTube: let `videos list` and `comments list` use OAuth when `--account` is supplied, preserving the API-key fallback for unauthenticated public reads. (#664)
 - YouTube: add `youtube search list` / `yt search ls` for YouTube Data API search across videos, channels, and playlists. (#650, #651) — thanks @BRO3886.
+- Gmail: add `gmail search --from-contact` to resolve a contact's email addresses into a `from:(...)` OR query. (#657) — thanks @chrischall.
+- Docs: add named `--page-size` presets for `docs write` and `docs page-layout`. (#640) — thanks @sebsnyk.
+- Docs: add smart-chip insertion commands for person, Drive file, and date chips. (#638) — thanks @sebsnyk.
+- Docs: add `docs cell-style` for table-cell background color and inline cell text styling. (#645) — thanks @sebsnyk.
+- Docs: add `docs insert-image` to upload a local image, temporarily share it for Docs insertion, and revoke the public permission afterward. (#648) — thanks @sebsnyk.
 - Docs: update the bundled `gog` agent skill to preserve broad user OAuth scopes during reauth and rely on command guards for scoped execution.
 
 ## 0.19.0 - 2026-05-22

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -220,6 +220,7 @@ Generated from `gog schema --json`.
   - [`gog docs (doc) <command> [flags]`](commands/gog-docs.md) - Google Docs (export via Drive)
     - [`gog docs (doc) add-tab <docId> [flags]`](commands/gog-docs-add-tab.md) - Add a tab to a Google Doc
     - [`gog docs (doc) cat (text,read) <docId> [flags]`](commands/gog-docs-cat.md) - Print a Google Doc as plain text
+    - [`gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]`](commands/gog-docs-cell-style.md) - Apply table cell background and text styling
     - [`gog docs (doc) cell-update (update-cell) --row=INT --col=INT <docId> [flags]`](commands/gog-docs-cell-update.md) - Replace or append content inside a specific table cell
     - [`gog docs (doc) clear <docId>`](commands/gog-docs-clear.md) - Clear all content from a Google Doc
     - [`gog docs (doc) comments <command>`](commands/gog-docs-comments.md) - Manage comments on files
@@ -240,7 +241,11 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) format <docId> [flags]`](commands/gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
     - [`gog docs (doc) info (get,show) <docId>`](commands/gog-docs-info.md) - Get Google Doc metadata
     - [`gog docs (doc) insert <docId> [<content>] [flags]`](commands/gog-docs-insert.md) - Insert text at a specific position
+    - [`gog docs (doc) insert-date-chip --date=STRING <docId> [flags]`](commands/gog-docs-insert-date-chip.md) - Insert a native date smart chip
+    - [`gog docs (doc) insert-file-chip (insert-rich-link) --file-id=STRING <docId> [flags]`](commands/gog-docs-insert-file-chip.md) - Insert a native Drive file smart chip
+    - [`gog docs (doc) insert-image --file=STRING <docId> [flags]`](commands/gog-docs-insert-image.md) - Upload a local image and insert it into a Google Doc
     - [`gog docs (doc) insert-page-break (page-break,pb) <docId> [flags]`](commands/gog-docs-insert-page-break.md) - Insert a page break at a specific position (or end-of-doc with --at-end)
+    - [`gog docs (doc) insert-person --email=STRING <docId> [flags]`](commands/gog-docs-insert-person.md) - Insert a native person smart chip
     - [`gog docs (doc) insert-table --rows=INT --cols=INT <docId> [flags]`](commands/gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [`gog docs (doc) list-tabs <docId>`](commands/gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [`gog docs (doc) page-layout (set-page-layout,page-setup) <docId> [flags]`](commands/gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 576.
+Generated pages: 581.
 
 ## Top-level Commands
 
@@ -271,6 +271,7 @@ Generated pages: 576.
   - [gog docs](gog-docs.md) - Google Docs (export via Drive)
     - [gog docs add-tab](gog-docs-add-tab.md) - Add a tab to a Google Doc
     - [gog docs cat](gog-docs-cat.md) - Print a Google Doc as plain text
+    - [gog docs cell-style](gog-docs-cell-style.md) - Apply table cell background and text styling
     - [gog docs cell-update](gog-docs-cell-update.md) - Replace or append content inside a specific table cell
     - [gog docs clear](gog-docs-clear.md) - Clear all content from a Google Doc
     - [gog docs comments](gog-docs-comments.md) - Manage comments on files
@@ -291,7 +292,11 @@ Generated pages: 576.
     - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
     - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
     - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
+    - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
+    - [gog docs insert-file-chip](gog-docs-insert-file-chip.md) - Insert a native Drive file smart chip
+    - [gog docs insert-image](gog-docs-insert-image.md) - Upload a local image and insert it into a Google Doc
     - [gog docs insert-page-break](gog-docs-insert-page-break.md) - Insert a page break at a specific position (or end-of-doc with --at-end)
+    - [gog docs insert-person](gog-docs-insert-person.md) - Insert a native person smart chip
     - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc

--- a/docs/commands/gog-docs-cell-style.md
+++ b/docs/commands/gog-docs-cell-style.md
@@ -1,18 +1,18 @@
-# `gog gmail search`
+# `gog docs cell-style`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Search threads using Gmail query syntax
+Apply table cell background and text styling
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
+gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 ```
 
 ## Parent
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 
 ## Flags
 
@@ -20,34 +20,37 @@ gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
-| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
+| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
+| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int` |  | 0-based column number |
+| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no results |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--from-contact` | `string` |  | Resolve a Google Contact and add from:(email OR email) to the Gmail query |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--local` | `bool` |  | Use local timezone (default behavior, useful to override --timezone) |
-| `--max`<br>`--limit` | `int64` | 10 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--oldest` | `bool` |  | Show first message date instead of last |
-| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int` |  | 0-based row number |
+| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `-z`<br>`--timezone` | `string` |  | Output timezone (IANA name, e.g. America/New_York, UTC). Default: local |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table-index` | `int` | 0 | 0-based table index in document order |
+| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
+| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-insert-date-chip.md
+++ b/docs/commands/gog-docs-insert-date-chip.md
@@ -1,18 +1,18 @@
-# `gog gmail search`
+# `gog docs insert-date-chip`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Search threads using Gmail query syntax
+Insert a native date smart chip
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
+gog docs (doc) insert-date-chip --date=STRING <docId> [flags]
 ```
 
 ## Parent
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 
 ## Flags
 
@@ -20,34 +20,31 @@ gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
-| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
+| `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--date` | `string` |  | Date to insert as YYYY-MM-DD |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no results |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--from-contact` | `string` |  | Resolve a Google Contact and add from:(email OR email) to the Gmail query |
+| `--format` | `string` | abbreviated | Date display format: abbreviated\|full\|iso |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index to insert at. Omit or use --at-end for end-of-doc. |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--local` | `bool` |  | Use local timezone (default behavior, useful to override --timezone) |
-| `--max`<br>`--limit` | `int64` | 10 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--oldest` | `bool` |  | Show first message date instead of last |
-| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `-z`<br>`--timezone` | `string` |  | Output timezone (IANA name, e.g. America/New_York, UTC). Default: local |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-insert-file-chip.md
+++ b/docs/commands/gog-docs-insert-file-chip.md
@@ -1,18 +1,18 @@
-# `gog gmail search`
+# `gog docs insert-file-chip`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Search threads using Gmail query syntax
+Insert a native Drive file smart chip
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
+gog docs (doc) insert-file-chip (insert-rich-link) --file-id=STRING <docId> [flags]
 ```
 
 ## Parent
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 
 ## Flags
 
@@ -20,34 +20,30 @@ gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
-| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
+| `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no results |
+| `--file-id` | `string` |  | Drive file ID to insert as a smart chip |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--from-contact` | `string` |  | Resolve a Google Contact and add from:(email OR email) to the Gmail query |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index to insert at. Omit or use --at-end for end-of-doc. |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--local` | `bool` |  | Use local timezone (default behavior, useful to override --timezone) |
-| `--max`<br>`--limit` | `int64` | 10 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--oldest` | `bool` |  | Show first message date instead of last |
-| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `-z`<br>`--timezone` | `string` |  | Output timezone (IANA name, e.g. America/New_York, UTC). Default: local |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-insert-image.md
+++ b/docs/commands/gog-docs-insert-image.md
@@ -1,18 +1,18 @@
-# `gog gmail search`
+# `gog docs insert-image`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Search threads using Gmail query syntax
+Upload a local image and insert it into a Google Doc
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
+gog docs (doc) insert-image --file=STRING <docId> [flags]
 ```
 
 ## Parent
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 
 ## Flags
 
@@ -20,34 +20,34 @@ gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
-| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
+| `--at` | `string` | end | Placeholder text to replace, or 'end' to append |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no results |
+| `--file` | `string` |  | Local PNG, JPEG, or GIF image to upload and insert |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--from-contact` | `string` |  | Resolve a Google Contact and add from:(email OR email) to the Gmail query |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `--height` | `float64` |  | Image height in points (optional; width-only preserves aspect ratio) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--local` | `bool` |  | Use local timezone (default behavior, useful to override --timezone) |
-| `--max`<br>`--limit` | `int64` | 10 | Max results |
+| `--name` | `string` |  | Override uploaded Drive filename |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--oldest` | `bool` |  | Show first message date instead of last |
-| `--page`<br>`--cursor` | `string` |  | Page token |
+| `--on-restricted` | `string` | error | If public sharing is blocked: error\|link |
+| `--parent` | `string` |  | Drive folder ID for the uploaded image |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `-z`<br>`--timezone` | `string` |  | Output timezone (IANA name, e.g. America/New_York, UTC). Default: local |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--width` | `float64` | 468 | Image width in points; default 468pt |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-insert-person.md
+++ b/docs/commands/gog-docs-insert-person.md
@@ -1,18 +1,18 @@
-# `gog gmail search`
+# `gog docs insert-person`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Search threads using Gmail query syntax
+Insert a native person smart chip
 
 ## Usage
 
 ```bash
-gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
+gog docs (doc) insert-person --email=STRING <docId> [flags]
 ```
 
 ## Parent
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 
 ## Flags
 
@@ -20,34 +20,30 @@ gog gmail (mail,email) search (find,query,ls,list) <query> ... [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/ads/photos) |
-| `--all`<br>`--all-pages`<br>`--allpages` | `bool` |  | Fetch all pages |
+| `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--email` | `string` |  | Email address for the person chip |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no results |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--from-contact` | `string` |  | Resolve a Google Contact and add from:(email OR email) to the Gmail query |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index to insert at. Omit or use --at-end for end-of-doc. |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--local` | `bool` |  | Use local timezone (default behavior, useful to override --timezone) |
-| `--max`<br>`--limit` | `int64` | 10 | Max results |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--oldest` | `bool` |  | Show first message date instead of last |
-| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `-z`<br>`--timezone` | `string` |  | Output timezone (IANA name, e.g. America/New_York, UTC). Default: local |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog gmail](gog-gmail.md)
+- [gog docs](gog-docs.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-page-layout.md
+++ b/docs/commands/gog-docs-page-layout.md
@@ -38,6 +38,7 @@ gog docs (doc) page-layout (set-page-layout,page-setup) <docId> [flags]
 | `--margin-top` | `string` |  | Set top page margin (points by default; supports pt, in, cm, mm) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `--page-height` | `string` |  | Set page height (points by default; supports pt, in, cm, mm) |
+| `--page-size` | `string` |  | Named page size: A4, A5, Letter, Legal, Tabloid |
 | `--page-width` | `string` |  | Set page width (points by default; supports pt, in, cm, mm) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |

--- a/docs/commands/gog-docs-write.md
+++ b/docs/commands/gog-docs-write.md
@@ -53,6 +53,7 @@ gog docs (doc) write <docId> [flags]
 | `--no-strikethrough`<br>`--no-strike` | `bool` |  | Clear strikethrough |
 | `--no-underline` | `bool` |  | Clear underline |
 | `--page-height` | `string` |  | Set page height (points by default; supports pt, in, cm, mm) |
+| `--page-size` | `string` |  | Named page size: A4, A5, Letter, Legal, Tabloid |
 | `--page-width` | `string` |  | Set page width (points by default; supports pt, in, cm, mm) |
 | `--pageless` | `bool` |  | Set document to pageless mode |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -18,6 +18,7 @@ gog docs (doc) <command> [flags]
 
 - [gog docs add-tab](gog-docs-add-tab.md) - Add a tab to a Google Doc
 - [gog docs cat](gog-docs-cat.md) - Print a Google Doc as plain text
+- [gog docs cell-style](gog-docs-cell-style.md) - Apply table cell background and text styling
 - [gog docs cell-update](gog-docs-cell-update.md) - Replace or append content inside a specific table cell
 - [gog docs clear](gog-docs-clear.md) - Clear all content from a Google Doc
 - [gog docs comments](gog-docs-comments.md) - Manage comments on files
@@ -31,7 +32,11 @@ gog docs (doc) <command> [flags]
 - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
 - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
 - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
+- [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
+- [gog docs insert-file-chip](gog-docs-insert-file-chip.md) - Insert a native Drive file smart chip
+- [gog docs insert-image](gog-docs-insert-image.md) - Upload a local image and insert it into a Google Doc
 - [gog docs insert-page-break](gog-docs-insert-page-break.md) - Insert a page break at a specific position (or end-of-doc with --at-end)
+- [gog docs insert-person](gog-docs-insert-person.md) - Insert a native person smart chip
 - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
 - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
 - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -33,6 +33,11 @@ type DocsCmd struct {
 	Insert          DocsInsertCmd          `cmd:"" name:"insert" help:"Insert text at a specific position"`
 	InsertTable     DocsInsertTableCmd     `cmd:"" name:"insert-table" help:"Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json"`
 	CellUpdate      DocsCellUpdateCmd      `cmd:"" name:"cell-update" aliases:"update-cell" help:"Replace or append content inside a specific table cell"`
+	CellStyle       DocsCellStyleCmd       `cmd:"" name:"cell-style" help:"Apply table cell background and text styling"`
+	InsertImage     DocsInsertImageCmd     `cmd:"" name:"insert-image" help:"Upload a local image and insert it into a Google Doc"`
+	InsertPerson    DocsInsertPersonCmd    `cmd:"" name:"insert-person" help:"Insert a native person smart chip"`
+	InsertFileChip  DocsInsertFileChipCmd  `cmd:"" name:"insert-file-chip" aliases:"insert-rich-link" help:"Insert a native Drive file smart chip"`
+	InsertDateChip  DocsInsertDateChipCmd  `cmd:"" name:"insert-date-chip" help:"Insert a native date smart chip"`
 	InsertPageBreak DocsInsertPageBreakCmd `cmd:"" name:"insert-page-break" aliases:"page-break,pb" help:"Insert a page break at a specific position (or end-of-doc with --at-end)"`
 	Delete          DocsDeleteCmd          `cmd:"" name:"delete" help:"Delete text range from document"`
 	FindReplace     DocsFindReplaceCmd     `cmd:"" name:"find-replace" help:"Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence."`

--- a/internal/cmd/docs_cell_style.go
+++ b/internal/cmd/docs_cell_style.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsCellStyleCmd struct {
+	DocID           string `arg:"" name:"docId" help:"Doc ID"`
+	TableIndex      int    `name:"table-index" help:"0-based table index in document order" default:"0"`
+	Row             int    `name:"row" required:"" help:"0-based row number"`
+	Col             int    `name:"col" required:"" help:"0-based column number"`
+	RowSpan         int64  `name:"row-span" help:"Number of rows to style" default:"1"`
+	ColSpan         int64  `name:"col-span" help:"Number of columns to style" default:"1"`
+	BackgroundColor string `name:"background-color" aliases:"bg-color" help:"Cell background color as #RRGGBB or #RGB"`
+	TextColor       string `name:"text-color" help:"Text color as #RRGGBB or #RGB"`
+	Bold            bool   `name:"bold" help:"Set cell text bold"`
+	Italic          bool   `name:"italic" help:"Set cell text italic"`
+	Underline       bool   `name:"underline" help:"Set cell text underline"`
+	Tab             string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := strings.TrimSpace(c.DocID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if c.TableIndex < 0 {
+		return usage("--table-index must be >= 0")
+	}
+	if c.Row < 0 {
+		return usage("--row must be >= 0")
+	}
+	if c.Col < 0 {
+		return usage("--col must be >= 0")
+	}
+	if c.RowSpan < 1 || c.ColSpan < 1 {
+		return usage("--row-span and --col-span must be >= 1")
+	}
+	if !c.anyStyle() {
+		return usage("no style flags provided")
+	}
+	if c.hasTextStyle() && (c.RowSpan != 1 || c.ColSpan != 1) {
+		return usage("--row-span/--col-span can only be combined with --background-color; text style flags target one cell")
+	}
+	if err := dryRunExit(ctx, flags, "docs.cell-style", map[string]any{
+		"documentId":      docID,
+		"tableIndex":      c.TableIndex,
+		"row":             c.Row,
+		"col":             c.Col,
+		"rowSpan":         c.RowSpan,
+		"colSpan":         c.ColSpan,
+		"backgroundColor": c.BackgroundColor,
+		"textColor":       c.TextColor,
+		"bold":            c.Bold,
+		"italic":          c.Italic,
+		"underline":       c.Underline,
+		"tab":             c.Tab,
+	}); err != nil {
+		return err
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, c.Tab)
+	if err != nil {
+		return err
+	}
+	c.Tab = loaded.tabID
+
+	tables := collectAllTablesWithIndex(loaded.target)
+	if len(tables) == 0 {
+		return fmt.Errorf("document has no tables")
+	}
+	if c.TableIndex >= len(tables) {
+		return fmt.Errorf("table %d out of range (document has %d tables)", c.TableIndex, len(tables))
+	}
+	table := tables[c.TableIndex]
+	cell, err := findTableCell(loaded.target, &tableCellRef{
+		tableIndex: c.TableIndex + 1,
+		row:        c.Row + 1,
+		col:        c.Col + 1,
+	})
+	if err != nil {
+		return err
+	}
+	reqs, err := c.buildRequests(table.startIdx, cell, c.Tab)
+	if err != nil {
+		return err
+	}
+	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		WriteControl: &docs.WriteControl{RequiredRevisionId: loaded.full.RevisionId},
+		Requests:     reqs,
+	}).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return fmt.Errorf("cell style: %w", err)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": resp.DocumentId,
+			"tableIndex": c.TableIndex,
+			"row":        c.Row,
+			"col":        c.Col,
+			"requests":   len(reqs),
+			"updated":    true,
+		}
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+	u.Out().Linef("documentId\t%s", resp.DocumentId)
+	u.Out().Linef("table_index\t%d", c.TableIndex)
+	u.Out().Linef("row\t%d", c.Row)
+	u.Out().Linef("col\t%d", c.Col)
+	u.Out().Linef("requests\t%d", len(reqs))
+	u.Out().Linef("updated\ttrue")
+	if c.Tab != "" {
+		u.Out().Linef("tabId\t%s", c.Tab)
+	}
+	return nil
+}
+
+func (c *DocsCellStyleCmd) anyStyle() bool {
+	return strings.TrimSpace(c.BackgroundColor) != "" ||
+		strings.TrimSpace(c.TextColor) != "" ||
+		c.Bold || c.Italic || c.Underline
+}
+
+func (c *DocsCellStyleCmd) hasTextStyle() bool {
+	return strings.TrimSpace(c.TextColor) != "" || c.Bold || c.Italic || c.Underline
+}
+
+func (c *DocsCellStyleCmd) buildRequests(tableStart int64, cell *docs.TableCell, tabID string) ([]*docs.Request, error) {
+	reqs := make([]*docs.Request, 0, 2)
+	if bg := strings.TrimSpace(c.BackgroundColor); bg != "" {
+		color, err := docsFormatColor(bg, "--background-color")
+		if err != nil {
+			return nil, err
+		}
+		reqs = append(reqs, &docs.Request{UpdateTableCellStyle: &docs.UpdateTableCellStyleRequest{
+			TableCellStyle: &docs.TableCellStyle{BackgroundColor: color},
+			Fields:         "backgroundColor",
+			TableRange: &docs.TableRange{
+				RowSpan:    c.RowSpan,
+				ColumnSpan: c.ColSpan,
+				TableCellLocation: &docs.TableCellLocation{
+					RowIndex:    int64(c.Row),
+					ColumnIndex: int64(c.Col),
+					TableStartLocation: &docs.Location{
+						Index: tableStart,
+						TabId: tabID,
+					},
+					ForceSendFields: []string{"RowIndex", "ColumnIndex"},
+				},
+			},
+		}})
+	}
+
+	textReq, ok, err := c.buildTextStyleRequest(cell, tabID)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		reqs = append(reqs, textReq)
+	}
+	if len(reqs) == 0 {
+		return nil, usage("no style flags provided")
+	}
+	return reqs, nil
+}
+
+func (c *DocsCellStyleCmd) buildTextStyleRequest(cell *docs.TableCell, tabID string) (*docs.Request, bool, error) {
+	style := &docs.TextStyle{}
+	fields := []string{}
+	if color := strings.TrimSpace(c.TextColor); color != "" {
+		optionalColor, err := docsFormatColor(color, "--text-color")
+		if err != nil {
+			return nil, false, err
+		}
+		style.ForegroundColor = optionalColor
+		fields = append(fields, "foregroundColor")
+	}
+	if c.Bold {
+		style.Bold = true
+		fields = append(fields, "bold")
+	}
+	if c.Italic {
+		style.Italic = true
+		fields = append(fields, "italic")
+	}
+	if c.Underline {
+		style.Underline = true
+		fields = append(fields, "underline")
+	}
+	if len(fields) == 0 {
+		return nil, false, nil
+	}
+	cellText, startIdx, endIdx := getCellText(cell)
+	if startIdx <= 0 || endIdx <= startIdx {
+		return nil, false, fmt.Errorf("target cell has no editable text range")
+	}
+	if strings.HasSuffix(cellText, "\n") {
+		endIdx--
+	}
+	if endIdx <= startIdx {
+		return nil, false, fmt.Errorf("target cell has no editable text")
+	}
+	return &docs.Request{UpdateTextStyle: &docs.UpdateTextStyleRequest{
+		Range:     &docs.Range{StartIndex: startIdx, EndIndex: endIdx, TabId: tabID},
+		TextStyle: style,
+		Fields:    strings.Join(fields, ","),
+	}}, true, nil
+}

--- a/internal/cmd/docs_insert_image.go
+++ b/internal/cmd/docs_insert_image.go
@@ -1,0 +1,321 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+	gapi "google.golang.org/api/googleapi"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsInsertImageCmd struct {
+	DocID        string  `arg:"" name:"docId" help:"Doc ID"`
+	File         string  `name:"file" required:"" help:"Local PNG, JPEG, or GIF image to upload and insert" type:"existingfile"`
+	At           string  `name:"at" help:"Placeholder text to replace, or 'end' to append" default:"end"`
+	Width        float64 `name:"width" help:"Image width in points; default 468pt" default:"468"`
+	Height       float64 `name:"height" help:"Image height in points (optional; width-only preserves aspect ratio)"`
+	Parent       string  `name:"parent" help:"Drive folder ID for the uploaded image"`
+	Name         string  `name:"name" help:"Override uploaded Drive filename"`
+	OnRestricted string  `name:"on-restricted" help:"If public sharing is blocked: error|link" default:"error" enum:"error,link"`
+	Tab          string  `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type docsInsertImageResult struct {
+	documentID       string
+	uploadedFileID   string
+	uploadedFileName string
+	permissionID     string
+	atIndex          int64
+	tabID            string
+	requests         int
+	revoked          bool
+	fallbackLink     bool
+}
+
+func (c *DocsInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := strings.TrimSpace(c.DocID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if c.Width < 0 || c.Height < 0 {
+		return usage("--width and --height must be non-negative")
+	}
+	localPath, err := config.ExpandPath(c.File)
+	if err != nil {
+		return err
+	}
+	mimeType := guessMimeType(localPath)
+	if !isDocsInsertImageMime(mimeType) {
+		return usage("--file must be a PNG, JPEG, or GIF image")
+	}
+	name := strings.TrimSpace(c.Name)
+	if name == "" {
+		name = filepath.Base(localPath)
+	}
+	at := strings.TrimSpace(c.At)
+	if at == "" {
+		return usage("empty --at")
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.insert-image", map[string]any{
+		"documentId":   docID,
+		"file":         localPath,
+		"name":         name,
+		"mimeType":     mimeType,
+		"at":           at,
+		"width":        c.Width,
+		"height":       c.Height,
+		"parent":       c.Parent,
+		"onRestricted": c.OnRestricted,
+		"tab":          c.Tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+	if confirmErr := confirmDestructiveChecked(ctx, flagsWithoutDryRun(flags), fmt.Sprintf("temporarily share uploaded image %s with anyone (public) so Google Docs can fetch it", name)); confirmErr != nil {
+		return confirmErr
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	docsSvc, err := newDocsService(ctx, account)
+	if err != nil {
+		return err
+	}
+	driveSvc, err := newDriveService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	result, err := c.run(ctx, docsSvc, driveSvc, docID, localPath, name, mimeType, at)
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId":       result.documentID,
+			"uploadedFileId":   result.uploadedFileID,
+			"uploadedFileName": result.uploadedFileName,
+			"permissionId":     result.permissionID,
+			"atIndex":          result.atIndex,
+			"requests":         result.requests,
+			"revoked":          result.revoked,
+			"fallbackLink":     result.fallbackLink,
+		}
+		if result.tabID != "" {
+			payload["tabId"] = result.tabID
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+	u.Out().Linef("documentId\t%s", result.documentID)
+	u.Out().Linef("uploadedFileId\t%s", result.uploadedFileID)
+	u.Out().Linef("atIndex\t%d", result.atIndex)
+	u.Out().Linef("requests\t%d", result.requests)
+	u.Out().Linef("revoked\t%t", result.revoked)
+	if result.fallbackLink {
+		u.Out().Linef("fallbackLink\ttrue")
+	}
+	if result.tabID != "" {
+		u.Out().Linef("tabId\t%s", result.tabID)
+	}
+	return nil
+}
+
+func (c *DocsInsertImageCmd) run(ctx context.Context, docsSvc *docs.Service, driveSvc *drive.Service, docID, localPath, name, mimeType, at string) (result docsInsertImageResult, err error) {
+	uploaded, err := uploadDocsInlineImage(ctx, driveSvc, localPath, name, mimeType, strings.TrimSpace(c.Parent))
+	if err != nil {
+		return result, err
+	}
+	result.uploadedFileID = uploaded.Id
+	result.uploadedFileName = uploaded.Name
+
+	perm, err := driveSvc.Permissions.Create(uploaded.Id, &drive.Permission{Type: "anyone", Role: drivePermRoleReader}).
+		SupportsAllDrives(true).
+		Fields("id,type,role").
+		Context(ctx).
+		Do()
+	if err != nil {
+		if strings.EqualFold(c.OnRestricted, "link") && isDrivePublicSharingRestricted(err) {
+			return c.insertRestrictedImageFallback(ctx, docsSvc, docID, uploaded, at, result)
+		}
+		return result, fmt.Errorf("share uploaded image publicly: %w", err)
+	}
+	result.permissionID = perm.Id
+
+	defer func() {
+		if perm.Id == "" {
+			return
+		}
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+		defer cancel()
+		revokeErr := driveSvc.Permissions.Delete(uploaded.Id, perm.Id).SupportsAllDrives(true).Context(cleanupCtx).Do()
+		if revokeErr == nil {
+			result.revoked = true
+			return
+		}
+		if err != nil {
+			err = fmt.Errorf("%w; additionally failed to revoke temporary public permission %s on %s: %w", err, perm.Id, uploaded.Id, revokeErr)
+			return
+		}
+		err = fmt.Errorf("revoke temporary public permission %s on %s: %w", perm.Id, uploaded.Id, revokeErr)
+	}()
+
+	imageURL := driveImageDownloadURL(uploaded.Id)
+	reqs, index, tabID, err := c.buildInsertRequests(ctx, docsSvc, docID, at, imageURL)
+	if err != nil {
+		return result, err
+	}
+	if err := batchUpdateImageInsertRequests(ctx, docsSvc, docID, reqs); err != nil {
+		return result, fmt.Errorf("insert image: %w", err)
+	}
+	result.documentID = docID
+	result.atIndex = index
+	result.tabID = tabID
+	result.requests = len(reqs)
+	return result, nil
+}
+
+func (c *DocsInsertImageCmd) insertRestrictedImageFallback(ctx context.Context, docsSvc *docs.Service, docID string, uploaded *drive.File, at string, result docsInsertImageResult) (docsInsertImageResult, error) {
+	link := uploaded.WebViewLink
+	if link == "" {
+		link = bestEffortWebURL("drive", uploaded.Id)
+	}
+	reqs, index, tabID, err := c.buildLinkFallbackRequests(ctx, docsSvc, docID, at, link)
+	if err != nil {
+		return result, err
+	}
+	_, err = docsSvc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: reqs}).Context(ctx).Do()
+	if err != nil {
+		return result, fmt.Errorf("insert image link fallback: %w", err)
+	}
+	result.documentID = docID
+	result.atIndex = index
+	result.tabID = tabID
+	result.requests = len(reqs)
+	result.fallbackLink = true
+	return result, nil
+}
+
+func uploadDocsInlineImage(ctx context.Context, svc *drive.Service, localPath, name, mimeType, parent string) (*drive.File, error) {
+	fh, err := os.Open(localPath) //nolint:gosec // user-provided path
+	if err != nil {
+		return nil, fmt.Errorf("open image: %w", err)
+	}
+	defer fh.Close()
+
+	meta := &drive.File{Name: name, MimeType: mimeType}
+	if parent != "" {
+		meta.Parents = []string{parent}
+	}
+	created, err := svc.Files.Create(meta).
+		Media(fh, gapi.ContentType(mimeType)).
+		SupportsAllDrives(true).
+		Fields("id,name,mimeType,webViewLink").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, fmt.Errorf("upload image: %w", err)
+	}
+	return created, nil
+}
+
+func (c *DocsInsertImageCmd) buildInsertRequests(ctx context.Context, svc *docs.Service, docID, at, imageURL string) ([]*docs.Request, int64, string, error) {
+	index, placeholder, tabID, err := c.resolveImageTarget(ctx, svc, docID, at)
+	if err != nil {
+		return nil, 0, "", err
+	}
+	objSize := &docs.Size{}
+	if c.Width > 0 {
+		objSize.Width = &docs.Dimension{Magnitude: c.Width, Unit: "PT"}
+	}
+	if c.Height > 0 {
+		objSize.Height = &docs.Dimension{Magnitude: c.Height, Unit: "PT"}
+	}
+	reqs := make([]*docs.Request, 0, 2)
+	if placeholder != nil {
+		reqs = append(reqs, &docs.Request{DeleteContentRange: &docs.DeleteContentRangeRequest{
+			Range: &docs.Range{StartIndex: placeholder.startIndex, EndIndex: placeholder.endIndex, TabId: tabID},
+		}})
+	}
+	reqs = append(reqs, &docs.Request{InsertInlineImage: &docs.InsertInlineImageRequest{
+		Uri:        imageURL,
+		Location:   &docs.Location{Index: index, TabId: tabID},
+		ObjectSize: objSize,
+	}})
+	return reqs, index, tabID, nil
+}
+
+func (c *DocsInsertImageCmd) buildLinkFallbackRequests(ctx context.Context, svc *docs.Service, docID, at, link string) ([]*docs.Request, int64, string, error) {
+	index, placeholder, tabID, err := c.resolveImageTarget(ctx, svc, docID, at)
+	if err != nil {
+		return nil, 0, "", err
+	}
+	reqs := make([]*docs.Request, 0, 2)
+	if placeholder != nil {
+		reqs = append(reqs, &docs.Request{DeleteContentRange: &docs.DeleteContentRangeRequest{
+			Range: &docs.Range{StartIndex: placeholder.startIndex, EndIndex: placeholder.endIndex, TabId: tabID},
+		}})
+	}
+	reqs = append(reqs, &docs.Request{InsertText: &docs.InsertTextRequest{
+		Location: &docs.Location{Index: index, TabId: tabID},
+		Text:     link,
+	}})
+	return reqs, index, tabID, nil
+}
+
+func (c *DocsInsertImageCmd) resolveImageTarget(ctx context.Context, svc *docs.Service, docID, at string) (int64, *docRange, string, error) {
+	if strings.EqualFold(at, docsAtIndexEnd) {
+		endIndex, tabID, err := docsTargetEndIndexAndTabID(ctx, svc, docID, c.Tab)
+		if err != nil {
+			return 0, nil, "", err
+		}
+		return docsAppendIndex(endIndex), nil, tabID, nil
+	}
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, c.Tab)
+	if err != nil {
+		return 0, nil, "", err
+	}
+	matches := findTextMatches(loaded.target, at, true)
+	if len(matches) == 0 {
+		return 0, nil, "", fmt.Errorf("placeholder not found: %q", at)
+	}
+	return matches[0].startIndex, &matches[0], loaded.tabID, nil
+}
+
+func isDocsInsertImageMime(mimeType string) bool {
+	switch mimeType {
+	case mimePNG, "image/jpeg", "image/gif":
+		return true
+	default:
+		return false
+	}
+}
+
+func driveImageDownloadURL(fileID string) string {
+	return "https://drive.google.com/uc?export=download&id=" + url.QueryEscape(fileID)
+}
+
+func isDrivePublicSharingRestricted(err error) bool {
+	var apiErr *gapi.Error
+	if errors.As(err, &apiErr) {
+		for _, e := range apiErr.Errors {
+			if strings.Contains(e.Reason, "publishOutNotPermitted") {
+				return true
+			}
+		}
+		return strings.Contains(apiErr.Message, "publishOutNotPermitted")
+	}
+	return strings.Contains(err.Error(), "publishOutNotPermitted")
+}

--- a/internal/cmd/docs_layout.go
+++ b/internal/cmd/docs_layout.go
@@ -11,6 +11,7 @@ import (
 )
 
 type DocsLayoutFlags struct {
+	PageSize     string `name:"page-size" help:"Named page size: A4, A5, Letter, Legal, Tabloid"`
 	PageWidth    string `name:"page-width" help:"Set page width (points by default; supports pt, in, cm, mm)"`
 	PageHeight   string `name:"page-height" help:"Set page height (points by default; supports pt, in, cm, mm)"`
 	MarginLeft   string `name:"margin-left" help:"Set left page margin (points by default; supports pt, in, cm, mm)"`
@@ -20,7 +21,8 @@ type DocsLayoutFlags struct {
 }
 
 func (f DocsLayoutFlags) any() bool {
-	return strings.TrimSpace(f.PageWidth) != "" ||
+	return strings.TrimSpace(f.PageSize) != "" ||
+		strings.TrimSpace(f.PageWidth) != "" ||
 		strings.TrimSpace(f.PageHeight) != "" ||
 		strings.TrimSpace(f.MarginLeft) != "" ||
 		strings.TrimSpace(f.MarginRight) != "" ||
@@ -30,6 +32,9 @@ func (f DocsLayoutFlags) any() bool {
 
 func (f DocsLayoutFlags) dryRunPayload() map[string]any {
 	payload := map[string]any{}
+	if strings.TrimSpace(f.PageSize) != "" {
+		payload["pageSize"] = f.PageSize
+	}
 	if strings.TrimSpace(f.PageWidth) != "" {
 		payload["pageWidth"] = f.PageWidth
 	}
@@ -88,7 +93,12 @@ func buildUpdateDocumentStyleRequest(opts docsDocumentStyleOptions) (*docs.Updat
 	// but live Docs readback shows pageless table/content width still follows
 	// documentStyle.pageSize minus margins. Keep these flags explicit, not
 	// automatic, so --pageless never widens existing docs unless requested.
-	pageWidth, ok, err := parseDocsDimension("page-width", opts.PageWidth, false)
+	pageWidthRaw, pageHeightRaw, err := resolveDocsPageSize(opts.PageSize, opts.PageWidth, opts.PageHeight)
+	if err != nil {
+		return nil, err
+	}
+
+	pageWidth, ok, err := parseDocsDimension("page-width", pageWidthRaw, false)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +110,7 @@ func buildUpdateDocumentStyleRequest(opts docsDocumentStyleOptions) (*docs.Updat
 		fields = append(fields, "pageSize.width")
 	}
 
-	pageHeight, ok, err := parseDocsDimension("page-height", opts.PageHeight, false)
+	pageHeight, ok, err := parseDocsDimension("page-height", pageHeightRaw, false)
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +142,34 @@ func buildUpdateDocumentStyleRequest(opts docsDocumentStyleOptions) (*docs.Updat
 		DocumentStyle: style,
 		Fields:        strings.Join(fields, ","),
 	}, nil
+}
+
+type docsPageSizePreset struct {
+	widthPt  float64
+	heightPt float64
+}
+
+var docsPageSizePresets = map[string]docsPageSizePreset{
+	"a4":      {widthPt: 595.275, heightPt: 841.890},
+	"a5":      {widthPt: 419.528, heightPt: 595.275},
+	"letter":  {widthPt: 612, heightPt: 792},
+	"legal":   {widthPt: 612, heightPt: 1008},
+	"tabloid": {widthPt: 792, heightPt: 1224},
+}
+
+func resolveDocsPageSize(pageSize, pageWidth, pageHeight string) (string, string, error) {
+	pageSize = strings.TrimSpace(pageSize)
+	if pageSize == "" {
+		return pageWidth, pageHeight, nil
+	}
+	if strings.TrimSpace(pageWidth) != "" || strings.TrimSpace(pageHeight) != "" {
+		return "", "", usage("--page-size cannot be combined with --page-width or --page-height")
+	}
+	preset, ok := docsPageSizePresets[strings.ToLower(pageSize)]
+	if !ok {
+		return "", "", usage("--page-size must be one of A4, A5, Letter, Legal, Tabloid")
+	}
+	return fmt.Sprintf("%.3fpt", preset.widthPt), fmt.Sprintf("%.3fpt", preset.heightPt), nil
 }
 
 func setMarginDimension(fields *[]string, flagName, fieldName, raw string, target **docs.Dimension) error {

--- a/internal/cmd/docs_remaining_features_test.go
+++ b/internal/cmd/docs_remaining_features_test.go
@@ -1,0 +1,122 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsPageSizePresetBuildsDimensions(t *testing.T) {
+	req, err := buildUpdateDocumentStyleRequest(docsDocumentStyleOptions{
+		DocsLayoutFlags: DocsLayoutFlags{PageSize: "A4"},
+	})
+	if err != nil {
+		t.Fatalf("buildUpdateDocumentStyleRequest: %v", err)
+	}
+	if req.Fields != "pageSize.width,pageSize.height" {
+		t.Fatalf("fields = %q", req.Fields)
+	}
+	if got := req.DocumentStyle.PageSize.Width.Magnitude; got != 595.275 {
+		t.Fatalf("width = %v", got)
+	}
+	if got := req.DocumentStyle.PageSize.Height.Magnitude; got != 841.890 {
+		t.Fatalf("height = %v", got)
+	}
+}
+
+func TestDocsPageSizeRejectsExplicitDimensions(t *testing.T) {
+	_, err := buildUpdateDocumentStyleRequest(docsDocumentStyleOptions{
+		DocsLayoutFlags: DocsLayoutFlags{PageSize: "Letter", PageWidth: "1in"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "cannot be combined") {
+		t.Fatalf("expected conflict error, got %v", err)
+	}
+}
+
+func TestDocsCellStyleBuildsTableAndTextRequests(t *testing.T) {
+	cmd := &DocsCellStyleCmd{
+		Row:             0,
+		Col:             1,
+		RowSpan:         1,
+		ColSpan:         2,
+		BackgroundColor: "#abc",
+		TextColor:       "#123456",
+		Bold:            true,
+	}
+	cell := &docs.TableCell{Content: []*docs.StructuralElement{{
+		Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{{
+			StartIndex: 10,
+			EndIndex:   16,
+			TextRun:    &docs.TextRun{Content: "Badge\n"},
+		}}},
+	}}}
+	reqs, err := cmd.buildRequests(5, cell, "tab-1")
+	if err != nil {
+		t.Fatalf("buildRequests: %v", err)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("requests = %d, want 2", len(reqs))
+	}
+	cellReq := reqs[0].UpdateTableCellStyle
+	if cellReq == nil || cellReq.Fields != "backgroundColor" {
+		t.Fatalf("unexpected cell style request: %#v", reqs[0])
+	}
+	loc := cellReq.TableRange.TableCellLocation
+	if loc.RowIndex != 0 || loc.ColumnIndex != 1 || loc.TableStartLocation.Index != 5 || loc.TableStartLocation.TabId != "tab-1" {
+		t.Fatalf("unexpected cell location: %#v", loc)
+	}
+	textReq := reqs[1].UpdateTextStyle
+	if textReq == nil || textReq.Range.StartIndex != 10 || textReq.Range.EndIndex != 15 || textReq.Range.TabId != "tab-1" {
+		t.Fatalf("unexpected text style request: %#v", reqs[1])
+	}
+	if !textReq.TextStyle.Bold || textReq.Fields != "foregroundColor,bold" {
+		t.Fatalf("unexpected text style: %#v fields=%q", textReq.TextStyle, textReq.Fields)
+	}
+}
+
+func TestDocsSmartChipCommandsBuildRequests(t *testing.T) {
+	person := &docs.Request{InsertPerson: &docs.InsertPersonRequest{PersonProperties: &docs.PersonProperties{Email: "a@example.com"}}}
+	setDocsInsertRequestLocation(person, 7, "tab-1")
+	if person.InsertPerson.Location.Index != 7 || person.InsertPerson.Location.TabId != "tab-1" {
+		t.Fatalf("person location = %#v", person.InsertPerson.Location)
+	}
+
+	dateFormat, err := normalizeDocsDateChipFormat("iso")
+	if err != nil {
+		t.Fatalf("normalize date: %v", err)
+	}
+	if dateFormat != "DATE_FORMAT_ISO8601" {
+		t.Fatalf("date format = %q", dateFormat)
+	}
+}
+
+func TestDocsInsertImageBuildsPlaceholderReplacement(t *testing.T) {
+	cmd := &DocsInsertImageCmd{At: "IMG_HERE", Width: 320}
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.Contains(r.URL.Path, "/v1/documents/doc1") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(docBodyWithText("before IMG_HERE after\n"))
+	}))
+	defer cleanup()
+
+	reqs, index, tabID, err := cmd.buildInsertRequests(context.Background(), docSvc, "doc1", "IMG_HERE", "https://example.com/i.png")
+	if err != nil {
+		t.Fatalf("buildInsertRequests: %v", err)
+	}
+	if tabID != "" || index != 8 {
+		t.Fatalf("index=%d tab=%q", index, tabID)
+	}
+	if len(reqs) != 2 || reqs[0].DeleteContentRange == nil || reqs[1].InsertInlineImage == nil {
+		t.Fatalf("unexpected requests: %#v", reqs)
+	}
+	if reqs[1].InsertInlineImage.Uri != "https://example.com/i.png" || reqs[1].InsertInlineImage.ObjectSize.Width.Magnitude != 320 {
+		t.Fatalf("unexpected image request: %#v", reqs[1].InsertInlineImage)
+	}
+}

--- a/internal/cmd/docs_smart_chips.go
+++ b/internal/cmd/docs_smart_chips.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsInsertPersonCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Email string `name:"email" required:"" help:"Email address for the person chip"`
+	Index *int64 `name:"index" help:"Character index to insert at. Omit or use --at-end for end-of-doc."`
+	AtEnd bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsInsertFileChipCmd struct {
+	DocID  string `arg:"" name:"docId" help:"Doc ID"`
+	FileID string `name:"file-id" required:"" help:"Drive file ID to insert as a smart chip"`
+	Index  *int64 `name:"index" help:"Character index to insert at. Omit or use --at-end for end-of-doc."`
+	AtEnd  bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
+	Tab    string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsInsertDateChipCmd struct {
+	DocID  string `arg:"" name:"docId" help:"Doc ID"`
+	Date   string `name:"date" required:"" help:"Date to insert as YYYY-MM-DD"`
+	Format string `name:"format" help:"Date display format: abbreviated|full|iso" default:"abbreviated"`
+	Index  *int64 `name:"index" help:"Character index to insert at. Omit or use --at-end for end-of-doc."`
+	AtEnd  bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
+	Tab    string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+const docsDateChipFormatFull = "full"
+
+type docsInsertLocationFlags struct {
+	docID string
+	index *int64
+	atEnd bool
+	tab   string
+}
+
+func (c *DocsInsertPersonCmd) Run(ctx context.Context, flags *RootFlags) error {
+	email := strings.TrimSpace(c.Email)
+	if email == "" {
+		return usage("empty --email")
+	}
+	req := &docs.Request{InsertPerson: &docs.InsertPersonRequest{
+		PersonProperties: &docs.PersonProperties{Email: email},
+	}}
+	return runDocsSingleInsert(ctx, flags, "docs.insert-person", docsInsertLocationFlags{
+		docID: c.DocID,
+		index: c.Index,
+		atEnd: c.AtEnd,
+		tab:   c.Tab,
+	}, req, map[string]any{"email": email})
+}
+
+func (c *DocsInsertFileChipCmd) Run(ctx context.Context, flags *RootFlags) error {
+	fileID := strings.TrimSpace(c.FileID)
+	if fileID == "" {
+		return usage("empty --file-id")
+	}
+	loc := docsInsertLocationFlags{
+		docID: c.DocID,
+		index: c.Index,
+		atEnd: c.AtEnd,
+		tab:   c.Tab,
+	}
+	if dryRunErr := dryRunDocsSingleInsert(ctx, flags, "docs.insert-file-chip", loc, map[string]any{"fileId": fileID}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	driveSvc, err := newDriveService(ctx, account)
+	if err != nil {
+		return err
+	}
+	file, err := driveSvc.Files.Get(fileID).
+		SupportsAllDrives(true).
+		Fields("id,name,mimeType,webViewLink").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return fmt.Errorf("get Drive file: %w", err)
+	}
+	uri := file.WebViewLink
+	if uri == "" {
+		uri = bestEffortWebURL("drive", fileID)
+	}
+	req := &docs.Request{InsertRichLink: &docs.InsertRichLinkRequest{
+		RichLinkProperties: &docs.RichLinkProperties{
+			Uri: uri,
+		},
+	}}
+	return runDocsSingleInsert(ctx, flags, "docs.insert-file-chip", docsInsertLocationFlags{
+		docID: c.DocID,
+		index: c.Index,
+		atEnd: c.AtEnd,
+		tab:   c.Tab,
+	}, req, map[string]any{"fileId": fileID, "title": file.Name})
+}
+
+func (c *DocsInsertDateChipCmd) Run(ctx context.Context, flags *RootFlags) error {
+	date := strings.TrimSpace(c.Date)
+	if date == "" {
+		return usage("empty --date")
+	}
+	t, err := time.Parse("2006-01-02", date)
+	if err != nil {
+		return usage("--date must be YYYY-MM-DD")
+	}
+	dateFormat, err := normalizeDocsDateChipFormat(c.Format)
+	if err != nil {
+		return err
+	}
+	req := &docs.Request{InsertDate: &docs.InsertDateRequest{
+		DateElementProperties: &docs.DateElementProperties{
+			DateFormat: dateFormat,
+			TimeFormat: "TIME_FORMAT_DISABLED",
+			Timestamp:  t.UTC().Format(time.RFC3339),
+		},
+	}}
+	return runDocsSingleInsert(ctx, flags, "docs.insert-date-chip", docsInsertLocationFlags{
+		docID: c.DocID,
+		index: c.Index,
+		atEnd: c.AtEnd,
+		tab:   c.Tab,
+	}, req, map[string]any{"date": date, "format": c.Format})
+}
+
+func normalizeDocsDateChipFormat(format string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "", "abbreviated", "abbr":
+		return "DATE_FORMAT_MONTH_DAY_YEAR_ABBREVIATED", nil
+	case docsDateChipFormatFull:
+		return "DATE_FORMAT_MONTH_DAY_FULL", nil
+	case "iso", "iso8601":
+		return "DATE_FORMAT_ISO8601", nil
+	default:
+		return "", usage("--format must be abbreviated, full, or iso")
+	}
+}
+
+func runDocsSingleInsert(ctx context.Context, flags *RootFlags, action string, loc docsInsertLocationFlags, req *docs.Request, payload map[string]any) error {
+	u := ui.FromContext(ctx)
+	docID := strings.TrimSpace(loc.docID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if loc.atEnd && loc.index != nil {
+		return usage("--at-end and --index are mutually exclusive")
+	}
+	if loc.index != nil && *loc.index < 1 {
+		return usage("--index must be >= 1 (index 0 is reserved)")
+	}
+
+	if err := dryRunDocsSingleInsert(ctx, flags, action, loc, payload); err != nil {
+		return err
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	insertIndex, tabID, err := resolveDocsInsertLocation(ctx, svc, docID, loc)
+	if err != nil {
+		return err
+	}
+	setDocsInsertRequestLocation(req, insertIndex, tabID)
+	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: []*docs.Request{req}}).Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		result := map[string]any{"documentId": resp.DocumentId, "atIndex": insertIndex, "inserted": true}
+		if tabID != "" {
+			result["tabId"] = tabID
+		}
+		for k, v := range payload {
+			result[k] = v
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, result)
+	}
+	u.Out().Linef("documentId\t%s", resp.DocumentId)
+	u.Out().Linef("atIndex\t%d", insertIndex)
+	u.Out().Linef("inserted\ttrue")
+	if tabID != "" {
+		u.Out().Linef("tabId\t%s", tabID)
+	}
+	return nil
+}
+
+func dryRunDocsSingleInsert(ctx context.Context, flags *RootFlags, action string, loc docsInsertLocationFlags, payload map[string]any) error {
+	docID := strings.TrimSpace(loc.docID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if loc.atEnd && loc.index != nil {
+		return usage("--at-end and --index are mutually exclusive")
+	}
+	if loc.index != nil && *loc.index < 1 {
+		return usage("--index must be >= 1 (index 0 is reserved)")
+	}
+	dryRunPayload := map[string]any{"documentId": docID, "tab": loc.tab}
+	for k, v := range payload {
+		dryRunPayload[k] = v
+	}
+	if loc.atEnd || loc.index == nil {
+		dryRunPayload["atIndex"] = docsAtIndexEnd
+	} else {
+		dryRunPayload["atIndex"] = *loc.index
+	}
+	return dryRunExit(ctx, flags, action, dryRunPayload)
+}
+
+func resolveDocsInsertLocation(ctx context.Context, svc *docs.Service, docID string, loc docsInsertLocationFlags) (int64, string, error) {
+	if loc.atEnd || loc.index == nil {
+		endIndex, tabID, err := docsTargetEndIndexAndTabID(ctx, svc, docID, loc.tab)
+		if err != nil {
+			return 0, "", err
+		}
+		return docsAppendIndex(endIndex), tabID, nil
+	}
+	tabID := ""
+	if strings.TrimSpace(loc.tab) != "" {
+		resolved, err := resolveDocsTabID(ctx, svc, docID, loc.tab)
+		if err != nil {
+			return 0, "", err
+		}
+		tabID = resolved
+	}
+	return *loc.index, tabID, nil
+}
+
+func setDocsInsertRequestLocation(req *docs.Request, index int64, tabID string) {
+	location := &docs.Location{Index: index, TabId: tabID}
+	switch {
+	case req.InsertPerson != nil:
+		req.InsertPerson.Location = location
+	case req.InsertRichLink != nil:
+		req.InsertRichLink.Location = location
+	case req.InsertDate != nil:
+		req.InsertDate.Location = location
+	case req.InsertInlineImage != nil:
+		req.InsertInlineImage.Location = location
+	}
+}

--- a/internal/cmd/gmail_from_contact_test.go
+++ b/internal/cmd/gmail_from_contact_test.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"testing"
+
+	"google.golang.org/api/people/v1"
+)
+
+func TestBuildGmailFromEmailsQuery(t *testing.T) {
+	if got := buildGmailFromEmailsQuery([]string{"a@example.com"}); got != "from:a@example.com" {
+		t.Fatalf("single = %q", got)
+	}
+	if got := buildGmailFromEmailsQuery([]string{"a@example.com", "b@example.com"}); got != "from:(a@example.com OR b@example.com)" {
+		t.Fatalf("multi = %q", got)
+	}
+}
+
+func TestSelectGmailFromContactPeoplePrefersExactMatch(t *testing.T) {
+	resp := &people.SearchResponse{Results: []*people.SearchResult{
+		{Person: &people.Person{Names: []*people.Name{{DisplayName: "Alice A"}}, EmailAddresses: []*people.EmailAddress{{Value: "alice@example.com"}}}},
+		{Person: &people.Person{Names: []*people.Name{{DisplayName: "Alice B"}}, EmailAddresses: []*people.EmailAddress{{Value: "b@example.com"}}}},
+	}}
+	got := selectGmailFromContactPeople("alice@example.com", resp)
+	if len(got) != 1 || primaryName(got[0]) != "Alice A" {
+		t.Fatalf("unexpected selection: %#v", got)
+	}
+}
+
+func TestAllContactEmailsDedupes(t *testing.T) {
+	got := allContactEmails(&people.Person{EmailAddresses: []*people.EmailAddress{
+		{Value: "A@example.com"},
+		{Value: "a@example.com"},
+		{Value: "b@example.com"},
+	}})
+	if len(got) != 2 || got[0] != "A@example.com" || got[1] != "b@example.com" {
+		t.Fatalf("emails = %#v", got)
+	}
+}

--- a/internal/cmd/gmail_search.go
+++ b/internal/cmd/gmail_search.go
@@ -6,20 +6,22 @@ import (
 	"strings"
 
 	"google.golang.org/api/gmail/v1"
+	"google.golang.org/api/people/v1"
 
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
 
 type GmailSearchCmd struct {
-	Query     []string `arg:"" name:"query" help:"Search query"`
-	Max       int64    `name:"max" aliases:"limit" help:"Max results" default:"10"`
-	Page      string   `name:"page" aliases:"cursor" help:"Page token"`
-	All       bool     `name:"all" aliases:"all-pages,allpages" help:"Fetch all pages"`
-	FailEmpty bool     `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no results"`
-	Oldest    bool     `name:"oldest" help:"Show first message date instead of last"`
-	Timezone  string   `name:"timezone" short:"z" help:"Output timezone (IANA name, e.g. America/New_York, UTC). Default: local"`
-	Local     bool     `name:"local" help:"Use local timezone (default behavior, useful to override --timezone)"`
+	Query       []string `arg:"" name:"query" help:"Search query"`
+	FromContact string   `name:"from-contact" help:"Resolve a Google Contact and add from:(email OR email) to the Gmail query"`
+	Max         int64    `name:"max" aliases:"limit" help:"Max results" default:"10"`
+	Page        string   `name:"page" aliases:"cursor" help:"Page token"`
+	All         bool     `name:"all" aliases:"all-pages,allpages" help:"Fetch all pages"`
+	FailEmpty   bool     `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no results"`
+	Oldest      bool     `name:"oldest" help:"Show first message date instead of last"`
+	Timezone    string   `name:"timezone" short:"z" help:"Output timezone (IANA name, e.g. America/New_York, UTC). Default: local"`
+	Local       bool     `name:"local" help:"Use local timezone (default behavior, useful to override --timezone)"`
 }
 
 func (c *GmailSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -29,6 +31,13 @@ func (c *GmailSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	query := strings.TrimSpace(strings.Join(c.Query, " "))
+	if strings.TrimSpace(c.FromContact) != "" {
+		expanded, expandErr := gmailFromContactQuery(ctx, account, c.FromContact)
+		if expandErr != nil {
+			return expandErr
+		}
+		query = strings.TrimSpace(strings.Join([]string{query, expanded}, " "))
+	}
 	if query == "" {
 		return usage("missing query")
 	}
@@ -104,4 +113,139 @@ func (c *GmailSearchCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	printNextPageHint(u, nextPageToken)
 	return nil
+}
+
+func gmailFromContactQuery(ctx context.Context, account, selector string) (string, error) {
+	selector = strings.TrimSpace(selector)
+	if selector == "" {
+		return "", usage("empty --from-contact")
+	}
+	svc, err := newPeopleContactsService(ctx, account)
+	if err != nil {
+		return "", err
+	}
+	resp, err := svc.People.SearchContacts().
+		Query(selector).
+		PageSize(10).
+		ReadMask("names,emailAddresses").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return "", fmt.Errorf("resolve --from-contact: %w", err)
+	}
+
+	matches := selectGmailFromContactPeople(selector, resp)
+	if len(matches) == 0 {
+		listed, listErr := listExactGmailFromContactPeople(ctx, svc, selector)
+		if listErr != nil {
+			return "", listErr
+		}
+		matches = listed
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("resolve --from-contact: no contact found for %q", selector)
+	}
+	if len(matches) > 1 {
+		names := make([]string, 0, len(matches))
+		for _, p := range matches {
+			names = append(names, firstNonEmpty(primaryName(p), primaryEmail(p), p.ResourceName))
+		}
+		return "", fmt.Errorf("resolve --from-contact: %q matched multiple contacts (%s); use a more specific name or email", selector, strings.Join(names, ", "))
+	}
+	emails := allContactEmails(matches[0])
+	if len(emails) == 0 {
+		return "", fmt.Errorf("resolve --from-contact: %q has no email addresses", selector)
+	}
+	return buildGmailFromEmailsQuery(emails), nil
+}
+
+func listExactGmailFromContactPeople(ctx context.Context, svc *people.Service, selector string) ([]*people.Person, error) {
+	selectorLower := strings.ToLower(strings.TrimSpace(selector))
+	var matches []*people.Person
+	pageToken := ""
+	for {
+		call := svc.People.Connections.List(peopleMeResource).
+			PersonFields("names,emailAddresses").
+			PageSize(200).
+			Context(ctx)
+		if pageToken != "" {
+			call = call.PageToken(pageToken)
+		}
+		resp, err := call.Do()
+		if err != nil {
+			return nil, fmt.Errorf("resolve --from-contact fallback list: %w", err)
+		}
+		for _, p := range resp.Connections {
+			if p == nil {
+				continue
+			}
+			if strings.ToLower(primaryName(p)) == selectorLower || contactHasEmail(p, selectorLower) {
+				matches = append(matches, p)
+			}
+		}
+		if resp.NextPageToken == "" {
+			return matches, nil
+		}
+		pageToken = resp.NextPageToken
+	}
+}
+
+func selectGmailFromContactPeople(selector string, resp *people.SearchResponse) []*people.Person {
+	if resp == nil {
+		return nil
+	}
+	selectorLower := strings.ToLower(strings.TrimSpace(selector))
+	exact := make([]*people.Person, 0, len(resp.Results))
+	fallback := make([]*people.Person, 0, len(resp.Results))
+	for _, result := range resp.Results {
+		if result == nil || result.Person == nil {
+			continue
+		}
+		p := result.Person
+		fallback = append(fallback, p)
+		if strings.ToLower(primaryName(p)) == selectorLower || contactHasEmail(p, selectorLower) {
+			exact = append(exact, p)
+		}
+	}
+	if len(exact) > 0 {
+		return exact
+	}
+	if len(fallback) == 1 {
+		return fallback
+	}
+	return fallback
+}
+
+func contactHasEmail(p *people.Person, emailLower string) bool {
+	for _, email := range p.EmailAddresses {
+		if email != nil && strings.ToLower(strings.TrimSpace(email.Value)) == emailLower {
+			return true
+		}
+	}
+	return false
+}
+
+func allContactEmails(p *people.Person) []string {
+	seen := map[string]bool{}
+	var emails []string
+	for _, email := range p.EmailAddresses {
+		if email == nil {
+			continue
+		}
+		value := strings.TrimSpace(email.Value)
+		key := strings.ToLower(value)
+		if value == "" || seen[key] {
+			continue
+		}
+		seen[key] = true
+		emails = append(emails, value)
+	}
+	return emails
+}
+
+func buildGmailFromEmailsQuery(emails []string) string {
+	if len(emails) == 1 {
+		return "from:" + emails[0]
+	}
+	return "from:(" + strings.Join(emails, " OR ") + ")"
 }


### PR DESCRIPTION
Closes #657, #648, #638, #645, #640.

Summary:
- Add `gmail search --from-contact` to resolve one Google Contact into `from:(email OR email)` Gmail queries, with a contacts-list fallback for newly-created contacts not yet visible to People search.
- Add `docs write/page-layout --page-size` presets for A4, A5, Letter, Legal, and Tabloid.
- Add native Docs smart-chip commands for person, Drive file rich link, and date chips.
- Add `docs cell-style` for table-cell background color plus single-cell text styling.
- Add `docs insert-image` to upload a local PNG/JPEG/GIF, temporarily share it publicly for Docs image fetch, insert it, and revoke the public permission with a bounded cleanup context.

Proof:
- `go test ./internal/cmd -run 'TestDocsPageSize|TestDocsCellStyle|TestDocsSmartChip|TestDocsInsertImage|TestBuildGmailFrom|TestSelectGmail|TestAllContactEmails'`
- `make ci`
- autoreview clean: no accepted/actionable findings reported
- Live with `clawdbot@gmail.com`:
  - Created temp Doc, wrote placeholder text, applied `docs page-layout --page-size=A5`.
  - Inserted a table and applied `docs cell-style`; raw readback had table cell background.
  - Inserted person/date/file smart chips; raw readback had person, dateElement, and richLink elements.
  - Ran `docs insert-image` on a local PNG placeholder; JSON returned `requests=2`, `revoked=true`, `fallbackLink=false`, raw readback had one inline object, and the uploaded image was trashed afterward.
  - Created a temp contact, ran `gmail search --from-contact "GogLive Contact" after:2099/01/01 --max 1`, got an empty successful Gmail search, then deleted the contact.
