### PR TITLE
feat(chat): support file attachments in messages send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.22.1 - Unreleased
 
+### Added
+
+- Chat: add repeatable `--attach` to `chat messages send` for sending local files with Google Chat messages. (#694) — thanks @omothm.
+
 ## 0.22.0 - 2026-06-07
 
 ### Added

--- a/docs/commands/gog-chat-messages-send.md
+++ b/docs/commands/gog-chat-messages-send.md
@@ -20,6 +20,7 @@ gog chat messages send (create,post) <space> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--attach` | `[]string` |  | Attachment file path, e.g. an image (repeatable) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -35,7 +36,7 @@ gog chat messages send (create,post) <space> [flags]
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--text` | `string` |  | Message text (required) |
+| `--text` | `string` |  | Message text (required unless --attach is provided) |
 | `--thread` | `string` |  | Reply to thread (spaces/.../threads/...) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |

--- a/internal/cmd/chat_helpers.go
+++ b/internal/cmd/chat_helpers.go
@@ -1,10 +1,15 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"google.golang.org/api/chat/v1"
+
+	"github.com/steipete/gogcli/internal/config"
 )
 
 func normalizeSpace(resource string) (string, error) {
@@ -182,4 +187,52 @@ func chatMessageThread(msg *chat.Message) string {
 func sanitizeChatText(s string) string {
 	replacer := strings.NewReplacer("\t", " ", "\n", " ", "\r", " ")
 	return replacer.Replace(s)
+}
+
+// expandChatAttachmentPaths resolves user-supplied attachment paths (~, env vars)
+// to absolute paths without reading the files. Used for validation and dry-run.
+func expandChatAttachmentPaths(paths []string) ([]string, error) {
+	expanded := make([]string, 0, len(paths))
+	for _, path := range paths {
+		trimmed := strings.TrimSpace(path)
+		if trimmed == "" {
+			return nil, usage("attachment path must not be empty")
+		}
+		resolved, err := config.ExpandPath(trimmed)
+		if err != nil {
+			return nil, err
+		}
+		expanded = append(expanded, resolved)
+	}
+	return expanded, nil
+}
+
+// uploadChatAttachments uploads each file to the given space and returns the
+// attachment refs to embed in a message. Uploads happen in order; the first
+// failure aborts and is returned to the caller.
+func uploadChatAttachments(ctx context.Context, svc *chat.Service, space string, paths []string) ([]*chat.Attachment, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	attachments := make([]*chat.Attachment, 0, len(paths))
+	for _, path := range paths {
+		f, err := os.Open(path) //nolint:gosec // path is user-supplied by design (local CLI)
+		if err != nil {
+			return nil, fmt.Errorf("open attachment %q: %w", path, err)
+		}
+		req := &chat.UploadAttachmentRequest{Filename: filepath.Base(path)}
+		resp, err := svc.Media.Upload(space, req).Media(f).Context(ctx).Do()
+		closeErr := f.Close()
+		if err != nil {
+			return nil, fmt.Errorf("upload attachment %q: %w", path, err)
+		}
+		if closeErr != nil {
+			return nil, fmt.Errorf("close attachment %q: %w", path, closeErr)
+		}
+		if resp == nil || resp.AttachmentDataRef == nil {
+			return nil, fmt.Errorf("upload attachment %q: empty data ref in response", path)
+		}
+		attachments = append(attachments, &chat.Attachment{AttachmentDataRef: resp.AttachmentDataRef})
+	}
+	return attachments, nil
 }

--- a/internal/cmd/chat_messages.go
+++ b/internal/cmd/chat_messages.go
@@ -154,9 +154,10 @@ func (c *ChatMessagesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type ChatMessagesSendCmd struct {
-	Space  string `arg:"" name:"space" help:"Space name (spaces/...)"`
-	Text   string `name:"text" help:"Message text (required)"`
-	Thread string `name:"thread" help:"Reply to thread (spaces/.../threads/...)"`
+	Space  string   `arg:"" name:"space" help:"Space name (spaces/...)"`
+	Text   string   `name:"text" help:"Message text (required unless --attach is provided)"`
+	Thread string   `name:"thread" help:"Reply to thread (spaces/.../threads/...)"`
+	Attach []string `name:"attach" help:"Attachment file path, e.g. an image (repeatable)"`
 }
 
 func (c *ChatMessagesSendCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -167,8 +168,12 @@ func (c *ChatMessagesSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	text := strings.TrimSpace(c.Text)
-	if text == "" {
-		return usage("required: --text")
+	attachPaths, err := expandChatAttachmentPaths(c.Attach)
+	if err != nil {
+		return err
+	}
+	if text == "" && len(attachPaths) == 0 {
+		return usage("required: --text or --attach")
 	}
 
 	message := &chat.Message{Text: text}
@@ -189,6 +194,7 @@ func (c *ChatMessagesSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"thread":                       threadName,
 		"thread_raw":                   thread,
 		"reply_fallback_to_new_thread": thread != "",
+		"attachments":                  attachPaths,
 	}); dryRunErr != nil {
 		return dryRunErr
 	}
@@ -204,6 +210,14 @@ func (c *ChatMessagesSendCmd) Run(ctx context.Context, flags *RootFlags) error {
 	svc, err := newChatService(ctx, account)
 	if err != nil {
 		return err
+	}
+
+	if len(attachPaths) > 0 {
+		attachments, uploadErr := uploadChatAttachments(ctx, svc, space, attachPaths)
+		if uploadErr != nil {
+			return uploadErr
+		}
+		message.Attachment = attachments
 	}
 
 	call := svc.Spaces.Messages.Create(space, message)

--- a/internal/cmd/execute_chat_test.go
+++ b/internal/cmd/execute_chat_test.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -441,6 +443,120 @@ func TestExecute_ChatMessagesSend_JSON(t *testing.T) {
 	if !strings.Contains(out, "spaces/aaa/messages/msg2") {
 		t.Fatalf("unexpected out=%q", out)
 	}
+}
+
+func TestExecute_ChatMessagesSend_WithAttachment(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "pic.png")
+	if err := os.WriteFile(imgPath, []byte("\x89PNG\r\n\x1a\nfake"), 0o600); err != nil {
+		t.Fatalf("write temp image: %v", err)
+	}
+
+	var uploadHits int
+	var gotUploadParent string
+	var gotAttachmentToken string
+
+	useFakeChatService(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "attachments:upload"):
+			uploadHits++
+			gotUploadParent = strings.TrimPrefix(r.URL.Path, "/upload/v1/")
+			gotUploadParent = strings.TrimPrefix(gotUploadParent, "v1/")
+			gotUploadParent = strings.TrimSuffix(gotUploadParent, "/attachments:upload")
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"attachmentDataRef": map[string]any{"attachmentUploadToken": "tok-123"},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/messages"):
+			var body map[string]any
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if atts, ok := body["attachment"].([]any); ok && len(atts) == 1 {
+				if att, ok := atts[0].(map[string]any); ok {
+					if ref, ok := att["attachmentDataRef"].(map[string]any); ok {
+						gotAttachmentToken, _ = ref["attachmentUploadToken"].(string)
+					}
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "spaces/aaa/messages/msg3"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	out := captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--json", "--account", "a@b.com", "chat", "messages", "send", "spaces/aaa", "--text", "look", "--attach", imgPath}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+
+	if uploadHits != 1 {
+		t.Fatalf("expected exactly 1 upload, got %d", uploadHits)
+	}
+	if gotUploadParent != "spaces/aaa" {
+		t.Fatalf("unexpected upload parent: %q", gotUploadParent)
+	}
+	if gotAttachmentToken != "tok-123" {
+		t.Fatalf("attachment token not forwarded to message, got %q", gotAttachmentToken)
+	}
+	if !strings.Contains(out, "spaces/aaa/messages/msg3") {
+		t.Fatalf("unexpected out=%q", out)
+	}
+}
+
+func TestExecute_ChatMessagesSend_AttachmentOnlyNoText(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "pic.png")
+	if err := os.WriteFile(imgPath, []byte("fake-bytes"), 0o600); err != nil {
+		t.Fatalf("write temp image: %v", err)
+	}
+
+	var messageSent bool
+	useFakeChatService(t, func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "attachments:upload"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"attachmentDataRef": map[string]any{"attachmentUploadToken": "tok-xyz"},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/messages"):
+			messageSent = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"name": "spaces/aaa/messages/msg4"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	_ = captureStdout(t, func() {
+		_ = captureStderr(t, func() {
+			if err := Execute([]string{"--account", "a@b.com", "chat", "messages", "send", "spaces/aaa", "--attach", imgPath}); err != nil {
+				t.Fatalf("Execute: %v", err)
+			}
+		})
+	})
+	if !messageSent {
+		t.Fatalf("expected message to be sent with attachment-only payload")
+	}
+}
+
+func TestExecute_ChatMessagesSend_NoTextNoAttachFails(t *testing.T) {
+	origNew := newChatService
+	t.Cleanup(func() { newChatService = origNew })
+	newChatService = func(context.Context, string) (*chat.Service, error) {
+		t.Fatalf("expected validation to fail before creating chat service")
+		return nil, errUnexpectedChatServiceCall
+	}
+
+	_ = captureStderr(t, func() {
+		err := Execute([]string{"--account", "a@b.com", "chat", "messages", "send", "spaces/aaa"})
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
 }
 
 func TestExecute_ChatMessagesSend_InvalidResourceFailsBeforeDryRun(t *testing.T) {


### PR DESCRIPTION
Adds a repeatable `--attach` flag to `chat messages send` for uploading local files (e.g. images) alongside a message. Each file is uploaded through the Chat Media API to obtain an attachment data ref, then attached to the single `Messages.Create` call. `--text` becomes optional when at least one attachment is provided, so attachment-only messages are allowed.

**No new OAuth scope** is required — the existing `chat.messages` scope already authorizes the upload endpoint. Attachments render as image/file cards beneath the message (Chat's standard preview), not embedded inline in the text body.

## Verification

The Chat command test suite covers the upload→ref→attach flow, attachment-only sends, and the no-text/no-attach validation error. `make lint` reports 0 issues.

Also exercised **live against the real Chat API** — a two-attachment message posted successfully. Redacted server response (auth tokens in `downloadUri`/`thumbnailUri` stripped):

```
$ gog --json --account <me> chat messages send spaces/<space> \
    --text "<message>" \
    --attach 20-e2etestcrs-FIXED-address-management.png \
    --attach 21-sbmmstestt-FIXED-address-management.png
```

```json
{
  "message": {
    "name": "spaces/REDACTED/messages/9WtvBkoxp3k.9WtvBkoxp3k",
    "thread": { "name": "spaces/REDACTED/threads/9WtvBkoxp3k" },
    "createTime": "2026-06-04T19:09:42.621295Z",
    "sender": { "name": "users/REDACTED", "type": "HUMAN" },
    "attachment": [
      {
        "contentName": "20-e2etestcrs-FIXED-address-management.png",
        "contentType": "image/png",
        "source": "UPLOADED_CONTENT",
        "attachmentDataRef": { "resourceName": "REDACTED" },
        "downloadUri": "https://chat.google.com/api/get_attachment_url?...&attachment_token=REDACTED",
        "thumbnailUri": "https://chat.google.com/api/get_attachment_url?...&attachment_token=REDACTED"
      },
      {
        "contentName": "21-sbmmstestt-FIXED-address-management.png",
        "contentType": "image/png",
        "source": "UPLOADED_CONTENT",
        "attachmentDataRef": { "resourceName": "REDACTED" },
        "downloadUri": "https://chat.google.com/api/get_attachment_url?...&attachment_token=REDACTED",
        "thumbnailUri": "https://chat.google.com/api/get_attachment_url?...&attachment_token=REDACTED"
      }
    ]
  }
}
```

Both files came back as `source: UPLOADED_CONTENT` / `contentType: image/png`, confirming the upload→ref→attach path end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
