### PR TITLE
feat(docs): add document enumerator commands

### DIFF
--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -241,6 +241,10 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) find-range <docId> <text> [flags]`](commands/gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
     - [`gog docs (doc) find-replace <docId> <find> [<replace>] [flags]`](commands/gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
     - [`gog docs (doc) format <docId> [flags]`](commands/gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+    - [`gog docs (doc) headings <command>`](commands/gog-docs-headings.md) - List Google Doc headings
+      - [`gog docs (doc) headings list (ls) <docId> [flags]`](commands/gog-docs-headings-list.md) - List headings in a Google Doc
+    - [`gog docs (doc) images <command>`](commands/gog-docs-images.md) - List Google Doc images
+      - [`gog docs (doc) images list (ls) <docId> [flags]`](commands/gog-docs-images-list.md) - List images in a Google Doc
     - [`gog docs (doc) info (get,show) <docId>`](commands/gog-docs-info.md) - Get Google Doc metadata
     - [`gog docs (doc) insert <docId> [<content>] [flags]`](commands/gog-docs-insert.md) - Insert text at a specific position
     - [`gog docs (doc) insert-date-chip --date=STRING <docId> [flags]`](commands/gog-docs-insert-date-chip.md) - Insert a native date smart chip
@@ -251,11 +255,15 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) insert-table --rows=INT --cols=INT <docId> [flags]`](commands/gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [`gog docs (doc) list-tabs <docId>`](commands/gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [`gog docs (doc) page-layout (set-page-layout,page-setup) <docId> [flags]`](commands/gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
+    - [`gog docs (doc) paragraphs <command>`](commands/gog-docs-paragraphs.md) - List Google Doc paragraphs
+      - [`gog docs (doc) paragraphs list (ls) <docId> [flags]`](commands/gog-docs-paragraphs-list.md) - List paragraphs in a Google Doc
     - [`gog docs (doc) raw <docId> [flags]`](commands/gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [`gog docs (doc) rename-tab <docId> [flags]`](commands/gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [`gog docs (doc) sed <docId> [<expression>] [flags]`](commands/gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [`gog docs (doc) structure (struct) <docId> [flags]`](commands/gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [`gog docs (doc) table-column-width (table-width,column-width) <docId> [flags]`](commands/gog-docs-table-column-width.md) - Set or reset native table column widths
+    - [`gog docs (doc) tables <command>`](commands/gog-docs-tables.md) - List Google Doc tables
+      - [`gog docs (doc) tables list (ls) <docId> [flags]`](commands/gog-docs-tables-list.md) - List tables in a Google Doc
     - [`gog docs (doc) tabs <command>`](commands/gog-docs-tabs.md) - Manage Google Doc tabs
       - [`gog docs (doc) tabs add (create,new) <docId> [flags]`](commands/gog-docs-tabs-add.md) - Add a tab to a Google Doc
       - [`gog docs (doc) tabs delete (rm,remove,del) <docId> [flags]`](commands/gog-docs-tabs-delete.md) - Delete a tab from a Google Doc

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 589.
+Generated pages: 597.
 
 ## Top-level Commands
 
@@ -293,6 +293,10 @@ Generated pages: 589.
     - [gog docs find-range](gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
     - [gog docs find-replace](gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
     - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+    - [gog docs headings](gog-docs-headings.md) - List Google Doc headings
+      - [gog docs headings list](gog-docs-headings-list.md) - List headings in a Google Doc
+    - [gog docs images](gog-docs-images.md) - List Google Doc images
+      - [gog docs images list](gog-docs-images-list.md) - List images in a Google Doc
     - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
     - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
     - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
@@ -303,11 +307,15 @@ Generated pages: 589.
     - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
+    - [gog docs paragraphs](gog-docs-paragraphs.md) - List Google Doc paragraphs
+      - [gog docs paragraphs list](gog-docs-paragraphs-list.md) - List paragraphs in a Google Doc
     - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
+    - [gog docs tables](gog-docs-tables.md) - List Google Doc tables
+      - [gog docs tables list](gog-docs-tables-list.md) - List tables in a Google Doc
     - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs
       - [gog docs tabs add](gog-docs-tabs-add.md) - Add a tab to a Google Doc
       - [gog docs tabs delete](gog-docs-tabs-delete.md) - Delete a tab from a Google Doc

--- a/docs/commands/gog-docs-headings-list.md
+++ b/docs/commands/gog-docs-headings-list.md
@@ -1,0 +1,47 @@
+# `gog docs headings list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List headings in a Google Doc
+
+## Usage
+
+```bash
+gog docs (doc) headings list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs headings](gog-docs-headings.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--level` | `int` |  | Heading level to include (1-6) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs headings](gog-docs-headings.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-headings.md
+++ b/docs/commands/gog-docs-headings.md
@@ -1,0 +1,49 @@
+# `gog docs headings`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List Google Doc headings
+
+## Usage
+
+```bash
+gog docs (doc) headings <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs headings list](gog-docs-headings-list.md) - List headings in a Google Doc
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-images-list.md
+++ b/docs/commands/gog-docs-images-list.md
@@ -1,0 +1,46 @@
+# `gog docs images list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List images in a Google Doc
+
+## Usage
+
+```bash
+gog docs (doc) images list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs images](gog-docs-images.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs images](gog-docs-images.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-images.md
+++ b/docs/commands/gog-docs-images.md
@@ -1,0 +1,49 @@
+# `gog docs images`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List Google Doc images
+
+## Usage
+
+```bash
+gog docs (doc) images <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs images list](gog-docs-images-list.md) - List images in a Google Doc
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-paragraphs-list.md
+++ b/docs/commands/gog-docs-paragraphs-list.md
@@ -1,0 +1,47 @@
+# `gog docs paragraphs list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List paragraphs in a Google Doc
+
+## Usage
+
+```bash
+gog docs (doc) paragraphs list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs paragraphs](gog-docs-paragraphs.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--style` | `string` |  | Named paragraph style to include (for example NORMAL_TEXT or HEADING_2) |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs paragraphs](gog-docs-paragraphs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-paragraphs.md
+++ b/docs/commands/gog-docs-paragraphs.md
@@ -1,0 +1,49 @@
+# `gog docs paragraphs`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List Google Doc paragraphs
+
+## Usage
+
+```bash
+gog docs (doc) paragraphs <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs paragraphs list](gog-docs-paragraphs-list.md) - List paragraphs in a Google Doc
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-tables-list.md
+++ b/docs/commands/gog-docs-tables-list.md
@@ -1,0 +1,46 @@
+# `gog docs tables list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List tables in a Google Doc
+
+## Usage
+
+```bash
+gog docs (doc) tables list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs tables](gog-docs-tables.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs tables](gog-docs-tables.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-tables.md
+++ b/docs/commands/gog-docs-tables.md
@@ -1,0 +1,49 @@
+# `gog docs tables`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List Google Doc tables
+
+## Usage
+
+```bash
+gog docs (doc) tables <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs tables list](gog-docs-tables-list.md) - List tables in a Google Doc
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -31,6 +31,8 @@ gog docs (doc) <command> [flags]
 - [gog docs find-range](gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
 - [gog docs find-replace](gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
 - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+- [gog docs headings](gog-docs-headings.md) - List Google Doc headings
+- [gog docs images](gog-docs-images.md) - List Google Doc images
 - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
 - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
 - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
@@ -41,11 +43,13 @@ gog docs (doc) <command> [flags]
 - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
 - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
 - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
+- [gog docs paragraphs](gog-docs-paragraphs.md) - List Google Doc paragraphs
 - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
 - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
 - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
 - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
 - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
+- [gog docs tables](gog-docs-tables.md) - List Google Doc tables
 - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs
 - [gog docs update](gog-docs-update.md) - Insert or replace text at a specific index or range in a Google Doc
 - [gog docs write](gog-docs-write.md) - Write content to a Google Doc

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -24,6 +24,10 @@ type DocsCmd struct {
 	Copy             DocsCopyCmd             `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Doc"`
 	Cat              DocsCatCmd              `cmd:"" name:"cat" aliases:"text,read" help:"Print a Google Doc as plain text"`
 	Comments         DocsCommentsCmd         `cmd:"" name:"comments" help:"Manage comments on files"`
+	Tables           DocsTablesCmd           `cmd:"" name:"tables" help:"List Google Doc tables"`
+	Images           DocsImagesCmd           `cmd:"" name:"images" help:"List Google Doc images"`
+	Headings         DocsHeadingsCmd         `cmd:"" name:"headings" help:"List Google Doc headings"`
+	Paragraphs       DocsParagraphsCmd       `cmd:"" name:"paragraphs" help:"List Google Doc paragraphs"`
 	Tabs             DocsTabsCmd             `cmd:"" name:"tabs" help:"Manage Google Doc tabs"`
 	AddTab           DocsAddTabCmd           `cmd:"" name:"add-tab" help:"Add a tab to a Google Doc"`
 	RenameTab        DocsRenameTabCmd        `cmd:"" name:"rename-tab" help:"Rename a tab in a Google Doc"`

--- a/internal/cmd/docs_enumerators.go
+++ b/internal/cmd/docs_enumerators.go
@@ -54,10 +54,11 @@ type DocsParagraphsListCmd struct {
 }
 
 type docsEnumeratorScope struct {
-	tabID    string
-	tabTitle string
-	content  []*docs.StructuralElement
-	doc      *docs.Document
+	tabID             string
+	tabTitle          string
+	content           []*docs.StructuralElement
+	inlineObjects     map[string]docs.InlineObject
+	positionedObjects map[string]docs.PositionedObject
 }
 
 type docsTableListItem struct {
@@ -231,7 +232,10 @@ func fetchDocsEnumeratorScope(ctx context.Context, flags *RootFlags, rawDocID, r
 		return nil, errors.New("doc not found")
 	}
 
-	scope := &docsEnumeratorScope{doc: doc}
+	scope := &docsEnumeratorScope{
+		inlineObjects:     doc.InlineObjects,
+		positionedObjects: doc.PositionedObjects,
+	}
 	if tabQuery != "" {
 		tabs := flattenTabs(doc.Tabs)
 		tab, tabErr := findTab(tabs, tabQuery)
@@ -242,6 +246,8 @@ func fetchDocsEnumeratorScope(ctx context.Context, flags *RootFlags, rawDocID, r
 			return nil, fmt.Errorf("tab has no content: %s", tabQuery)
 		}
 		scope.content = tab.DocumentTab.Body.Content
+		scope.inlineObjects = tab.DocumentTab.InlineObjects
+		scope.positionedObjects = tab.DocumentTab.PositionedObjects
 		if tab.TabProperties != nil {
 			scope.tabID = tab.TabProperties.TabId
 			scope.tabTitle = tab.TabProperties.Title
@@ -295,7 +301,7 @@ func enumerateDocsTables(scope *docsEnumeratorScope) []docsTableListItem {
 func enumerateDocsImages(scope *docsEnumeratorScope) []docsImageListItem {
 	var items []docsImageListItem
 	inlineProps := make(map[string]*docs.InlineObjectProperties)
-	for id, obj := range scope.doc.InlineObjects {
+	for id, obj := range scope.inlineObjects {
 		if obj.InlineObjectProperties != nil {
 			inlineProps[id] = obj.InlineObjectProperties
 		}
@@ -342,24 +348,24 @@ func enumerateDocsImages(scope *docsEnumeratorScope) []docsImageListItem {
 	}
 	walk(scope.content)
 
-	if scope.tabID == "" {
-		ids := make([]string, 0, len(scope.doc.PositionedObjects))
-		for id := range scope.doc.PositionedObjects {
-			ids = append(ids, id)
+	ids := make([]string, 0, len(scope.positionedObjects))
+	for id := range scope.positionedObjects {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	for _, id := range ids {
+		obj := scope.positionedObjects[id]
+		item := docsImageListItem{
+			Index:      len(items) + 1,
+			ObjectID:   id,
+			Positioned: true,
+			TabID:      scope.tabID,
+			TabTitle:   scope.tabTitle,
 		}
-		sort.Strings(ids)
-		for _, id := range ids {
-			obj := scope.doc.PositionedObjects[id]
-			item := docsImageListItem{
-				Index:      len(items) + 1,
-				ObjectID:   id,
-				Positioned: true,
-			}
-			if obj.PositionedObjectProperties != nil && obj.PositionedObjectProperties.EmbeddedObject != nil {
-				fillDocsImageEmbeddedObject(&item, obj.PositionedObjectProperties.EmbeddedObject)
-			}
-			items = append(items, item)
+		if obj.PositionedObjectProperties != nil && obj.PositionedObjectProperties.EmbeddedObject != nil {
+			fillDocsImageEmbeddedObject(&item, obj.PositionedObjectProperties.EmbeddedObject)
 		}
+		items = append(items, item)
 	}
 	return items
 }

--- a/internal/cmd/docs_enumerators.go
+++ b/internal/cmd/docs_enumerators.go
@@ -1,0 +1,578 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsTablesCmd struct {
+	List DocsTablesListCmd `cmd:"" name:"list" aliases:"ls" help:"List tables in a Google Doc"`
+}
+
+type DocsImagesCmd struct {
+	List DocsImagesListCmd `cmd:"" name:"list" aliases:"ls" help:"List images in a Google Doc"`
+}
+
+type DocsHeadingsCmd struct {
+	List DocsHeadingsListCmd `cmd:"" name:"list" aliases:"ls" help:"List headings in a Google Doc"`
+}
+
+type DocsParagraphsCmd struct {
+	List DocsParagraphsListCmd `cmd:"" name:"list" aliases:"ls" help:"List paragraphs in a Google Doc"`
+}
+
+type DocsTablesListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+}
+
+type DocsImagesListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+}
+
+type DocsHeadingsListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+	Level int    `name:"level" help:"Heading level to include (1-6)"`
+}
+
+type DocsParagraphsListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+	Style string `name:"style" help:"Named paragraph style to include (for example NORMAL_TEXT or HEADING_2)"`
+}
+
+type docsEnumeratorScope struct {
+	tabID    string
+	tabTitle string
+	content  []*docs.StructuralElement
+	doc      *docs.Document
+}
+
+type docsTableListItem struct {
+	Index      int      `json:"index"`
+	StartIndex int64    `json:"startIndex,omitempty"`
+	EndIndex   int64    `json:"endIndex,omitempty"`
+	Rows       int      `json:"rows"`
+	Cols       int      `json:"cols"`
+	HeaderRow  []string `json:"headerRow"`
+	TabID      string   `json:"tabId,omitempty"`
+	TabTitle   string   `json:"tabTitle,omitempty"`
+}
+
+type docsImageListItem struct {
+	Index      int     `json:"index"`
+	ObjectID   string  `json:"objectId"`
+	StartIndex int64   `json:"startIndex,omitempty"`
+	Alt        string  `json:"alt"`
+	Positioned bool    `json:"positioned"`
+	WidthPt    float64 `json:"widthPt,omitempty"`
+	HeightPt   float64 `json:"heightPt,omitempty"`
+	WidthUnit  string  `json:"widthUnit,omitempty"`
+	HeightUnit string  `json:"heightUnit,omitempty"`
+	TabID      string  `json:"tabId,omitempty"`
+	TabTitle   string  `json:"tabTitle,omitempty"`
+}
+
+type docsHeadingListItem struct {
+	Index      int    `json:"index"`
+	Level      int    `json:"level"`
+	StartIndex int64  `json:"startIndex,omitempty"`
+	EndIndex   int64  `json:"endIndex,omitempty"`
+	Style      string `json:"style"`
+	HeadingID  string `json:"headingId,omitempty"`
+	Text       string `json:"text"`
+	TabID      string `json:"tabId,omitempty"`
+	TabTitle   string `json:"tabTitle,omitempty"`
+}
+
+type docsParagraphListItem struct {
+	Index      int    `json:"index"`
+	StartIndex int64  `json:"startIndex,omitempty"`
+	EndIndex   int64  `json:"endIndex,omitempty"`
+	Style      string `json:"style"`
+	Bullet     bool   `json:"bullet"`
+	NestLevel  int    `json:"nestLevel,omitempty"`
+	Text       string `json:"text"`
+	TabID      string `json:"tabId,omitempty"`
+	TabTitle   string `json:"tabTitle,omitempty"`
+}
+
+func (c *DocsTablesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scope, err := fetchDocsEnumeratorScope(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+
+	items := enumerateDocsTables(scope)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, items)
+	}
+
+	u := ui.FromContext(ctx)
+	for _, item := range items {
+		if outfmt.IsPlain(ctx) {
+			u.Out().Linef("table\t%d\t%d\t%d\t%d\t%d\t%s", item.Index, item.Rows, item.Cols, item.StartIndex, item.EndIndex, docsTSV(strings.Join(item.HeaderRow, " | ")))
+			continue
+		}
+		u.Out().Linef("table %d  rows=%d cols=%d", item.Index, item.Rows, item.Cols)
+		if len(item.HeaderRow) > 0 {
+			u.Out().Linef("  row 1: %s", strings.Join(item.HeaderRow, " | "))
+		}
+	}
+	return nil
+}
+
+func (c *DocsImagesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	scope, err := fetchDocsEnumeratorScope(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+
+	items := enumerateDocsImages(scope)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, items)
+	}
+
+	u := ui.FromContext(ctx)
+	for _, item := range items {
+		if outfmt.IsPlain(ctx) {
+			u.Out().Linef("image\t%d\t%s\t%d\t%s\t%s\t%t", item.Index, item.ObjectID, item.StartIndex, docsTSV(item.Alt), docsTSV(formatDocsImageSize(item)), item.Positioned)
+			continue
+		}
+		u.Out().Linef("image %d  objectId=%s  alt=%q  size=%s", item.Index, item.ObjectID, item.Alt, formatDocsImageSize(item))
+	}
+	return nil
+}
+
+func (c *DocsHeadingsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if c.Level < 0 || c.Level > 6 {
+		return usage("--level must be between 1 and 6")
+	}
+	scope, err := fetchDocsEnumeratorScope(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+
+	items := enumerateDocsHeadings(scope, c.Level)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, items)
+	}
+
+	u := ui.FromContext(ctx)
+	for _, item := range items {
+		if outfmt.IsPlain(ctx) {
+			u.Out().Linef("heading\t%d\t%d\t%d\t%d\t%s", item.Index, item.Level, item.StartIndex, item.EndIndex, docsTSV(item.Text))
+			continue
+		}
+		u.Out().Linef("heading %d  level=%d  index=%d  %q", item.Index, item.Level, item.StartIndex, item.Text)
+	}
+	return nil
+}
+
+func (c *DocsParagraphsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	style := strings.ToUpper(strings.TrimSpace(c.Style))
+	scope, err := fetchDocsEnumeratorScope(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+
+	items := enumerateDocsParagraphs(scope, style)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, items)
+	}
+
+	u := ui.FromContext(ctx)
+	for _, item := range items {
+		if outfmt.IsPlain(ctx) {
+			u.Out().Linef("paragraph\t%d\t%s\t%d\t%d\t%t\t%d\t%s", item.Index, item.Style, item.StartIndex, item.EndIndex, item.Bullet, item.NestLevel, docsTSV(item.Text))
+			continue
+		}
+		u.Out().Linef("paragraph %d  style=%s  index=%d  %q", item.Index, item.Style, item.StartIndex, item.Text)
+	}
+	return nil
+}
+
+func fetchDocsEnumeratorScope(ctx context.Context, flags *RootFlags, rawDocID, rawTab string) (*docsEnumeratorScope, error) {
+	id := strings.TrimSpace(rawDocID)
+	if id == "" {
+		return nil, usage("empty docId")
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	tabQuery := strings.TrimSpace(rawTab)
+	getCall := svc.Documents.Get(id)
+	if tabQuery != "" {
+		getCall = getCall.IncludeTabsContent(true)
+	}
+	doc, err := getCall.Context(ctx).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return nil, fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return nil, err
+	}
+	if doc == nil {
+		return nil, errors.New("doc not found")
+	}
+
+	scope := &docsEnumeratorScope{doc: doc}
+	if tabQuery != "" {
+		tabs := flattenTabs(doc.Tabs)
+		tab, tabErr := findTab(tabs, tabQuery)
+		if tabErr != nil {
+			return nil, tabErr
+		}
+		if tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
+			return nil, fmt.Errorf("tab has no content: %s", tabQuery)
+		}
+		scope.content = tab.DocumentTab.Body.Content
+		if tab.TabProperties != nil {
+			scope.tabID = tab.TabProperties.TabId
+			scope.tabTitle = tab.TabProperties.Title
+		}
+		return scope, nil
+	}
+
+	if doc.Body == nil {
+		return nil, errors.New("document has no body")
+	}
+	scope.content = doc.Body.Content
+	return scope, nil
+}
+
+func enumerateDocsTables(scope *docsEnumeratorScope) []docsTableListItem {
+	var items []docsTableListItem
+	var walk func(content []*docs.StructuralElement)
+	walk = func(content []*docs.StructuralElement) {
+		for _, elem := range content {
+			if elem == nil {
+				continue
+			}
+			if elem.Table != nil {
+				items = append(items, docsTableListItem{
+					Index:      len(items) + 1,
+					StartIndex: elem.StartIndex,
+					EndIndex:   elem.EndIndex,
+					Rows:       len(elem.Table.TableRows),
+					Cols:       docsTableMaxColumnCount(elem.Table),
+					HeaderRow:  docsTableHeaderRow(elem.Table),
+					TabID:      scope.tabID,
+					TabTitle:   scope.tabTitle,
+				})
+				for _, row := range elem.Table.TableRows {
+					if row == nil {
+						continue
+					}
+					for _, cell := range row.TableCells {
+						if cell != nil {
+							walk(cell.Content)
+						}
+					}
+				}
+			}
+		}
+	}
+	walk(scope.content)
+	return items
+}
+
+func enumerateDocsImages(scope *docsEnumeratorScope) []docsImageListItem {
+	var items []docsImageListItem
+	inlineProps := make(map[string]*docs.InlineObjectProperties)
+	for id, obj := range scope.doc.InlineObjects {
+		if obj.InlineObjectProperties != nil {
+			inlineProps[id] = obj.InlineObjectProperties
+		}
+	}
+
+	var walk func(content []*docs.StructuralElement)
+	walk = func(content []*docs.StructuralElement) {
+		for _, elem := range content {
+			if elem == nil {
+				continue
+			}
+			if elem.Paragraph != nil {
+				for _, pe := range elem.Paragraph.Elements {
+					if pe == nil || pe.InlineObjectElement == nil {
+						continue
+					}
+					objID := pe.InlineObjectElement.InlineObjectId
+					item := docsImageListItem{
+						Index:      len(items) + 1,
+						ObjectID:   objID,
+						StartIndex: pe.StartIndex,
+						TabID:      scope.tabID,
+						TabTitle:   scope.tabTitle,
+					}
+					if props := inlineProps[objID]; props != nil && props.EmbeddedObject != nil {
+						fillDocsImageEmbeddedObject(&item, props.EmbeddedObject)
+					}
+					items = append(items, item)
+				}
+			}
+			if elem.Table != nil {
+				for _, row := range elem.Table.TableRows {
+					if row == nil {
+						continue
+					}
+					for _, cell := range row.TableCells {
+						if cell != nil {
+							walk(cell.Content)
+						}
+					}
+				}
+			}
+		}
+	}
+	walk(scope.content)
+
+	if scope.tabID == "" {
+		ids := make([]string, 0, len(scope.doc.PositionedObjects))
+		for id := range scope.doc.PositionedObjects {
+			ids = append(ids, id)
+		}
+		sort.Strings(ids)
+		for _, id := range ids {
+			obj := scope.doc.PositionedObjects[id]
+			item := docsImageListItem{
+				Index:      len(items) + 1,
+				ObjectID:   id,
+				Positioned: true,
+			}
+			if obj.PositionedObjectProperties != nil && obj.PositionedObjectProperties.EmbeddedObject != nil {
+				fillDocsImageEmbeddedObject(&item, obj.PositionedObjectProperties.EmbeddedObject)
+			}
+			items = append(items, item)
+		}
+	}
+	return items
+}
+
+func enumerateDocsHeadings(scope *docsEnumeratorScope, level int) []docsHeadingListItem {
+	var items []docsHeadingListItem
+	walkDocsParagraphs(scope.content, func(elem *docs.StructuralElement, p *docs.Paragraph) {
+		style := docsParagraphStyle(p)
+		headingLevel, ok := docsHeadingLevel(style)
+		if !ok || (level > 0 && headingLevel != level) {
+			return
+		}
+		headingID := ""
+		if p.ParagraphStyle != nil {
+			headingID = p.ParagraphStyle.HeadingId
+		}
+		items = append(items, docsHeadingListItem{
+			Index:      len(items) + 1,
+			Level:      headingLevel,
+			StartIndex: elem.StartIndex,
+			EndIndex:   elem.EndIndex,
+			Style:      style,
+			HeadingID:  headingID,
+			Text:       paragraphText(p),
+			TabID:      scope.tabID,
+			TabTitle:   scope.tabTitle,
+		})
+	})
+	return items
+}
+
+func enumerateDocsParagraphs(scope *docsEnumeratorScope, styleFilter string) []docsParagraphListItem {
+	var items []docsParagraphListItem
+	walkDocsParagraphs(scope.content, func(elem *docs.StructuralElement, p *docs.Paragraph) {
+		style := docsParagraphStyle(p)
+		if styleFilter != "" && style != styleFilter {
+			return
+		}
+		item := docsParagraphListItem{
+			Index:      len(items) + 1,
+			StartIndex: elem.StartIndex,
+			EndIndex:   elem.EndIndex,
+			Style:      style,
+			Text:       paragraphText(p),
+			TabID:      scope.tabID,
+			TabTitle:   scope.tabTitle,
+		}
+		if p.Bullet != nil {
+			item.Bullet = true
+			item.NestLevel = int(p.Bullet.NestingLevel)
+		}
+		items = append(items, item)
+	})
+	return items
+}
+
+func walkDocsParagraphs(content []*docs.StructuralElement, visit func(*docs.StructuralElement, *docs.Paragraph)) {
+	for _, elem := range content {
+		if elem == nil {
+			continue
+		}
+		if elem.Paragraph != nil {
+			visit(elem, elem.Paragraph)
+		}
+		if elem.Table != nil {
+			for _, row := range elem.Table.TableRows {
+				if row == nil {
+					continue
+				}
+				for _, cell := range row.TableCells {
+					if cell != nil {
+						walkDocsParagraphs(cell.Content, visit)
+					}
+				}
+			}
+		}
+	}
+}
+
+func docsTableMaxColumnCount(table *docs.Table) int {
+	if table == nil || len(table.TableRows) == 0 {
+		return 0
+	}
+	maxCols := 0
+	for _, row := range table.TableRows {
+		if row == nil {
+			continue
+		}
+		if len(row.TableCells) > maxCols {
+			maxCols = len(row.TableCells)
+		}
+	}
+	return maxCols
+}
+
+func docsTableHeaderRow(table *docs.Table) []string {
+	if table == nil || len(table.TableRows) == 0 {
+		return nil
+	}
+	if table.TableRows[0] == nil {
+		return nil
+	}
+	header := make([]string, 0, len(table.TableRows[0].TableCells))
+	for _, cell := range table.TableRows[0].TableCells {
+		header = append(header, docsTableCellPlainText(cell))
+	}
+	return header
+}
+
+func docsTableCellPlainText(cell *docs.TableCell) string {
+	if cell == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, elem := range cell.Content {
+		appendDocsStructuralPlainText(&b, elem)
+	}
+	return strings.TrimSpace(b.String())
+}
+
+func appendDocsStructuralPlainText(b *strings.Builder, elem *docs.StructuralElement) {
+	if elem == nil {
+		return
+	}
+	if elem.Paragraph != nil {
+		if b.Len() > 0 {
+			b.WriteByte(' ')
+		}
+		b.WriteString(paragraphText(elem.Paragraph))
+	}
+	if elem.Table != nil {
+		for _, row := range elem.Table.TableRows {
+			if row == nil {
+				continue
+			}
+			for _, cell := range row.TableCells {
+				if text := docsTableCellPlainText(cell); text != "" {
+					if b.Len() > 0 {
+						b.WriteByte(' ')
+					}
+					b.WriteString(text)
+				}
+			}
+		}
+	}
+}
+
+func fillDocsImageEmbeddedObject(item *docsImageListItem, obj *docs.EmbeddedObject) {
+	if item == nil || obj == nil {
+		return
+	}
+	item.Alt = firstNonEmpty(obj.Title, obj.Description)
+	if obj.Size == nil {
+		return
+	}
+	if obj.Size.Width != nil {
+		item.WidthPt = obj.Size.Width.Magnitude
+		item.WidthUnit = obj.Size.Width.Unit
+	}
+	if obj.Size.Height != nil {
+		item.HeightPt = obj.Size.Height.Magnitude
+		item.HeightUnit = obj.Size.Height.Unit
+	}
+}
+
+func docsParagraphStyle(p *docs.Paragraph) string {
+	if p != nil && p.ParagraphStyle != nil && strings.TrimSpace(p.ParagraphStyle.NamedStyleType) != "" {
+		return strings.ToUpper(strings.TrimSpace(p.ParagraphStyle.NamedStyleType))
+	}
+	return docsNamedStyleNormalText
+}
+
+func docsHeadingLevel(style string) (int, bool) {
+	raw := strings.TrimPrefix(style, "HEADING_")
+	if raw == style {
+		return 0, false
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 1 || n > 6 {
+		return 0, false
+	}
+	return n, true
+}
+
+func formatDocsImageSize(item docsImageListItem) string {
+	if item.WidthPt == 0 && item.HeightPt == 0 {
+		return ""
+	}
+	width := docsFormatDimension(item.WidthPt, item.WidthUnit)
+	height := docsFormatDimension(item.HeightPt, item.HeightUnit)
+	if width == "" {
+		return "x" + height
+	}
+	if height == "" {
+		return width + "x"
+	}
+	return width + "x" + height
+}
+
+func docsFormatDimension(value float64, unit string) string {
+	if value == 0 {
+		return ""
+	}
+	if unit == "" {
+		unit = "PT"
+	}
+	if value == float64(int64(value)) {
+		return fmt.Sprintf("%.0f%s", value, strings.ToLower(unit))
+	}
+	return fmt.Sprintf("%.3g%s", value, strings.ToLower(unit))
+}
+
+func docsTSV(s string) string {
+	replacer := strings.NewReplacer("\t", " ", "\r", " ", "\n", " ")
+	return replacer.Replace(s)
+}

--- a/internal/cmd/docs_enumerators_test.go
+++ b/internal/cmd/docs_enumerators_test.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+func TestDocsEnumerateTables(t *testing.T) {
+	scope := &docsEnumeratorScope{content: []*docs.StructuralElement{
+		{
+			StartIndex: 10,
+			EndIndex:   40,
+			Table: &docs.Table{TableRows: []*docs.TableRow{
+				docsEnumTableRow("Author", "Sebastian Roth"),
+				docsEnumTableRow("Reviewer", "Status"),
+			}},
+		},
+	}}
+
+	items := enumerateDocsTables(scope)
+	if len(items) != 1 {
+		t.Fatalf("expected 1 table, got %d", len(items))
+	}
+	got := items[0]
+	if got.Index != 1 || got.StartIndex != 10 || got.EndIndex != 40 {
+		t.Fatalf("unexpected table indices: %#v", got)
+	}
+	if got.Rows != 2 || got.Cols != 2 {
+		t.Fatalf("unexpected dimensions: %#v", got)
+	}
+	if strings.Join(got.HeaderRow, "|") != "Author|Sebastian Roth" {
+		t.Fatalf("unexpected header row: %#v", got.HeaderRow)
+	}
+}
+
+func TestDocsEnumerateImages(t *testing.T) {
+	scope := &docsEnumeratorScope{
+		doc: &docs.Document{
+			InlineObjects: map[string]docs.InlineObject{
+				"img.inline": {InlineObjectProperties: &docs.InlineObjectProperties{
+					EmbeddedObject: &docs.EmbeddedObject{
+						Description: "Architecture diagram",
+						Size: &docs.Size{
+							Width:  &docs.Dimension{Magnitude: 1008, Unit: "PT"},
+							Height: &docs.Dimension{Magnitude: 500, Unit: "PT"},
+						},
+					},
+				}},
+			},
+			PositionedObjects: map[string]docs.PositionedObject{
+				"img.positioned": {PositionedObjectProperties: &docs.PositionedObjectProperties{
+					EmbeddedObject: &docs.EmbeddedObject{Title: "Floating logo"},
+				}},
+			},
+		},
+		content: []*docs.StructuralElement{
+			{Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{
+				{StartIndex: 42, InlineObjectElement: &docs.InlineObjectElement{InlineObjectId: "img.inline"}},
+			}}},
+		},
+	}
+
+	items := enumerateDocsImages(scope)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 images, got %d", len(items))
+	}
+	if got := items[0]; got.Index != 1 || got.ObjectID != "img.inline" || got.StartIndex != 42 || got.Alt != "Architecture diagram" {
+		t.Fatalf("unexpected inline image: %#v", got)
+	}
+	if items[0].WidthPt != 1008 || items[0].HeightPt != 500 {
+		t.Fatalf("unexpected image size: %#v", items[0])
+	}
+	if got := items[1]; got.Index != 2 || got.ObjectID != "img.positioned" || !got.Positioned || got.Alt != "Floating logo" {
+		t.Fatalf("unexpected positioned image: %#v", got)
+	}
+}
+
+func TestDocsEnumerateHeadingsAndParagraphs(t *testing.T) {
+	scope := &docsEnumeratorScope{content: []*docs.StructuralElement{
+		docsEnumParagraphElement(5, 18, "HEADING_1", "Intro\n"),
+		docsEnumParagraphElement(18, 35, docsNamedStyleNormalText, "Body text\n"),
+		docsEnumParagraphElement(35, 50, "HEADING_2", "Details\n"),
+	}}
+
+	headings := enumerateDocsHeadings(scope, 2)
+	if len(headings) != 1 {
+		t.Fatalf("expected 1 h2, got %d", len(headings))
+	}
+	if got := headings[0]; got.Index != 1 || got.Level != 2 || got.StartIndex != 35 || got.Text != "Details" {
+		t.Fatalf("unexpected heading: %#v", got)
+	}
+
+	paragraphs := enumerateDocsParagraphs(scope, docsNamedStyleNormalText)
+	if len(paragraphs) != 1 {
+		t.Fatalf("expected 1 normal paragraph, got %d", len(paragraphs))
+	}
+	if got := paragraphs[0]; got.Index != 1 || got.Style != docsNamedStyleNormalText || got.Text != "Body text" {
+		t.Fatalf("unexpected paragraph: %#v", got)
+	}
+}
+
+func TestDocsHeadingsList_TabJSON(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var includeTabs bool
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v1/documents/") {
+			http.NotFound(w, r)
+			return
+		}
+		includeTabs = strings.Contains(r.URL.RawQuery, "includeTabsContent=true")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"documentId": "doc1",
+			"tabs": []any{
+				map[string]any{
+					"tabProperties": map[string]any{"tabId": "t.first", "title": "First", "index": 0},
+					"documentTab": map[string]any{
+						"body": map[string]any{"content": []any{
+							docsEnumParagraphMap(1, 10, "HEADING_1", "First heading\n"),
+						}},
+					},
+				},
+			},
+		})
+	}))
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	ctx := outfmt.WithMode(newCmdOutputContext(t, &bytes.Buffer{}, &bytes.Buffer{}), outfmt.Mode{JSON: true})
+	out := captureStdout(t, func() {
+		err := runKong(t, &DocsHeadingsListCmd{}, []string{"doc1", "--tab", "First"}, ctx, &RootFlags{Account: "a@b.com"})
+		if err != nil {
+			t.Fatalf("headings list: %v", err)
+		}
+	})
+	if !includeTabs {
+		t.Fatalf("expected includeTabsContent=true")
+	}
+
+	var got []docsHeadingListItem
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("parse json: %v\n%s", err, out)
+	}
+	if len(got) != 1 || got[0].TabID != "t.first" || got[0].TabTitle != "First" || got[0].Text != "First heading" {
+		t.Fatalf("unexpected JSON: %#v", got)
+	}
+}
+
+func TestDocsParagraphsList_PlainTSV(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/v1/documents/") {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"documentId": "doc1",
+			"body": map[string]any{"content": []any{
+				docsEnumParagraphMap(1, 15, docsNamedStyleNormalText, "line\tone\n"),
+			}},
+		})
+	}))
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	var stdout bytes.Buffer
+	ctx := outfmt.WithMode(newCmdOutputContext(t, &stdout, &bytes.Buffer{}), outfmt.Mode{Plain: true})
+	err := runKong(t, &DocsParagraphsListCmd{}, []string{"doc1"}, ctx, &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("paragraphs list: %v", err)
+	}
+
+	want := "paragraph\t1\tNORMAL_TEXT\t1\t15\tfalse\t0\tline one\n"
+	if stdout.String() != want {
+		t.Fatalf("plain output = %q, want %q", stdout.String(), want)
+	}
+}
+
+func docsEnumParagraphElement(start, end int64, style, text string) *docs.StructuralElement {
+	return &docs.StructuralElement{
+		StartIndex: start,
+		EndIndex:   end,
+		Paragraph: &docs.Paragraph{
+			ParagraphStyle: &docs.ParagraphStyle{NamedStyleType: style},
+			Elements:       []*docs.ParagraphElement{{TextRun: &docs.TextRun{Content: text}}},
+		},
+	}
+}
+
+func docsEnumParagraphMap(start, end int64, style, text string) map[string]any {
+	return map[string]any{
+		"startIndex": start,
+		"endIndex":   end,
+		"paragraph": map[string]any{
+			"paragraphStyle": map[string]any{"namedStyleType": style},
+			"elements": []any{
+				map[string]any{"textRun": map[string]any{"content": text}},
+			},
+		},
+	}
+}
+
+func docsEnumTableRow(values ...string) *docs.TableRow {
+	cells := make([]*docs.TableCell, 0, len(values))
+	for _, value := range values {
+		cells = append(cells, &docs.TableCell{Content: []*docs.StructuralElement{
+			docsEnumParagraphElement(0, 0, docsNamedStyleNormalText, value+"\n"),
+		}})
+	}
+	return &docs.TableRow{TableCells: cells}
+}

