### PR TITLE
feat(sheets): add `links set` to write cell hyperlinks (incl. multi-link rich text)

### DIFF
--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -501,7 +501,9 @@ Generated from `gog schema --json`.
     - [`gog sheets (sheet) freeze <spreadsheetId> [flags]`](commands/gog-sheets-freeze.md) - Freeze rows and columns on a sheet
     - [`gog sheets (sheet) get (read,show) <spreadsheetId> <range> [flags]`](commands/gog-sheets-get.md) - Get values from a range
     - [`gog sheets (sheet) insert <spreadsheetId> <sheet> <dimension> <start> [flags]`](commands/gog-sheets-insert.md) - Insert empty rows or columns into a sheet
-    - [`gog sheets (sheet) links (hyperlinks) <spreadsheetId> <range>`](commands/gog-sheets-links.md) - Get cell hyperlinks from a range
+    - [`gog sheets (sheet) links (hyperlinks) <command>`](commands/gog-sheets-links.md) - Get or set cell hyperlinks
+      - [`gog sheets (sheet) links (hyperlinks) get (list,show) <spreadsheetId> <range>`](commands/gog-sheets-links-get.md) - Get cell hyperlinks from a range
+      - [`gog sheets (sheet) links (hyperlinks) set (write) <spreadsheetId> [<cell> [<url> [<text>]]] [flags]`](commands/gog-sheets-links-set.md) - Set cell hyperlinks (rich-text links)
     - [`gog sheets (sheet) merge <spreadsheetId> <range> [flags]`](commands/gog-sheets-merge.md) - Merge cells in a range
     - [`gog sheets (sheet) metadata (info) <spreadsheetId>`](commands/gog-sheets-metadata.md) - Get spreadsheet metadata
     - [`gog sheets (sheet) named-ranges (namedranges,nr) <command>`](commands/gog-sheets-named-ranges.md) - Manage named ranges

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 585.
+Generated pages: 587.
 
 ## Top-level Commands
 
@@ -553,7 +553,9 @@ Generated pages: 585.
     - [gog sheets freeze](gog-sheets-freeze.md) - Freeze rows and columns on a sheet
     - [gog sheets get](gog-sheets-get.md) - Get values from a range
     - [gog sheets insert](gog-sheets-insert.md) - Insert empty rows or columns into a sheet
-    - [gog sheets links](gog-sheets-links.md) - Get cell hyperlinks from a range
+    - [gog sheets links](gog-sheets-links.md) - Get or set cell hyperlinks
+      - [gog sheets links get](gog-sheets-links-get.md) - Get cell hyperlinks from a range
+      - [gog sheets links set](gog-sheets-links-set.md) - Set cell hyperlinks (rich-text links)
     - [gog sheets merge](gog-sheets-merge.md) - Merge cells in a range
     - [gog sheets metadata](gog-sheets-metadata.md) - Get spreadsheet metadata
     - [gog sheets named-ranges](gog-sheets-named-ranges.md) - Manage named ranges

--- a/docs/commands/gog-sheets-links-get.md
+++ b/docs/commands/gog-sheets-links-get.md
@@ -1,23 +1,18 @@
-# `gog sheets links`
+# `gog sheets links get`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Get or set cell hyperlinks
+Get cell hyperlinks from a range
 
 ## Usage
 
 ```bash
-gog sheets (sheet) links (hyperlinks) <command>
+gog sheets (sheet) links (hyperlinks) get (list,show) <spreadsheetId> <range>
 ```
 
 ## Parent
 
-- [gog sheets](gog-sheets.md)
-
-## Subcommands
-
-- [gog sheets links get](gog-sheets-links-get.md) - Get cell hyperlinks from a range
-- [gog sheets links set](gog-sheets-links-set.md) - Set cell hyperlinks (rich-text links)
+- [gog sheets links](gog-sheets-links.md)
 
 ## Flags
 
@@ -46,5 +41,5 @@ gog sheets (sheet) links (hyperlinks) <command>
 
 ## See Also
 
-- [gog sheets](gog-sheets.md)
+- [gog sheets links](gog-sheets-links.md)
 - [Command index](README.md)

