### PR TITLE
feat(docs): add content enumerators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Gmail: report attached filenames and byte sizes in JSON results for send and draft create/update. (#716) — thanks @chrischall.
 - Gmail: add `gmail watch pull` for Pub/Sub pull subscription consumers with hook retry support. (#700) — thanks @joshp123.
 - Docs: add `--tab` and `--all-tabs` to `docs raw` for inspecting specific or complete multi-tab document content. (#697) — thanks @sebsnyk.
+- Docs: add tab-aware table, image, heading, and paragraph enumerators with structured and plain output. (#719) — thanks @sebsnyk.
 
 ### Fixed
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -241,6 +241,10 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) find-range <docId> <text> [flags]`](commands/gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
     - [`gog docs (doc) find-replace <docId> <find> [<replace>] [flags]`](commands/gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
     - [`gog docs (doc) format <docId> [flags]`](commands/gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+    - [`gog docs (doc) headings <command>`](commands/gog-docs-headings.md) - List document headings
+      - [`gog docs (doc) headings list (ls) <docId> [flags]`](commands/gog-docs-headings-list.md) - List heading paragraphs
+    - [`gog docs (doc) images <command>`](commands/gog-docs-images.md) - List document images
+      - [`gog docs (doc) images list (ls) <docId> [flags]`](commands/gog-docs-images-list.md) - List inline and positioned images
     - [`gog docs (doc) info (get,show) <docId>`](commands/gog-docs-info.md) - Get Google Doc metadata
     - [`gog docs (doc) insert <docId> [<content>] [flags]`](commands/gog-docs-insert.md) - Insert text at a specific position
     - [`gog docs (doc) insert-date-chip --date=STRING <docId> [flags]`](commands/gog-docs-insert-date-chip.md) - Insert a native date smart chip
@@ -251,11 +255,15 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) insert-table --rows=INT --cols=INT <docId> [flags]`](commands/gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [`gog docs (doc) list-tabs <docId>`](commands/gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [`gog docs (doc) page-layout (set-page-layout,page-setup) <docId> [flags]`](commands/gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
+    - [`gog docs (doc) paragraphs <command>`](commands/gog-docs-paragraphs.md) - List document paragraphs
+      - [`gog docs (doc) paragraphs list (ls) <docId> [flags]`](commands/gog-docs-paragraphs-list.md) - List paragraphs
     - [`gog docs (doc) raw <docId> [flags]`](commands/gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [`gog docs (doc) rename-tab <docId> [flags]`](commands/gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [`gog docs (doc) sed <docId> [<expression>] [flags]`](commands/gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [`gog docs (doc) structure (struct) <docId> [flags]`](commands/gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [`gog docs (doc) table-column-width (table-width,column-width) <docId> [flags]`](commands/gog-docs-table-column-width.md) - Set or reset native table column widths
+    - [`gog docs (doc) tables <command>`](commands/gog-docs-tables.md) - List native tables
+      - [`gog docs (doc) tables list (ls) <docId> [flags]`](commands/gog-docs-tables-list.md) - List native tables in document order
     - [`gog docs (doc) tabs <command>`](commands/gog-docs-tabs.md) - Manage Google Doc tabs
       - [`gog docs (doc) tabs add (create,new) <docId> [flags]`](commands/gog-docs-tabs-add.md) - Add a tab to a Google Doc
       - [`gog docs (doc) tabs delete (rm,remove,del) <docId> [flags]`](commands/gog-docs-tabs-delete.md) - Delete a tab from a Google Doc

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 589.
+Generated pages: 597.
 
 ## Top-level Commands
 
@@ -293,6 +293,10 @@ Generated pages: 589.
     - [gog docs find-range](gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
     - [gog docs find-replace](gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
     - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+    - [gog docs headings](gog-docs-headings.md) - List document headings
+      - [gog docs headings list](gog-docs-headings-list.md) - List heading paragraphs
+    - [gog docs images](gog-docs-images.md) - List document images
+      - [gog docs images list](gog-docs-images-list.md) - List inline and positioned images
     - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
     - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
     - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
@@ -303,11 +307,15 @@ Generated pages: 589.
     - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
+    - [gog docs paragraphs](gog-docs-paragraphs.md) - List document paragraphs
+      - [gog docs paragraphs list](gog-docs-paragraphs-list.md) - List paragraphs
     - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
+    - [gog docs tables](gog-docs-tables.md) - List native tables
+      - [gog docs tables list](gog-docs-tables-list.md) - List native tables in document order
     - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs
       - [gog docs tabs add](gog-docs-tabs-add.md) - Add a tab to a Google Doc
       - [gog docs tabs delete](gog-docs-tabs-delete.md) - Delete a tab from a Google Doc

--- a/docs/commands/gog-docs-headings-list.md
+++ b/docs/commands/gog-docs-headings-list.md
@@ -1,0 +1,47 @@
+# `gog docs headings list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List heading paragraphs
+
+## Usage
+
+```bash
+gog docs (doc) headings list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs headings](gog-docs-headings.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--level` | `int` |  | Only return this heading level (1-6) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs headings](gog-docs-headings.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-headings.md
+++ b/docs/commands/gog-docs-headings.md
@@ -1,0 +1,49 @@
+# `gog docs headings`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List document headings
+
+## Usage
+
+```bash
+gog docs (doc) headings <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs headings list](gog-docs-headings-list.md) - List heading paragraphs
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-images-list.md
+++ b/docs/commands/gog-docs-images-list.md
@@ -1,0 +1,46 @@
+# `gog docs images list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List inline and positioned images
+
+## Usage
+
+```bash
+gog docs (doc) images list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs images](gog-docs-images.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs images](gog-docs-images.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-images.md
+++ b/docs/commands/gog-docs-images.md
@@ -1,0 +1,49 @@
+# `gog docs images`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List document images
+
+## Usage
+
+```bash
+gog docs (doc) images <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs images list](gog-docs-images-list.md) - List inline and positioned images
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-paragraphs-list.md
+++ b/docs/commands/gog-docs-paragraphs-list.md
@@ -1,0 +1,47 @@
+# `gog docs paragraphs list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List paragraphs
+
+## Usage
+
+```bash
+gog docs (doc) paragraphs list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs paragraphs](gog-docs-paragraphs.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--style` | `string` |  | Only return this named style (for example NORMAL_TEXT or HEADING_2) |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs paragraphs](gog-docs-paragraphs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-paragraphs.md
+++ b/docs/commands/gog-docs-paragraphs.md
@@ -1,0 +1,49 @@
+# `gog docs paragraphs`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List document paragraphs
+
+## Usage
+
+```bash
+gog docs (doc) paragraphs <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs paragraphs list](gog-docs-paragraphs-list.md) - List paragraphs
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-tables-list.md
+++ b/docs/commands/gog-docs-tables-list.md
@@ -1,0 +1,46 @@
+# `gog docs tables list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List native tables in document order
+
+## Usage
+
+```bash
+gog docs (doc) tables list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs tables](gog-docs-tables.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for default) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs tables](gog-docs-tables.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-tables.md
+++ b/docs/commands/gog-docs-tables.md
@@ -1,0 +1,49 @@
+# `gog docs tables`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List native tables
+
+## Usage
+
+```bash
+gog docs (doc) tables <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs tables list](gog-docs-tables-list.md) - List native tables in document order
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -31,6 +31,8 @@ gog docs (doc) <command> [flags]
 - [gog docs find-range](gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
 - [gog docs find-replace](gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
 - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+- [gog docs headings](gog-docs-headings.md) - List document headings
+- [gog docs images](gog-docs-images.md) - List document images
 - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
 - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
 - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
@@ -41,11 +43,13 @@ gog docs (doc) <command> [flags]
 - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
 - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
 - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
+- [gog docs paragraphs](gog-docs-paragraphs.md) - List document paragraphs
 - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
 - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
 - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
 - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
 - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
+- [gog docs tables](gog-docs-tables.md) - List native tables
 - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs
 - [gog docs update](gog-docs-update.md) - Insert or replace text at a specific index or range in a Google Doc
 - [gog docs write](gog-docs-write.md) - Write content to a Google Doc

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -54,6 +54,21 @@ Command page:
 
 - [`gog docs format`](commands/gog-docs-format.md)
 
+## Discover Content
+
+List document elements before using index- or object-ID-based edit commands:
+
+```bash
+gog docs tables list <docId> --json
+gog docs images list <docId> --plain
+gog docs headings list <docId> --level 2
+gog docs paragraphs list <docId> --style NORMAL_TEXT --tab "Notes"
+```
+
+All four commands accept `--tab` by title or ID. JSON output includes stable
+element indexes and Docs API positions; `--plain` emits headerless TSV for
+shell pipelines.
+
 ## Page Breaks
 
 Markdown has no native page-break construct, so multi-page deliverables need a

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -50,6 +50,10 @@ type DocsCmd struct {
 	Sed              DocsSedCmd              `cmd:"" name:"sed" help:"Regex find/replace (sed-style: s/pattern/replacement/g)"`
 	Clear            DocsClearCmd            `cmd:"" name:"clear" help:"Clear all content from a Google Doc"`
 	Structure        DocsStructureCmd        `cmd:"" name:"structure" aliases:"struct" help:"Show document structure with numbered paragraphs"`
+	Tables           DocsTablesCmd           `cmd:"" name:"tables" help:"List native tables"`
+	Images           DocsImagesCmd           `cmd:"" name:"images" help:"List document images"`
+	Headings         DocsHeadingsCmd         `cmd:"" name:"headings" help:"List document headings"`
+	Paragraphs       DocsParagraphsCmd       `cmd:"" name:"paragraphs" help:"List document paragraphs"`
 	Raw              DocsRawCmd              `cmd:"" name:"raw" help:"Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)"`
 	PageLayout       DocsPageLayoutCmd       `cmd:"" name:"page-layout" aliases:"set-page-layout,page-setup" help:"Set page layout (pageless|pages) on an existing Google Doc"`
 }

--- a/internal/cmd/docs_enumerators.go
+++ b/internal/cmd/docs_enumerators.go
@@ -1,0 +1,499 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type DocsTablesCmd struct {
+	List DocsTablesListCmd `cmd:"" name:"list" aliases:"ls" help:"List native tables in document order"`
+}
+
+type DocsImagesCmd struct {
+	List DocsImagesListCmd `cmd:"" name:"list" aliases:"ls" help:"List inline and positioned images"`
+}
+
+type DocsHeadingsCmd struct {
+	List DocsHeadingsListCmd `cmd:"" name:"list" aliases:"ls" help:"List heading paragraphs"`
+}
+
+type DocsParagraphsCmd struct {
+	List DocsParagraphsListCmd `cmd:"" name:"list" aliases:"ls" help:"List paragraphs"`
+}
+
+type DocsTablesListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+}
+
+type DocsImagesListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+}
+
+type DocsHeadingsListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+	Level int    `name:"level" help:"Only return this heading level (1-6)"`
+}
+
+type DocsParagraphsListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for default)"`
+	Style string `name:"style" help:"Only return this named style (for example NORMAL_TEXT or HEADING_2)"`
+}
+
+type docsTableListItem struct {
+	Index      int      `json:"index"`
+	StartIndex int64    `json:"startIndex"`
+	Rows       int      `json:"rows"`
+	Columns    int      `json:"columns"`
+	Header     []string `json:"header"`
+}
+
+type docsImageListItem struct {
+	Index      int     `json:"index"`
+	ObjectID   string  `json:"objectId"`
+	StartIndex int64   `json:"startIndex,omitempty"`
+	Alt        string  `json:"alt"`
+	Positioned bool    `json:"positioned"`
+	Width      float64 `json:"width,omitempty"`
+	Height     float64 `json:"height,omitempty"`
+	SizeUnit   string  `json:"sizeUnit,omitempty"`
+}
+
+type docsParagraphListItem struct {
+	Index      int    `json:"index"`
+	StartIndex int64  `json:"startIndex"`
+	EndIndex   int64  `json:"endIndex"`
+	Style      string `json:"style"`
+	Text       string `json:"text"`
+}
+
+func (c *DocsTablesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	doc, tabID, err := loadDocsEnumeratorDocument(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+	tables := collectAllTablesWithIndex(doc)
+	items := make([]docsTableListItem, 0, len(tables))
+	for i, table := range tables {
+		rows := int(table.table.Rows)
+		if rows == 0 {
+			rows = len(table.table.TableRows)
+		}
+		columns := int(table.table.Columns)
+		var header []string
+		if len(table.table.TableRows) > 0 {
+			if columns == 0 {
+				columns = len(table.table.TableRows[0].TableCells)
+			}
+			header = tableRowText(table.table.TableRows[0])
+		}
+		items = append(items, docsTableListItem{
+			Index:      i + 1,
+			StartIndex: table.startIdx,
+			Rows:       rows,
+			Columns:    columns,
+			Header:     header,
+		})
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": doc.DocumentId,
+			"tabId":      tabID,
+			"tables":     items,
+		})
+	}
+	w, flush := tableWriter(ctx)
+	defer flush()
+	if !outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "#\tSTART\tROWS\tCOLS\tHEADER")
+	}
+	for _, item := range items {
+		fmt.Fprintf(w, "%d\t%d\t%d\t%d\t%s\n",
+			item.Index, item.StartIndex, item.Rows, item.Columns, docsTSVField(strings.Join(item.Header, " | ")))
+	}
+	return nil
+}
+
+func (c *DocsImagesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	doc, tabID, err := loadDocsEnumeratorDocument(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+	items := enumerateDocsImages(doc)
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": doc.DocumentId,
+			"tabId":      tabID,
+			"images":     items,
+		})
+	}
+	w, flush := tableWriter(ctx)
+	defer flush()
+	if !outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "#\tOBJECT ID\tSTART\tPOSITIONED\tWIDTH\tHEIGHT\tUNIT\tALT")
+	}
+	for _, item := range items {
+		fmt.Fprintf(w, "%d\t%s\t%d\t%t\t%s\t%s\t%s\t%s\n",
+			item.Index,
+			item.ObjectID,
+			item.StartIndex,
+			item.Positioned,
+			formatOptionalFloat(item.Width),
+			formatOptionalFloat(item.Height),
+			item.SizeUnit,
+			docsTSVField(item.Alt),
+		)
+	}
+	return nil
+}
+
+func (c *DocsHeadingsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if c.Level < 0 || c.Level > 6 {
+		return usage("level must be between 1 and 6")
+	}
+	doc, tabID, err := loadDocsEnumeratorDocument(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+	paragraphs := enumerateDocsParagraphs(doc)
+	items := make([]docsParagraphListItem, 0)
+	headingIndex := 0
+	for _, paragraph := range paragraphs {
+		level, ok := headingLevel(paragraph.Style)
+		if !ok {
+			continue
+		}
+		headingIndex++
+		if c.Level > 0 && level != c.Level {
+			continue
+		}
+		items = append(items, docsParagraphListItem{
+			Index:      headingIndex,
+			StartIndex: paragraph.StartIndex,
+			EndIndex:   paragraph.EndIndex,
+			Style:      paragraph.Style,
+			Text:       paragraph.Text,
+		})
+	}
+	return writeDocsParagraphEnumerator(ctx, doc.DocumentId, tabID, "headings", items)
+}
+
+func (c *DocsParagraphsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	doc, tabID, err := loadDocsEnumeratorDocument(ctx, flags, c.DocID, c.Tab)
+	if err != nil {
+		return err
+	}
+	style := strings.ToUpper(strings.TrimSpace(c.Style))
+	paragraphs := enumerateDocsParagraphs(doc)
+	items := make([]docsParagraphListItem, 0)
+	for i, paragraph := range paragraphs {
+		if style != "" && paragraph.Style != style {
+			continue
+		}
+		items = append(items, docsParagraphListItem{
+			Index:      i + 1,
+			StartIndex: paragraph.StartIndex,
+			EndIndex:   paragraph.EndIndex,
+			Style:      paragraph.Style,
+			Text:       paragraph.Text,
+		})
+	}
+	return writeDocsParagraphEnumerator(ctx, doc.DocumentId, tabID, "paragraphs", items)
+}
+
+func loadDocsEnumeratorDocument(
+	ctx context.Context,
+	flags *RootFlags,
+	docID string,
+	tabQuery string,
+) (*docs.Document, string, error) {
+	id := normalizeGoogleID(strings.TrimSpace(docID))
+	if id == "" {
+		return nil, "", usage("empty docId")
+	}
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return nil, "", err
+	}
+	tabQuery = strings.TrimSpace(tabQuery)
+	call := svc.Documents.Get(id).Context(ctx)
+	if tabQuery != "" {
+		call = call.IncludeTabsContent(true)
+	}
+	doc, err := call.Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return nil, "", fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return nil, "", err
+	}
+	if doc == nil {
+		return nil, "", fmt.Errorf("doc not found")
+	}
+	if tabQuery == "" {
+		return doc, "", nil
+	}
+	tab, err := findTab(flattenTabs(doc.Tabs), tabQuery)
+	if err != nil {
+		return nil, "", err
+	}
+	projected, err := projectRawDocumentTab(doc, tab)
+	if err != nil {
+		return nil, "", err
+	}
+	tabID := ""
+	if tab.TabProperties != nil {
+		tabID = tab.TabProperties.TabId
+	}
+	return projected, tabID, nil
+}
+
+func writeDocsParagraphEnumerator(
+	ctx context.Context,
+	documentID string,
+	tabID string,
+	key string,
+	items []docsParagraphListItem,
+) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": documentID,
+			"tabId":      tabID,
+			key:          items,
+		})
+	}
+	w, flush := tableWriter(ctx)
+	defer flush()
+	if !outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "#\tSTART\tEND\tSTYLE\tTEXT")
+	}
+	for _, item := range items {
+		fmt.Fprintf(w, "%d\t%d\t%d\t%s\t%s\n",
+			item.Index, item.StartIndex, item.EndIndex, item.Style, docsTSVField(item.Text))
+	}
+	return nil
+}
+
+func tableRowText(row *docs.TableRow) []string {
+	if row == nil {
+		return nil
+	}
+	cells := make([]string, 0, len(row.TableCells))
+	for _, cell := range row.TableCells {
+		var text strings.Builder
+		for _, element := range cell.Content {
+			if element != nil && element.Paragraph != nil {
+				if text.Len() > 0 {
+					text.WriteByte(' ')
+				}
+				text.WriteString(paragraphText(element.Paragraph))
+			}
+		}
+		cells = append(cells, strings.TrimSpace(text.String()))
+	}
+	return cells
+}
+
+func enumerateDocsImages(doc *docs.Document) []docsImageListItem {
+	if doc == nil {
+		return nil
+	}
+	inline := make(map[string]*docs.EmbeddedObject, len(doc.InlineObjects))
+	for id, object := range doc.InlineObjects {
+		if object.InlineObjectProperties != nil &&
+			object.InlineObjectProperties.EmbeddedObject != nil &&
+			object.InlineObjectProperties.EmbeddedObject.ImageProperties != nil {
+			inline[id] = object.InlineObjectProperties.EmbeddedObject
+		}
+	}
+
+	items := make([]docsImageListItem, 0, len(inline)+len(doc.PositionedObjects))
+	seenPositioned := make(map[string]bool, len(doc.PositionedObjects))
+	var walk func([]*docs.StructuralElement)
+	walk = func(content []*docs.StructuralElement) {
+		for _, element := range content {
+			if element == nil {
+				continue
+			}
+			if element.Paragraph != nil {
+				for _, paragraphElement := range element.Paragraph.Elements {
+					if paragraphElement == nil || paragraphElement.InlineObjectElement == nil {
+						continue
+					}
+					id := paragraphElement.InlineObjectElement.InlineObjectId
+					object, ok := inline[id]
+					if !ok {
+						continue
+					}
+					item := docsImageListItem{
+						ObjectID:   id,
+						StartIndex: paragraphElement.StartIndex,
+					}
+					applyEmbeddedObjectImage(&item, object)
+					items = append(items, item)
+				}
+				for _, id := range element.Paragraph.PositionedObjectIds {
+					object, ok := doc.PositionedObjects[id]
+					if !ok || object.PositionedObjectProperties == nil ||
+						object.PositionedObjectProperties.EmbeddedObject == nil ||
+						object.PositionedObjectProperties.EmbeddedObject.ImageProperties == nil {
+						continue
+					}
+					item := docsImageListItem{
+						ObjectID:   id,
+						StartIndex: element.StartIndex,
+						Positioned: true,
+					}
+					applyEmbeddedObjectImage(&item, object.PositionedObjectProperties.EmbeddedObject)
+					items = append(items, item)
+					seenPositioned[id] = true
+				}
+			}
+			if element.Table != nil {
+				for _, row := range element.Table.TableRows {
+					for _, cell := range row.TableCells {
+						walk(cell.Content)
+					}
+				}
+			}
+		}
+	}
+	if doc.Body != nil {
+		walk(doc.Body.Content)
+	}
+	sort.SliceStable(items, func(i, j int) bool {
+		return items[i].StartIndex < items[j].StartIndex
+	})
+
+	positionedIDs := make([]string, 0, len(doc.PositionedObjects))
+	for id, object := range doc.PositionedObjects {
+		if seenPositioned[id] ||
+			object.PositionedObjectProperties == nil ||
+			object.PositionedObjectProperties.EmbeddedObject == nil ||
+			object.PositionedObjectProperties.EmbeddedObject.ImageProperties == nil {
+			continue
+		}
+		positionedIDs = append(positionedIDs, id)
+	}
+	sort.Strings(positionedIDs)
+	for _, id := range positionedIDs {
+		object := doc.PositionedObjects[id]
+		item := docsImageListItem{ObjectID: id, Positioned: true}
+		if object.PositionedObjectProperties != nil {
+			applyEmbeddedObjectImage(&item, object.PositionedObjectProperties.EmbeddedObject)
+		}
+		items = append(items, item)
+	}
+	for i := range items {
+		items[i].Index = i + 1
+	}
+	return items
+}
+
+func applyEmbeddedObjectImage(item *docsImageListItem, object *docs.EmbeddedObject) {
+	if item == nil || object == nil {
+		return
+	}
+	item.Alt = strings.TrimSpace(strings.Join([]string{object.Title, object.Description}, " "))
+	if object.Size == nil {
+		return
+	}
+	if object.Size.Width != nil {
+		item.Width = object.Size.Width.Magnitude
+		item.SizeUnit = object.Size.Width.Unit
+	}
+	if object.Size.Height != nil {
+		item.Height = object.Size.Height.Magnitude
+		if item.SizeUnit == "" {
+			item.SizeUnit = object.Size.Height.Unit
+		}
+	}
+}
+
+func headingLevel(style string) (int, bool) {
+	const prefix = "HEADING_"
+	if !strings.HasPrefix(style, prefix) {
+		return 0, false
+	}
+	level, err := strconv.Atoi(strings.TrimPrefix(style, prefix))
+	if err != nil || level < 1 || level > 6 {
+		return 0, false
+	}
+	return level, true
+}
+
+func formatOptionalFloat(value float64) string {
+	if value == 0 {
+		return ""
+	}
+	return strconv.FormatFloat(value, 'f', -1, 64)
+}
+
+type docsEnumeratedParagraph struct {
+	StartIndex int64
+	EndIndex   int64
+	Style      string
+	Text       string
+}
+
+func enumerateDocsParagraphs(doc *docs.Document) []docsEnumeratedParagraph {
+	if doc == nil || doc.Body == nil {
+		return nil
+	}
+	var paragraphs []docsEnumeratedParagraph
+	var walk func([]*docs.StructuralElement)
+	walk = func(content []*docs.StructuralElement) {
+		for _, element := range content {
+			if element == nil {
+				continue
+			}
+			if element.Paragraph != nil {
+				style := docsNamedStyleNormalText
+				if element.Paragraph.ParagraphStyle != nil &&
+					element.Paragraph.ParagraphStyle.NamedStyleType != "" {
+					style = element.Paragraph.ParagraphStyle.NamedStyleType
+				}
+				paragraphs = append(paragraphs, docsEnumeratedParagraph{
+					StartIndex: element.StartIndex,
+					EndIndex:   element.EndIndex,
+					Style:      style,
+					Text:       paragraphText(element.Paragraph),
+				})
+			}
+			if element.Table != nil {
+				for _, row := range element.Table.TableRows {
+					for _, cell := range row.TableCells {
+						walk(cell.Content)
+					}
+				}
+			}
+			if element.TableOfContents != nil {
+				walk(element.TableOfContents.Content)
+			}
+		}
+	}
+	walk(doc.Body.Content)
+	return paragraphs
+}
+
+func docsTSVField(value string) string {
+	return strings.NewReplacer(
+		"\\", "\\\\",
+		"\t", "\\t",
+		"\r", "\\r",
+		"\n", "\\n",
+	).Replace(value)
+}

