### PR TITLE
feat(slides): add insert-image to place a sized image on an existing slide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Chat: add repeatable `--attach` to `chat messages send` for sending local files with Google Chat messages. (#694) — thanks @omothm.
+- Slides: add `slides insert-image` to place a positioned, sized local image on an existing slide. (#695) — thanks @Czaruno.
 
 ## 0.22.0 - 2026-06-07
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -541,6 +541,7 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) delete-slide <presentationId> <slideId>`](commands/gog-slides-delete-slide.md) - Delete a slide by object ID
     - [`gog slides (slide) export (download,dl) <presentationId> [flags]`](commands/gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
     - [`gog slides (slide) info (get,show) <presentationId>`](commands/gog-slides-info.md) - Get Google Slides presentation metadata
+    - [`gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> <image> [flags]`](commands/gog-slides-insert-image.md) - Insert an image at a position and size on an existing slide
     - [`gog slides (slide) insert-text <presentationId> <objectId> <text> [flags]`](commands/gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [`gog slides (slide) list-slides <presentationId>`](commands/gog-slides-list-slides.md) - List all slides with their object IDs
     - [`gog slides (slide) raw <presentationId> [flags]`](commands/gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 583.
+Generated pages: 584.
 
 ## Top-level Commands
 
@@ -593,6 +593,7 @@ Generated pages: 583.
     - [gog slides delete-slide](gog-slides-delete-slide.md) - Delete a slide by object ID
     - [gog slides export](gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
     - [gog slides info](gog-slides-info.md) - Get Google Slides presentation metadata
+    - [gog slides insert-image](gog-slides-insert-image.md) - Insert an image at a position and size on an existing slide
     - [gog slides insert-text](gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
     - [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs
     - [gog slides raw](gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)

--- a/docs/commands/gog-slides-insert-image.md
+++ b/docs/commands/gog-slides-insert-image.md
@@ -1,38 +1,18 @@
-# `gog slides`
+# `gog slides insert-image`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Slides
+Insert an image at a position and size on an existing slide
 
 ## Usage
 
 ```bash
-gog slides (slide) <command> [flags]
+gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> <image> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog slides add-slide](gog-slides-add-slide.md) - Add a slide with a full-bleed image and optional speaker notes
-- [gog slides copy](gog-slides-copy.md) - Copy a Google Slides presentation
-- [gog slides create](gog-slides-create.md) - Create a Google Slides presentation
-- [gog slides create-from-markdown](gog-slides-create-from-markdown.md) - Create a Google Slides presentation from markdown
-- [gog slides create-from-template](gog-slides-create-from-template.md) - Create a presentation from template with text replacements
-- [gog slides delete-slide](gog-slides-delete-slide.md) - Delete a slide by object ID
-- [gog slides export](gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
-- [gog slides info](gog-slides-info.md) - Get Google Slides presentation metadata
-- [gog slides insert-image](gog-slides-insert-image.md) - Insert an image at a position and size on an existing slide
-- [gog slides insert-text](gog-slides-insert-text.md) - Insert text into an existing page element (shape or table) by objectId
-- [gog slides list-slides](gog-slides-list-slides.md) - List all slides with their object IDs
-- [gog slides raw](gog-slides-raw.md) - Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)
-- [gog slides read-slide](gog-slides-read-slide.md) - Read slide content: speaker notes, text elements, and images
-- [gog slides replace-slide](gog-slides-replace-slide.md) - Replace the image on an existing slide in-place
-- [gog slides replace-text](gog-slides-replace-text.md) - Find-and-replace text across a presentation
-- [gog slides thumbnail](gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
-- [gog slides update-notes](gog-slides-update-notes.md) - Update speaker notes on an existing slide
+- [gog slides](gog-slides.md)
 
 ## Flags
 
@@ -48,6 +28,7 @@ gog slides (slide) <command> [flags]
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `--height` | `float64` | 0 | Image height, in --unit; omit to keep the image's aspect ratio |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
@@ -55,11 +36,15 @@ gog slides (slide) <command> [flags]
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--unit` | `string` | PT | Measurement unit for x/y/width/height (PT or EMU) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--width` | `float64` |  | Image width, in --unit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+| `--x` | `float64` | 0 | Left position of the image, in --unit |
+| `--y` | `float64` | 0 | Top position of the image, in --unit |
 
 ## See Also
 
-- [gog](gog.md)
+- [gog slides](gog-slides.md)
 - [Command index](README.md)

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -30,6 +30,7 @@ type SlidesCmd struct {
 	Thumbnail          SlidesThumbnailCmd          `cmd:"" name:"thumbnail" aliases:"thumb" help:"Get or download a rendered thumbnail for a slide"`
 	UpdateNotes        SlidesUpdateNotesCmd        `cmd:"" name:"update-notes" help:"Update speaker notes on an existing slide"`
 	ReplaceSlide       SlidesReplaceSlideCmd       `cmd:"" name:"replace-slide" help:"Replace the image on an existing slide in-place"`
+	InsertImage        SlidesInsertImageCmd        `cmd:"" name:"insert-image" help:"Insert an image at a position and size on an existing slide"`
 	InsertText         SlidesInsertTextCmd         `cmd:"" name:"insert-text" help:"Insert text into an existing page element (shape or table) by objectId"`
 	ReplaceText        SlidesReplaceTextCmd        `cmd:"" name:"replace-text" help:"Find-and-replace text across a presentation"`
 	Raw                SlidesRawCmd                `cmd:"" name:"raw" help:"Dump raw Google Slides API response as JSON (Presentations.Get; lossless; for scripting and LLM consumption)"`

--- a/internal/cmd/slides_insert_image.go
+++ b/internal/cmd/slides_insert_image.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"image"
+	_ "image/gif"  // register GIF decoder for aspect detection
+	_ "image/jpeg" // register JPEG decoder for aspect detection
+	_ "image/png"  // register PNG decoder for aspect detection
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// SlidesInsertImageCmd inserts an image at an explicit position and size on an
+// existing slide. Unlike add-slide (which lays a full-bleed image on a new
+// slide), this places a sized element on a slide you already have, so callers
+// can build native decks via the Slides API and still drop in a logo, chart,
+// or badge at a precise location. It reuses the same private-image flow as
+// add-slide: upload to Drive, grant a temporary read permission so the Slides
+// image fetcher can read it, create the image, then delete the temp file.
+type SlidesInsertImageCmd struct {
+	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	SlideID        string  `arg:"" name:"slideId" help:"Slide object ID to place the image on"`
+	Image          string  `arg:"" name:"image" help:"Local image file (PNG/JPG/GIF)" type:"existingfile"`
+	X              float64 `name:"x" default:"0" help:"Left position of the image, in --unit"`
+	Y              float64 `name:"y" default:"0" help:"Top position of the image, in --unit"`
+	Width          float64 `name:"width" required:"" help:"Image width, in --unit"`
+	Height         float64 `name:"height" default:"0" help:"Image height, in --unit; omit to keep the image's aspect ratio"`
+	Unit           string  `name:"unit" enum:"PT,EMU" default:"PT" help:"Measurement unit for x/y/width/height (PT or EMU)"`
+}
+
+func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+
+	presentationID := strings.TrimSpace(c.PresentationID)
+	if presentationID == "" {
+		return usage("empty presentationId")
+	}
+	slideID := strings.TrimSpace(c.SlideID)
+	if slideID == "" {
+		return usage("empty slideId")
+	}
+	if c.Width <= 0 {
+		return usage("--width must be greater than 0")
+	}
+	if c.Height < 0 {
+		return usage("--height cannot be negative")
+	}
+
+	// Validate image format.
+	ext := strings.ToLower(filepath.Ext(c.Image))
+	var mimeType string
+	switch ext {
+	case extPNG:
+		mimeType = mimePNG
+	case imageExtJPG, imageExtJPEG:
+		mimeType = imageMimeJPEG
+	case imageExtGIF:
+		mimeType = imageMimeGIF
+	default:
+		return usagef("unsupported image format %q (use PNG, JPG, or GIF)", ext)
+	}
+
+	// Resolve height from the image's aspect ratio when not supplied.
+	height := c.Height
+	if height == 0 {
+		ar, err := imageAspectRatio(c.Image)
+		if err != nil {
+			return fmt.Errorf("determine image aspect ratio (pass --height to skip): %w", err)
+		}
+		height = c.Width * ar
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "slides.insert-image", map[string]any{
+		"presentation_id": presentationID,
+		"slide_id":        slideID,
+		"image":           c.Image,
+		"mime_type":       mimeType,
+		"x":               c.X,
+		"y":               c.Y,
+		"width":           c.Width,
+		"height":          height,
+		"unit":            c.Unit,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+
+	slidesSvc, err := newSlidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+	driveSvc, err := newDriveService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	// Confirm the target slide exists before uploading anything.
+	pres, err := slidesSvc.Presentations.Get(presentationID).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("get presentation: %w", err)
+	}
+	if _, idx := findSlidesPageByID(pres, slideID); idx == -1 {
+		return fmt.Errorf("slide %q not found in presentation", slideID)
+	}
+
+	// Upload the image to Drive as a temporary file.
+	imgFile, err := os.Open(c.Image)
+	if err != nil {
+		return fmt.Errorf("open image: %w", err)
+	}
+	defer imgFile.Close()
+
+	driveFile, err := driveSvc.Files.Create(&drive.File{
+		Name:     filepath.Base(c.Image),
+		MimeType: mimeType,
+	}).Media(imgFile).Fields("id, webContentLink").Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("upload image to Drive: %w", err)
+	}
+
+	// Clean up the temporary Drive file when done.
+	defer func() {
+		_ = driveSvc.Files.Delete(driveFile.Id).Context(ctx).Do()
+	}()
+
+	// Make publicly readable so the Slides API can fetch it.
+	_, err = driveSvc.Permissions.Create(driveFile.Id, &drive.Permission{
+		Type: "anyone",
+		Role: "reader",
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("set image permissions: %w", err)
+	}
+
+	imageURL := driveImageDownloadURL(driveFile.Id)
+	imageID := fmt.Sprintf("img_%d", time.Now().UnixNano())
+
+	err = batchUpdateSlidesImageRequests(ctx, slidesSvc, presentationID, &slides.BatchUpdatePresentationRequest{
+		Requests: []*slides.Request{
+			{
+				CreateImage: &slides.CreateImageRequest{
+					ObjectId: imageID,
+					Url:      imageURL,
+					ElementProperties: &slides.PageElementProperties{
+						PageObjectId: slideID,
+						Size: &slides.Size{
+							Width:  &slides.Dimension{Magnitude: c.Width, Unit: c.Unit},
+							Height: &slides.Dimension{Magnitude: height, Unit: c.Unit},
+						},
+						Transform: &slides.AffineTransform{
+							ScaleX:     1,
+							ScaleY:     1,
+							TranslateX: c.X,
+							TranslateY: c.Y,
+							Unit:       c.Unit,
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("insert image: %w", err)
+	}
+
+	link := fmt.Sprintf("https://docs.google.com/presentation/d/%s/edit", presentationID)
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"presentationId": presentationID,
+			"slideObjectId":  slideID,
+			"imageObjectId":  imageID,
+			"link":           link,
+		})
+	}
+
+	u.Out().Linef("image\t%s", imageID)
+	u.Out().Linef("link\t%s", link)
+	return nil
+}
+
+// imageAspectRatio returns height/width for the given image file.
+func imageAspectRatio(path string) (float64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0, fmt.Errorf("open image: %w", err)
+	}
+	defer f.Close()
+
+	cfg, _, err := image.DecodeConfig(f)
+	if err != nil {
+		return 0, fmt.Errorf("decode image config: %w", err)
+	}
+	if cfg.Width <= 0 {
+		return 0, fmt.Errorf("image has zero width")
+	}
+	return float64(cfg.Height) / float64(cfg.Width), nil
+}

--- a/internal/cmd/slides_insert_image.go
+++ b/internal/cmd/slides_insert_image.go
@@ -102,18 +102,20 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if err != nil {
 		return err
 	}
-	driveSvc, err := newDriveService(ctx, account)
-	if err != nil {
-		return err
-	}
 
-	// Confirm the target slide exists before uploading anything.
+	// Confirm the target slide exists before creating the Drive service or
+	// uploading anything, so a bad slide id never touches Drive.
 	pres, err := slidesSvc.Presentations.Get(presentationID).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("get presentation: %w", err)
 	}
 	if _, idx := findSlidesPageByID(pres, slideID); idx == -1 {
 		return fmt.Errorf("slide %q not found in presentation", slideID)
+	}
+
+	driveSvc, err := newDriveService(ctx, account)
+	if err != nil {
+		return err
 	}
 
 	// Upload the image to Drive as a temporary file.
@@ -131,9 +133,14 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return fmt.Errorf("upload image to Drive: %w", err)
 	}
 
-	// Clean up the temporary Drive file when done.
+	// Clean up the temporary Drive file when done. Use a cancellation-immune
+	// context so the public temp file is still removed if the request context
+	// was canceled, and surface a loud warning if deletion fails (otherwise the
+	// uploaded image stays world-readable until someone removes it by hand).
 	defer func() {
-		_ = driveSvc.Files.Delete(driveFile.Id).Context(ctx).Do()
+		if delErr := driveSvc.Files.Delete(driveFile.Id).Context(context.WithoutCancel(ctx)).Do(); delErr != nil {
+			u.Err().Linef("Warning: failed to delete temporary Drive image %s; it may remain publicly readable until removed: %v", driveFile.Id, delErr)
+		}
 	}()
 
 	// Make publicly readable so the Slides API can fetch it.

--- a/internal/cmd/slides_insert_image.go
+++ b/internal/cmd/slides_insert_image.go
@@ -201,7 +201,7 @@ func (c *SlidesInsertImageCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 // imageAspectRatio returns height/width for the given image file.
 func imageAspectRatio(path string) (float64, error) {
-	f, err := os.Open(path)
+	f, err := os.Open(path) //nolint:gosec // user-provided local image path is the command input.
 	if err != nil {
 		return 0, fmt.Errorf("open image: %w", err)
 	}

--- a/internal/cmd/slides_insert_image_test.go
+++ b/internal/cmd/slides_insert_image_test.go
@@ -133,7 +133,11 @@ func TestSlidesInsertImage_PlacesSizedImageOnExistingSlide(t *testing.T) {
 
 func TestSlidesInsertImage_RejectsMissingSlide(t *testing.T) {
 	origSlides := newSlidesService
-	t.Cleanup(func() { newSlidesService = origSlides })
+	origDrive := newDriveService
+	t.Cleanup(func() {
+		newSlidesService = origSlides
+		newDriveService = origDrive
+	})
 
 	slidesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/slides_insert_image_test.go
+++ b/internal/cmd/slides_insert_image_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"image"
 	"image/color"
 	"image/png"
@@ -152,7 +153,7 @@ func TestSlidesInsertImage_RejectsMissingSlide(t *testing.T) {
 	newSlidesService = func(context.Context, string) (*slides.Service, error) { return slidesSvc, nil }
 	newDriveService = func(context.Context, string) (*drive.Service, error) {
 		t.Fatal("Drive should not be called when the slide is missing")
-		return nil, nil
+		return nil, errors.New("unexpected Drive service call")
 	}
 
 	imgPath := newTestImage(t, "logo.png")
@@ -243,8 +244,8 @@ func TestImageAspectRatio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
-	if err := png.Encode(f, img); err != nil {
-		t.Fatalf("encode: %v", err)
+	if encodeErr := png.Encode(f, img); encodeErr != nil {
+		t.Fatalf("encode: %v", encodeErr)
 	}
 	_ = f.Close()
 

--- a/internal/cmd/slides_insert_image_test.go
+++ b/internal/cmd/slides_insert_image_test.go
@@ -161,6 +161,75 @@ func TestSlidesInsertImage_RejectsMissingSlide(t *testing.T) {
 	}
 }
 
+func TestSlidesInsertImage_WarnsWhenCleanupFails(t *testing.T) {
+	origSlides := newSlidesService
+	origDrive := newDriveService
+	t.Cleanup(func() {
+		newSlidesService = origSlides
+		newDriveService = origDrive
+	})
+
+	slidesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, ":batchUpdate") && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{"presentationId": "pres1", "replies": []any{map[string]any{}}})
+		case strings.Contains(r.URL.Path, "/presentations/pres1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(slidesPresGetResponse("", false))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer slidesSrv.Close()
+
+	driveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/upload/") && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "img_123"})
+		case strings.Contains(r.URL.Path, "/files/img_123/permissions") && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "perm1"})
+		case strings.Contains(r.URL.Path, "/files/img_123") && r.Method == http.MethodDelete:
+			// Simulate a cleanup failure.
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": 500, "message": "boom"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer driveSrv.Close()
+
+	slidesSvc, err := slides.NewService(context.Background(),
+		option.WithoutAuthentication(), option.WithHTTPClient(slidesSrv.Client()), option.WithEndpoint(slidesSrv.URL+"/"))
+	if err != nil {
+		t.Fatalf("slides.NewService: %v", err)
+	}
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return slidesSvc, nil }
+	driveSvc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(), option.WithHTTPClient(driveSrv.Client()), option.WithEndpoint(driveSrv.URL+"/"))
+	if err != nil {
+		t.Fatalf("drive.NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return driveSvc, nil }
+
+	imgPath := newTestImage(t, "logo.png")
+	flags := &RootFlags{Account: "a@b.com"}
+
+	var stderr strings.Builder
+	u, uiErr := ui.New(ui.Options{Stdout: io.Discard, Stderr: &stderr, Color: "never"})
+	if uiErr != nil {
+		t.Fatalf("ui.New: %v", uiErr)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	cmd := &SlidesInsertImageCmd{PresentationID: "pres1", SlideID: "existing_slide_1", Image: imgPath, Width: 100, Height: 100, Unit: "PT"}
+	if err := cmd.Run(ctx, flags); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(stderr.String(), "failed to delete temporary Drive image") {
+		t.Errorf("expected a cleanup-failure warning on stderr, got: %q", stderr.String())
+	}
+}
+
 func TestImageAspectRatio(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "wide.png")

--- a/internal/cmd/slides_insert_image_test.go
+++ b/internal/cmd/slides_insert_image_test.go
@@ -1,0 +1,185 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/png"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestSlidesInsertImage_PlacesSizedImageOnExistingSlide(t *testing.T) {
+	origSlides := newSlidesService
+	origDrive := newDriveService
+	t.Cleanup(func() {
+		newSlidesService = origSlides
+		newDriveService = origDrive
+	})
+
+	var captured slides.BatchUpdatePresentationRequest
+	slidesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, ":batchUpdate") && r.Method == http.MethodPost:
+			_ = json.NewDecoder(r.Body).Decode(&captured)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"presentationId": "pres1",
+				"replies":        []any{map[string]any{}},
+			})
+		case strings.Contains(r.URL.Path, "/presentations/pres1") && r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(slidesPresGetResponse("", false))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer slidesSrv.Close()
+
+	var deleteCalled, permsCalled bool
+	driveSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "/upload/") && r.Method == http.MethodPost:
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "img_123", "webContentLink": "https://drive.google.com/uc?id=img_123"})
+		case strings.Contains(r.URL.Path, "/files/img_123/permissions") && r.Method == http.MethodPost:
+			permsCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "perm1"})
+		case strings.Contains(r.URL.Path, "/files/img_123") && r.Method == http.MethodDelete:
+			deleteCalled = true
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer driveSrv.Close()
+
+	slidesSvc, err := slides.NewService(context.Background(),
+		option.WithoutAuthentication(), option.WithHTTPClient(slidesSrv.Client()), option.WithEndpoint(slidesSrv.URL+"/"))
+	if err != nil {
+		t.Fatalf("slides.NewService: %v", err)
+	}
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return slidesSvc, nil }
+
+	driveSvc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(), option.WithHTTPClient(driveSrv.Client()), option.WithEndpoint(driveSrv.URL+"/"))
+	if err != nil {
+		t.Fatalf("drive.NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return driveSvc, nil }
+
+	imgPath := newTestImage(t, "logo.png")
+	flags := &RootFlags{Account: "a@b.com"}
+
+	out := captureStdout(t, func() {
+		u, uiErr := ui.New(ui.Options{Stdout: os.Stdout, Stderr: io.Discard, Color: "never"})
+		if uiErr != nil {
+			t.Fatalf("ui.New: %v", uiErr)
+		}
+		ctx := ui.WithUI(context.Background(), u)
+		cmd := &SlidesInsertImageCmd{
+			PresentationID: "pres1",
+			SlideID:        "existing_slide_1",
+			Image:          imgPath,
+			X:              560,
+			Y:              24,
+			Width:          120,
+			Height:         60,
+			Unit:           "PT",
+		}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	})
+
+	if !permsCalled {
+		t.Errorf("expected a temporary public read permission to be set")
+	}
+	if !deleteCalled {
+		t.Errorf("expected the temporary Drive file to be deleted")
+	}
+	if len(captured.Requests) != 1 || captured.Requests[0].CreateImage == nil {
+		t.Fatalf("expected one createImage request, got %+v", captured.Requests)
+	}
+	ci := captured.Requests[0].CreateImage
+	ep := ci.ElementProperties
+	if ep == nil || ep.PageObjectId != "existing_slide_1" {
+		t.Errorf("image not placed on the target slide: %+v", ep)
+	}
+	if ep.Size == nil || ep.Size.Width == nil || ep.Size.Width.Magnitude != 120 || ep.Size.Width.Unit != "PT" {
+		t.Errorf("unexpected width: %+v", ep.Size)
+	}
+	if ep.Size.Height == nil || ep.Size.Height.Magnitude != 60 {
+		t.Errorf("unexpected height: %+v", ep.Size)
+	}
+	if ep.Transform == nil || ep.Transform.TranslateX != 560 || ep.Transform.TranslateY != 24 || ep.Transform.Unit != "PT" {
+		t.Errorf("unexpected transform: %+v", ep.Transform)
+	}
+	if !strings.Contains(out, "image\t") || !strings.Contains(out, "/presentation/d/pres1/edit") {
+		t.Errorf("unexpected output: %q", out)
+	}
+}
+
+func TestSlidesInsertImage_RejectsMissingSlide(t *testing.T) {
+	origSlides := newSlidesService
+	t.Cleanup(func() { newSlidesService = origSlides })
+
+	slidesSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(slidesPresGetResponse("", false))
+	}))
+	defer slidesSrv.Close()
+	slidesSvc, err := slides.NewService(context.Background(),
+		option.WithoutAuthentication(), option.WithHTTPClient(slidesSrv.Client()), option.WithEndpoint(slidesSrv.URL+"/"))
+	if err != nil {
+		t.Fatalf("slides.NewService: %v", err)
+	}
+	newSlidesService = func(context.Context, string) (*slides.Service, error) { return slidesSvc, nil }
+	newDriveService = func(context.Context, string) (*drive.Service, error) {
+		t.Fatal("Drive should not be called when the slide is missing")
+		return nil, nil
+	}
+
+	imgPath := newTestImage(t, "logo.png")
+	flags := &RootFlags{Account: "a@b.com"}
+	u, _ := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	ctx := ui.WithUI(context.Background(), u)
+	cmd := &SlidesInsertImageCmd{PresentationID: "pres1", SlideID: "nope", Image: imgPath, Width: 100}
+	if err := cmd.Run(ctx, flags); err == nil {
+		t.Fatal("expected error for missing slide")
+	}
+}
+
+func TestImageAspectRatio(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "wide.png")
+	img := image.NewRGBA(image.Rect(0, 0, 200, 100)) // 2:1, so height/width = 0.5
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if err := png.Encode(f, img); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	_ = f.Close()
+
+	ar, err := imageAspectRatio(path)
+	if err != nil {
+		t.Fatalf("imageAspectRatio: %v", err)
+	}
+	if ar != 0.5 {
+		t.Errorf("expected aspect ratio 0.5, got %v", ar)
+	}
+}


