### PR TITLE
feat(gmail): preserve draft attachments on update; add --clear-attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Gmail: preserve existing `gmail drafts update` attachments when `--attach` is omitted, add `--clear-attachments` for intentional removal, and keep `--attach` as explicit replacement. (#680, #681) — thanks @chrischall.
+
 ## 0.21.0 - 2026-06-01
 
 ### Added

--- a/docs/commands/gog-gmail-drafts-update.md
+++ b/docs/commands/gog-gmail-drafts-update.md
@@ -20,12 +20,13 @@ gog gmail (mail,email) drafts (draft) update (edit,set) <draftId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--attach` | `[]string` |  | Attachment file path (repeatable) |
+| `--attach` | `[]string` |  | Attachment file path (repeatable). Replaces existing attachments; omit to preserve them, or use --clear-attachments to remove all. |
 | `--bcc` | `string` |  | BCC recipients (comma-separated) |
 | `--body` | `string` |  | Body (plain text; required unless --body-html is set) |
 | `--body-file` | `string` |  | Body file path (plain text; '-' for stdin) |
 | `--body-html` | `string` |  | Body (HTML; optional) |
 | `--cc` | `string` |  | CC recipients (comma-separated) |
+| `--clear-attachments` | `bool` |  | Remove all attachments from the draft. By default, omitting --attach preserves the draft's existing attachments. |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -335,21 +335,49 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 // attachments so they can be re-attached to a rebuilt draft on update. Returns
 // nil when the draft has no attachments. Mirrors the gmail forward reattach path.
 func carryForwardDraftAttachments(ctx context.Context, svc *gmail.Service, messageID string, payload *gmail.MessagePart) ([]mailAttachment, error) {
-	metas := collectAttachments(payload)
-	if len(metas) == 0 {
-		return nil, nil
-	}
-	out := make([]mailAttachment, 0, len(metas))
-	for _, att := range metas {
-		data, dlErr := fetchAttachmentBytes(ctx, svc, messageID, att.AttachmentID)
-		if dlErr != nil {
-			return nil, fmt.Errorf("preserve attachment %q: %w", att.Filename, dlErr)
+	var out []mailAttachment
+	var walk func(*gmail.MessagePart) error
+	walk = func(part *gmail.MessagePart) error {
+		if part == nil {
+			return nil
 		}
-		out = append(out, mailAttachment{
-			Filename: att.Filename,
-			MIMEType: att.MimeType,
-			Data:     data,
-		})
+		if part.Body != nil {
+			filename := strings.TrimSpace(part.Filename)
+			if filename == "" && part.Body.AttachmentId != "" {
+				filename = defaultAttachmentFilename
+			}
+			switch {
+			case part.Body.AttachmentId != "":
+				data, dlErr := fetchAttachmentBytes(ctx, svc, messageID, part.Body.AttachmentId)
+				if dlErr != nil {
+					return fmt.Errorf("preserve attachment %q: %w", filename, dlErr)
+				}
+				out = append(out, mailAttachment{
+					Filename: filename,
+					MIMEType: part.MimeType,
+					Data:     data,
+				})
+			case filename != "" && part.Body.Data != "":
+				data, decErr := decodeBase64URLBytes(part.Body.Data)
+				if decErr != nil {
+					return fmt.Errorf("preserve attachment %q: %w", filename, decErr)
+				}
+				out = append(out, mailAttachment{
+					Filename: filename,
+					MIMEType: part.MimeType,
+					Data:     data,
+				})
+			}
+		}
+		for _, child := range part.Parts {
+			if err := walk(child); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := walk(payload); err != nil {
+		return nil, err
 	}
 	return out, nil
 }

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -275,7 +275,10 @@ type draftComposeInput struct {
 	ReplyTo          string
 	Quote            bool
 	Attach           []string
-	From             string
+	// PrebuiltAttachments carry already-resolved attachment bytes (e.g. existing
+	// draft attachments preserved across an update) alongside any --attach paths.
+	PrebuiltAttachments []mailAttachment
+	From                string
 }
 
 func (c draftComposeInput) validate() error {
@@ -302,6 +305,7 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	}
 	threadID := info.ThreadID
 	atts := attachmentsFromPaths(input.Attach)
+	atts = append(atts, input.PrebuiltAttachments...)
 	subject := input.Subject
 	if strings.TrimSpace(subject) == "" {
 		subject = autoReplySubject("", info.Subject)
@@ -325,6 +329,29 @@ func buildDraftMessage(ctx context.Context, svc *gmail.Service, account string, 
 	}
 
 	return msg, threadID, nil
+}
+
+// carryForwardDraftAttachments fetches the bytes of an existing draft message's
+// attachments so they can be re-attached to a rebuilt draft on update. Returns
+// nil when the draft has no attachments. Mirrors the gmail forward reattach path.
+func carryForwardDraftAttachments(ctx context.Context, svc *gmail.Service, messageID string, payload *gmail.MessagePart) ([]mailAttachment, error) {
+	metas := collectAttachments(payload)
+	if len(metas) == 0 {
+		return nil, nil
+	}
+	out := make([]mailAttachment, 0, len(metas))
+	for _, att := range metas {
+		data, dlErr := fetchAttachmentBytes(ctx, svc, messageID, att.AttachmentID)
+		if dlErr != nil {
+			return nil, fmt.Errorf("preserve attachment %q: %w", att.Filename, dlErr)
+		}
+		out = append(out, mailAttachment{
+			Filename: att.Filename,
+			MIMEType: att.MimeType,
+			Data:     data,
+		})
+	}
+	return out, nil
 }
 
 func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threadID string) error {
@@ -524,7 +551,8 @@ type GmailDraftsUpdateCmd struct {
 	ThreadID         string   `name:"thread-id" help:"Reply within a Gmail thread (uses latest message for headers); overrides the draft's existing thread"`
 	ReplyTo          string   `name:"reply-to" help:"Reply-To header address"`
 	Quote            bool     `name:"quote" help:"Include quoted original message in reply"`
-	Attach           []string `name:"attach" help:"Attachment file path (repeatable)"`
+	Attach           []string `name:"attach" help:"Attachment file path (repeatable). Replaces existing attachments; omit to preserve them, or use --clear-attachments to remove all."`
+	ClearAttachments bool     `name:"clear-attachments" help:"Remove all attachments from the draft. By default, omitting --attach preserves the draft's existing attachments."`
 	From             string   `name:"from" help:"Send from this email address (must be a verified send-as alias)"`
 }
 
@@ -556,6 +584,13 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if err != nil {
 		return err
 	}
+	if c.ClearAttachments && len(attachPaths) > 0 {
+		return usage("use only one of --attach or --clear-attachments")
+	}
+	// gmail drafts update rebuilds the whole message, so without intervention an
+	// omitted --attach would silently drop the draft's existing attachments.
+	// Preserve them by default; --attach replaces, --clear-attachments removes.
+	preserveAttachments := len(attachPaths) == 0 && !c.ClearAttachments
 
 	input := draftComposeInput{
 		To:               to,
@@ -579,20 +614,22 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	}
 
 	if dryRunErr := dryRunExit(ctx, flags, "gmail.drafts.update", map[string]any{
-		"draft_id":            draftID,
-		"to_keep_existing":    !toWasSet,
-		"to":                  splitCSV(input.To),
-		"cc":                  splitCSV(input.Cc),
-		"bcc":                 splitCSV(input.Bcc),
-		"subject":             strings.TrimSpace(input.Subject),
-		"body_len":            len(strings.TrimSpace(input.Body)),
-		"body_html_len":       len(strings.TrimSpace(input.BodyHTML)),
-		"reply_to_message_id": strings.TrimSpace(input.ReplyToMessageID),
-		"thread_id":           strings.TrimSpace(threadID),
-		"reply_to":            strings.TrimSpace(input.ReplyTo),
-		"quote":               input.Quote,
-		"from":                strings.TrimSpace(input.From),
-		"attachments":         attachPaths,
+		"draft_id":             draftID,
+		"to_keep_existing":     !toWasSet,
+		"to":                   splitCSV(input.To),
+		"cc":                   splitCSV(input.Cc),
+		"bcc":                  splitCSV(input.Bcc),
+		"subject":              strings.TrimSpace(input.Subject),
+		"body_len":             len(strings.TrimSpace(input.Body)),
+		"body_html_len":        len(strings.TrimSpace(input.BodyHTML)),
+		"reply_to_message_id":  strings.TrimSpace(input.ReplyToMessageID),
+		"reply_to":             strings.TrimSpace(input.ReplyTo),
+		"quote":                input.Quote,
+		"from":                 strings.TrimSpace(input.From),
+		"attachments":          attachPaths,
+		"clear_attachments":    c.ClearAttachments,
+		"preserve_attachments": preserveAttachments,
+		"thread_id":            strings.TrimSpace(threadID),
 	}); dryRunErr != nil {
 		return dryRunErr
 	}
@@ -605,7 +642,8 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	existingThreadID := ""
 	existingMessageID := ""
 	existingTo := ""
-	if !toWasSet || strings.TrimSpace(replyToMessageID) == "" {
+	var existingPayload *gmail.MessagePart
+	if !toWasSet || strings.TrimSpace(replyToMessageID) == "" || preserveAttachments {
 		existing, fetchErr := svc.Users.Drafts.Get("me", draftID).Format("full").Do()
 		if fetchErr != nil {
 			return fetchErr
@@ -613,6 +651,7 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 		if existing != nil && existing.Message != nil {
 			existingThreadID = strings.TrimSpace(existing.Message.ThreadId)
 			existingMessageID = strings.TrimSpace(existing.Message.Id)
+			existingPayload = existing.Message.Payload
 			if !toWasSet {
 				existingTo = strings.TrimSpace(headerValue(existing.Message.Payload, "To"))
 			}
@@ -628,6 +667,16 @@ func (c *GmailDraftsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error 
 	targetThreadID := existingThreadID
 	if threadID != "" {
 		targetThreadID = threadID
+	}
+
+	// Carry the existing draft's attachments forward unless the caller replaced
+	// (--attach) or explicitly cleared (--clear-attachments) them.
+	if preserveAttachments && existingMessageID != "" {
+		carried, attErr := carryForwardDraftAttachments(ctx, svc, existingMessageID, existingPayload)
+		if attErr != nil {
+			return attErr
+		}
+		input.PrebuiltAttachments = carried
 	}
 
 	replyToThreadID := ""

--- a/internal/cmd/gmail_drafts.go
+++ b/internal/cmd/gmail_drafts.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -348,7 +349,7 @@ func carryForwardDraftAttachments(ctx context.Context, svc *gmail.Service, messa
 			}
 			switch {
 			case part.Body.AttachmentId != "":
-				data, dlErr := fetchAttachmentBytes(ctx, svc, messageID, part.Body.AttachmentId)
+				data, dlErr := fetchDraftAttachmentBytes(ctx, svc, messageID, part.Body.AttachmentId, part.Body.Size)
 				if dlErr != nil {
 					return fmt.Errorf("preserve attachment %q: %w", filename, dlErr)
 				}
@@ -356,16 +357,22 @@ func carryForwardDraftAttachments(ctx context.Context, svc *gmail.Service, messa
 					Filename: filename,
 					MIMEType: part.MimeType,
 					Data:     data,
+					DataSet:  true,
 				})
-			case filename != "" && part.Body.Data != "":
-				data, decErr := decodeBase64URLBytes(part.Body.Data)
-				if decErr != nil {
-					return fmt.Errorf("preserve attachment %q: %w", filename, decErr)
+			case filename != "" && (part.Body.Data != "" || part.Body.Size == 0):
+				var data []byte
+				if part.Body.Data != "" {
+					decoded, decErr := decodeBase64URLBytes(part.Body.Data)
+					if decErr != nil {
+						return fmt.Errorf("preserve attachment %q: %w", filename, decErr)
+					}
+					data = decoded
 				}
 				out = append(out, mailAttachment{
 					Filename: filename,
 					MIMEType: part.MimeType,
 					Data:     data,
+					DataSet:  true,
 				})
 			}
 		}
@@ -380,6 +387,23 @@ func carryForwardDraftAttachments(ctx context.Context, svc *gmail.Service, messa
 		return nil, err
 	}
 	return out, nil
+}
+
+func fetchDraftAttachmentBytes(ctx context.Context, svc *gmail.Service, messageID, attachmentID string, expectedSize int64) ([]byte, error) {
+	body, err := svc.Users.Messages.Attachments.Get("me", messageID, attachmentID).Context(ctx).Do()
+	if err != nil {
+		return nil, err
+	}
+	if body == nil {
+		return nil, errors.New("empty attachment data")
+	}
+	if body.Data == "" {
+		if expectedSize == 0 {
+			return []byte{}, nil
+		}
+		return nil, errors.New("empty attachment data")
+	}
+	return decodeBase64URLBytes(body.Data)
 }
 
 func writeDraftResult(ctx context.Context, u *ui.UI, draft *gmail.Draft, threadID string) error {

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1270,6 +1270,15 @@ func TestGmailDraftsUpdateCmd_WithQuoteAndReplyToMessageID(t *testing.T) {
 				},
 			})
 			return
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			// Update now reads the existing draft to preserve attachments; this
+			// draft has none, so preservation is a no-op.
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "d1",
+				"message": map[string]any{"id": "dm1", "threadId": "t1"},
+			})
+			return
 		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
 			body, err := io.ReadAll(r.Body)
 			if err != nil {
@@ -1588,5 +1597,133 @@ func TestGmailDraftsUpdateCmd_WithThreadIDOverridesExisting(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), "Subject: Re: Original") {
 		t.Fatalf("subject not auto-filled from caller thread:\n%s", string(raw))
+	}
+}
+
+// draftUpdateAttachmentServer stubs a draft (with one attachment) get, the
+// attachment bytes endpoint, and the update PUT (capturing the posted draft).
+func draftUpdateAttachmentServer(t *testing.T, posted *gmail.Draft, attBytesHit *bool) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id": "d1",
+				"message": map[string]any{
+					"id": "dm1",
+					"payload": map[string]any{
+						"mimeType": "multipart/mixed",
+						"headers":  []map[string]any{{"name": "To", "value": "keep@example.com"}},
+						"parts": []map[string]any{
+							{"mimeType": "text/plain", "body": map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("old body"))}},
+							{"filename": "report.pdf", "mimeType": "application/pdf", "body": map[string]any{"attachmentId": "att1", "size": 5}},
+						},
+					},
+				},
+			})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/dm1/attachments/att1") && r.Method == http.MethodGet:
+			*attBytesHit = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("HELLO")), "size": 5})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			if unmarshalErr := json.Unmarshal(body, posted); unmarshalErr != nil {
+				t.Fatalf("unmarshal: %v", unmarshalErr)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "d1", "message": map[string]any{"id": "m2", "threadId": "t1"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func runDraftUpdate(t *testing.T, srv *httptest.Server, args []string) {
+	t.Helper()
+	origNew := newGmailService
+	t.Cleanup(func() { newGmailService = origNew })
+	svc, err := gmail.NewService(context.Background(),
+		option.WithoutAuthentication(), option.WithHTTPClient(srv.Client()), option.WithEndpoint(srv.URL+"/"))
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newGmailService = func(context.Context, string) (*gmail.Service, error) { return svc, nil }
+	flags := &RootFlags{Account: "a@b.com"}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+	_ = captureStdout(t, func() {
+		if runErr := runKong(t, &GmailDraftsUpdateCmd{}, args, ctx, flags); runErr != nil {
+			t.Fatalf("execute: %v", runErr)
+		}
+	})
+}
+
+// Omitting --attach on update preserves the draft's existing attachments.
+func TestGmailDraftsUpdateCmd_PreservesAttachmentsWhenOmitted(t *testing.T) {
+	var posted gmail.Draft
+	attBytesHit := false
+	srv := draftUpdateAttachmentServer(t, &posted, &attBytesHit)
+	defer srv.Close()
+
+	runDraftUpdate(t, srv, []string{"d1", "--to", "keep@example.com", "--subject", "S", "--body", "new body"})
+
+	if !attBytesHit {
+		t.Fatal("expected attachment bytes to be fetched for preservation")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(posted.Message.Raw)
+	if err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	s := string(raw)
+	if !strings.Contains(s, `filename="report.pdf"`) {
+		t.Fatalf("preserved attachment filename missing from rebuilt draft:\n%s", s)
+	}
+	if !strings.Contains(s, base64.StdEncoding.EncodeToString([]byte("HELLO"))) {
+		t.Fatalf("preserved attachment bytes missing from rebuilt draft:\n%s", s)
+	}
+}
+
+// --clear-attachments drops the draft's existing attachments and skips the byte fetch.
+func TestGmailDraftsUpdateCmd_ClearAttachmentsRemovesThem(t *testing.T) {
+	var posted gmail.Draft
+	attBytesHit := false
+	srv := draftUpdateAttachmentServer(t, &posted, &attBytesHit)
+	defer srv.Close()
+
+	runDraftUpdate(t, srv, []string{"d1", "--to", "keep@example.com", "--subject", "S", "--body", "new body", "--clear-attachments"})
+
+	if attBytesHit {
+		t.Fatal("did not expect attachment bytes to be fetched when clearing")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(posted.Message.Raw)
+	if err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if strings.Contains(string(raw), "report.pdf") {
+		t.Fatalf("attachment should have been cleared:\n%s", string(raw))
+	}
+}
+
+// --attach and --clear-attachments are mutually exclusive.
+func TestGmailDraftsUpdateCmd_AttachAndClearMutuallyExclusive(t *testing.T) {
+	attachPath := filepath.Join(t.TempDir(), "f.txt")
+	if err := os.WriteFile(attachPath, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write attach: %v", err)
+	}
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	flags := &RootFlags{Account: "a@b.com"}
+	err := runKong(t, &GmailDraftsUpdateCmd{}, []string{
+		"d1", "--subject", "S", "--body", "B", "--attach", attachPath, "--clear-attachments",
+	}, ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "use only one of --attach or --clear-attachments") {
+		t.Fatalf("expected mutual-exclusion error, got %v", err)
 	}
 }

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1618,7 +1618,9 @@ func draftUpdateAttachmentServer(t *testing.T, posted *gmail.Draft, attBytesHit 
 						"parts": []map[string]any{
 							{"mimeType": "text/plain", "body": map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("old body"))}},
 							{"filename": "report.pdf", "mimeType": "application/pdf", "body": map[string]any{"attachmentId": "att1", "size": 5}},
+							{"filename": "empty.bin", "mimeType": "application/octet-stream", "body": map[string]any{"attachmentId": "att-empty", "size": 0}},
 							{"filename": "inline.txt", "mimeType": "text/plain", "body": map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("INLINE")), "size": 6}},
+							{"filename": "zero.txt", "mimeType": "text/plain", "body": map[string]any{"data": "", "size": 0}},
 						},
 					},
 				},
@@ -1627,6 +1629,9 @@ func draftUpdateAttachmentServer(t *testing.T, posted *gmail.Draft, attBytesHit 
 			*attBytesHit = true
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("HELLO")), "size": 5})
+		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/messages/dm1/attachments/att-empty") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"data": "", "size": 0})
 		case strings.Contains(r.URL.Path, "/gmail/v1/users/me/drafts/d1") && r.Method == http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
 			if unmarshalErr := json.Unmarshal(body, posted); unmarshalErr != nil {
@@ -1686,11 +1691,17 @@ func TestGmailDraftsUpdateCmd_PreservesAttachmentsWhenOmitted(t *testing.T) {
 	if !strings.Contains(s, base64.StdEncoding.EncodeToString([]byte("HELLO"))) {
 		t.Fatalf("preserved attachment bytes missing from rebuilt draft:\n%s", s)
 	}
+	if !strings.Contains(s, `filename="empty.bin"`) {
+		t.Fatalf("zero-byte fetched attachment filename missing from rebuilt draft:\n%s", s)
+	}
 	if !strings.Contains(s, `filename="inline.txt"`) {
 		t.Fatalf("inline attachment filename missing from rebuilt draft:\n%s", s)
 	}
 	if !strings.Contains(s, base64.StdEncoding.EncodeToString([]byte("INLINE"))) {
 		t.Fatalf("inline attachment bytes missing from rebuilt draft:\n%s", s)
+	}
+	if !strings.Contains(s, `filename="zero.txt"`) {
+		t.Fatalf("zero-byte inline attachment filename missing from rebuilt draft:\n%s", s)
 	}
 }
 

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -1618,6 +1618,7 @@ func draftUpdateAttachmentServer(t *testing.T, posted *gmail.Draft, attBytesHit 
 						"parts": []map[string]any{
 							{"mimeType": "text/plain", "body": map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("old body"))}},
 							{"filename": "report.pdf", "mimeType": "application/pdf", "body": map[string]any{"attachmentId": "att1", "size": 5}},
+							{"filename": "inline.txt", "mimeType": "text/plain", "body": map[string]any{"data": base64.RawURLEncoding.EncodeToString([]byte("INLINE")), "size": 6}},
 						},
 					},
 				},
@@ -1684,6 +1685,12 @@ func TestGmailDraftsUpdateCmd_PreservesAttachmentsWhenOmitted(t *testing.T) {
 	}
 	if !strings.Contains(s, base64.StdEncoding.EncodeToString([]byte("HELLO"))) {
 		t.Fatalf("preserved attachment bytes missing from rebuilt draft:\n%s", s)
+	}
+	if !strings.Contains(s, `filename="inline.txt"`) {
+		t.Fatalf("inline attachment filename missing from rebuilt draft:\n%s", s)
+	}
+	if !strings.Contains(s, base64.StdEncoding.EncodeToString([]byte("INLINE"))) {
+		t.Fatalf("inline attachment bytes missing from rebuilt draft:\n%s", s)
 	}
 }
 

--- a/internal/cmd/gmail_forward.go
+++ b/internal/cmd/gmail_forward.go
@@ -100,6 +100,7 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 				Filename: att.Filename,
 				MIMEType: att.MimeType,
 				Data:     data,
+				DataSet:  true,
 			})
 		}
 	}

--- a/internal/cmd/gmail_mime.go
+++ b/internal/cmd/gmail_mime.go
@@ -21,6 +21,7 @@ type mailAttachment struct {
 	Filename string
 	MIMEType string
 	Data     []byte
+	DataSet  bool
 }
 
 type rfc822Config struct {
@@ -195,7 +196,7 @@ func buildRFC822(opts mailOptions, cfg *rfc822Config) ([]byte, error) {
 				a.MIMEType = "application/octet-stream"
 			}
 		}
-		if len(a.Data) == 0 {
+		if len(a.Data) == 0 && !a.DataSet {
 			data, err := os.ReadFile(a.Path)
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
Closes #680.

## Problem
`gmail drafts update` rebuilds the whole message from the flags on that invocation, so omitting `--attach` **silently drops the draft's existing attachments** — a data-loss footgun when editing only the body/subject of a draft that has files attached.

**Live repro on shipped `gog v0.20.0`:**
```
$ gog gmail drafts create --subject bugrepro --body v1 --attach ev.png
$ gog gmail drafts get <id>   → attachments: ['ev.png']
$ gog gmail drafts update <id> --subject bugrepro --body v2     # no --attach
$ gog gmail drafts get <id>   → attachments: NONE               # dropped
```

## Fix (addresses the product question raised on the issue)
The issue flagged that preserve-by-default needs an explicit clear/replace path. This PR does both:

- **Preserve by default:** when `--attach` is omitted (and `--clear-attachments` is not set), re-read the existing draft's attachment bytes and carry them into the rebuilt message — reusing the exact `collectAttachments` + `fetchAttachmentBytes` path `gmail forward` already uses to re-attach.
- **`--attach` replaces** attachments (explicit replacement; unchanged).
- **New `--clear-attachments`** removes all attachments; mutually exclusive with `--attach`.
- `clear_attachments` + `preserve_attachments` added to the dry-run/JSON payload.

So: edit a draft body → attachments stay; `--attach` → replace; `--clear-attachments` → intentional removal. No silent loss, and the intentional-clear workflow still has a home.

## Tests
- `TestGmailDraftsUpdateCmd_PreservesAttachmentsWhenOmitted` — wire-level: stubs the draft GET (with an attachment), the attachment-bytes GET, and the update PUT; asserts the rebuilt draft's raw MIME contains the preserved `filename="report.pdf"` and its bytes, and that the attachment-bytes endpoint was hit.
- `TestGmailDraftsUpdateCmd_ClearAttachmentsRemovesThem` — `--clear-attachments` drops the attachment and skips the byte fetch.
- `TestGmailDraftsUpdateCmd_AttachAndClearMutuallyExclusive` — guard.
- `go test ./internal/cmd` green; `make lint` 0 issues; `make docs-commands` regenerated.

## Verification notes
- The **bug** is reproduced live above on shipped `gog v0.20.0`.
- The **fix** is verified by the wire-level tests, which simulate the exact Gmail API interaction (draft GET → attachment bytes GET → PUT with the attachment re-embedded). A live run of the *patched* binary against a real account was blocked locally — the unsigned dev build can't get a non-interactive macOS Keychain grant — but the reattach mechanism is identical to the already-shipped `gmail forward` path.

(Reported via the gogcli-mcp wrapper, which currently documents the replace-semantics caveat; once this ships the wrapper drops that caveat.)

## ⚠️ Migration note (behavior change)

This intentionally changes the default semantics of `gmail drafts update`:

- **Before:** omitting `--attach` rebuilt the draft *without* attachments — i.e. an omitted `--attach` silently **cleared** them.
- **After:** omitting `--attach` **preserves** the existing attachments. To intentionally clear them, pass the new **`--clear-attachments`** flag.

Callers/scripts that relied on omitted-`--attach` to drop attachments must switch to `--clear-attachments`. `--attach <paths>` still replaces.

## Patched live proof (real Gmail account)

Ran a **patched** binary (`v0.21.1-…-8a8bc925`, this branch) against a real account — all three semantics confirmed:

```
1. create --attach ev.png            -> attachments: [(ev.png, 67)]
2. update --body "v2" (no --attach)   -> attachments: [(ev.png, 67)]   # PRESERVED (was NONE on shipped gog)
3. update --attach notes.txt          -> attachments: [(notes.txt, 11)] # REPLACED
4. update --clear-attachments         -> attachments: NONE              # CLEARED
```

Preserve-by-default, explicit `--attach` replace, and explicit `--clear-attachments` removal all verified live (scratch draft created, exercised, deleted). Combined with the shipped-gog bug repro above, this covers the before/after end to end.