--- a/docs/commands/gog-sheets-links-set.md
+++ b/docs/commands/gog-sheets-links-set.md
@@ -1,23 +1,18 @@
-# `gog sheets links`
+# `gog sheets links set`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Get or set cell hyperlinks
+Set cell hyperlinks (rich-text links)
 
 ## Usage
 
 ```bash
-gog sheets (sheet) links (hyperlinks) <command>
+gog sheets (sheet) links (hyperlinks) set (write) <spreadsheetId> [<cell> [<url> [<text>]]] [flags]
 ```
 
 ## Parent
 
-- [gog sheets](gog-sheets.md)
-
-## Subcommands
-
-- [gog sheets links get](gog-sheets-links-get.md) - Get cell hyperlinks from a range
-- [gog sheets links set](gog-sheets-links-set.md) - Set cell hyperlinks (rich-text links)
+- [gog sheets links](gog-sheets-links.md)
 
 ## Flags
 
@@ -25,6 +20,7 @@ gog sheets (sheet) links (hyperlinks) <command>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--cells-json` | `string` |  | Batch: JSON array of {cell,url,text} or {cell,runs:[{text,uri}]} objects, written in one request. |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -39,6 +35,7 @@ gog sheets (sheet) links (hyperlinks) <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--runs-json` | `string` |  | Multi-link cell: JSON array of runs, eg. [{"text":"Act A","uri":"https://a"},{"text":" / "},{"text":"Act B","uri":"https://b"}]. A run with an empty uri is plain text. |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -46,5 +43,5 @@ gog sheets (sheet) links (hyperlinks) <command>
 
 ## See Also
 
-- [gog sheets](gog-sheets.md)
+- [gog sheets links](gog-sheets-links.md)
 - [Command index](README.md)

--- a/docs/commands/gog-sheets.md
+++ b/docs/commands/gog-sheets.md
@@ -33,7 +33,7 @@ gog sheets (sheet) <command> [flags]
 - [gog sheets freeze](gog-sheets-freeze.md) - Freeze rows and columns on a sheet
 - [gog sheets get](gog-sheets-get.md) - Get values from a range
 - [gog sheets insert](gog-sheets-insert.md) - Insert empty rows or columns into a sheet