--- a/internal/cmd/docs_enumerators_test.go
+++ b/internal/cmd/docs_enumerators_test.go
@@ -43,23 +43,21 @@ func TestDocsEnumerateTables(t *testing.T) {
 
 func TestDocsEnumerateImages(t *testing.T) {
 	scope := &docsEnumeratorScope{
-		doc: &docs.Document{
-			InlineObjects: map[string]docs.InlineObject{
-				"img.inline": {InlineObjectProperties: &docs.InlineObjectProperties{
-					EmbeddedObject: &docs.EmbeddedObject{
-						Description: "Architecture diagram",
-						Size: &docs.Size{
-							Width:  &docs.Dimension{Magnitude: 1008, Unit: "PT"},
-							Height: &docs.Dimension{Magnitude: 500, Unit: "PT"},
-						},
+		inlineObjects: map[string]docs.InlineObject{
+			"img.inline": {InlineObjectProperties: &docs.InlineObjectProperties{
+				EmbeddedObject: &docs.EmbeddedObject{
+					Description: "Architecture diagram",
+					Size: &docs.Size{
+						Width:  &docs.Dimension{Magnitude: 1008, Unit: "PT"},
+						Height: &docs.Dimension{Magnitude: 500, Unit: "PT"},
 					},
-				}},
-			},
-			PositionedObjects: map[string]docs.PositionedObject{
-				"img.positioned": {PositionedObjectProperties: &docs.PositionedObjectProperties{
-					EmbeddedObject: &docs.EmbeddedObject{Title: "Floating logo"},
-				}},
-			},
+				},
+			}},
+		},
+		positionedObjects: map[string]docs.PositionedObject{
+			"img.positioned": {PositionedObjectProperties: &docs.PositionedObjectProperties{
+				EmbeddedObject: &docs.EmbeddedObject{Title: "Floating logo"},
+			}},
 		},
 		content: []*docs.StructuralElement{
 			{Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{
@@ -80,6 +78,42 @@ func TestDocsEnumerateImages(t *testing.T) {
 	}
 	if got := items[1]; got.Index != 2 || got.ObjectID != "img.positioned" || !got.Positioned || got.Alt != "Floating logo" {
 		t.Fatalf("unexpected positioned image: %#v", got)
+	}
+}
+
+func TestDocsEnumerateImages_UsesTabObjectMaps(t *testing.T) {
+	scope := &docsEnumeratorScope{
+		tabID:    "t.second",
+		tabTitle: "Second",
+		inlineObjects: map[string]docs.InlineObject{
+			"tab.inline": {InlineObjectProperties: &docs.InlineObjectProperties{
+				EmbeddedObject: &docs.EmbeddedObject{
+					Title: "Tab image",
+					Size:  &docs.Size{Width: &docs.Dimension{Magnitude: 320, Unit: "PT"}},
+				},
+			}},
+		},
+		positionedObjects: map[string]docs.PositionedObject{
+			"tab.positioned": {PositionedObjectProperties: &docs.PositionedObjectProperties{
+				EmbeddedObject: &docs.EmbeddedObject{Description: "Tab positioned image"},
+			}},
+		},
+		content: []*docs.StructuralElement{
+			{Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{
+				{StartIndex: 9, InlineObjectElement: &docs.InlineObjectElement{InlineObjectId: "tab.inline"}},
+			}}},
+		},
+	}
+
+	items := enumerateDocsImages(scope)
+	if len(items) != 2 {
+		t.Fatalf("expected 2 tab images, got %d", len(items))
+	}
+	if got := items[0]; got.ObjectID != "tab.inline" || got.Alt != "Tab image" || got.WidthPt != 320 || got.TabID != "t.second" {
+		t.Fatalf("unexpected tab inline image: %#v", got)
+	}
+	if got := items[1]; got.ObjectID != "tab.positioned" || got.Alt != "Tab positioned image" || !got.Positioned || got.TabTitle != "Second" {
+		t.Fatalf("unexpected tab positioned image: %#v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `gog docs tables/images/headings/paragraphs list` read-only enumerator subcommands
- support tab-scoped enumeration, JSON arrays, TSV `--plain`, and readable default output
- add focused command/enumerator tests and regenerate command reference docs

Fixes #719

## Validation
- `go test ./internal/cmd -run 'TestDocsEnumerate|TestDocsHeadingsList_TabJSON|TestDocsParagraphsList_PlainTSV'`
- `go test ./internal/cmd`
- `make docs-commands`
- `make fmt`
- `make ci`