### PR DESCRIPTION
## What

Adds `gog slides insert-image`: place a **positioned, sized** image on an **existing** slide.

`add-slide` is great for full-bleed image slides, but there's no way to drop a sized image (a logo top-right, a chart in a content area) onto a slide you already have. The Slides REST `createImage` only accepts a publicly-fetchable URL, so callers otherwise have to hand-roll the upload + temporary public permission + `createImage` + cleanup, or make files public by hand.

This reuses the exact private-image flow `add-slide`/`replace-slide` already use, so nothing is left public:

1. Upload the image to Drive as a temp file.
2. Grant a temporary `anyone: reader` permission so the Slides image fetcher can read it.
3. `createImage` onto the target slide with explicit size + transform.
4. Delete the temp Drive file (`defer`).

## Usage

```
gog slides insert-image <presentationId> <slideId> <image> \
  --x=<n> --y=<n> --width=<n> [--height=<n>] [--unit=PT|EMU]
```

- Args: `presentationId`, `slideId`, `image` (PNG/JPG/GIF).
- `--width` is required; `--height` is optional and derived from the image's aspect ratio when omitted.
- `--unit` defaults to `PT`.
- Confirms the target slide exists before uploading anything.

## Testing

- `go build ./...`, `go vet ./internal/cmd/` clean.
- New unit tests (httptest-mocked Drive + Slides, mirroring `slides_add_slide_test.go`):
  - places the image on the target slide with the expected size/transform, sets the temp permission, and deletes the temp file;
  - rejects a missing slide before any Drive call;
  - aspect-ratio derivation.
- Existing `./internal/cmd` tests still pass.
- Verified live end to end against a real presentation: inserted a 120pt square logo at the top-right of an existing slide and confirmed placement via the rendered thumbnail.

## Notes

- No new module dependencies (stdlib `image` for aspect detection).
- Per-command docs under `docs/commands/` can be regenerated by the maintainers' doc tooling.