### PR TITLE
feat(docs): add named range commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Docs: add `docs named-range` create/list/delete/replace commands for durable, tab-aware document anchors. (#692) — thanks @sebsnyk.
 - Gmail: report attached filenames and byte sizes in JSON results for send and draft create/update. (#716) — thanks @chrischall.
 - Gmail: add `gmail watch pull` for Pub/Sub pull subscription consumers with hook retry support. (#700) — thanks @joshp123.
 - Docs: add `--tab` and `--all-tabs` to `docs raw` for inspecting specific or complete multi-tab document content. (#697) — thanks @sebsnyk.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -254,6 +254,11 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) insert-person --email=STRING <docId> [flags]`](commands/gog-docs-insert-person.md) - Insert a native person smart chip
     - [`gog docs (doc) insert-table --rows=INT --cols=INT <docId> [flags]`](commands/gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [`gog docs (doc) list-tabs <docId>`](commands/gog-docs-list-tabs.md) - List all tabs in a Google Doc
+    - [`gog docs (doc) named-range (named-ranges,namedranges,nr) <command>`](commands/gog-docs-named-range.md) - Manage named ranges
+      - [`gog docs (doc) named-range (named-ranges,namedranges,nr) create (add,new) <docId> [flags]`](commands/gog-docs-named-range-create.md) - Create a named range
+      - [`gog docs (doc) named-range (named-ranges,namedranges,nr) delete (rm,remove,del) <docId> <nameOrId> [flags]`](commands/gog-docs-named-range-delete.md) - Delete a named range
+      - [`gog docs (doc) named-range (named-ranges,namedranges,nr) list <docId> [flags]`](commands/gog-docs-named-range-list.md) - List named ranges
+      - [`gog docs (doc) named-range (named-ranges,namedranges,nr) replace (set,update) <docId> <nameOrId> [flags]`](commands/gog-docs-named-range-replace.md) - Replace a named range with plain text
     - [`gog docs (doc) page-layout (set-page-layout,page-setup) <docId> [flags]`](commands/gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
     - [`gog docs (doc) paragraphs <command>`](commands/gog-docs-paragraphs.md) - List document paragraphs
       - [`gog docs (doc) paragraphs list (ls) <docId> [flags]`](commands/gog-docs-paragraphs-list.md) - List paragraphs

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 597.
+Generated pages: 602.
 
 ## Top-level Commands
 
@@ -306,6 +306,11 @@ Generated pages: 597.
     - [gog docs insert-person](gog-docs-insert-person.md) - Insert a native person smart chip
     - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
+    - [gog docs named-range](gog-docs-named-range.md) - Manage named ranges
+      - [gog docs named-range create](gog-docs-named-range-create.md) - Create a named range
+      - [gog docs named-range delete](gog-docs-named-range-delete.md) - Delete a named range
+      - [gog docs named-range list](gog-docs-named-range-list.md) - List named ranges
+      - [gog docs named-range replace](gog-docs-named-range-replace.md) - Replace a named range with plain text
     - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
     - [gog docs paragraphs](gog-docs-paragraphs.md) - List document paragraphs
       - [gog docs paragraphs list](gog-docs-paragraphs-list.md) - List paragraphs

--- a/docs/commands/gog-docs-named-range-create.md
+++ b/docs/commands/gog-docs-named-range-create.md
@@ -1,0 +1,52 @@
+# `gog docs named-range create`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Create a named range
+
+## Usage
+
+```bash
+gog docs (doc) named-range (named-ranges,namedranges,nr) create (add,new) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs named-range](gog-docs-named-range.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--at` | `string` |  | Create the range around literal matched text |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--end` | `*int64` |  | Range end UTF-16 index (exclusive) |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
+| `--name` | `string` |  | Unique named range name |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--start` | `*int64` |  | Range start UTF-16 index (inclusive) |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs named-range](gog-docs-named-range.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-named-range-delete.md
+++ b/docs/commands/gog-docs-named-range-delete.md
@@ -1,0 +1,46 @@
+# `gog docs named-range delete`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Delete a named range
+
+## Usage
+
+```bash
+gog docs (doc) named-range (named-ranges,namedranges,nr) delete (rm,remove,del) <docId> <nameOrId> [flags]
+```
+
+## Parent
+
+- [gog docs named-range](gog-docs-named-range.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs named-range](gog-docs-named-range.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-named-range-list.md
+++ b/docs/commands/gog-docs-named-range-list.md
@@ -1,0 +1,47 @@
+# `gog docs named-range list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List named ranges
+
+## Usage
+
+```bash
+gog docs (doc) named-range (named-ranges,namedranges,nr) list <docId> [flags]
+```
+
+## Parent
+
+- [gog docs named-range](gog-docs-named-range.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--name` | `string` |  | Filter by exact named range name |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs named-range](gog-docs-named-range.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-named-range-replace.md
+++ b/docs/commands/gog-docs-named-range-replace.md
@@ -1,0 +1,48 @@
+# `gog docs named-range replace`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Replace a named range with plain text
+
+## Usage
+
+```bash
+gog docs (doc) named-range (named-ranges,namedranges,nr) replace (set,update) <docId> <nameOrId> [flags]
+```
+
+## Parent
+
+- [gog docs named-range](gog-docs-named-range.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--file` | `string` |  | Plain text file path ('-' for stdin) |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--text`<br>`--content` | `string` |  | Plain replacement text (empty text clears the range) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs named-range](gog-docs-named-range.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-named-range.md
+++ b/docs/commands/gog-docs-named-range.md
@@ -1,0 +1,52 @@
+# `gog docs named-range`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Manage named ranges
+
+## Usage
+
+```bash
+gog docs (doc) named-range (named-ranges,namedranges,nr) <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs named-range create](gog-docs-named-range-create.md) - Create a named range
+- [gog docs named-range delete](gog-docs-named-range-delete.md) - Delete a named range
+- [gog docs named-range list](gog-docs-named-range-list.md) - List named ranges
+- [gog docs named-range replace](gog-docs-named-range-replace.md) - Replace a named range with plain text
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -42,6 +42,7 @@ gog docs (doc) <command> [flags]
 - [gog docs insert-person](gog-docs-insert-person.md) - Insert a native person smart chip
 - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
 - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
+- [gog docs named-range](gog-docs-named-range.md) - Manage named ranges
 - [gog docs page-layout](gog-docs-page-layout.md) - Set page layout (pageless|pages) on an existing Google Doc
 - [gog docs paragraphs](gog-docs-paragraphs.md) - List document paragraphs
 - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -54,6 +54,7 @@ type DocsCmd struct {
 	Images           DocsImagesCmd           `cmd:"" name:"images" help:"List document images"`
 	Headings         DocsHeadingsCmd         `cmd:"" name:"headings" help:"List document headings"`
 	Paragraphs       DocsParagraphsCmd       `cmd:"" name:"paragraphs" help:"List document paragraphs"`
+	NamedRanges      DocsNamedRangesCmd      `cmd:"" name:"named-range" aliases:"named-ranges,namedranges,nr" help:"Manage named ranges"`
 	Raw              DocsRawCmd              `cmd:"" name:"raw" help:"Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)"`
 	PageLayout       DocsPageLayoutCmd       `cmd:"" name:"page-layout" aliases:"set-page-layout,page-setup" help:"Set page layout (pageless|pages) on an existing Google Doc"`
 }

--- a/internal/cmd/docs_named_ranges.go
+++ b/internal/cmd/docs_named_ranges.go
@@ -1,0 +1,518 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsNamedRangesCmd struct {
+	List    DocsNamedRangesListCmd    `cmd:"" default:"withargs" help:"List named ranges"`
+	Create  DocsNamedRangesCreateCmd  `cmd:"" aliases:"add,new" help:"Create a named range"`
+	Delete  DocsNamedRangesDeleteCmd  `cmd:"" aliases:"rm,remove,del" help:"Delete a named range"`
+	Replace DocsNamedRangesReplaceCmd `cmd:"" aliases:"set,update" help:"Replace a named range with plain text"`
+}
+
+type DocsNamedRangesListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	Name  string `name:"name" help:"Filter by exact named range name"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+}
+
+func (c *DocsNamedRangesListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	tab, err := resolveTabArg(ctx, c.Tab, c.TabID)
+	if err != nil {
+		return err
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, tab)
+	if err != nil {
+		return err
+	}
+	items, err := docsNamedRangeItemsForLoaded(loaded)
+	if err != nil {
+		return err
+	}
+	if name := strings.TrimSpace(c.Name); name != "" {
+		items = filterDocsNamedRangesByName(items, name)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId":  docID,
+			"tabId":       loaded.tabID,
+			"namedRanges": items,
+		})
+	}
+	if len(items) == 0 {
+		if !outfmt.IsPlain(ctx) {
+			u.Err().Println("No named ranges")
+		}
+		return nil
+	}
+
+	w, flush := tableWriter(ctx)
+	defer flush()
+	if !outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "NAME\tID\tSTART\tEND\tTAB_ID\tSEGMENT_ID")
+	}
+	for _, item := range items {
+		if len(item.Ranges) == 0 {
+			fmt.Fprintf(w, "%s\t%s\t\t\t\t\n", docsNamedRangeTSV(item.Name), docsNamedRangeTSV(item.NamedRangeID))
+			continue
+		}
+		for _, span := range item.Ranges {
+			fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\t%s\n",
+				docsNamedRangeTSV(item.Name),
+				docsNamedRangeTSV(item.NamedRangeID),
+				span.StartIndex,
+				span.EndIndex,
+				docsNamedRangeTSV(span.TabID),
+				docsNamedRangeTSV(span.SegmentID),
+			)
+		}
+	}
+	return nil
+}
+
+type DocsNamedRangesCreateCmd struct {
+	DocID      string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	Name       string `name:"name" help:"Unique named range name"`
+	At         string `name:"at" help:"Create the range around literal matched text"`
+	Occurrence *int   `name:"occurrence" help:"Use the Nth --at match (1-based; required when --at is ambiguous)"`
+	MatchCase  bool   `name:"match-case" help:"Use case-sensitive --at matching"`
+	Start      *int64 `name:"start" help:"Range start UTF-16 index (inclusive)"`
+	End        *int64 `name:"end" help:"Range end UTF-16 index (exclusive)"`
+	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+}
+
+func (c *DocsNamedRangesCreateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	name := strings.TrimSpace(c.Name)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if name == "" {
+		return usage("empty --name")
+	}
+	if utf16Len(name) > 256 {
+		return usage("--name must be at most 256 UTF-16 code units")
+	}
+	atProvided := flagProvided(kctx, "at")
+	if err := validateDocsAtAnchorFlags(docsAtAnchorFlags{
+		At:         c.At,
+		AtProvided: atProvided,
+		Occurrence: c.Occurrence,
+		MatchCase:  c.MatchCase,
+	}); err != nil {
+		return err
+	}
+	indexProvided := c.Start != nil || c.End != nil
+	if atProvided && indexProvided {
+		return usage("--at cannot be combined with --start or --end")
+	}
+	if !atProvided && (c.Start == nil || c.End == nil) {
+		return usage("provide --at or both --start and --end")
+	}
+	if !atProvided {
+		if *c.Start < 1 {
+			return usage("--start must be >= 1")
+		}
+		if *c.End <= *c.Start {
+			return usage("--end must be greater than --start")
+		}
+	}
+	tab, err := resolveTabArg(ctx, c.Tab, c.TabID)
+	if err != nil {
+		return err
+	}
+
+	dryRunPayload := map[string]any{
+		"document_id": docID,
+		"name":        name,
+		"tab":         tab,
+	}
+	if atProvided {
+		addDocsAtAnchorDryRunPayload(dryRunPayload, docsAtAnchorFlags{
+			At:         c.At,
+			Occurrence: c.Occurrence,
+			MatchCase:  c.MatchCase,
+		})
+	} else {
+		dryRunPayload["start_index"] = *c.Start
+		dryRunPayload["end_index"] = *c.End
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.named-range.create", dryRunPayload); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	var loaded *docsLoadedTarget
+	var span docsNamedRangeSpan
+	if atProvided {
+		resolved, resolveErr := resolveDocsAtAnchor(ctx, svc, docID, docsAtAnchorFlags{
+			At:         c.At,
+			Occurrence: c.Occurrence,
+			MatchCase:  c.MatchCase,
+			Tab:        tab,
+		})
+		if resolveErr != nil {
+			return resolveErr
+		}
+		loaded = &docsLoadedTarget{full: resolved.Document, target: resolved.Document, tabID: resolved.Match.TabID}
+		span = docsNamedRangeSpan{
+			StartIndex: resolved.Match.StartIndex,
+			EndIndex:   resolved.Match.EndIndex,
+			TabID:      resolved.Match.TabID,
+		}
+	} else {
+		loaded, err = loadDocsTargetDocument(ctx, svc, docID, tab)
+		if err != nil {
+			return err
+		}
+		span = docsNamedRangeSpan{StartIndex: *c.Start, EndIndex: *c.End, TabID: loaded.tabID}
+	}
+
+	items, err := docsNamedRangeItemsForLoaded(loaded)
+	if err != nil {
+		return err
+	}
+	if matches := filterDocsNamedRangesByName(items, name); len(matches) > 0 {
+		return usagef("named range name already exists: %q", name)
+	}
+
+	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		WriteControl: docsRequiredRevisionWriteControl(loaded.full.RevisionId),
+		Requests: []*docs.Request{{
+			CreateNamedRange: &docs.CreateNamedRangeRequest{
+				Name: name,
+				Range: &docs.Range{
+					StartIndex: span.StartIndex,
+					EndIndex:   span.EndIndex,
+					TabId:      span.TabID,
+				},
+			},
+		}},
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("create named range: %w", err)
+	}
+	createdID := ""
+	if resp != nil && len(resp.Replies) > 0 && resp.Replies[0] != nil && resp.Replies[0].CreateNamedRange != nil {
+		createdID = strings.TrimSpace(resp.Replies[0].CreateNamedRange.NamedRangeId)
+	}
+	if createdID == "" {
+		return fmt.Errorf("create named range: response missing namedRangeId")
+	}
+	return writeResult(ctx, ui.FromContext(ctx),
+		kv("documentId", docID),
+		kv("namedRange", docsNamedRangeItem{Name: name, NamedRangeID: createdID, Ranges: []docsNamedRangeSpan{span}}),
+	)
+}
+
+type DocsNamedRangesDeleteCmd struct {
+	DocID    string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	NameOrID string `arg:"" name:"nameOrId" help:"Exact named range name or ID"`
+	Tab      string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID    string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+}
+
+func (c *DocsNamedRangesDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	in := strings.TrimSpace(c.NameOrID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if in == "" {
+		return usage("empty nameOrId")
+	}
+	tab, err := resolveTabArg(ctx, c.Tab, c.TabID)
+	if err != nil {
+		return err
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.named-range.delete", map[string]any{
+		"document_id": docID,
+		"name_or_id":  in,
+		"tab":         tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	loaded, item, err := loadAndResolveDocsNamedRange(ctx, svc, docID, tab, in)
+	if err != nil {
+		return err
+	}
+	deleteReq := &docs.DeleteNamedRangeRequest{NamedRangeId: item.NamedRangeID}
+	if loaded.tabID != "" {
+		deleteReq.TabsCriteria = &docs.TabsCriteria{TabIds: []string{loaded.tabID}}
+	}
+	_, err = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		WriteControl: docsRequiredRevisionWriteControl(loaded.full.RevisionId),
+		Requests:     []*docs.Request{{DeleteNamedRange: deleteReq}},
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("delete named range: %w", err)
+	}
+	return writeResult(ctx, ui.FromContext(ctx),
+		kv("documentId", docID),
+		kv("deleted", map[string]any{"name": item.Name, "namedRangeId": item.NamedRangeID}),
+	)
+}
+
+type DocsNamedRangesReplaceCmd struct {
+	DocID    string `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	NameOrID string `arg:"" name:"nameOrId" help:"Exact named range name or ID"`
+	Text     string `name:"text" aliases:"content" help:"Plain replacement text (empty text clears the range)"`
+	File     string `name:"file" help:"Plain text file path ('-' for stdin)"`
+	Tab      string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID    string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+}
+
+func (c *DocsNamedRangesReplaceCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	in := strings.TrimSpace(c.NameOrID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if in == "" {
+		return usage("empty nameOrId")
+	}
+	text, provided, err := resolveTextInput(c.Text, c.File, kctx, "text", "file")
+	if err != nil {
+		return err
+	}
+	if !provided {
+		return usage("required: --text or --file")
+	}
+	tab, err := resolveTabArg(ctx, c.Tab, c.TabID)
+	if err != nil {
+		return err
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.named-range.replace", map[string]any{
+		"document_id": docID,
+		"name_or_id":  in,
+		"text_length": utf16Len(text),
+		"tab":         tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	loaded, item, err := loadAndResolveDocsNamedRange(ctx, svc, docID, tab, in)
+	if err != nil {
+		return err
+	}
+	replaceReq := &docs.ReplaceNamedRangeContentRequest{
+		NamedRangeId: item.NamedRangeID,
+		Text:         text,
+	}
+	if text == "" {
+		replaceReq.ForceSendFields = []string{"Text"}
+	}
+	if loaded.tabID != "" {
+		replaceReq.TabsCriteria = &docs.TabsCriteria{TabIds: []string{loaded.tabID}}
+	}
+	_, err = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		WriteControl: docsRequiredRevisionWriteControl(loaded.full.RevisionId),
+		Requests:     []*docs.Request{{ReplaceNamedRangeContent: replaceReq}},
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("replace named range: %w", err)
+	}
+	updated, err := loadDocsTargetDocument(ctx, svc, docID, tab)
+	if err != nil {
+		return fmt.Errorf("read replaced named range: %w", err)
+	}
+	updatedItems, err := docsNamedRangeItemsForLoaded(updated)
+	if err != nil {
+		return fmt.Errorf("read replaced named range: %w", err)
+	}
+	updatedItem, found, err := resolveDocsNamedRange(item.NamedRangeID, updatedItems)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return fmt.Errorf("replaced named range not found (id=%q)", item.NamedRangeID)
+	}
+	return writeResult(ctx, ui.FromContext(ctx),
+		kv("documentId", docID),
+		kv("namedRange", updatedItem),
+		kv("replaced", true),
+		kv("textLength", utf16Len(text)),
+	)
+}
+
+type docsNamedRangeSpan struct {
+	StartIndex int64  `json:"startIndex"`
+	EndIndex   int64  `json:"endIndex"`
+	TabID      string `json:"tabId,omitempty"`
+	SegmentID  string `json:"segmentId,omitempty"`
+}
+
+type docsNamedRangeItem struct {
+	Name         string               `json:"name"`
+	NamedRangeID string               `json:"namedRangeId"`
+	Ranges       []docsNamedRangeSpan `json:"ranges"`
+}
+
+func loadAndResolveDocsNamedRange(ctx context.Context, svc *docs.Service, docID, tab, in string) (*docsLoadedTarget, docsNamedRangeItem, error) {
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, tab)
+	if err != nil {
+		return nil, docsNamedRangeItem{}, err
+	}
+	items, err := docsNamedRangeItemsForLoaded(loaded)
+	if err != nil {
+		return nil, docsNamedRangeItem{}, err
+	}
+	item, found, err := resolveDocsNamedRange(in, items)
+	if err != nil {
+		return nil, docsNamedRangeItem{}, err
+	}
+	if !found {
+		return nil, docsNamedRangeItem{}, &ExitError{
+			Code: emptyResultsExitCode,
+			Err:  fmt.Errorf("named range not found: %q", in),
+		}
+	}
+	return loaded, item, nil
+}
+
+func docsNamedRangeItemsForLoaded(loaded *docsLoadedTarget) ([]docsNamedRangeItem, error) {
+	if loaded == nil || loaded.full == nil {
+		return nil, fmt.Errorf("document not loaded")
+	}
+	namedRanges := loaded.full.NamedRanges
+	if loaded.tabID != "" {
+		tab, err := findTab(flattenTabs(loaded.full.Tabs), loaded.tabID)
+		if err != nil {
+			return nil, err
+		}
+		if tab.DocumentTab == nil {
+			return nil, fmt.Errorf("tab has no document content: %s", loaded.tabID)
+		}
+		namedRanges = tab.DocumentTab.NamedRanges
+	}
+
+	items := make([]docsNamedRangeItem, 0)
+	for mapName, group := range namedRanges {
+		groupName := strings.TrimSpace(group.Name)
+		if groupName == "" {
+			groupName = strings.TrimSpace(mapName)
+		}
+		for _, namedRange := range group.NamedRanges {
+			if namedRange == nil {
+				continue
+			}
+			name := strings.TrimSpace(namedRange.Name)
+			if name == "" {
+				name = groupName
+			}
+			item := docsNamedRangeItem{
+				Name:         name,
+				NamedRangeID: strings.TrimSpace(namedRange.NamedRangeId),
+				Ranges:       make([]docsNamedRangeSpan, 0, len(namedRange.Ranges)),
+			}
+			for _, span := range namedRange.Ranges {
+				if span == nil {
+					continue
+				}
+				item.Ranges = append(item.Ranges, docsNamedRangeSpan{
+					StartIndex: span.StartIndex,
+					EndIndex:   span.EndIndex,
+					TabID:      strings.TrimSpace(span.TabId),
+					SegmentID:  strings.TrimSpace(span.SegmentId),
+				})
+			}
+			sort.Slice(item.Ranges, func(i, j int) bool {
+				if item.Ranges[i].TabID != item.Ranges[j].TabID {
+					return item.Ranges[i].TabID < item.Ranges[j].TabID
+				}
+				if item.Ranges[i].SegmentID != item.Ranges[j].SegmentID {
+					return item.Ranges[i].SegmentID < item.Ranges[j].SegmentID
+				}
+				if item.Ranges[i].StartIndex != item.Ranges[j].StartIndex {
+					return item.Ranges[i].StartIndex < item.Ranges[j].StartIndex
+				}
+				return item.Ranges[i].EndIndex < item.Ranges[j].EndIndex
+			})
+			items = append(items, item)
+		}
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Name != items[j].Name {
+			return items[i].Name < items[j].Name
+		}
+		return items[i].NamedRangeID < items[j].NamedRangeID
+	})
+	return items, nil
+}
+
+func filterDocsNamedRangesByName(items []docsNamedRangeItem, name string) []docsNamedRangeItem {
+	filtered := make([]docsNamedRangeItem, 0)
+	for _, item := range items {
+		if item.Name == name {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func resolveDocsNamedRange(in string, items []docsNamedRangeItem) (docsNamedRangeItem, bool, error) {
+	for _, item := range items {
+		if item.NamedRangeID == in {
+			return item, true, nil
+		}
+	}
+	matches := filterDocsNamedRangesByName(items, in)
+	switch len(matches) {
+	case 0:
+		return docsNamedRangeItem{}, false, nil
+	case 1:
+		return matches[0], true, nil
+	default:
+		ids := make([]string, 0, len(matches))
+		for _, item := range matches {
+			ids = append(ids, item.NamedRangeID)
+		}
+		sort.Strings(ids)
+		return docsNamedRangeItem{}, false, usagef("ambiguous named range %q; use ID: %s", in, strings.Join(ids, ", "))
+	}
+}
+
+func docsNamedRangeTSV(value string) string {
+	return strings.NewReplacer(
+		"\t", `\t`,
+		"\r", `\r`,
+		"\n", `\n`,
+	).Replace(value)
+}

--- a/internal/cmd/docs_named_ranges.go
+++ b/internal/cmd/docs_named_ranges.go
@@ -227,10 +227,15 @@ func (c *DocsNamedRangesCreateCmd) Run(ctx context.Context, kctx *kong.Context, 
 	if createdID == "" {
 		return fmt.Errorf("create named range: response missing namedRangeId")
 	}
-	return writeResult(ctx, ui.FromContext(ctx),
-		kv("documentId", docID),
-		kv("namedRange", docsNamedRangeItem{Name: name, NamedRangeID: createdID, Ranges: []docsNamedRangeSpan{span}}),
-	)
+	created := docsNamedRangeItem{Name: name, NamedRangeID: createdID, Ranges: []docsNamedRangeSpan{span}}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": docID,
+			"namedRange": created,
+		})
+	}
+	writeDocsNamedRangeTextResult(ui.FromContext(ctx), docID, created)
+	return nil
 }
 
 type DocsNamedRangesDeleteCmd struct {
@@ -280,10 +285,15 @@ func (c *DocsNamedRangesDeleteCmd) Run(ctx context.Context, flags *RootFlags) er
 	if err != nil {
 		return fmt.Errorf("delete named range: %w", err)
 	}
-	return writeResult(ctx, ui.FromContext(ctx),
-		kv("documentId", docID),
-		kv("deleted", map[string]any{"name": item.Name, "namedRangeId": item.NamedRangeID}),
-	)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": docID,
+			"deleted":    map[string]any{"name": item.Name, "namedRangeId": item.NamedRangeID},
+		})
+	}
+	writeDocsNamedRangeTextResult(ui.FromContext(ctx), docID, item)
+	ui.FromContext(ctx).Out().Linef("deleted\ttrue")
+	return nil
 }
 
 type DocsNamedRangesReplaceCmd struct {
@@ -364,12 +374,19 @@ func (c *DocsNamedRangesReplaceCmd) Run(ctx context.Context, kctx *kong.Context,
 	if !found {
 		return fmt.Errorf("replaced named range not found (id=%q)", item.NamedRangeID)
 	}
-	return writeResult(ctx, ui.FromContext(ctx),
-		kv("documentId", docID),
-		kv("namedRange", updatedItem),
-		kv("replaced", true),
-		kv("textLength", utf16Len(text)),
-	)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"documentId": docID,
+			"namedRange": updatedItem,
+			"replaced":   true,
+			"textLength": utf16Len(text),
+		})
+	}
+	u := ui.FromContext(ctx)
+	writeDocsNamedRangeTextResult(u, docID, updatedItem)
+	u.Out().Linef("replaced\ttrue")
+	u.Out().Linef("textLength\t%d", utf16Len(text))
+	return nil
 }
 
 type docsNamedRangeSpan struct {
@@ -515,4 +532,18 @@ func docsNamedRangeTSV(value string) string {
 		"\r", `\r`,
 		"\n", `\n`,
 	).Replace(value)
+}
+
+func writeDocsNamedRangeTextResult(u *ui.UI, docID string, item docsNamedRangeItem) {
+	u.Out().Linef("documentId\t%s", docsNamedRangeTSV(docID))
+	u.Out().Linef("name\t%s", docsNamedRangeTSV(item.Name))
+	u.Out().Linef("namedRangeId\t%s", docsNamedRangeTSV(item.NamedRangeID))
+	u.Out().Linef("rangeCount\t%d", len(item.Ranges))
+	for i, span := range item.Ranges {
+		prefix := fmt.Sprintf("range%d", i+1)
+		u.Out().Linef("%sStartIndex\t%d", prefix, span.StartIndex)
+		u.Out().Linef("%sEndIndex\t%d", prefix, span.EndIndex)
+		u.Out().Linef("%sTabId\t%s", prefix, docsNamedRangeTSV(span.TabID))
+		u.Out().Linef("%sSegmentId\t%s", prefix, docsNamedRangeTSV(span.SegmentID))
+	}
 }