-- [gog sheets links](gog-sheets-links.md) - Get cell hyperlinks from a range
+- [gog sheets links](gog-sheets-links.md) - Get or set cell hyperlinks
 - [gog sheets merge](gog-sheets-merge.md) - Merge cells in a range
 - [gog sheets metadata](gog-sheets-metadata.md) - Get spreadsheet metadata
 - [gog sheets named-ranges](gog-sheets-named-ranges.md) - Manage named ranges

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -47,7 +47,7 @@ type SheetsCmd struct {
 	Notes         SheetsNotesCmd         `cmd:"" name:"notes" help:"Get cell notes from a range"`
 	UpdateNote    SheetsUpdateNoteCmd    `cmd:"" name:"update-note" aliases:"set-note" help:"Set or clear a cell note"`
 	FindReplace   SheetsFindReplaceCmd   `cmd:"" name:"find-replace" help:"Find and replace text across a spreadsheet"`
-	Links         SheetsLinksCmd         `cmd:"" name:"links" aliases:"hyperlinks" help:"Get cell hyperlinks from a range"`
+	Links         SheetsLinksCmd         `cmd:"" name:"links" aliases:"hyperlinks" help:"Get or set cell hyperlinks"`
 	Named         SheetsNamedRangesCmd   `cmd:"" name:"named-ranges" aliases:"namedranges,nr" help:"Manage named ranges"`
 	Table         SheetsTableCmd         `cmd:"" name:"table" aliases:"tables" help:"Manage Google Sheets tables"`
 	Metadata      SheetsMetadataCmd      `cmd:"" name:"metadata" aliases:"info" help:"Get spreadsheet metadata"`

--- a/internal/cmd/sheets_links.go
+++ b/internal/cmd/sheets_links.go
@@ -12,12 +12,20 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+// SheetsLinksCmd groups the hyperlink read (get) and write (set) subcommands.
+// get is the default so the historical `gog sheets links <id> <range>` form
+// keeps working unchanged.
 type SheetsLinksCmd struct {
+	Get SheetsLinksGetCmd `cmd:"" default:"withargs" aliases:"list,show" help:"Get cell hyperlinks from a range"`
+	Set SheetsLinksSetCmd `cmd:"" name:"set" aliases:"write" help:"Set cell hyperlinks (rich-text links)"`
+}
+
+type SheetsLinksGetCmd struct {
 	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
 	Range         string `arg:"" name:"range" help:"Range (eg. Sheet1!A1:B10)"`
 }
 
-func (c *SheetsLinksCmd) Run(ctx context.Context, flags *RootFlags) error {
+func (c *SheetsLinksGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 
 	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))

--- a/internal/cmd/sheets_links_set.go
+++ b/internal/cmd/sheets_links_set.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"unicode/utf16"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+// linkRun is one styled segment of a cell's text. A run with an empty Uri is
+// plain (unlinked) text; runs with a Uri become a hyperlinked segment.
+type linkRun struct {
+	Text string `json:"text"`
+	Uri  string `json:"uri"`
+}
+
+// linkCellSpec is one cell to write, from --cells-json or the positional form.
+// Provide either Runs (multi-link rich text) or URL[+Text] (single link).
+type linkCellSpec struct {
+	Cell string    `json:"cell"`
+	URL  string    `json:"url"`
+	Text string    `json:"text"`
+	Runs []linkRun `json:"runs"`
+}
+
+// resolvedCell is a spec turned into the concrete payload to send.
+type resolvedCell struct {
+	a1   string
+	text string
+	runs []*sheets.TextFormatRun
+	uris []string
+}
+
+type SheetsLinksSetCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	Cell          string `arg:"" optional:"" name:"cell" help:"Target cell (eg. Sheet1!B2). Omit when using --cells-json."`
+	URL           string `arg:"" optional:"" name:"url" help:"URL to link to."`
+	Text          string `arg:"" optional:"" name:"text" help:"Display text (defaults to the URL)."`
+
+	RunsJSON  string `name:"runs-json" help:"Multi-link cell: JSON array of runs, eg. [{\"text\":\"Act A\",\"uri\":\"https://a\"},{\"text\":\" / \"},{\"text\":\"Act B\",\"uri\":\"https://b\"}]. A run with an empty uri is plain text."`
+	CellsJSON string `name:"cells-json" help:"Batch: JSON array of {cell,url,text} or {cell,runs:[{text,uri}]} objects, written in one request."`
+}
+
+func (c *SheetsLinksSetCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+
+	specs, err := c.collectSpecs()
+	if err != nil {
+		return err
+	}
+
+	// Resolve each spec into text + runs, validating cells (single cell each)
+	// before any network call so dry-run reports the real plan.
+	resolved := make([]resolvedCell, 0, len(specs))
+	for i, s := range specs {
+		rc, rcErr := resolveLinkCell(s, i)
+		if rcErr != nil {
+			return rcErr
+		}
+		resolved = append(resolved, rc)
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "sheets.links.set", map[string]any{
+		"spreadsheet_id": spreadsheetID,
+		"cells":          summarizeResolved(resolved),
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := newSheetsService(ctx, account)
+	if err != nil {
+		return err
+	}
+	sheetIDs, err := fetchSheetIDMap(ctx, svc, spreadsheetID)
+	if err != nil {
+		return err
+	}
+
+	requests := make([]*sheets.Request, 0, len(resolved))
+	for _, rc := range resolved {
+		parsed, perr := parseSheetRange(rc.a1, "links")
+		if perr != nil {
+			return perr
+		}
+		grid, gerr := gridRangeFromMap(parsed, sheetIDs, "links")
+		if gerr != nil {
+			return gerr
+		}
+		start := &sheets.GridCoordinate{
+			SheetId:         grid.SheetId,
+			RowIndex:        grid.StartRowIndex,
+			ColumnIndex:     grid.StartColumnIndex,
+			ForceSendFields: []string{"SheetId", "RowIndex", "ColumnIndex"},
+		}
+		text := rc.text
+		cell := &sheets.CellData{
+			UserEnteredValue: &sheets.ExtendedValue{
+				StringValue:     &text,
+				ForceSendFields: []string{"StringValue"},
+			},
+			TextFormatRuns: rc.runs,
+		}
+		requests = append(requests, &sheets.Request{
+			UpdateCells: &sheets.UpdateCellsRequest{
+				Start:  start,
+				Rows:   []*sheets.RowData{{Values: []*sheets.CellData{cell}}},
+				Fields: "userEnteredValue,textFormatRuns",
+			},
+		})
+	}
+
+	batchReq := &sheets.BatchUpdateSpreadsheetRequest{Requests: requests}
+	if _, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, batchReq).Do(); err != nil {
+		return fmt.Errorf("set links: %w", err)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"spreadsheetId": spreadsheetID,
+			"cellsUpdated":  len(resolved),
+			"cells":         summarizeResolved(resolved),
+		})
+	}
+
+	if len(resolved) == 1 {
+		u.Out().Linef("Set links on %s", resolved[0].a1)
+	} else {
+		u.Out().Linef("Set links on %d cells", len(resolved))
+	}
+	return nil
+}
+
+// collectSpecs builds the list of cells to write from either --cells-json
+// (batch) or the positional/single-cell form, rejecting a mix of the two.
+func (c *SheetsLinksSetCmd) collectSpecs() ([]linkCellSpec, error) {
+	if strings.TrimSpace(c.CellsJSON) != "" {
+		if c.Cell != "" || c.URL != "" || c.Text != "" || c.RunsJSON != "" {
+			return nil, usage("use either positional cell args or --cells-json, not both")
+		}
+		var specs []linkCellSpec
+		if err := json.Unmarshal([]byte(c.CellsJSON), &specs); err != nil {
+			return nil, usagef("parse --cells-json: %v", err)
+		}
+		if len(specs) == 0 {
+			return nil, usage("--cells-json is empty")
+		}
+		return specs, nil
+	}
+
+	if strings.TrimSpace(c.Cell) == "" {
+		return nil, usage("provide a target cell (or use --cells-json)")
+	}
+	spec := linkCellSpec{Cell: c.Cell, URL: c.URL, Text: c.Text}
+	if strings.TrimSpace(c.RunsJSON) != "" {
+		if c.URL != "" {
+			return nil, usage("use either url/text or --runs-json, not both")
+		}
+		if err := json.Unmarshal([]byte(c.RunsJSON), &spec.Runs); err != nil {
+			return nil, usagef("parse --runs-json: %v", err)
+		}
+	}
+	return []linkCellSpec{spec}, nil
+}
+
+// resolveLinkCell turns a spec into the concrete cell text + text-format runs.
+func resolveLinkCell(s linkCellSpec, idx int) (resolvedCell, error) {
+	cellA1 := cleanRange(s.Cell)
+	if strings.TrimSpace(cellA1) == "" {
+		return resolvedCell{}, usagef("entry %d: empty cell", idx)
+	}
+	// Each write targets exactly one cell.
+	parsed, err := parseSheetRange(cellA1, "links")
+	if err != nil {
+		return resolvedCell{}, err
+	}
+	if parsed.StartRow != parsed.EndRow || parsed.StartCol != parsed.EndCol ||
+		parsed.StartRow == 0 || parsed.StartCol == 0 {
+		return resolvedCell{}, usagef("links set targets a single cell, got %q", cellA1)
+	}
+
+	if len(s.Runs) > 0 {
+		var sb strings.Builder
+		runs := make([]*sheets.TextFormatRun, 0, len(s.Runs))
+		uris := make([]string, 0, len(s.Runs))
+		offset := 0
+		for _, r := range s.Runs {
+			run := &sheets.TextFormatRun{
+				StartIndex:      int64(offset),
+				Format:          &sheets.TextFormat{},
+				ForceSendFields: []string{"StartIndex"},
+			}
+			if strings.TrimSpace(r.Uri) != "" {
+				run.Format.Link = &sheets.Link{Uri: r.Uri}
+				uris = append(uris, r.Uri)
+			}
+			runs = append(runs, run)
+			sb.WriteString(r.Text)
+			offset += len(utf16.Encode([]rune(r.Text)))
+		}
+		text := sb.String()
+		if text == "" {
+			return resolvedCell{}, usagef("entry %d (%s): runs produce empty text", idx, cellA1)
+		}
+		return resolvedCell{a1: cellA1, text: text, runs: runs, uris: uris}, nil
+	}
+
+	url := strings.TrimSpace(s.URL)
+	if url == "" {
+		return resolvedCell{}, usagef("entry %d (%s): provide url (or runs)", idx, cellA1)
+	}
+	text := s.Text
+	if text == "" {
+		text = url
+	}
+	run := &sheets.TextFormatRun{
+		StartIndex:      0,
+		Format:          &sheets.TextFormat{Link: &sheets.Link{Uri: url}},
+		ForceSendFields: []string{"StartIndex"},
+	}
+	return resolvedCell{a1: cellA1, text: text, runs: []*sheets.TextFormatRun{run}, uris: []string{url}}, nil
+}
+
+func summarizeResolved(resolved []resolvedCell) []map[string]any {
+	out := make([]map[string]any, 0, len(resolved))
+	for _, rc := range resolved {
+		out = append(out, map[string]any{
+			"cell": rc.a1,
+			"text": rc.text,
+			"uris": rc.uris,
+		})
+	}
+	return out
+}

