### PR TITLE
ci: add deadcode check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,13 @@ jobs:
       - name: Lint
         run: make lint
       - name: Deadcode
-        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
+        run: |
+          output_file=$(mktemp)
+          go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./... > "$output_file"
+          if [ -s "$output_file" ]; then
+            cat "$output_file"
+            exit 1
+          fi
       - name: Docs check
         run: make docs-check
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
         run: make test
       - name: Lint
         run: make lint
+      - name: Deadcode
+        run: go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...
       - name: Docs check
         run: make docs-check
 

--- a/internal/cmd/slides_formatter.go
+++ b/internal/cmd/slides_formatter.go
@@ -537,16 +537,6 @@ func buildSlideyDryRunBatchUpdate(slideData []Slide) *slides.BatchUpdatePresenta
 	return &slides.BatchUpdatePresentationRequest{Requests: mainReqs}
 }
 
-// SlidesToAPIRequests is retained as a thin wrapper for any legacy caller.
-func SlidesToAPIRequests(in []Slide) ([]*slides.Request, map[int]string) {
-	reqs, _ := RenderSlides(in, NewAssetMap(), defaultPageGeometry())
-	ids := map[int]string{}
-	for i := range in {
-		ids[i] = fmt.Sprintf("slide_%d", i+1)
-	}
-	return reqs, ids
-}
-
 func defaultPageGeometry() LayoutGeometry {
 	// Standard 16:9 Slides page = 10in x 5.625in = 720pt x 405pt.
 	return LayoutGeometry{

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -296,19 +296,6 @@ func EnsureStateDir() (string, error) {
 	return dir, nil
 }
 
-func EnsureCacheDir() (string, error) {
-	dir, err := CacheDir()
-	if err != nil {
-		return "", err
-	}
-
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("ensure cache dir: %w", err)
-	}
-
-	return dir, nil
-}
-
 // KeyringDir is where the keyring "file" backend stores encrypted entries.
 //
 // We keep this separate from the main config dir because the file backend creates

--- a/internal/googleapi/maps.go
+++ b/internal/googleapi/maps.go
@@ -35,14 +35,6 @@ func WithMapsBaseURL(baseURL string) MapsClientOption {
 	}
 }
 
-func WithMapsHTTPClient(client *http.Client) MapsClientOption {
-	return func(c *MapsClient) {
-		if client != nil {
-			c.client = client
-		}
-	}
-}
-
 func NewMapsClient(apiKey string, opts ...MapsClientOption) *MapsClient {
 	c := &MapsClient{
 		apiKey:  strings.TrimSpace(apiKey),

--- a/internal/googleauth/token_email.go
+++ b/internal/googleauth/token_email.go
@@ -58,13 +58,3 @@ func IdentityForRefreshToken(ctx context.Context, client string, refreshToken st
 
 	return fetchUserIdentityWithURL(ctx, tok.AccessToken, userinfoURL)
 }
-
-// EmailForRefreshToken exchanges a refresh token and returns the authorized email address.
-func EmailForRefreshToken(ctx context.Context, client string, refreshToken string, scopes []string, timeout time.Duration) (string, error) {
-	identity, err := IdentityForRefreshToken(ctx, client, refreshToken, scopes, timeout)
-	if err != nil {
-		return "", err
-	}
-
-	return identity.Email, nil
-}

--- a/internal/secrets/keychain_other.go
+++ b/internal/secrets/keychain_other.go
@@ -7,16 +7,6 @@ func IsKeychainLockedError(_ string) bool {
 	return false
 }
 
-// CheckKeychainLocked returns false on non-macOS platforms.
-func CheckKeychainLocked() bool {
-	return false
-}
-
-// UnlockKeychain is a no-op on non-macOS platforms.
-func UnlockKeychain() error {
-	return nil
-}
-
 // EnsureKeychainAccess is a no-op on non-macOS platforms.
 func EnsureKeychainAccess() error {
 	return nil

--- a/internal/zoom/client.go
+++ b/internal/zoom/client.go
@@ -50,14 +50,6 @@ func WithRoundTripper(rt http.RoundTripper) Option {
 	}
 }
 
-func WithHTTPClient(httpClient *http.Client) Option {
-	return func(c *Client) {
-		if httpClient != nil {
-			c.httpClient = httpClient
-		}
-	}
-}
-
 func WithNow(now func() time.Time) Option {
 	return func(c *Client) {
 		if now != nil {


### PR DESCRIPTION
## Summary
- add an enforced Go deadcode CI gate pinned to `golang.org/x/tools/cmd/deadcode@v0.45.0`
- remove unreachable helpers reported by deadcode, including unused non-darwin keychain stubs caught by CI
- make the workflow fail when deadcode emits findings

## Validation
- `git diff --check`
- `go run golang.org/x/tools/cmd/deadcode@v0.45.0 -test ./...`
- `GOOS=linux $(go env GOPATH)/bin/deadcode -test ./...`
- `go test ./internal/config ./internal/googleapi ./internal/zoom ./internal/secrets`
- `autoreview --mode branch --base origin/main --no-web-search --thinking low` clean

Note: `make test` still hits local keychain/no-TTY auth plus an existing `internal/cmd TestHelpProfileAutoDefault` failure in this shell; the touched packages passed.
