### PR TITLE
feat(docs): add tab-aware raw output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Gmail: report attached filenames and byte sizes in JSON results for send and draft create/update. (#716) — thanks @chrischall.
 - Gmail: add `gmail watch pull` for Pub/Sub pull subscription consumers with hook retry support. (#700) — thanks @joshp123.
+- Docs: add `--tab` and `--all-tabs` to `docs raw` for inspecting specific or complete multi-tab document content. (#697) — thanks @sebsnyk.
 
 ### Fixed
 

--- a/docs/commands/gog-docs-raw.md
+++ b/docs/commands/gog-docs-raw.md
@@ -20,6 +20,7 @@ gog docs (doc) raw <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--all-tabs` | `bool` |  | Return the canonical Document response with all tab content populated |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -36,6 +37,7 @@ gog docs (doc) raw <docId> [flags]
 | `--pretty` | `bool` |  | Pretty-print JSON (default: compact single-line) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Return one tab by title or ID in the legacy top-level Document shape |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -201,6 +201,11 @@ Use raw output when a script needs the Google Docs API object:
 
 ```bash
 gog docs raw <docId> --pretty
+gog docs raw <docId> --tab "Notes" --pretty
+gog docs raw <docId> --all-tabs --json
 ```
+
+`--tab` returns one tab in the same top-level Document shape used by the
+default response. `--all-tabs` returns the canonical recursive `tabs` tree.
 
 See [Raw API Dumps](raw-api.md) for lossless-output safety notes.

--- a/docs/raw-api.md
+++ b/docs/raw-api.md
@@ -28,9 +28,17 @@ returns it.
 ```bash
 gog drive raw <fileId> --pretty
 gog docs raw <docId> --json > doc-api.json
+gog docs raw <docId> --tab "Notes" --pretty
+gog docs raw <docId> --all-tabs --json > doc-tabs-api.json
 gog gmail raw <messageId> --format metadata --json
 gog sheets raw <spreadsheetId> --include-grid-data --json
 ```
+
+`gog docs raw --tab` resolves a tab title or ID and projects that tab into the
+legacy top-level `Document` fields such as `body`, `lists`, and
+`inlineObjects`. `--all-tabs` keeps the canonical `Documents.Get` response and
+populates its recursive `tabs` tree. Without either flag, the command keeps the
+existing first-tab response.
 
 Use service-native field masks when available:
 

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 
+	"google.golang.org/api/docs/v1"
 	"google.golang.org/api/drive/v3"
 	gapi "google.golang.org/api/googleapi"
 
@@ -68,8 +69,10 @@ type DocsTabsCmd struct {
 // REST reference: https://developers.google.com/docs/api/reference/rest/v1/documents/get
 // Go type: https://pkg.go.dev/google.golang.org/api/docs/v1#Document
 type DocsRawCmd struct {
-	DocID  string `arg:"" name:"docId" help:"Doc ID"`
-	Pretty bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
+	DocID   string `arg:"" name:"docId" help:"Doc ID"`
+	Pretty  bool   `name:"pretty" help:"Pretty-print JSON (default: compact single-line)"`
+	Tab     string `name:"tab" help:"Return one tab by title or ID in the legacy top-level Document shape"`
+	AllTabs bool   `name:"all-tabs" help:"Return the canonical Document response with all tab content populated"`
 }
 
 func (c *DocsRawCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -77,13 +80,20 @@ func (c *DocsRawCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if id == "" {
 		return usage("empty docId")
 	}
+	if strings.TrimSpace(c.Tab) != "" && c.AllTabs {
+		return usage("--tab and --all-tabs cannot be used together")
+	}
 
 	svc, err := requireDocsService(ctx, flags)
 	if err != nil {
 		return err
 	}
 
-	doc, err := svc.Documents.Get(id).Context(ctx).Do()
+	getCall := svc.Documents.Get(id).Context(ctx)
+	if strings.TrimSpace(c.Tab) != "" || c.AllTabs {
+		getCall = getCall.IncludeTabsContent(true)
+	}
+	doc, err := getCall.Do()
 	if err != nil {
 		if isDocsNotFound(err) {
 			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
@@ -95,7 +105,44 @@ func (c *DocsRawCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	if strings.TrimSpace(c.Tab) != "" {
+		tab, tabErr := findTab(flattenTabs(doc.Tabs), c.Tab)
+		if tabErr != nil {
+			return tabErr
+		}
+		doc, err = projectRawDocumentTab(doc, tab)
+		if err != nil {
+			return err
+		}
+	}
+
 	return writeRawJSON(ctx, doc, c.Pretty)
+}
+
+func projectRawDocumentTab(doc *docs.Document, tab *docs.Tab) (*docs.Document, error) {
+	if tab == nil || tab.DocumentTab == nil {
+		return nil, errors.New("selected tab has no document content")
+	}
+
+	content := tab.DocumentTab
+	return &docs.Document{
+		Body:                          content.Body,
+		DocumentId:                    doc.DocumentId,
+		DocumentStyle:                 content.DocumentStyle,
+		Footers:                       content.Footers,
+		Footnotes:                     content.Footnotes,
+		Headers:                       content.Headers,
+		InlineObjects:                 content.InlineObjects,
+		Lists:                         content.Lists,
+		NamedRanges:                   content.NamedRanges,
+		NamedStyles:                   content.NamedStyles,
+		PositionedObjects:             content.PositionedObjects,
+		RevisionId:                    doc.RevisionId,
+		SuggestedDocumentStyleChanges: content.SuggestedDocumentStyleChanges,
+		SuggestedNamedStylesChanges:   content.SuggestedNamedStylesChanges,
+		SuggestionsViewMode:           doc.SuggestionsViewMode,
+		Title:                         doc.Title,
+	}, nil
 }
 
 type DocsExportCmd struct {

--- a/internal/cmd/docs_raw_test.go
+++ b/internal/cmd/docs_raw_test.go
@@ -46,14 +46,86 @@ func fullDocResponse(id string) map[string]any {
 	}
 }
 
+func tabbedDocResponse(id string) map[string]any {
+	return map[string]any{
+		"documentId":          id,
+		"title":               "Tabbed Doc",
+		"revisionId":          "rev-tabs",
+		"suggestionsViewMode": "SUGGESTIONS_INLINE",
+		"tabs": []any{
+			map[string]any{
+				"tabProperties": map[string]any{
+					"tabId": "t.first",
+					"title": "First",
+					"index": 0,
+				},
+				"documentTab": map[string]any{
+					"body": rawBodyWithText("first tab\n"),
+				},
+				"childTabs": []any{
+					map[string]any{
+						"tabProperties": map[string]any{
+							"tabId": "t.nested",
+							"title": "Nested Notes",
+							"index": 0,
+						},
+						"documentTab": map[string]any{
+							"body": rawBodyWithText("nested tab\n"),
+							"inlineObjects": map[string]any{
+								"kix.image": map[string]any{
+									"objectId": "kix.image",
+								},
+							},
+							"namedStyles": map[string]any{
+								"styles": []any{map[string]any{"namedStyleType": "NORMAL_TEXT"}},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func rawBodyWithText(text string) map[string]any {
+	return map[string]any{
+		"content": []any{
+			map[string]any{
+				"startIndex": 1,
+				"endIndex":   1 + len(text),
+				"paragraph": map[string]any{
+					"elements": []any{
+						map[string]any{
+							"textRun": map[string]any{"content": text},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 // newDocsRawTestServer builds a test Docs server; if status != 0 it returns
 // that status instead of a successful response.
 func newDocsRawTestServer(t *testing.T, status int, body map[string]any) *httptest.Server {
+	t.Helper()
+	return newDocsRawTestServerWithRequest(t, status, body, nil)
+}
+
+func newDocsRawTestServerWithRequest(
+	t *testing.T,
+	status int,
+	body map[string]any,
+	checkRequest func(*http.Request),
+) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !strings.HasPrefix(r.URL.Path, "/v1/documents/") || r.Method != http.MethodGet {
 			http.NotFound(w, r)
 			return
+		}
+		if checkRequest != nil {
+			checkRequest(r)
 		}
 		if status != 0 {
 			w.WriteHeader(status)
@@ -93,7 +165,11 @@ func rawTestContext(t *testing.T) context.Context {
 }
 
 func TestDocsRaw_HappyPath(t *testing.T) {
-	srv := newDocsRawTestServer(t, 0, fullDocResponse("doc1"))
+	srv := newDocsRawTestServerWithRequest(t, 0, fullDocResponse("doc1"), func(r *http.Request) {
+		if _, ok := r.URL.Query()["includeTabsContent"]; ok {
+			t.Fatalf("default raw request unexpectedly set includeTabsContent: %s", r.URL.RawQuery)
+		}
+	})
 	defer srv.Close()
 	installMockDocsService(t, srv)
 
@@ -123,6 +199,164 @@ func TestDocsRaw_HappyPath(t *testing.T) {
 	if _, ok := body["content"]; !ok {
 		t.Fatalf("expected body.content in raw output")
 	}
+}
+
+func TestProjectRawDocumentTabCopiesLegacyFields(t *testing.T) {
+	content := &docs.DocumentTab{
+		Body:                          &docs.Body{},
+		DocumentStyle:                 &docs.DocumentStyle{},
+		Footers:                       map[string]docs.Footer{"footer": {}},
+		Footnotes:                     map[string]docs.Footnote{"footnote": {}},
+		Headers:                       map[string]docs.Header{"header": {}},
+		InlineObjects:                 map[string]docs.InlineObject{"inline": {}},
+		Lists:                         map[string]docs.List{"list": {}},
+		NamedRanges:                   map[string]docs.NamedRanges{"range": {}},
+		NamedStyles:                   &docs.NamedStyles{},
+		PositionedObjects:             map[string]docs.PositionedObject{"positioned": {}},
+		SuggestedDocumentStyleChanges: map[string]docs.SuggestedDocumentStyle{"doc-style": {}},
+		SuggestedNamedStylesChanges:   map[string]docs.SuggestedNamedStyles{"named-style": {}},
+	}
+	doc := &docs.Document{
+		DocumentId:          "doc1",
+		RevisionId:          "rev1",
+		SuggestionsViewMode: "SUGGESTIONS_INLINE",
+		Title:               "Full Doc",
+		Tabs:                []*docs.Tab{{}},
+	}
+
+	got, err := projectRawDocumentTab(doc, &docs.Tab{DocumentTab: content})
+	if err != nil {
+		t.Fatalf("projectRawDocumentTab: %v", err)
+	}
+	if got.DocumentId != doc.DocumentId || got.RevisionId != doc.RevisionId ||
+		got.SuggestionsViewMode != doc.SuggestionsViewMode || got.Title != doc.Title {
+		t.Fatalf("top-level metadata was not preserved: %#v", got)
+	}
+	if got.Body != content.Body || got.DocumentStyle != content.DocumentStyle || got.NamedStyles != content.NamedStyles {
+		t.Fatal("selected tab pointer fields were not projected")
+	}
+	if len(got.Footers) != 1 || len(got.Footnotes) != 1 || len(got.Headers) != 1 ||
+		len(got.InlineObjects) != 1 || len(got.Lists) != 1 || len(got.NamedRanges) != 1 ||
+		len(got.PositionedObjects) != 1 || len(got.SuggestedDocumentStyleChanges) != 1 ||
+		len(got.SuggestedNamedStylesChanges) != 1 {
+		t.Fatalf("selected tab map fields were not projected: %#v", got)
+	}
+	if got.Tabs != nil {
+		t.Fatalf("projected tab unexpectedly retained tabs: %#v", got.Tabs)
+	}
+}
+
+func TestDocsRaw_TabProjectsSelectedNestedTab(t *testing.T) {
+	for _, query := range []string{"t.nested", "nested notes"} {
+		t.Run(query, func(t *testing.T) {
+			srv := newDocsRawTestServerWithRequest(t, 0, tabbedDocResponse("doc1"), func(r *http.Request) {
+				if got := r.URL.Query().Get("includeTabsContent"); got != "true" {
+					t.Fatalf("includeTabsContent = %q, want true", got)
+				}
+			})
+			defer srv.Close()
+			installMockDocsService(t, srv)
+
+			ctx := rawTestContext(t)
+			flags := &RootFlags{Account: "a@b.com"}
+			out := captureStdout(t, func() {
+				cmd := &DocsRawCmd{}
+				if err := runKong(t, cmd, []string{"doc1", "--tab", query}, ctx, flags); err != nil {
+					t.Fatalf("run: %v", err)
+				}
+			})
+
+			var got map[string]any
+			if err := json.Unmarshal([]byte(out), &got); err != nil {
+				t.Fatalf("output is not valid JSON: %v\nraw: %s", err, out)
+			}
+			if got["documentId"] != "doc1" || got["title"] != "Tabbed Doc" || got["revisionId"] != "rev-tabs" {
+				t.Fatalf("top-level document metadata was not preserved: %#v", got)
+			}
+			if _, ok := got["tabs"]; ok {
+				t.Fatalf("selected-tab projection unexpectedly included tabs: %#v", got["tabs"])
+			}
+			if _, ok := got["inlineObjects"].(map[string]any)["kix.image"]; !ok {
+				t.Fatalf("selected tab inline objects missing: %#v", got["inlineObjects"])
+			}
+			if text := rawDocumentText(t, got); text != "nested tab\n" {
+				t.Fatalf("selected tab text = %q, want %q", text, "nested tab\n")
+			}
+		})
+	}
+}
+
+func TestDocsRaw_TabNotFound(t *testing.T) {
+	srv := newDocsRawTestServer(t, 0, tabbedDocResponse("doc1"))
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	_ = captureStdout(t, func() {
+		cmd := &DocsRawCmd{}
+		err := runKong(t, cmd, []string{"doc1", "--tab", "Missing"}, ctx, flags)
+		if err == nil || !strings.Contains(err.Error(), "tab not found") {
+			t.Fatalf("expected tab-not-found error, got %v", err)
+		}
+	})
+}
+
+func TestDocsRaw_AllTabsReturnsCanonicalDocument(t *testing.T) {
+	srv := newDocsRawTestServerWithRequest(t, 0, tabbedDocResponse("doc1"), func(r *http.Request) {
+		if got := r.URL.Query().Get("includeTabsContent"); got != "true" {
+			t.Fatalf("includeTabsContent = %q, want true", got)
+		}
+	})
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	out := captureStdout(t, func() {
+		cmd := &DocsRawCmd{}
+		if err := runKong(t, cmd, []string{"doc1", "--all-tabs"}, ctx, flags); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	var got map[string]any
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw: %s", err, out)
+	}
+	tabs, ok := got["tabs"].([]any)
+	if !ok || len(tabs) != 1 {
+		t.Fatalf("canonical tabs output = %#v, want one top-level tab", got["tabs"])
+	}
+	first := tabs[0].(map[string]any)
+	children, ok := first["childTabs"].([]any)
+	if !ok || len(children) != 1 {
+		t.Fatalf("nested tabs output = %#v, want one child tab", first["childTabs"])
+	}
+}
+
+func TestDocsRaw_TabAndAllTabsConflict(t *testing.T) {
+	ctx := rawTestContext(t)
+	flags := &RootFlags{Account: "a@b.com"}
+	err := (&DocsRawCmd{DocID: "doc1", Tab: "First", AllTabs: true}).Run(ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("expected conflicting flags error, got %v", err)
+	}
+}
+
+func rawDocumentText(t *testing.T, doc map[string]any) string {
+	t.Helper()
+	body, ok := doc["body"].(map[string]any)
+	if !ok {
+		t.Fatalf("body = %#v, want object", doc["body"])
+	}
+	content, ok := body["content"].([]any)
+	if !ok || len(content) == 0 {
+		t.Fatalf("body.content = %#v, want elements", body["content"])
+	}
+	paragraph := content[0].(map[string]any)["paragraph"].(map[string]any)
+	elements := paragraph["elements"].([]any)
+	return elements[0].(map[string]any)["textRun"].(map[string]any)["content"].(string)
 }
 
 func TestDocsRaw_APIError(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `docs raw --tab <title-or-id>` for one selected tab in the existing top-level Document shape
- add `docs raw --all-tabs` for the canonical recursive tabs response
- preserve the unflagged request and first-tab output contract
- document the new modes and cover nested tabs, request parameters, field projection, conflicts, and errors

Fixes #697.

## Validation

- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make ci`
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools go test ./internal/cmd -run '^Test(DocsRaw|ProjectRawDocumentTab)' -count=1`
- autoreview: clean, no accepted/actionable findings
- live Google Docs smoke with `clawdbot@gmail.com`:
  - default output retained first-tab shape without `tabs`
  - nested tab resolved by both title and ID
  - selected-tab output retained top-level Document metadata and nested sentinel content
  - `--all-tabs` returned all three tabs recursively
  - disposable document trashed after verification