--- a/internal/cmd/sheets_links_set.go
+++ b/internal/cmd/sheets_links_set.go
@@ -118,9 +118,15 @@ func (c *SheetsLinksSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 		requests = append(requests, &sheets.Request{
 			UpdateCells: &sheets.UpdateCellsRequest{
-				Start:  start,
-				Rows:   []*sheets.RowData{{Values: []*sheets.CellData{cell}}},
-				Fields: "userEnteredValue,textFormatRuns",
+				Start: start,
+				Rows:  []*sheets.RowData{{Values: []*sheets.CellData{cell}}},
+				// Also clear any pre-existing whole-cell hyperlink
+				// (userEnteredFormat.textFormat.link): the cell above leaves
+				// that field unset, so listing it in the mask resets it to none.
+				// Without this, a cell that previously held a whole-cell link
+				// would keep the stale URL alongside the new runs and `links
+				// get` would still report it — the write wouldn't round-trip.
+				Fields: "userEnteredValue,textFormatRuns,userEnteredFormat.textFormat.link",
 			},
 		})
 	}

--- a/internal/cmd/sheets_links_set_test.go
+++ b/internal/cmd/sheets_links_set_test.go
@@ -1,0 +1,294 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type linksSetRecorder struct {
+	requests []map[string]any
+}
+
+func linksSetHandler(recorder *linksSetRecorder) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/sheets/v4")
+		path = strings.TrimPrefix(path, "/v4")
+
+		// Metadata GET → resolve sheet name → ID.
+		if strings.HasPrefix(path, "/spreadsheets/s1") && r.Method == http.MethodGet && !strings.Contains(path, "batchUpdate") {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "s1",
+				"sheets": []map[string]any{
+					{"properties": map[string]any{"sheetId": 0, "title": "Sheet1"}},
+				},
+			})
+			return
+		}
+
+		// batchUpdate POST → record requests.
+		if strings.HasPrefix(path, "/spreadsheets/s1:batchUpdate") && r.Method == http.MethodPost {
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			reqs, _ := body["requests"].([]any)
+			recorder.requests = recorder.requests[:0]
+			for _, rq := range reqs {
+				if m, ok := rq.(map[string]any); ok {
+					recorder.requests = append(recorder.requests, m)
+				}
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"spreadsheetId": "s1"})
+			return
+		}
+
+		http.Error(w, "unexpected "+r.Method+" "+path, http.StatusNotFound)
+	})
+}
+
+func newLinksSetService(t *testing.T, recorder *linksSetRecorder) *sheets.Service {
+	t.Helper()
+	srv := httptest.NewServer(linksSetHandler(recorder))
+	t.Cleanup(srv.Close)
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	return svc
+}
+
+func linksSetCtx(t *testing.T) context.Context {
+	t.Helper()
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	return outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+}
+
+// updateCellsCell digs the single CellData map out of recorded request index i.
+func updateCellsCell(t *testing.T, rec *linksSetRecorder, i int) map[string]any {
+	t.Helper()
+	uc, ok := rec.requests[i]["updateCells"].(map[string]any)
+	if !ok {
+		t.Fatalf("request %d not updateCells: %#v", i, rec.requests[i])
+	}
+	rows := uc["rows"].([]any)
+	values := rows[0].(map[string]any)["values"].([]any)
+	return values[0].(map[string]any)
+}
+
+func cellRuns(t *testing.T, cell map[string]any) []any {
+	t.Helper()
+	runs, ok := cell["textFormatRuns"].([]any)
+	if !ok {
+		t.Fatalf("no textFormatRuns: %#v", cell)
+	}
+	return runs
+}
+
+func runLink(run any) (start float64, uri string) {
+	m := run.(map[string]any)
+	if s, ok := m["startIndex"].(float64); ok {
+		start = s
+	}
+	if fmtM, ok := m["format"].(map[string]any); ok {
+		if link, ok := fmtM["link"].(map[string]any); ok {
+			uri, _ = link["uri"].(string)
+		}
+	}
+	return start, uri
+}
+
+func TestSheetsLinksSet_SingleLink(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	rec := &linksSetRecorder{}
+	svc := newLinksSetService(t, rec)
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "Sheet1!B2", "https://x.test/a", "Act A"}, linksSetCtx(t), flags); err != nil {
+			t.Fatalf("links set: %v", err)
+		}
+	})
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if result["cellsUpdated"] != float64(1) {
+		t.Fatalf("cellsUpdated = %v", result["cellsUpdated"])
+	}
+	if len(rec.requests) != 1 {
+		t.Fatalf("expected 1 request, got %d", len(rec.requests))
+	}
+	cell := updateCellsCell(t, rec, 0)
+	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "Act A" {
+		t.Errorf("stringValue = %v, want Act A", got)
+	}
+	runs := cellRuns(t, cell)
+	if len(runs) != 1 {
+		t.Fatalf("expected 1 run, got %d", len(runs))
+	}
+	if _, uri := runLink(runs[0]); uri != "https://x.test/a" {
+		t.Errorf("run uri = %q", uri)
+	}
+	// targets B2 → rowIndex 1, columnIndex 1
+	start := rec.requests[0]["updateCells"].(map[string]any)["start"].(map[string]any)
+	if start["rowIndex"] != float64(1) || start["columnIndex"] != float64(1) {
+		t.Errorf("start = %#v, want row1/col1", start)
+	}
+}
+
+func TestSheetsLinksSet_DefaultTextIsURL(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	rec := &linksSetRecorder{}
+	svc := newLinksSetService(t, rec)
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "Sheet1!A1", "https://only.url/"}, linksSetCtx(t), flags); err != nil {
+			t.Fatalf("links set: %v", err)
+		}
+	})
+	cell := updateCellsCell(t, rec, 0)
+	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "https://only.url/" {
+		t.Errorf("stringValue = %v, want the url", got)
+	}
+}
+
+func TestSheetsLinksSet_MultiLinkRuns(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	rec := &linksSetRecorder{}
+	svc := newLinksSetService(t, rec)
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	runsJSON := `[{"text":"Act A","uri":"https://a"},{"text":" / "},{"text":"Act B","uri":"https://b"}]`
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "Sheet1!C3", "--runs-json", runsJSON}, linksSetCtx(t), flags); err != nil {
+			t.Fatalf("links set: %v", err)
+		}
+	})
+	cell := updateCellsCell(t, rec, 0)
+	if got := cell["userEnteredValue"].(map[string]any)["stringValue"]; got != "Act A / Act B" {
+		t.Errorf("stringValue = %q, want concat", got)
+	}
+	runs := cellRuns(t, cell)
+	if len(runs) != 3 {
+		t.Fatalf("expected 3 runs, got %d", len(runs))
+	}
+	// Run boundaries: "Act A"=5 → " / "=3 → start 0,5,8 with links a, (none), b
+	s0, u0 := runLink(runs[0])
+	s1, u1 := runLink(runs[1])
+	s2, u2 := runLink(runs[2])
+	if s0 != 0 || u0 != "https://a" {
+		t.Errorf("run0 = (%v,%q)", s0, u0)
+	}
+	if s1 != 5 || u1 != "" {
+		t.Errorf("run1 = (%v,%q), want plain at 5", s1, u1)
+	}
+	if s2 != 8 || u2 != "https://b" {
+		t.Errorf("run2 = (%v,%q)", s2, u2)
+	}
+}
+
+func TestSheetsLinksSet_BatchCellsJSON(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	rec := &linksSetRecorder{}
+	svc := newLinksSetService(t, rec)
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	cellsJSON := `[{"cell":"Sheet1!B2","url":"https://b2","text":"B2"},{"cell":"Sheet1!B3","runs":[{"text":"x","uri":"https://x"}]}]`
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "--cells-json", cellsJSON}, linksSetCtx(t), flags); err != nil {
+			t.Fatalf("links set: %v", err)
+		}
+	})
+	var result map[string]any
+	_ = json.Unmarshal([]byte(out), &result)
+	if result["cellsUpdated"] != float64(2) {
+		t.Errorf("cellsUpdated = %v, want 2", result["cellsUpdated"])
+	}
+	if len(rec.requests) != 2 {
+		t.Fatalf("expected 2 requests, got %d", len(rec.requests))
+	}
+}
+
+func TestSheetsLinksSet_DryRun(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	rec := &linksSetRecorder{}
+	svc := newLinksSetService(t, rec)
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com", DryRun: true}
+	out := captureStdout(t, func() {
+		err := (&SheetsLinksSetCmd{SpreadsheetID: "s1", Cell: "Sheet1!B2", URL: "https://x", Text: "L"}).Run(linksSetCtx(t), flags)
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+			t.Fatalf("expected dry-run exit 0, got %v", err)
+		}
+	})
+	var result map[string]any
+	if err := json.Unmarshal([]byte(out), &result); err != nil {
+		t.Fatalf("unmarshal %q: %v", out, err)
+	}
+	if result["dry_run"] != true || result["op"] != "sheets.links.set" {
+		t.Errorf("unexpected dry-run output: %#v", result)
+	}
+	if len(rec.requests) != 0 {
+		t.Errorf("dry-run should not call batchUpdate, got %d requests", len(rec.requests))
+	}
+}
+
+func TestSheetsLinksSet_RejectsMultiCellRange(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	err := (&SheetsLinksSetCmd{SpreadsheetID: "s1", Cell: "Sheet1!A1:B2", URL: "https://x"}).Run(linksSetCtx(t), flags)
+	if err == nil || !strings.Contains(err.Error(), "single cell") {
+		t.Fatalf("expected single-cell error, got %v", err)
+	}
+}
+
+func TestSheetsLinksSet_RejectsMixedInput(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	err := (&SheetsLinksSetCmd{SpreadsheetID: "s1", Cell: "Sheet1!A1", CellsJSON: `[{"cell":"Sheet1!A1","url":"u"}]`}).Run(linksSetCtx(t), flags)
+	if err == nil || !strings.Contains(err.Error(), "not both") {
+		t.Fatalf("expected mixed-input error, got %v", err)
+	}
+}
+
+func TestSheetsLinksSet_RequiresURLorRuns(t *testing.T) {
+	flags := &RootFlags{Account: "a@b.com"}
+	err := (&SheetsLinksSetCmd{SpreadsheetID: "s1", Cell: "Sheet1!A1"}).Run(linksSetCtx(t), flags)
+	if err == nil || !strings.Contains(err.Error(), "provide url") {
+		t.Fatalf("expected url-required error, got %v", err)
+	}
+}