--- a/internal/cmd/docs_named_ranges_test.go
+++ b/internal/cmd/docs_named_ranges_test.go
@@ -1,0 +1,334 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type docsNamedRangeRecorder struct {
+	batches     []docs.BatchUpdateDocumentRequest
+	rawBatches  [][]byte
+	includeTabs []string
+}
+
+func setupDocsNamedRangeTestService(t *testing.T, doc *docs.Document, rec *docsNamedRangeRecorder) {
+	t.Helper()
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			rec.includeTabs = append(rec.includeTabs, r.URL.Query().Get("includeTabsContent"))
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, ":batchUpdate"):
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read batch body: %v", err)
+			}
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.Unmarshal(body, &req); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			rec.rawBatches = append(rec.rawBatches, body)
+			rec.batches = append(rec.batches, req)
+			response := map[string]any{"documentId": "doc1"}
+			if len(req.Requests) == 1 && req.Requests[0].CreateNamedRange != nil {
+				response["replies"] = []any{map[string]any{
+					"createNamedRange": map[string]any{"namedRangeId": "nr-new"},
+				}}
+			}
+			if len(req.Requests) == 1 && req.Requests[0].ReplaceNamedRangeContent != nil {
+				updateDocsNamedRangeForTest(doc, req.Requests[0].ReplaceNamedRangeContent)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(response)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(cleanup)
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+}
+
+func TestDocsNamedRangesListTabJSONAndPlain(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsNamedRangeTabbedDocument()
+	rec := &docsNamedRangeRecorder{}
+	setupDocsNamedRangeTestService(t, doc, rec)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runKong(t, &DocsNamedRangesListCmd{}, []string{"doc1", "--tab", "Work"}, newDocsJSONContext(t), &RootFlags{Account: "a@b.com"})
+	})
+	if runErr != nil {
+		t.Fatalf("list: %v", runErr)
+	}
+	if len(rec.includeTabs) != 1 || rec.includeTabs[0] != "true" {
+		t.Fatalf("includeTabsContent = %#v, want true", rec.includeTabs)
+	}
+	var payload struct {
+		DocumentID  string               `json:"documentId"`
+		TabID       string               `json:"tabId"`
+		NamedRanges []docsNamedRangeItem `json:"namedRanges"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if payload.DocumentID != "doc1" || payload.TabID != "t.work" || len(payload.NamedRanges) != 2 {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if payload.NamedRanges[0].Name != "alpha" || payload.NamedRanges[1].Name != "stable" {
+		t.Fatalf("order = %#v", payload.NamedRanges)
+	}
+	if got := payload.NamedRanges[0].Ranges[0].SegmentID; got != "header-1" {
+		t.Fatalf("alpha segmentId = %q, want header-1", got)
+	}
+	if got := payload.NamedRanges[1].Ranges[0]; got.StartIndex != 7 || got.EndIndex != 13 || got.TabID != "t.work" {
+		t.Fatalf("stable range = %#v", got)
+	}
+
+	var plainErr error
+	plain := captureStdout(t, func() {
+		ctx := outfmt.WithMode(newDocsCmdContext(t), outfmt.Mode{Plain: true})
+		plainErr = runKong(t, &DocsNamedRangesListCmd{}, []string{"doc1", "--tab", "Work", "--name", "stable"}, ctx, &RootFlags{Account: "a@b.com"})
+	})
+	if plainErr != nil {
+		t.Fatalf("plain list: %v", plainErr)
+	}
+	if got, want := plain, "stable\tnr-stable\t7\t13\tt.work\t\n"; got != want {
+		t.Fatalf("plain output = %q, want %q", got, want)
+	}
+}
+
+func TestDocsNamedRangesCreateAtUsesUTF16TabAndRevision(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsNamedRangeTabbedDocument()
+	rec := &docsNamedRangeRecorder{}
+	setupDocsNamedRangeTestService(t, doc, rec)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runKong(t, &DocsNamedRangesCreateCmd{}, []string{
+			"doc1", "--name", "new-anchor", "--at", "😀 anchor", "--tab", "Work",
+		}, newDocsJSONContext(t), &RootFlags{Account: "a@b.com"})
+	})
+	if runErr != nil {
+		t.Fatalf("create: %v", runErr)
+	}
+	if len(rec.batches) != 1 {
+		t.Fatalf("batches = %d, want 1", len(rec.batches))
+	}
+	batch := rec.batches[0]
+	if batch.WriteControl == nil || batch.WriteControl.RequiredRevisionId != "rev1" {
+		t.Fatalf("write control = %#v", batch.WriteControl)
+	}
+	req := batch.Requests[0].CreateNamedRange
+	if req == nil || req.Name != "new-anchor" {
+		t.Fatalf("create request = %#v", req)
+	}
+	if got := req.Range; got.StartIndex != 14 || got.EndIndex != 23 || got.TabId != "t.work" {
+		t.Fatalf("range = %#v, want 14..23 on t.work", got)
+	}
+	var payload struct {
+		NamedRange docsNamedRangeItem `json:"namedRange"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if payload.NamedRange.NamedRangeID != "nr-new" {
+		t.Fatalf("output = %s", out)
+	}
+}
+
+func TestDocsNamedRangesCreateIndexAndRejectDuplicate(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsFindRangeDoc(docsFindRangeParagraph(1, "plain body\n"))
+	doc.DocumentId = "doc1"
+	doc.RevisionId = "rev-index"
+	doc.NamedRanges = map[string]docs.NamedRanges{
+		"stable": {
+			Name: "stable",
+			NamedRanges: []*docs.NamedRange{{
+				Name:         "stable",
+				NamedRangeId: "nr-existing",
+				Ranges:       []*docs.Range{{StartIndex: 1, EndIndex: 6}},
+			}},
+		},
+	}
+	rec := &docsNamedRangeRecorder{}
+	setupDocsNamedRangeTestService(t, doc, rec)
+
+	if err := runKong(t, &DocsNamedRangesCreateCmd{}, []string{
+		"doc1", "--name", "index-anchor", "--start", "2", "--end", "5",
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("index create: %v", err)
+	}
+	got := rec.batches[0].Requests[0].CreateNamedRange.Range
+	if got.StartIndex != 2 || got.EndIndex != 5 || got.TabId != "" {
+		t.Fatalf("range = %#v", got)
+	}
+
+	err := runKong(t, &DocsNamedRangesCreateCmd{}, []string{
+		"doc1", "--name", "stable", "--start", "2", "--end", "5",
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("duplicate error = %v", err)
+	}
+	if len(rec.batches) != 1 {
+		t.Fatalf("duplicate sent mutation; batches = %d", len(rec.batches))
+	}
+}
+
+func TestDocsNamedRangesDeleteAndReplaceByExactID(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsFindRangeDoc(docsFindRangeParagraph(1, "stable\n"))
+	doc.DocumentId = "doc1"
+	doc.RevisionId = "rev-mutate"
+	doc.NamedRanges = map[string]docs.NamedRanges{
+		"stable": {
+			Name: "stable",
+			NamedRanges: []*docs.NamedRange{{
+				Name:         "stable",
+				NamedRangeId: "nr-stable",
+				Ranges:       []*docs.Range{{StartIndex: 1, EndIndex: 7}},
+			}},
+		},
+	}
+	rec := &docsNamedRangeRecorder{}
+	setupDocsNamedRangeTestService(t, doc, rec)
+
+	if err := runKong(t, &DocsNamedRangesDeleteCmd{}, []string{"doc1", "stable"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	deleteBatch := rec.batches[0]
+	if deleteBatch.WriteControl == nil || deleteBatch.WriteControl.RequiredRevisionId != "rev-mutate" {
+		t.Fatalf("delete write control = %#v", deleteBatch.WriteControl)
+	}
+	if got := deleteBatch.Requests[0].DeleteNamedRange; got == nil || got.NamedRangeId != "nr-stable" || got.Name != "" {
+		t.Fatalf("delete request = %#v", got)
+	}
+
+	var replaceErr error
+	replaceOut := captureStdout(t, func() {
+		replaceErr = runKong(t, &DocsNamedRangesReplaceCmd{}, []string{"doc1", "nr-stable", "--text", "replacement"}, newDocsJSONContext(t), &RootFlags{Account: "a@b.com"})
+	})
+	if replaceErr != nil {
+		t.Fatalf("replace: %v", replaceErr)
+	}
+	replaceBatch := rec.batches[1]
+	if got := replaceBatch.Requests[0].ReplaceNamedRangeContent; got == nil || got.NamedRangeId != "nr-stable" {
+		t.Fatalf("replace request = %#v", got)
+	}
+	var replacePayload struct {
+		NamedRange docsNamedRangeItem `json:"namedRange"`
+	}
+	if err := json.Unmarshal([]byte(replaceOut), &replacePayload); err != nil {
+		t.Fatalf("replace json: %v\n%s", err, replaceOut)
+	}
+	if got := replacePayload.NamedRange.Ranges[0].EndIndex; got != 12 {
+		t.Fatalf("post-replace endIndex = %d, want 12", got)
+	}
+
+	if err := runKong(t, &DocsNamedRangesReplaceCmd{}, []string{"doc1", "nr-stable", "--text="}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("replace empty: %v", err)
+	}
+	if !bytes.Contains(rec.rawBatches[2], []byte(`"text":""`)) {
+		t.Fatalf("empty text omitted from wire body: %s", rec.rawBatches[2])
+	}
+}
+
+func TestDocsNamedRangeTSVPreservesUnicodeAndLiteralCharacters(t *testing.T) {
+	input := "Résumé \"quoted\" C:\\path\tline\nnext"
+	got := docsNamedRangeTSV(input)
+	want := `Résumé "quoted" C:\path\tline\nnext`
+	if got != want {
+		t.Fatalf("TSV value = %q, want %q", got, want)
+	}
+}
+
+func TestResolveDocsNamedRangeRejectsAmbiguousName(t *testing.T) {
+	items := []docsNamedRangeItem{
+		{Name: "same", NamedRangeID: "nr2"},
+		{Name: "same", NamedRangeID: "nr1"},
+	}
+	if got, found, err := resolveDocsNamedRange("nr2", items); err != nil || !found || got.NamedRangeID != "nr2" {
+		t.Fatalf("id resolve = %#v, %t, %v", got, found, err)
+	}
+	_, found, err := resolveDocsNamedRange("same", items)
+	if err == nil || found || !strings.Contains(err.Error(), "nr1, nr2") {
+		t.Fatalf("ambiguous resolve = found %t, err %v", found, err)
+	}
+}
+
+func docsNamedRangeTabbedDocument() *docs.Document {
+	return &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev1",
+		Tabs: []*docs.Tab{{
+			TabProperties: &docs.TabProperties{TabId: "t.work", Title: "Work"},
+			DocumentTab: &docs.DocumentTab{
+				Body: docsFindRangeDoc(docsFindRangeParagraph(1, "Hello stable 😀 anchor\n")).Body,
+				NamedRanges: map[string]docs.NamedRanges{
+					"stable": {
+						Name: "stable",
+						NamedRanges: []*docs.NamedRange{{
+							Name:         "stable",
+							NamedRangeId: "nr-stable",
+							Ranges:       []*docs.Range{{StartIndex: 7, EndIndex: 13, TabId: "t.work"}},
+						}},
+					},
+					"alpha": {
+						Name: "alpha",
+						NamedRanges: []*docs.NamedRange{{
+							Name:         "alpha",
+							NamedRangeId: "nr-alpha",
+							Ranges:       []*docs.Range{{StartIndex: 1, EndIndex: 6, TabId: "t.work", SegmentId: "header-1"}},
+						}},
+					},
+				},
+			},
+		}},
+	}
+}
+
+func updateDocsNamedRangeForTest(doc *docs.Document, req *docs.ReplaceNamedRangeContentRequest) {
+	if doc == nil || req == nil {
+		return
+	}
+	updateGroups := func(groups map[string]docs.NamedRanges) {
+		for name, group := range groups {
+			for _, namedRange := range group.NamedRanges {
+				if namedRange == nil || namedRange.NamedRangeId != req.NamedRangeId || len(namedRange.Ranges) == 0 {
+					continue
+				}
+				namedRange.Ranges[0].EndIndex = namedRange.Ranges[0].StartIndex + utf16Len(req.Text)
+				namedRange.Ranges = namedRange.Ranges[:1]
+				group.NamedRanges = []*docs.NamedRange{namedRange}
+				groups[name] = group
+			}
+		}
+	}
+	updateGroups(doc.NamedRanges)
+	for _, tab := range flattenTabs(doc.Tabs) {
+		if tab != nil && tab.DocumentTab != nil {
+			updateGroups(tab.DocumentTab.NamedRanges)
+		}
+	}
+}

--- a/internal/cmd/docs_named_ranges_test.go
+++ b/internal/cmd/docs_named_ranges_test.go
@@ -12,6 +12,7 @@ import (
 	"google.golang.org/api/docs/v1"
 
 	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
 )
 
 type docsNamedRangeRecorder struct {
@@ -260,6 +261,33 @@ func TestDocsNamedRangeTSVPreservesUnicodeAndLiteralCharacters(t *testing.T) {
 	want := `Résumé "quoted" C:\path\tline\nnext`
 	if got != want {
 		t.Fatalf("TSV value = %q, want %q", got, want)
+	}
+}
+
+func TestWriteDocsNamedRangeTextResultIsStableTSV(t *testing.T) {
+	ctx, out := newDocsCmdOutputContext(t)
+	ctx = outfmt.WithMode(ctx, outfmt.Mode{Plain: true})
+	writeDocsNamedRangeTextResult(ui.FromContext(ctx), "doc1", docsNamedRangeItem{
+		Name:         "Résumé\tline\nnext",
+		NamedRangeID: "nr1",
+		Ranges: []docsNamedRangeSpan{{
+			StartIndex: 2,
+			EndIndex:   5,
+			TabID:      "tab\t1",
+			SegmentID:  "header\n1",
+		}},
+	})
+	want := "" +
+		"documentId\tdoc1\n" +
+		"name\tRésumé\\tline\\nnext\n" +
+		"namedRangeId\tnr1\n" +
+		"rangeCount\t1\n" +
+		"range1StartIndex\t2\n" +
+		"range1EndIndex\t5\n" +
+		"range1TabId\ttab\\t1\n" +
+		"range1SegmentId\theader\\n1\n"
+	if got := out.String(); got != want {
+		t.Fatalf("output = %q, want %q", got, want)
 	}
 }
 

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -112,6 +112,21 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			op:   "docs.delete-tab",
 		},
 		{
+			name: "docs named range create",
+			args: []string{"docs", "named-range", "create", "doc123", "--name", "Intro", "--start", "1", "--end", "5"},
+			op:   "docs.named-range.create",
+		},
+		{
+			name: "docs named range replace",
+			args: []string{"docs", "named-range", "replace", "doc123", "nr123", "--text", "hello"},
+			op:   "docs.named-range.replace",
+		},
+		{
+			name: "docs named range delete",
+			args: []string{"docs", "named-range", "delete", "doc123", "nr123"},
+			op:   "docs.named-range.delete",
+		},
+		{
 			name: "docs export tab",
 			args: []string{"docs", "export", "doc123", "--tab", "Tab 1", "--format", "pdf", "--out", "/tmp/gog-dryrun-tab.pdf"},
 			op:   "docs.tab-export",

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -153,6 +153,11 @@ docs:
   sed: false
   clear: false
   structure: true
+  named-range:
+    list: true
+    create: false
+    delete: false
+    replace: false
   comments:
     list: true
     get: true

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -158,6 +158,11 @@ docs:
   sed: false
   clear: false
   structure: true
+  named-range:
+    list: true
+    create: false
+    delete: false
+    replace: false
   comments:
     list: true
     get: true


### PR DESCRIPTION
## Summary

- add tab-aware `docs named-range` create/list/delete/replace commands
- support UTF-16 index ranges and literal-text `--at` resolution
- enforce unique names while accepting exact name or ID for mutations
- preserve segment IDs, stable JSON/plain output, dry-run, safety profiles, and generated docs

Replacement is plain text only. Complex-content or Markdown fallback is intentionally out of scope.

## Verification

- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make ci`
- autoreview clean after accepted fixes for generated docs, safety profiles, segment IDs, post-replace metadata, and TSV output
- live disposable Google Docs smoke with `clawdbot@gmail.com`:
  - create by text in a secondary tab
  - create by explicit UTF-16 indexes
  - list JSON and headerless plain TSV
  - replace by ID with post-mutation range readback
  - delete by ID and name
  - duplicate-name rejection
  - disposable document cleanup

Fixes #692.
