### PR TITLE
fix(docs): suppress heading-adjacent markdown blanks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Gmail: report attached filenames and byte sizes in JSON results for send and draft create/update. (#716) — thanks @chrischall.
 - Gmail: add `gmail watch pull` for Pub/Sub pull subscription consumers with hook retry support. (#700) — thanks @joshp123.
 
+### Fixed
+
+- Docs: avoid duplicate empty paragraphs adjacent to Markdown headings while preserving body paragraph spacing. (#717, #720) — thanks @TurboTheTurtle.
+
 ## 0.23.0 - 2026-06-09
 
 ### Added

--- a/internal/cmd/docs_formatter.go
+++ b/internal/cmd/docs_formatter.go
@@ -314,8 +314,8 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64, tabID s
 			// InsertTable supplies the paragraph before a native table, while
 			// the table placeholder supplies the paragraph after it. Emitting
 			// the source blank line too would double both gaps.
-			if (i > 0 && elements[i-1].Type == MDTable) ||
-				(i+1 < len(elements) && elements[i+1].Type == MDTable) {
+			if (i > 0 && (elements[i-1].Type == MDTable || isMarkdownHeadingElement(elements[i-1].Type))) ||
+				(i+1 < len(elements) && (elements[i+1].Type == MDTable || isMarkdownHeadingElement(elements[i+1].Type))) {
 				continue
 			}
 			plainText.WriteString("\n")

--- a/internal/cmd/docs_formatter.go
+++ b/internal/cmd/docs_formatter.go
@@ -311,9 +311,8 @@ func MarkdownToDocsRequests(elements []MarkdownElement, baseIndex int64, tabID s
 			}
 
 		case MDEmptyLine:
-			// InsertTable supplies the paragraph before a native table, while
-			// the table placeholder supplies the paragraph after it. Emitting
-			// the source blank line too would double both gaps.
+			// Native tables and heading styles already supply visual spacing.
+			// Emitting an adjacent source blank line would double those gaps.
 			if (i > 0 && (elements[i-1].Type == MDTable || isMarkdownHeadingElement(elements[i-1].Type))) ||
 				(i+1 < len(elements) && (elements[i+1].Type == MDTable || isMarkdownHeadingElement(elements[i+1].Type))) {
 				continue

--- a/internal/cmd/docs_formatter_test.go
+++ b/internal/cmd/docs_formatter_test.go
@@ -60,7 +60,7 @@ func TestMarkdownToDocsRequests_TableConsumesAdjacentBlankLines(t *testing.T) {
 
 	_, text, tables := MarkdownToDocsRequests(elements, 1, "t.0")
 
-	wantText := "Title\n\nNext section\n\nParagraph after the table.\n"
+	wantText := "Title\n\nNext section\nParagraph after the table.\n"
 	if text != wantText {
 		t.Fatalf("text = %q, want %q", text, wantText)
 	}
@@ -76,6 +76,30 @@ func TestMarkdownToDocsRequests_PreservesNonTableBlankLines(t *testing.T) {
 	_, text, tables := MarkdownToDocsRequests(ParseMarkdown("First\n\nSecond"), 1, "")
 	if text != "First\n\nSecond\n" {
 		t.Fatalf("text = %q, want preserved body paragraph gap", text)
+	}
+	if len(tables) != 0 {
+		t.Fatalf("unexpected tables: %d", len(tables))
+	}
+}
+
+func TestMarkdownToDocsRequests_ConsumesHeadingAdjacentBlankLines(t *testing.T) {
+	markdown := strings.Join([]string{
+		"## Section A",
+		"",
+		"Paragraph one.",
+		"",
+		"Paragraph two.",
+		"",
+		"## Section B",
+		"",
+		"Paragraph three.",
+	}, "\n")
+
+	_, text, tables := MarkdownToDocsRequests(ParseMarkdown(markdown), 1, "")
+
+	wantText := "Section A\nParagraph one.\n\nParagraph two.\nSection B\nParagraph three.\n"
+	if text != wantText {
+		t.Fatalf("text = %q, want %q", text, wantText)
 	}
 	if len(tables) != 0 {
 		t.Fatalf("unexpected tables: %d", len(tables))

--- a/internal/cmd/docs_write_markdown_tab_test.go
+++ b/internal/cmd/docs_write_markdown_tab_test.go
@@ -101,8 +101,8 @@ func TestDocsWrite_MarkdownReplaceWithTab(t *testing.T) {
 	if loc.TabId != "t.second" || loc.Index != 1 {
 		t.Fatalf("insert location = %+v, want {TabId:t.second Index:1}", loc)
 	}
-	if got := insertReqs[0].InsertText.Text; got != "Title\n\nbold\n" {
-		t.Fatalf("inserted text = %q, want %q", got, "Title\n\nbold\n")
+	if got := insertReqs[0].InsertText.Text; got != "Title\nbold\n" {
+		t.Fatalf("inserted text = %q, want %q", got, "Title\nbold\n")
 	}
 	for i, req := range insertReqs[1:] {
 		var r *docs.Range
@@ -168,12 +168,12 @@ func TestDocsWrite_MarkdownReplaceWithTabRewritesExplicitHeadingAnchorLinks(t *t
 							},
 						},
 						{
-							StartIndex: 8,
-							EndIndex:   13,
+							StartIndex: 7,
+							EndIndex:   12,
 							Paragraph: &docs.Paragraph{
 								Elements: []*docs.ParagraphElement{{
-									StartIndex: 8,
-									EndIndex:   12,
+									StartIndex: 7,
+									EndIndex:   11,
 									TextRun: &docs.TextRun{
 										Content:   "Jump",
 										TextStyle: &docs.TextStyle{Link: &docs.Link{Url: "#attachments"}},
@@ -227,7 +227,7 @@ func TestDocsWrite_MarkdownReplaceWithTabRewritesExplicitHeadingAnchorLinks(t *t
 	if len(insertReqs) == 0 || insertReqs[0].InsertText == nil {
 		t.Fatalf("expected insert batch, got %#v", insertReqs)
 	}
-	if got := insertReqs[0].InsertText.Text; got != "Files\n\nJump\n" {
+	if got := insertReqs[0].InsertText.Text; got != "Files\nJump\n" {
 		t.Fatalf("inserted text = %q, want explicit anchor stripped", got)
 	}
 	rewriteReqs := batchRequests[2]
@@ -235,7 +235,7 @@ func TestDocsWrite_MarkdownReplaceWithTabRewritesExplicitHeadingAnchorLinks(t *t
 		t.Fatalf("expected one link rewrite request, got %#v", rewriteReqs)
 	}
 	styleReq := rewriteReqs[0].UpdateTextStyle
-	if styleReq.Range.TabId != "t.second" || styleReq.Range.StartIndex != 8 || styleReq.Range.EndIndex != 12 {
+	if styleReq.Range.TabId != "t.second" || styleReq.Range.StartIndex != 7 || styleReq.Range.EndIndex != 11 {
 		t.Fatalf("unexpected rewrite range: %#v", styleReq.Range)
 	}
 	if styleReq.TextStyle == nil || styleReq.TextStyle.Link == nil ||

--- a/internal/cmd/docs_write_markdown_test.go
+++ b/internal/cmd/docs_write_markdown_test.go
@@ -610,7 +610,7 @@ func TestDocsWrite_MarkdownAppendUsesDocsFormatting(t *testing.T) {
 	if reqs[0].InsertText == nil {
 		t.Fatalf("expected first request to insert text, got %#v", reqs[0])
 	}
-	if got := reqs[0].InsertText; got.Location.Index != 9 || got.Text != "\nTitle\n\nbold\n" {
+	if got := reqs[0].InsertText; got.Location.Index != 9 || got.Text != "\nTitle\nbold\n" {
 		t.Fatalf("unexpected markdown insert: %#v", got)
 	}
 	if reqs[1].UpdateParagraphStyle == nil {
@@ -622,7 +622,7 @@ func TestDocsWrite_MarkdownAppendUsesDocsFormatting(t *testing.T) {
 	if reqs[2].UpdateTextStyle == nil {
 		t.Fatalf("expected bold text style request, got %#v", reqs[2])
 	}
-	if got := reqs[2].UpdateTextStyle.Range; got.StartIndex != 17 || got.EndIndex != 21 {
+	if got := reqs[2].UpdateTextStyle.Range; got.StartIndex != 16 || got.EndIndex != 20 {
 		t.Fatalf("unexpected bold range: %#v", got)
 	}
 }
@@ -676,11 +676,11 @@ func TestDocsWrite_MarkdownAppendRewritesExplicitHeadingAnchorLinks(t *testing.T
 						},
 					},
 					{
-						StartIndex: 17,
-						EndIndex:   22,
+						StartIndex: 16,
+						EndIndex:   21,
 						Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{{
-							StartIndex: 17,
-							EndIndex:   21,
+							StartIndex: 16,
+							EndIndex:   20,
 							TextRun: &docs.TextRun{
 								Content:   "Jump",
 								TextStyle: &docs.TextStyle{Link: &docs.Link{Url: "#attachments"}},
@@ -726,7 +726,7 @@ func TestDocsWrite_MarkdownAppendRewritesExplicitHeadingAnchorLinks(t *testing.T
 	if len(insertReqs) == 0 || insertReqs[0].InsertText == nil {
 		t.Fatalf("expected first batch to insert text, got %#v", insertReqs)
 	}
-	if got := insertReqs[0].InsertText; got.Location.Index != 9 || got.Text != "\nFiles\n\nJump\n" {
+	if got := insertReqs[0].InsertText; got.Location.Index != 9 || got.Text != "\nFiles\nJump\n" {
 		t.Fatalf("unexpected append insert: %#v", got)
 	}
 	rewriteReqs := batchRequests[1]
@@ -734,7 +734,7 @@ func TestDocsWrite_MarkdownAppendRewritesExplicitHeadingAnchorLinks(t *testing.T
 		t.Fatalf("expected one link rewrite request, got %#v", rewriteReqs)
 	}
 	styleReq := rewriteReqs[0].UpdateTextStyle
-	if styleReq.Range.StartIndex != 17 || styleReq.Range.EndIndex != 21 {
+	if styleReq.Range.StartIndex != 16 || styleReq.Range.EndIndex != 20 {
 		t.Fatalf("unexpected rewrite range: %#v", styleReq.Range)
 	}
 	if styleReq.TextStyle == nil || styleReq.TextStyle.Link == nil || styleReq.TextStyle.Link.HeadingId != "h.files" {

--- a/internal/cmd/docs_write_update_test.go
+++ b/internal/cmd/docs_write_update_test.go
@@ -167,7 +167,7 @@ func TestDocsUpdate_MarkdownWithTab(t *testing.T) {
 	if insert.Location.TabId != "t.second" || insert.Location.Index != 19 {
 		t.Fatalf("insert location = %+v, want tab t.second index 19", insert.Location)
 	}
-	if got := insert.Text; got != "\nHeading\n\nbold and link\n" {
+	if got := insert.Text; got != "\nHeading\nbold and link\n" {
 		t.Fatalf("inserted text = %q, want markdown-rendered text", got)
 	}
 	for i, req := range reqs[1:] {
@@ -465,7 +465,7 @@ func TestDocsUpdate_ReplaceRangeMarkdownWithTab(t *testing.T) {
 	if got := reqs[0].DeleteContentRange.Range; got.StartIndex != 7 || got.EndIndex != 12 || got.TabId != "t.second" {
 		t.Fatalf("delete range = %+v, want 7:12 in t.second", got)
 	}
-	if got := reqs[1].InsertText; got.Location.Index != 7 || got.Location.TabId != "t.second" || got.Text != "\nNew Heading\n\nbold and link\n" {
+	if got := reqs[1].InsertText; got.Location.Index != 7 || got.Location.TabId != "t.second" || got.Text != "\nNew Heading\nbold and link\n" {
 		t.Fatalf("insert text = %+v, want rendered markdown at 7 in t.second", got)
 	}
 	var payload struct {


### PR DESCRIPTION
## Summary

- suppress explicit empty markdown paragraphs when the blank line is adjacent to a heading
- preserve body-to-body blank paragraph spacing and existing table anchor behavior
- update tab/append/update markdown tests for the new heading-adjacent spacing contract

Fixes #717.

## Validation

- `go test ./internal/cmd -run 'TestMarkdownToDocsRequests|TestDocsWrite_MarkdownReplaceWithTab|TestParseMarkdown' -count=1`
- `make ci`
- autoreview clean: no accepted/actionable findings
- live Google Docs smoke on `clawdbot@gmail.com`, default tab `t.0`
  - heading-adjacent empty paragraphs absent
  - body-to-body empty paragraph preserved
  - JSON readback matched expected paragraph styles and text
  - disposable document moved to trash