--- a/internal/cmd/sheets_links_set_test.go
+++ b/internal/cmd/sheets_links_set_test.go
@@ -162,6 +162,27 @@ func TestSheetsLinksSet_SingleLink(t *testing.T) {
 	}
 }
 
+func TestSheetsLinksSet_ClearsStaleWholeCellLink(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	rec := &linksSetRecorder{}
+	svc := newLinksSetService(t, rec)
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		if err := runKong(t, &SheetsLinksSetCmd{}, []string{"s1", "Sheet1!B2", "https://x.test/a", "A"}, linksSetCtx(t), flags); err != nil {
+			t.Fatalf("links set: %v", err)
+		}
+	})
+	// The field mask must clear a pre-existing whole-cell link, else a replaced
+	// cell keeps the stale URL and `links get` reports it (does not round-trip).
+	fields := rec.requests[0]["updateCells"].(map[string]any)["fields"]
+	if fields != "userEnteredValue,textFormatRuns,userEnteredFormat.textFormat.link" {
+		t.Errorf("fields mask = %q, must clear userEnteredFormat.textFormat.link", fields)
+	}
+}
+
 func TestSheetsLinksSet_DefaultTextIsURL(t *testing.T) {
 	origNew := newSheetsService
 	t.Cleanup(func() { newSheetsService = origNew })

--- a/internal/cmd/sheets_validation_more_test.go
+++ b/internal/cmd/sheets_validation_more_test.go
@@ -249,10 +249,10 @@ func TestSheetsClearMetadataCreate_ValidationErrors(t *testing.T) {
 	if err := (&SheetsMetadataCmd{}).Run(ctx, flags); err == nil {
 		t.Fatalf("expected metadata missing spreadsheetId error")
 	}
-	if err := (&SheetsLinksCmd{}).Run(ctx, flags); err == nil {
+	if err := (&SheetsLinksGetCmd{}).Run(ctx, flags); err == nil {
 		t.Fatalf("expected links missing spreadsheetId error")
 	}
-	if err := (&SheetsLinksCmd{SpreadsheetID: "s1"}).Run(ctx, flags); err == nil {
+	if err := (&SheetsLinksGetCmd{SpreadsheetID: "s1"}).Run(ctx, flags); err == nil {
 		t.Fatalf("expected links missing range error")
 	}
 	if err := (&SheetsCreateCmd{}).Run(ctx, flags); err == nil {


### PR DESCRIPTION
Closes #712.

## What

`gog sheets links` could only **read** hyperlinks. This adds a `set` subcommand to write them, including the headline gap from #712 — **multiple labelled links in one cell** via `textFormatRuns`.

```
# single link (rich-text run)
gog sheets links set <id> Sheet1!B2 https://example.com "Example"

# multi-link cell — one cell, several links; a run with empty uri is plain text
gog sheets links set <id> Sheet1!B3 \
  --runs-json='[{"text":"Act A","uri":"https://a"},{"text":" / "},{"text":"Act B","uri":"https://b"}]'

# batch many cells in one BatchUpdate
gog sheets links set <id> \
  --cells-json='[{"cell":"Sheet1!B2","url":"https://b2","text":"B2"},{"cell":"Sheet1!B3","runs":[{"text":"x","uri":"https://x"}]}]'
```

## Design notes

- `links` becomes a command group; the existing read is now `links get` with `default:"withargs"`, so **`gog sheets links <id> <range>` keeps working unchanged** (backward compatible).
- Writes go through `UpdateCells` with `textFormatRuns`, which **round-trips with `links get`** (it already reads `textFormatRuns(format(link(uri)))`).
- Honors `--dry-run` (reports the resolved cells/text/uris without touching the API).
- Each write targets a single cell; run `startIndex` values use UTF-16 offsets to match the Sheets API.
- Run with an empty `uri` is emitted as a plain (unlinked) segment so links don't bleed across boundaries.

## Testing

- `go test ./internal/cmd/` — full package green, incl. new tests: single link, default-text-is-url, multi-link run offsets/links, batch `--cells-json`, `--dry-run`, and validation errors (multi-cell range rejected, mixed input rejected, url/runs required). Tests assert the exact `UpdateCells`/`textFormatRuns` request shape via httptest.
- `gofumpt`, `go vet`, `golangci-lint` (0 issues), and `docs-check` (regenerated command pages) all pass.

**Verification (updated):** Live write/read round-trip done — single link, a multi-link cell (two `textFormatRuns`), and batch, all read back via `links get` (see the proof comment on this PR). Also fixed a follow-up the review caught: the field mask now clears any pre-existing whole-cell hyperlink so replacement writes round-trip cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
