### PR TITLE
feat(docs): add code format flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Docs: add `--code` to `docs format` and plain-text `docs write` for the existing monospace grey code style. (#685) — thanks @sebsnyk.
 - Drive/Docs: add `--since` to `drive comments list` and `docs comments list` for server-side comment modified-time filtering. (#688) — thanks @sebsnyk.
 - Gmail: add `--thread-id` to `gmail drafts create` and `gmail drafts update` so drafts can reply within a thread using the latest message headers. (#673, #674) — thanks @chrischall.
 

--- a/docs/commands/gog-docs-format.md
+++ b/docs/commands/gog-docs-format.md
@@ -24,6 +24,7 @@ gog docs (doc) format <docId> [flags]
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--code` | `bool` |  | Apply code style (Courier New + grey background) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |

--- a/docs/commands/gog-docs-write.md
+++ b/docs/commands/gog-docs-write.md
@@ -25,6 +25,7 @@ gog docs (doc) write <docId> [flags]
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--code` | `bool` |  | Apply code style (Courier New + grey background) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |

--- a/internal/cmd/docs_format.go
+++ b/internal/cmd/docs_format.go
@@ -27,6 +27,7 @@ type DocsFormatFlags struct {
 	FontSize      float64 `name:"font-size" help:"Font size in points"`
 	TextColor     string  `name:"text-color" help:"Text color as #RRGGBB or #RGB"`
 	BgColor       string  `name:"bg-color" help:"Text background color as #RRGGBB or #RGB"`
+	Code          bool    `name:"code" help:"Apply code style (Courier New + grey background)"`
 	Bold          bool    `name:"bold" help:"Set bold"`
 	NoBold        bool    `name:"no-bold" help:"Clear bold"`
 	Italic        bool    `name:"italic" help:"Set italic"`
@@ -86,6 +87,7 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 			"font_size":     c.Format.FontSize,
 			"text_color":    c.Format.TextColor,
 			"bg_color":      c.Format.BgColor,
+			"code":          c.Format.Code,
 			"bold":          c.Format.Bold,
 			"no_bold":       c.Format.NoBold,
 			"italic":        c.Format.Italic,
@@ -218,6 +220,7 @@ func (f DocsFormatFlags) any() bool {
 		f.FontSize != 0 ||
 		strings.TrimSpace(f.TextColor) != "" ||
 		strings.TrimSpace(f.BgColor) != "" ||
+		f.Code ||
 		f.Bold || f.NoBold ||
 		f.Italic || f.NoItalic ||
 		f.Underline || f.NoUnderline ||
@@ -257,6 +260,17 @@ func (f DocsFormatFlags) buildTextStyleRequest(start, end int64, tabID string) (
 	style := &docs.TextStyle{}
 	var fields []string
 
+	if f.Code {
+		if strings.TrimSpace(f.FontFamily) != "" {
+			return nil, false, usage("--code cannot be combined with --font-family")
+		}
+		if strings.TrimSpace(f.BgColor) != "" {
+			return nil, false, usage("--code cannot be combined with --bg-color")
+		}
+		style.WeightedFontFamily = &docs.WeightedFontFamily{FontFamily: "Courier New"}
+		style.BackgroundColor = greyColor(codeBackgroundGrey)
+		fields = append(fields, "weightedFontFamily", "backgroundColor")
+	}
 	if font := strings.TrimSpace(f.FontFamily); font != "" {
 		style.WeightedFontFamily = &docs.WeightedFontFamily{FontFamily: font}
 		fields = append(fields, "weightedFontFamily")

--- a/internal/cmd/docs_format_test.go
+++ b/internal/cmd/docs_format_test.go
@@ -67,6 +67,34 @@ func TestDocsFormatFlagsBuildRequests(t *testing.T) {
 	}
 }
 
+func TestDocsFormatFlagsBuildRequestsCode(t *testing.T) {
+	reqs, err := (DocsFormatFlags{Code: true}).buildRequests(3, 9, "t.second")
+	if err != nil {
+		t.Fatalf("buildRequests: %v", err)
+	}
+	if len(reqs) != 1 {
+		t.Fatalf("expected text request, got %d", len(reqs))
+	}
+	textReq := reqs[0].UpdateTextStyle
+	if textReq == nil {
+		t.Fatalf("missing text request: %#v", reqs[0])
+	}
+	if textReq.Fields != "weightedFontFamily,backgroundColor" {
+		t.Fatalf("unexpected text fields: %q", textReq.Fields)
+	}
+	style := textReq.TextStyle
+	if style.WeightedFontFamily == nil || style.WeightedFontFamily.FontFamily != "Courier New" {
+		t.Fatalf("unexpected code font: %#v", style.WeightedFontFamily)
+	}
+	rgb := style.BackgroundColor.Color.RgbColor
+	if rgb.Red != codeBackgroundGrey || rgb.Green != codeBackgroundGrey || rgb.Blue != codeBackgroundGrey {
+		t.Fatalf("unexpected code background: %#v", rgb)
+	}
+	if got := textReq.Range; got.StartIndex != 3 || got.EndIndex != 9 || got.TabId != "t.second" {
+		t.Fatalf("unexpected text range: %#v", got)
+	}
+}
+
 func TestDocsFormatFlagsValidation(t *testing.T) {
 	if _, err := (DocsFormatFlags{TextColor: "oops"}).buildRequests(1, 2, ""); err == nil {
 		t.Fatalf("expected invalid color error")
@@ -76,6 +104,12 @@ func TestDocsFormatFlagsValidation(t *testing.T) {
 	}
 	if _, err := (DocsFormatFlags{Alignment: "sideways"}).buildRequests(1, 2, ""); err == nil {
 		t.Fatalf("expected invalid alignment error")
+	}
+	if _, err := (DocsFormatFlags{Code: true, FontFamily: "Arial"}).buildRequests(1, 2, ""); err == nil {
+		t.Fatalf("expected conflicting code/font-family flags error")
+	}
+	if _, err := (DocsFormatFlags{Code: true, BgColor: "#fff"}).buildRequests(1, 2, ""); err == nil {
+		t.Fatalf("expected conflicting code/bg-color flags error")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `--code` to the shared Docs format flags, applying the existing Courier New + grey background code style.
- Reject `--code` with `--font-family` or `--bg-color`, because those fields are owned by the code style.
- Regenerate command docs and add the changelog entry for #685.

Closes #685.

## Proof

- `go test ./internal/cmd -run 'TestDocsFormatFlags|TestDocsFormatCmdMatchAll'`
- `go test ./internal/cmd/...`
- `make docs-commands`
- `make ci`
- `autoreview --mode local` clean, no accepted/actionable findings
- Live E2E with `clawdbot@gmail.com`: created scratch Doc `1Uir0CrHQoOCW13kRLtOZcR0VRlIja43XcLzsYjk5QVM`, verified raw Docs API styling for both `docs format --code` and plain-text `docs write --code`, verified conflicts for `--font-family` and `--bg-color`, then trashed the Doc and verified `trashed:true`.