--- a/internal/cmd/docs_enumerators_test.go
+++ b/internal/cmd/docs_enumerators_test.go
@@ -1,0 +1,279 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+func TestDocsTablesListNestedTabJSON(t *testing.T) {
+	response := map[string]any{
+		"documentId": "doc1",
+		"revisionId": "rev1",
+		"tabs": []any{
+			map[string]any{
+				"tabProperties": map[string]any{"tabId": "t.main", "title": "Main"},
+				"documentTab":   map[string]any{"body": rawBodyWithText("main\n")},
+				"childTabs": []any{
+					map[string]any{
+						"tabProperties": map[string]any{"tabId": "t.data", "title": "Data"},
+						"documentTab": map[string]any{
+							"body": map[string]any{
+								"content": []any{
+									map[string]any{
+										"startIndex": 1,
+										"endIndex":   20,
+										"table": map[string]any{
+											"rows":    3,
+											"columns": 4,
+											"tableRows": []any{
+												map[string]any{
+													"tableCells": []any{
+														rawTableCell("Name"),
+														rawTableCell("Status"),
+													},
+												},
+												map[string]any{
+													"tableCells": []any{
+														rawTableCell("One"),
+														rawTableCell("Ready"),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	srv := newDocsRawTestServerWithRequest(t, 0, response, func(r *http.Request) {
+		if got := r.URL.Query().Get("includeTabsContent"); got != "true" {
+			t.Fatalf("includeTabsContent = %q, want true", got)
+		}
+	})
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := outfmt.WithMode(rawTestContext(t), outfmt.Mode{JSON: true})
+	out := captureStdout(t, func() {
+		cmd := &DocsTablesListCmd{}
+		if err := runKong(t, cmd, []string{"doc1", "--tab", "Data"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	var got struct {
+		DocumentID string              `json:"documentId"`
+		TabID      string              `json:"tabId"`
+		Tables     []docsTableListItem `json:"tables"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if got.DocumentID != "doc1" || got.TabID != "t.data" || len(got.Tables) != 1 {
+		t.Fatalf("unexpected result: %#v", got)
+	}
+	table := got.Tables[0]
+	if table.Index != 1 || table.StartIndex != 1 || table.Rows != 3 || table.Columns != 4 {
+		t.Fatalf("unexpected table: %#v", table)
+	}
+	if strings.Join(table.Header, "|") != "Name|Status" {
+		t.Fatalf("header = %#v", table.Header)
+	}
+}
+
+func TestEnumerateDocsImagesOrderAndMetadata(t *testing.T) {
+	doc := &docs.Document{
+		Body: &docs.Body{Content: []*docs.StructuralElement{
+			{
+				StartIndex: 3,
+				Paragraph: &docs.Paragraph{
+					PositionedObjectIds: []string{"z-last"},
+					Elements: []*docs.ParagraphElement{
+						{StartIndex: 4, InlineObjectElement: &docs.InlineObjectElement{InlineObjectId: "inline"}},
+					},
+				},
+			},
+		}},
+		InlineObjects: map[string]docs.InlineObject{
+			"inline": {
+				InlineObjectProperties: &docs.InlineObjectProperties{
+					EmbeddedObject: &docs.EmbeddedObject{
+						Title:           "Diagram",
+						Description:     "Flow",
+						ImageProperties: &docs.ImageProperties{},
+						Size: &docs.Size{
+							Width:  &docs.Dimension{Magnitude: 720, Unit: "PT"},
+							Height: &docs.Dimension{Magnitude: 166, Unit: "PT"},
+						},
+					},
+				},
+			},
+		},
+		PositionedObjects: map[string]docs.PositionedObject{
+			"a-first": {
+				PositionedObjectProperties: &docs.PositionedObjectProperties{
+					EmbeddedObject: &docs.EmbeddedObject{
+						Description:     "Floating",
+						ImageProperties: &docs.ImageProperties{},
+					},
+				},
+			},
+			"z-last": {
+				PositionedObjectProperties: &docs.PositionedObjectProperties{
+					EmbeddedObject: &docs.EmbeddedObject{
+						Description:     "Anchored",
+						ImageProperties: &docs.ImageProperties{},
+					},
+				},
+			},
+		},
+	}
+
+	items := enumerateDocsImages(doc)
+	if len(items) != 3 {
+		t.Fatalf("items = %#v", items)
+	}
+	if items[0].ObjectID != "z-last" || items[0].StartIndex != 3 || !items[0].Positioned {
+		t.Fatalf("anchored positioned image = %#v", items[0])
+	}
+	if items[1].ObjectID != "inline" || items[1].StartIndex != 4 ||
+		items[1].Alt != "Diagram Flow" || items[1].Width != 720 || items[1].Height != 166 ||
+		items[1].SizeUnit != "PT" {
+		t.Fatalf("inline image = %#v", items[1])
+	}
+	if items[2].ObjectID != "a-first" {
+		t.Fatalf("unanchored positioned image = %#v", items[2])
+	}
+}
+
+func TestDocsHeadingsAndParagraphsFilters(t *testing.T) {
+	response := map[string]any{
+		"documentId": "doc1",
+		"body": map[string]any{"content": []any{
+			rawStyledParagraph(1, 10, "HEADING_1", "Title\n"),
+			rawStyledParagraph(10, 20, "HEADING_2", "Section\n"),
+			rawStyledParagraph(20, 30, "NORMAL_TEXT", "Body\n"),
+		}},
+	}
+	srv := newDocsRawTestServer(t, 0, response)
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := outfmt.WithMode(rawTestContext(t), outfmt.Mode{JSON: true})
+	headingsOut := captureStdout(t, func() {
+		if err := runKong(t, &DocsHeadingsListCmd{}, []string{"doc1", "--level", "2"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+			t.Fatalf("headings run: %v", err)
+		}
+	})
+	if !strings.Contains(headingsOut, `"index": 2`) ||
+		!strings.Contains(headingsOut, `"text": "Section"`) ||
+		strings.Contains(headingsOut, `"text": "Title"`) {
+		t.Fatalf("headings output: %s", headingsOut)
+	}
+
+	paragraphsOut := captureStdout(t, func() {
+		if err := runKong(t, &DocsParagraphsListCmd{}, []string{"doc1", "--style", "normal_text"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+			t.Fatalf("paragraphs run: %v", err)
+		}
+	})
+	if !strings.Contains(paragraphsOut, `"index": 3`) ||
+		!strings.Contains(paragraphsOut, `"text": "Body"`) ||
+		strings.Contains(paragraphsOut, `"text": "Section"`) {
+		t.Fatalf("paragraphs output: %s", paragraphsOut)
+	}
+}
+
+func TestDocsParagraphsPlainHasNoHeader(t *testing.T) {
+	response := map[string]any{
+		"documentId": "doc1",
+		"body": map[string]any{"content": []any{
+			rawStyledParagraph(1, 18, "NORMAL_TEXT", "Hello\tWorld\nNext\n"),
+		}},
+	}
+	srv := newDocsRawTestServer(t, 0, response)
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := outfmt.WithMode(rawTestContext(t), outfmt.Mode{Plain: true})
+	out := captureStdout(t, func() {
+		if err := runKong(t, &DocsParagraphsListCmd{}, []string{"doc1"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if strings.Contains(out, "START") || out != `1	1	18	NORMAL_TEXT	Hello\tWorld\nNext
+` {
+		t.Fatalf("plain output = %q", out)
+	}
+}
+
+func TestEnumerateDocsParagraphsRecursesIntoTablesAndTOC(t *testing.T) {
+	doc := &docs.Document{Body: &docs.Body{Content: []*docs.StructuralElement{
+		{
+			StartIndex: 1,
+			Table: &docs.Table{TableRows: []*docs.TableRow{
+				{TableCells: []*docs.TableCell{
+					{Content: []*docs.StructuralElement{
+						{
+							StartIndex: 3,
+							EndIndex:   10,
+							Paragraph: &docs.Paragraph{
+								ParagraphStyle: &docs.ParagraphStyle{NamedStyleType: "HEADING_3"},
+								Elements:       []*docs.ParagraphElement{{TextRun: &docs.TextRun{Content: "Nested\n"}}},
+							},
+						},
+					}},
+				}},
+			}},
+		},
+		{
+			TableOfContents: &docs.TableOfContents{Content: []*docs.StructuralElement{
+				{
+					StartIndex: 11,
+					EndIndex:   17,
+					Paragraph: &docs.Paragraph{
+						Elements: []*docs.ParagraphElement{{TextRun: &docs.TextRun{Content: "TOC\n"}}},
+					},
+				},
+			}},
+		},
+	}}}
+
+	got := enumerateDocsParagraphs(doc)
+	if len(got) != 2 || got[0].Style != "HEADING_3" || got[0].Text != "Nested" ||
+		got[1].Style != "NORMAL_TEXT" || got[1].Text != "TOC" {
+		t.Fatalf("paragraphs = %#v", got)
+	}
+}
+
+func rawTableCell(text string) map[string]any {
+	return map[string]any{
+		"content": []any{rawStyledParagraph(1, int64(len(text)+2), "NORMAL_TEXT", text+"\n")},
+	}
+}
+
+func rawStyledParagraph(start, end int64, style, text string) map[string]any {
+	return map[string]any{
+		"startIndex": start,
+		"endIndex":   end,
+		"paragraph": map[string]any{
+			"paragraphStyle": map[string]any{"namedStyleType": style},
+			"elements": []any{
+				map[string]any{
+					"startIndex": start,
+					"endIndex":   end,
+					"textRun":    map[string]any{"content": text},
+				},
+			},
+		},
+	}
+}

--- a/internal/cmd/docs_formatter.go
+++ b/internal/cmd/docs_formatter.go
@@ -427,6 +427,6 @@ func getHeadingStyle(elType MarkdownElementType) string {
 	case MDHeading6:
 		return "HEADING_6"
 	default:
-		return "NORMAL_TEXT"
+		return docsNamedStyleNormalText
 	}
 }

--- a/internal/cmd/docs_paragraphs.go
+++ b/internal/cmd/docs_paragraphs.go
@@ -95,7 +95,7 @@ func buildParagraphMap(doc *docs.Document, tabID string) (*paragraphMap, error) 
 				dp.Type = el.Paragraph.ParagraphStyle.NamedStyleType
 			}
 			if dp.Type == "" {
-				dp.Type = "NORMAL_TEXT"
+				dp.Type = docsNamedStyleNormalText
 			}
 
 			// Extract bullet info.

--- a/internal/cmd/docs_sed_brace_resolve.go
+++ b/internal/cmd/docs_sed_brace_resolve.go
@@ -51,7 +51,7 @@ var headingMap = map[string]string{
 	"4": "HEADING_4",
 	"5": "HEADING_5",
 	"6": "HEADING_6",
-	"0": "NORMAL_TEXT",
+	"0": docsNamedStyleNormalText,
 }
 
 // resolveHeading converts SEDMAT heading shorthand to Google Docs named style.

--- a/internal/cmd/docs_sed_insert.go
+++ b/internal/cmd/docs_sed_insert.go
@@ -67,7 +67,7 @@ func (c *DocsSedCmd) doPositionalInsert(ctx context.Context, docsSvc *docs.Servi
 			UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{
 				Range: &docs.Range{StartIndex: idx, EndIndex: end},
 				ParagraphStyle: &docs.ParagraphStyle{
-					NamedStyleType: "NORMAL_TEXT",
+					NamedStyleType: docsNamedStyleNormalText,
 				},
 				Fields: "namedStyleType",
 			},


### PR DESCRIPTION
## Summary

- add tab-aware `docs tables list`, `docs images list`, `docs headings list`, and `docs paragraphs list`
- provide structured JSON envelopes and headerless escaped TSV under `--plain`
- preserve stable source ordinals through filters and recurse through table cells and table-of-contents content
- emit image object IDs, document anchors, positioning, alt text, and dimensions in document order

Fixes #719.

## Validation

- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make ci`
- focused enumerator tests
- final autoreview clean after addressing all initial findings
- disposable live Google Docs proof with `clawdbot@gmail.com`:
  - recursively selected a nested tab
  - enumerated a native table and header cells
  - enumerated an inserted image with object ID and dimensions
  - filtered headings and paragraphs
  - enumerated paragraphs nested inside table cells
  - verified headerless plain TSV
  - trashed the Doc and uploaded image
