### PR TITLE
feat(docs): add direct table operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Sheets: add `sheets validation` get/set/clear commands for dropdown, checkbox, number, date, range, and custom-formula rules, and preserve table-managed dropdowns during validation-only copy/paste. (#710) — thanks @chrischall.
+- Docs: add direct `docs table-row`, `docs table-column`, `docs table-merge`, and `docs table-unmerge` commands with index, header-text, all-table, and tab-aware selection. (#686) — thanks @sebsnyk.
 - Docs: add `docs named-range` create/list/delete/replace commands for durable, tab-aware document anchors. (#692) — thanks @sebsnyk.
 - Gmail: report attached filenames and byte sizes in JSON results for send and draft create/update. (#716) — thanks @chrischall.
 - Gmail: add `gmail watch pull` for Pub/Sub pull subscription consumers with hook retry support. (#700) — thanks @joshp123.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -266,7 +266,15 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) rename-tab <docId> [flags]`](commands/gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [`gog docs (doc) sed <docId> [<expression>] [flags]`](commands/gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [`gog docs (doc) structure (struct) <docId> [flags]`](commands/gog-docs-structure.md) - Show document structure with numbered paragraphs
+    - [`gog docs (doc) table-column <command>`](commands/gog-docs-table-column.md) - Insert or delete native table columns
+      - [`gog docs (doc) table-column delete (rm,remove,del) --col=INT <docId> [flags]`](commands/gog-docs-table-column-delete.md) - Delete a native table column
+      - [`gog docs (doc) table-column insert (add,append) <docId> [flags]`](commands/gog-docs-table-column-insert.md) - Insert a native table column
     - [`gog docs (doc) table-column-width (table-width,column-width) <docId> [flags]`](commands/gog-docs-table-column-width.md) - Set or reset native table column widths
+    - [`gog docs (doc) table-merge --range=STRING <docId> [flags]`](commands/gog-docs-table-merge.md) - Merge a native table cell range
+    - [`gog docs (doc) table-row <command>`](commands/gog-docs-table-row.md) - Insert or delete native table rows
+      - [`gog docs (doc) table-row delete (rm,remove,del) --row=INT <docId> [flags]`](commands/gog-docs-table-row-delete.md) - Delete a native table row
+      - [`gog docs (doc) table-row insert (add,append) <docId> [flags]`](commands/gog-docs-table-row-insert.md) - Insert a native table row
+    - [`gog docs (doc) table-unmerge (table-split) --cell=STRING <docId> [flags]`](commands/gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
     - [`gog docs (doc) tables <command>`](commands/gog-docs-tables.md) - List native tables
       - [`gog docs (doc) tables list (ls) <docId> [flags]`](commands/gog-docs-tables-list.md) - List native tables in document order
     - [`gog docs (doc) tabs <command>`](commands/gog-docs-tabs.md) - Manage Google Doc tabs

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 606.
+Generated pages: 614.
 
 ## Top-level Commands
 
@@ -318,7 +318,15 @@ Generated pages: 606.
     - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
+    - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns
+      - [gog docs table-column delete](gog-docs-table-column-delete.md) - Delete a native table column
+      - [gog docs table-column insert](gog-docs-table-column-insert.md) - Insert a native table column
     - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
+    - [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range
+    - [gog docs table-row](gog-docs-table-row.md) - Insert or delete native table rows
+      - [gog docs table-row delete](gog-docs-table-row-delete.md) - Delete a native table row
+      - [gog docs table-row insert](gog-docs-table-row-insert.md) - Insert a native table row
+    - [gog docs table-unmerge](gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
     - [gog docs tables](gog-docs-tables.md) - List native tables
       - [gog docs tables list](gog-docs-tables-list.md) - List native tables in document order
     - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs

--- a/docs/commands/gog-docs-table-column-delete.md
+++ b/docs/commands/gog-docs-table-column-delete.md
@@ -1,0 +1,48 @@
+# `gog docs table-column delete`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Delete a native table column
+
+## Usage
+
+```bash
+gog docs (doc) table-column delete (rm,remove,del) --col=INT <docId> [flags]
+```
+
+## Parent
+
+- [gog docs table-column](gog-docs-table-column.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int` |  | 1-based column number; negative indexes count from the end |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs table-column](gog-docs-table-column.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-column-insert.md
+++ b/docs/commands/gog-docs-table-column-insert.md
@@ -1,0 +1,48 @@
+# `gog docs table-column insert`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Insert a native table column
+
+## Usage
+
+```bash
+gog docs (doc) table-column insert (add,append) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs table-column](gog-docs-table-column.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--at` | `string` | end | Insert before this 1-based column, use a negative index from the end, or end |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs table-column](gog-docs-table-column.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-column.md
+++ b/docs/commands/gog-docs-table-column.md
@@ -1,0 +1,50 @@
+# `gog docs table-column`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Insert or delete native table columns
+
+## Usage
+
+```bash
+gog docs (doc) table-column <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs table-column delete](gog-docs-table-column-delete.md) - Delete a native table column
+- [gog docs table-column insert](gog-docs-table-column-insert.md) - Insert a native table column
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-merge.md
+++ b/docs/commands/gog-docs-table-merge.md
@@ -1,0 +1,48 @@
+# `gog docs table-merge`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Merge a native table cell range
+
+## Usage
+
+```bash
+gog docs (doc) table-merge --range=STRING <docId> [flags]
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--range` | `string` |  | 1-based cell range r1,c1:r2,c2 |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-row-delete.md
+++ b/docs/commands/gog-docs-table-row-delete.md
@@ -1,0 +1,48 @@
+# `gog docs table-row delete`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Delete a native table row
+
+## Usage
+
+```bash
+gog docs (doc) table-row delete (rm,remove,del) --row=INT <docId> [flags]
+```
+
+## Parent
+
+- [gog docs table-row](gog-docs-table-row.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int` |  | 1-based row number; negative indexes count from the end |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs table-row](gog-docs-table-row.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-row-insert.md
+++ b/docs/commands/gog-docs-table-row-insert.md
@@ -1,0 +1,49 @@
+# `gog docs table-row insert`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Insert a native table row
+
+## Usage
+
+```bash
+gog docs (doc) table-row insert (add,append) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs table-row](gog-docs-table-row.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--at` | `string` | end | Insert before this 1-based row, use a negative index from the end, or end |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
+| `--values-json` | `string` |  | Optional JSON string array containing the new row values |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs table-row](gog-docs-table-row.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-row.md
+++ b/docs/commands/gog-docs-table-row.md
@@ -1,0 +1,50 @@
+# `gog docs table-row`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Insert or delete native table rows
+
+## Usage
+
+```bash
+gog docs (doc) table-row <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs table-row delete](gog-docs-table-row-delete.md) - Delete a native table row
+- [gog docs table-row insert](gog-docs-table-row-insert.md) - Insert a native table row
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-table-unmerge.md
+++ b/docs/commands/gog-docs-table-unmerge.md
@@ -1,0 +1,48 @@
+# `gog docs table-unmerge`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Unmerge the region containing a native table cell
+
+## Usage
+
+```bash
+gog docs (doc) table-unmerge (table-split) --cell=STRING <docId> [flags]
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--cell` | `string` |  | 1-based cell r,c inside the merged region |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -49,7 +49,11 @@ gog docs (doc) <command> [flags]
 - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
 - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
 - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
+- [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns
 - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
+- [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range
+- [gog docs table-row](gog-docs-table-row.md) - Insert or delete native table rows
+- [gog docs table-unmerge](gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
 - [gog docs tables](gog-docs-tables.md) - List native tables
 - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs
 - [gog docs update](gog-docs-update.md) - Insert or replace text at a specific index or range in a Google Doc

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -153,10 +153,45 @@ gog docs table-column-width <docId> --table-index 1 --evenly-distributed
 `--width` uses points and requires `--col`. `--evenly-distributed` resets one
 column when `--col` is supplied, or all columns when it is omitted.
 
+Insert or delete rows and columns without using the `docs sed` table syntax:
+
+```bash
+gog docs table-row insert <docId> --table 2 --at end
+gog docs table-row insert <docId> --table "Status" --at 2 \
+  --values-json '["Ready","Owner"]'
+gog docs table-row delete <docId> --table -1 --row 3
+gog docs table-column insert <docId> --table 1 --at 2
+gog docs table-column delete <docId> --table '*' --col -1
+```
+
+`--table` accepts a 1-based index, a negative index counted from the end, exact
+first-cell text, or `*` for every table. Prefix numeric or syntax-looking header
+text with `text:`, for example `--table text:2026` or `--table 'text:*'`.
+Header-text matches must be unique. Row and column indexes are 1-based and may
+be negative; `--at end` appends. `--values-json` accepts one JSON string array
+and is limited to a single table.
+
+Merge a rectangular cell range or unmerge the region containing one cell:
+
+```bash
+gog docs table-merge <docId> --table 1 --range 1,1:1,3
+gog docs table-unmerge <docId> --table 1 --cell 1,1
+```
+
+All direct table mutation commands accept `--tab`, `--dry-run`, `--json`, and
+`--plain`. Multi-table mutations are preflighted and preserve descending
+document order across Docs API-capped batch updates. Row and column structural
+operations reject non-rectangular API table shapes rather than guessing a cell
+reference that could broaden a merged-cell mutation.
+
 Command page:
 
 - [`gog docs insert-table`](commands/gog-docs-insert-table.md)
 - [`gog docs cell-update`](commands/gog-docs-cell-update.md)
+- [`gog docs table-row`](commands/gog-docs-table-row.md)
+- [`gog docs table-column`](commands/gog-docs-table-column.md)
+- [`gog docs table-merge`](commands/gog-docs-table-merge.md)
+- [`gog docs table-unmerge`](commands/gog-docs-table-unmerge.md)
 - [`gog docs table-column-width`](commands/gog-docs-table-column-width.md)
 
 ## Tabs

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -35,6 +35,10 @@ type DocsCmd struct {
 	InsertTable      DocsInsertTableCmd      `cmd:"" name:"insert-table" help:"Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json"`
 	CellUpdate       DocsCellUpdateCmd       `cmd:"" name:"cell-update" aliases:"update-cell" help:"Replace or append content inside a specific table cell"`
 	CellStyle        DocsCellStyleCmd        `cmd:"" name:"cell-style" help:"Apply table cell background and text styling"`
+	TableRow         DocsTableRowCmd         `cmd:"" name:"table-row" help:"Insert or delete native table rows"`
+	TableColumn      DocsTableColumnCmd      `cmd:"" name:"table-column" help:"Insert or delete native table columns"`
+	TableMerge       DocsTableMergeCmd       `cmd:"" name:"table-merge" help:"Merge a native table cell range"`
+	TableUnmerge     DocsTableUnmergeCmd     `cmd:"" name:"table-unmerge" aliases:"table-split" help:"Unmerge the region containing a native table cell"`
 	TableColumnWidth DocsTableColumnWidthCmd `cmd:"" name:"table-column-width" aliases:"table-width,column-width" help:"Set or reset native table column widths"`
 	InsertImage      DocsInsertImageCmd      `cmd:"" name:"insert-image" help:"Upload a local image and insert it into a Google Doc"`
 	InsertPerson     DocsInsertPersonCmd     `cmd:"" name:"insert-person" help:"Insert a native person smart chip"`

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -322,23 +322,37 @@ func applyTabIDToFormattingRequests(requests []*docs.Request, tabID string) {
 // hard limit. Each chunk preserves the source order so cell-index
 // arithmetic remains consistent across the split. Returns the total number
 // of requests submitted (matches len(requests) on success); chunk events are
-// announced on stderr so callers can correlate wire traffic with logs.
+// announced on stderr so callers can correlate wire traffic with logs. When
+// revision control is supplied, each response's updated control is chained
+// into the next chunk so stale structural indexes fail closed.
 func submitBatchedDocsRequests(ctx context.Context, svc *docs.Service, docID string, requests []*docs.Request, writeControl *docs.WriteControl) (int, error) {
+	count, _, err := submitBatchedDocsRequestsWithRevision(ctx, svc, docID, requests, writeControl)
+	return count, err
+}
+
+func submitBatchedDocsRequestsWithRevision(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	requests []*docs.Request,
+	writeControl *docs.WriteControl,
+) (int, string, error) {
 	if len(requests) == 0 {
-		return 0, nil
+		return 0, docsRequiredRevisionID(writeControl), nil
 	}
 	if len(requests) <= docsBatchUpdateRequestCap {
-		_, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 			WriteControl: writeControl,
 			Requests:     requests,
 		}).Context(ctx).Do()
 		if err != nil {
-			return 0, err
+			return 0, "", err
 		}
-		return len(requests), nil
+		return len(requests), docsBatchResponseRevisionID(resp), nil
 	}
 
 	totalChunks := (len(requests) + docsBatchUpdateRequestCap - 1) / docsBatchUpdateRequestCap
+	revisionID := docsRequiredRevisionID(writeControl)
 	for i := 0; i < len(requests); i += docsBatchUpdateRequestCap {
 		end := i + docsBatchUpdateRequestCap
 		if end > len(requests) {
@@ -347,21 +361,38 @@ func submitBatchedDocsRequests(ctx context.Context, svc *docs.Service, docID str
 		chunkIdx := i/docsBatchUpdateRequestCap + 1
 		fmt.Fprintf(os.Stderr, "gog: docs batchUpdate split %d/%d (%d requests; Docs API per-call cap is %d)\n",
 			chunkIdx, totalChunks, end-i, docsBatchUpdateRequestCap)
-		// WriteControl is only meaningful on the first chunk — subsequent
-		// chunks operate on whatever revision the prior chunk produced.
-		var wc *docs.WriteControl
-		if i == 0 {
-			wc = writeControl
-		}
-		_, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
-			WriteControl: wc,
+		resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+			WriteControl: writeControl,
 			Requests:     requests[i:end],
 		}).Context(ctx).Do()
 		if err != nil {
-			return i, err
+			return i, revisionID, err
+		}
+		if end < len(requests) && writeControl != nil {
+			if resp == nil || resp.WriteControl == nil || resp.WriteControl.RequiredRevisionId == "" {
+				return end, revisionID, fmt.Errorf("docs batchUpdate split %d/%d did not return required revision control", chunkIdx, totalChunks)
+			}
+			revisionID = resp.WriteControl.RequiredRevisionId
+			writeControl = &docs.WriteControl{RequiredRevisionId: revisionID}
+		} else if responseRevisionID := docsBatchResponseRevisionID(resp); responseRevisionID != "" {
+			revisionID = responseRevisionID
 		}
 	}
-	return len(requests), nil
+	return len(requests), revisionID, nil
+}
+
+func docsRequiredRevisionID(writeControl *docs.WriteControl) string {
+	if writeControl == nil {
+		return ""
+	}
+	return writeControl.RequiredRevisionId
+}
+
+func docsBatchResponseRevisionID(resp *docs.BatchUpdateDocumentResponse) string {
+	if resp == nil || resp.WriteControl == nil {
+		return ""
+	}
+	return resp.WriteControl.RequiredRevisionId
 }
 
 func markdownAppendNeedsParagraphBoundary(elements []MarkdownElement) bool {

--- a/internal/cmd/docs_sed_table_ops.go
+++ b/internal/cmd/docs_sed_table_ops.go
@@ -19,171 +19,46 @@ func (c *DocsSedCmd) runTableRowColOp(ctx context.Context, u *ui.UI, account, id
 		return err
 	}
 
-	tablesWithIdx := collectAllTablesWithIndex(doc)
-	if len(tablesWithIdx) == 0 {
-		return usage("document has no tables")
+	target, _, err := resolveDocsTableWithIndex(doc, ref.tableIndex)
+	if err != nil {
+		return err
 	}
-
-	// Resolve table index
-	ti := ref.tableIndex
-	if ti < 0 {
-		ti = len(tablesWithIdx) + ti + 1
-	}
-	if ti < 1 || ti > len(tablesWithIdx) {
-		return usagef("table %d out of range (document has %d tables)", ref.tableIndex, len(tablesWithIdx))
-	}
-	tw := tablesWithIdx[ti-1]
-	table := tw.table
-	tableStartLoc := &docs.Location{Index: tw.startIdx}
-
-	var requests []*docs.Request
-	opDesc := ""
-
-	if ref.rowOp != "" {
-		numRows := len(table.TableRows)
-		switch ref.rowOp {
-		case opDelete:
-			target := ref.opTarget
-			if target < 0 {
-				target = numRows + target + 1
-			}
-			if target < 1 || target > numRows {
-				return usagef("row %d out of range (table has %d rows)", ref.opTarget, numRows)
-			}
-			if numRows <= 1 {
-				return usage("cannot delete the only row in a table")
-			}
-			cellLoc := &docs.TableCellLocation{
-				TableStartLocation: tableStartLoc,
-				RowIndex:           int64(target - 1),
-				ColumnIndex:        0,
-			}
-			requests = append(requests, &docs.Request{
-				DeleteTableRow: &docs.DeleteTableRowRequest{
-					TableCellLocation: cellLoc,
-				},
-			})
-			opDesc = fmt.Sprintf("deleted row %d", target)
-
-		case opInsert:
-			target := ref.opTarget
-			if target < 0 {
-				target = numRows + target + 1
-			}
-			if target < 1 || target > numRows {
-				return usagef("row %d out of range for insert (table has %d rows)", ref.opTarget, numRows)
-			}
-			cellLoc := &docs.TableCellLocation{
-				TableStartLocation: tableStartLoc,
-				RowIndex:           int64(target - 1),
-				ColumnIndex:        0,
-			}
-			requests = append(requests, &docs.Request{
-				InsertTableRow: &docs.InsertTableRowRequest{
-					TableCellLocation: cellLoc,
-					InsertBelow:       false,
-				},
-			})
-			opDesc = fmt.Sprintf("inserted row before row %d", target)
-
-		case opAppend:
-			lastRow := numRows - 1
-			cellLoc := &docs.TableCellLocation{
-				TableStartLocation: tableStartLoc,
-				RowIndex:           int64(lastRow),
-				ColumnIndex:        0,
-			}
-			requests = append(requests, &docs.Request{
-				InsertTableRow: &docs.InsertTableRowRequest{
-					TableCellLocation: cellLoc,
-					InsertBelow:       true,
-				},
-			})
-			opDesc = "appended row at end"
-		}
-	}
-
-	if ref.colOp != "" {
-		numCols := 0
-		if len(table.TableRows) > 0 {
-			numCols = len(table.TableRows[0].TableCells)
-		}
-		switch ref.colOp {
-		case opDelete:
-			target := ref.opTarget
-			if target < 0 {
-				target = numCols + target + 1
-			}
-			if target < 1 || target > numCols {
-				return usagef("col %d out of range (table has %d columns)", ref.opTarget, numCols)
-			}
-			if numCols <= 1 {
-				return usage("cannot delete the only column in a table")
-			}
-			cellLoc := &docs.TableCellLocation{
-				TableStartLocation: tableStartLoc,
-				RowIndex:           0,
-				ColumnIndex:        int64(target - 1),
-			}
-			requests = append(requests, &docs.Request{
-				DeleteTableColumn: &docs.DeleteTableColumnRequest{
-					TableCellLocation: cellLoc,
-				},
-			})
-			opDesc = fmt.Sprintf("deleted column %d", target)
-
-		case opInsert:
-			target := ref.opTarget
-			if target < 0 {
-				target = numCols + target + 1
-			}
-			if target < 1 || target > numCols {
-				return usagef("col %d out of range for insert (table has %d columns)", ref.opTarget, numCols)
-			}
-			cellLoc := &docs.TableCellLocation{
-				TableStartLocation: tableStartLoc,
-				RowIndex:           0,
-				ColumnIndex:        int64(target - 1),
-			}
-			requests = append(requests, &docs.Request{
-				InsertTableColumn: &docs.InsertTableColumnRequest{
-					TableCellLocation: cellLoc,
-					InsertRight:       false,
-				},
-			})
-			opDesc = fmt.Sprintf("inserted column before column %d", target)
-
-		case opAppend:
-			lastCol := numCols - 1
-			cellLoc := &docs.TableCellLocation{
-				TableStartLocation: tableStartLoc,
-				RowIndex:           0,
-				ColumnIndex:        int64(lastCol),
-			}
-			requests = append(requests, &docs.Request{
-				InsertTableColumn: &docs.InsertTableColumnRequest{
-					TableCellLocation: cellLoc,
-					InsertRight:       true,
-				},
-			})
-			opDesc = "appended column at end"
-		}
-	}
-
-	if len(requests) == 0 {
+	var dimension docsTableDimension
+	var action string
+	switch {
+	case ref.rowOp != "":
+		dimension = docsTableDimensionRow
+		action = ref.rowOp
+	case ref.colOp != "":
+		dimension = docsTableDimensionColumn
+		action = ref.colOp
+	default:
 		return usage("no row/column operation to perform")
 	}
 
-	err = retryOnQuota(ctx, func() error {
-		_, e := docsSvc.Documents.BatchUpdate(id, &docs.BatchUpdateDocumentRequest{
-			Requests: requests,
-		}).Context(ctx).Do()
-		return e
-	})
+	builderAction := action
+	if builderAction == opAppend {
+		builderAction = opInsert
+	}
+	req, resolved, err := buildDocsTableDimensionRequest(
+		target, dimension, builderAction, ref.opTarget, action == opAppend, "",
+	)
 	if err != nil {
+		return err
+	}
+	if _, err := batchUpdate(ctx, docsSvc, id, []*docs.Request{req}); err != nil {
 		return fmt.Errorf("batch update (row/col op): %w", err)
 	}
 
+	var opDesc string
+	switch action {
+	case opDelete:
+		opDesc = fmt.Sprintf("deleted %s %d", dimension, resolved)
+	case opInsert:
+		opDesc = fmt.Sprintf("inserted %s before %s %d", dimension, dimension, resolved)
+	case opAppend:
+		opDesc = fmt.Sprintf("appended %s at end", dimension)
+	}
 	return sedOutputOK(ctx, u, id, sedOutputKV{"op", opDesc})
 }
 
@@ -198,22 +73,11 @@ func (c *DocsSedCmd) runTableMerge(ctx context.Context, u *ui.UI, account, id st
 		return err
 	}
 
-	tablesWithIdx := collectAllTablesWithIndex(doc)
-	tIdx := ref.tableIndex
-	if tIdx < 0 {
-		tIdx = len(tablesWithIdx) + tIdx + 1
+	target, _, err := resolveDocsTableWithIndex(doc, ref.tableIndex)
+	if err != nil {
+		return err
 	}
-	if tIdx < 1 || tIdx > len(tablesWithIdx) {
-		return usagef("table index %d out of range (have %d tables)", ref.tableIndex, len(tablesWithIdx))
-	}
-	table := tablesWithIdx[tIdx-1].table
-	if validationErr := validateMergeTableRef(table, ref); validationErr != nil {
-		return validationErr
-	}
-	tableStartLoc := &docs.Location{Index: tablesWithIdx[tIdx-1].startIdx}
-
 	repl := strings.TrimSpace(strings.ToLower(expr.replacement))
-	var requests []*docs.Request
 	var opDesc string
 
 	switch repl {
@@ -221,80 +85,24 @@ func (c *DocsSedCmd) runTableMerge(ctx context.Context, u *ui.UI, account, id st
 		if ref.endRow == 0 || ref.endCol == 0 {
 			return usage("merge requires a range: |N|[r1,c1:r2,c2]")
 		}
-		requests = append(requests, &docs.Request{
-			MergeTableCells: &docs.MergeTableCellsRequest{
-				TableRange: &docs.TableRange{
-					TableCellLocation: &docs.TableCellLocation{
-						TableStartLocation: tableStartLoc,
-						RowIndex:           int64(ref.row - 1),
-						ColumnIndex:        int64(ref.col - 1),
-					},
-					RowSpan:    int64(ref.endRow - ref.row + 1),
-					ColumnSpan: int64(ref.endCol - ref.col + 1),
-				},
-			},
-		})
 		opDesc = fmt.Sprintf("merged [%d,%d:%d,%d]", ref.row, ref.col, ref.endRow, ref.endCol)
 	case unmergeOp, splitOp:
-		requests = append(requests, &docs.Request{
-			UnmergeTableCells: &docs.UnmergeTableCellsRequest{
-				TableRange: &docs.TableRange{
-					TableCellLocation: &docs.TableCellLocation{
-						TableStartLocation: tableStartLoc,
-						RowIndex:           int64(ref.row - 1),
-						ColumnIndex:        int64(ref.col - 1),
-					},
-					// For unmerge, span the minimum (1x1) — Google will unmerge whatever
-					// merged region contains this cell
-					RowSpan:    1,
-					ColumnSpan: 1,
-				},
-			},
-		})
 		opDesc = fmt.Sprintf("unmerged [%d,%d]", ref.row, ref.col)
 	default:
 		return usagef("unknown merge operation %q (expected merge, unmerge, or split)", repl)
 	}
 
-	err = retryOnQuota(ctx, func() error {
-		_, e := docsSvc.Documents.BatchUpdate(id, &docs.BatchUpdateDocumentRequest{
-			Requests: requests,
-		}).Context(ctx).Do()
-		return e
-	})
+	endRow, endCol := ref.endRow, ref.endCol
+	if repl == unmergeOp || repl == splitOp {
+		endRow, endCol = ref.row, ref.col
+	}
+	req, err := buildDocsTableMergeRequest(target, repl, ref.row, ref.col, endRow, endCol, "")
 	if err != nil {
+		return err
+	}
+	if _, err := batchUpdate(ctx, docsSvc, id, []*docs.Request{req}); err != nil {
 		return fmt.Errorf("batch update (%s): %w", opDesc, err)
 	}
 
 	return sedOutputOK(ctx, u, id, sedOutputKV{"action", opDesc})
-}
-
-func validateMergeTableRef(table *docs.Table, ref *tableCellRef) error {
-	rows := len(table.TableRows)
-	if ref.row < 1 || ref.row > rows {
-		return usagef("row %d out of range (table has %d rows)", ref.row, rows)
-	}
-	cols := len(table.TableRows[ref.row-1].TableCells)
-	if ref.col < 1 || ref.col > cols {
-		return usagef("col %d out of range (row has %d columns)", ref.col, cols)
-	}
-	if ref.endRow != 0 {
-		if ref.endRow < ref.row || ref.endRow > rows {
-			return usagef("row %d out of range (table has %d rows)", ref.endRow, rows)
-		}
-	}
-	if ref.endCol != 0 {
-		maxCols := cols
-		if ref.endRow != 0 {
-			for i := ref.row - 1; i <= ref.endRow-1; i++ {
-				if len(table.TableRows[i].TableCells) > maxCols {
-					maxCols = len(table.TableRows[i].TableCells)
-				}
-			}
-		}
-		if ref.endCol < ref.col || ref.endCol > maxCols {
-			return usagef("col %d out of range (table has %d columns)", ref.endCol, maxCols)
-		}
-	}
-	return nil
 }

--- a/internal/cmd/docs_table_ops.go
+++ b/internal/cmd/docs_table_ops.go
@@ -1,0 +1,869 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsTableRowCmd struct {
+	Insert DocsTableRowInsertCmd `cmd:"" name:"insert" aliases:"add,append" help:"Insert a native table row"`
+	Delete DocsTableRowDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a native table row"`
+}
+
+type DocsTableColumnCmd struct {
+	Insert DocsTableColumnInsertCmd `cmd:"" name:"insert" aliases:"add,append" help:"Insert a native table column"`
+	Delete DocsTableColumnDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a native table column"`
+}
+
+type DocsTableRowInsertCmd struct {
+	DocID      string `arg:"" name:"docId" help:"Doc ID"`
+	Table      string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	At         string `name:"at" help:"Insert before this 1-based row, use a negative index from the end, or end" default:"end"`
+	ValuesJSON string `name:"values-json" help:"Optional JSON string array containing the new row values"`
+	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsTableRowDeleteCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Table string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	Row   int    `name:"row" required:"" help:"1-based row number; negative indexes count from the end"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsTableColumnInsertCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Table string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	At    string `name:"at" help:"Insert before this 1-based column, use a negative index from the end, or end" default:"end"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsTableColumnDeleteCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Table string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	Col   int    `name:"col" required:"" help:"1-based column number; negative indexes count from the end"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsTableMergeCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Table string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	Range string `name:"range" required:"" help:"1-based cell range r1,c1:r2,c2"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsTableUnmergeCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Table string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	Cell  string `name:"cell" required:"" help:"1-based cell r,c inside the merged region"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type docsSelectedTable struct {
+	tableWithIndex
+	index int
+}
+
+type docsTableMutationResult struct {
+	TableIndex int    `json:"tableIndex"`
+	Index      int    `json:"index,omitempty"`
+	Range      string `json:"range,omitempty"`
+}
+
+func (c *DocsTableRowInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	docID, err := validateDocsTableMutationArgs(c.DocID, c.Table)
+	if err != nil {
+		return err
+	}
+	at, appendAtEnd, err := parseDocsTableInsertAt(c.At, "row")
+	if err != nil {
+		return err
+	}
+	values, err := parseDocsTableRowValues(c.ValuesJSON)
+	if err != nil {
+		return err
+	}
+	hasValues := strings.TrimSpace(c.ValuesJSON) != ""
+	if dryRunErr := dryRunExit(ctx, flags, "docs.table-row.insert", map[string]any{
+		"documentId": docID,
+		"table":      c.Table,
+		"at":         c.At,
+		"values":     values,
+		"tab":        c.Tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, loaded, selected, err := loadDocsSelectedTables(ctx, flags, docID, c.Tab, c.Table)
+	if err != nil {
+		return err
+	}
+	if hasValues && len(selected) != 1 {
+		return usagef("--values-json requires exactly one selected table (matched %d)", len(selected))
+	}
+	requests := make([]*docs.Request, 0, len(selected))
+	results := make([]docsTableMutationResult, 0, len(selected))
+	for _, target := range selected {
+		req, resolved, buildErr := buildDocsTableDimensionRequest(
+			target.tableWithIndex, docsTableDimensionRow, opInsert, at, appendAtEnd, loaded.tabID,
+		)
+		if buildErr != nil {
+			return buildErr
+		}
+		if hasValues && docsTableRowBoundaryCrossesMerge(target.table, resolved) {
+			return usagef(
+				"cannot insert row %d with --values-json because a vertically merged cell crosses that boundary",
+				resolved,
+			)
+		}
+		if hasValues && len(values) != docsTableColumnCount(target.table) {
+			return usagef("--values-json has %d values, table has %d columns", len(values), docsTableColumnCount(target.table))
+		}
+		requests = append(requests, req)
+		results = append(results, docsTableMutationResult{TableIndex: target.index, Index: resolved})
+	}
+	insertedRevisionID, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests)
+	if err != nil {
+		return fmt.Errorf("insert table row: %w", err)
+	}
+	if hasValues {
+		if insertedRevisionID == "" {
+			return fmt.Errorf("insert table row: provider did not return required revision control")
+		}
+		if err := populateDocsTableRow(
+			ctx, svc, docID, loaded.tabID, insertedRevisionID,
+			results[0].TableIndex, results[0].Index, values,
+		); err != nil {
+			return err
+		}
+	}
+	return writeDocsTableMutationResult(ctx, docID, loaded.tabID, "insert", "row", results)
+}
+
+func (c *DocsTableRowDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runDocsTableDimensionCommand(ctx, flags, docsTableDimensionCommand{
+		docID: c.DocID, table: c.Table, tab: c.Tab, dimension: docsTableDimensionRow,
+		action: opDelete, target: c.Row, dryRunOp: "docs.table-row.delete",
+	})
+}
+
+func (c *DocsTableColumnInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	at, appendAtEnd, err := parseDocsTableInsertAt(c.At, "column")
+	if err != nil {
+		return err
+	}
+	return runDocsTableDimensionCommand(ctx, flags, docsTableDimensionCommand{
+		docID: c.DocID, table: c.Table, tab: c.Tab, dimension: docsTableDimensionColumn,
+		action: opInsert, target: at, appendAtEnd: appendAtEnd, dryRunOp: "docs.table-column.insert",
+	})
+}
+
+func (c *DocsTableColumnDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runDocsTableDimensionCommand(ctx, flags, docsTableDimensionCommand{
+		docID: c.DocID, table: c.Table, tab: c.Tab, dimension: docsTableDimensionColumn,
+		action: opDelete, target: c.Col, dryRunOp: "docs.table-column.delete",
+	})
+}
+
+type docsTableDimension string
+
+const (
+	docsTableDimensionRow    docsTableDimension = "row"
+	docsTableDimensionColumn docsTableDimension = "column"
+)
+
+type docsTableDimensionCommand struct {
+	docID       string
+	table       string
+	tab         string
+	dimension   docsTableDimension
+	action      string
+	target      int
+	appendAtEnd bool
+	dryRunOp    string
+}
+
+func runDocsTableDimensionCommand(ctx context.Context, flags *RootFlags, command docsTableDimensionCommand) error {
+	docID, err := validateDocsTableMutationArgs(command.docID, command.table)
+	if err != nil {
+		return err
+	}
+	if command.target == 0 && !command.appendAtEnd {
+		return usagef("--%s cannot be 0", command.dimension)
+	}
+	targetValue := any(command.target)
+	if command.appendAtEnd {
+		targetValue = "end"
+	}
+	if dryRunErr := dryRunExit(ctx, flags, command.dryRunOp, map[string]any{
+		"documentId":              docID,
+		"table":                   command.table,
+		string(command.dimension): targetValue,
+		"tab":                     command.tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, loaded, selected, err := loadDocsSelectedTables(ctx, flags, docID, command.tab, command.table)
+	if err != nil {
+		return err
+	}
+	requests := make([]*docs.Request, 0, len(selected))
+	results := make([]docsTableMutationResult, 0, len(selected))
+	for _, target := range selected {
+		req, resolved, buildErr := buildDocsTableDimensionRequest(
+			target.tableWithIndex, command.dimension, command.action, command.target, command.appendAtEnd, loaded.tabID,
+		)
+		if buildErr != nil {
+			return buildErr
+		}
+		requests = append(requests, req)
+		results = append(results, docsTableMutationResult{TableIndex: target.index, Index: resolved})
+	}
+	if _, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests); err != nil {
+		return fmt.Errorf("%s table %s: %w", command.action, command.dimension, err)
+	}
+	return writeDocsTableMutationResult(ctx, docID, loaded.tabID, command.action, string(command.dimension), results)
+}
+
+func (c *DocsTableMergeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	startRow, startCol, endRow, endCol, err := parseDocsTableRange(c.Range)
+	if err != nil {
+		return err
+	}
+	return runDocsTableMergeCommand(ctx, flags, docsTableMergeCommand{
+		docID: c.DocID, table: c.Table, tab: c.Tab, action: mergeOp,
+		startRow: startRow, startCol: startCol, endRow: endRow, endCol: endCol,
+	})
+}
+
+func (c *DocsTableUnmergeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	row, col, err := parseDocsTableCell(c.Cell, "--cell")
+	if err != nil {
+		return err
+	}
+	return runDocsTableMergeCommand(ctx, flags, docsTableMergeCommand{
+		docID: c.DocID, table: c.Table, tab: c.Tab, action: unmergeOp,
+		startRow: row, startCol: col, endRow: row, endCol: col,
+	})
+}
+
+type docsTableMergeCommand struct {
+	docID              string
+	table              string
+	tab                string
+	action             string
+	startRow, startCol int
+	endRow, endCol     int
+}
+
+func runDocsTableMergeCommand(ctx context.Context, flags *RootFlags, command docsTableMergeCommand) error {
+	docID, err := validateDocsTableMutationArgs(command.docID, command.table)
+	if err != nil {
+		return err
+	}
+	rangeValue := formatDocsTableRange(command.startRow, command.startCol, command.endRow, command.endCol)
+	if command.action == unmergeOp {
+		rangeValue = fmt.Sprintf("%d,%d", command.startRow, command.startCol)
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.table-"+command.action, map[string]any{
+		"documentId": docID,
+		"table":      command.table,
+		"range":      rangeValue,
+		"tab":        command.tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, loaded, selected, err := loadDocsSelectedTables(ctx, flags, docID, command.tab, command.table)
+	if err != nil {
+		return err
+	}
+	requests := make([]*docs.Request, 0, len(selected))
+	results := make([]docsTableMutationResult, 0, len(selected))
+	for _, target := range selected {
+		req, buildErr := buildDocsTableMergeRequest(
+			target.tableWithIndex, command.action,
+			command.startRow, command.startCol, command.endRow, command.endCol, loaded.tabID,
+		)
+		if buildErr != nil {
+			return buildErr
+		}
+		requests = append(requests, req)
+		results = append(results, docsTableMutationResult{TableIndex: target.index, Range: rangeValue})
+	}
+	if _, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests); err != nil {
+		return fmt.Errorf("table %s: %w", command.action, err)
+	}
+	return writeDocsTableMutationResult(ctx, docID, loaded.tabID, command.action, "cell", results)
+}
+
+func validateDocsTableMutationArgs(rawDocID, table string) (string, error) {
+	docID := normalizeGoogleID(strings.TrimSpace(rawDocID))
+	if docID == "" {
+		return "", usage("empty docId")
+	}
+	if table == "" {
+		return "", usage("empty --table")
+	}
+	return docID, nil
+}
+
+func loadDocsSelectedTables(
+	ctx context.Context,
+	flags *RootFlags,
+	docID, tab, selector string,
+) (*docs.Service, *docsLoadedTarget, []docsSelectedTable, error) {
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, strings.TrimSpace(tab))
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	selected, err := resolveDocsTableSelector(loaded.target, selector)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	sort.Slice(selected, func(i, j int) bool {
+		return selected[i].startIdx > selected[j].startIdx
+	})
+	return svc, loaded, selected, nil
+}
+
+func resolveDocsTableSelector(doc *docs.Document, raw string) ([]docsSelectedTable, error) {
+	tables := collectAllTablesWithIndex(doc)
+	if len(tables) == 0 {
+		return nil, usage("document has no tables")
+	}
+	if strings.HasPrefix(raw, "text:") {
+		return resolveDocsTableHeaderText(tables, strings.TrimPrefix(raw, "text:"))
+	}
+	syntax := strings.TrimSpace(raw)
+	if syntax == "*" {
+		selected := make([]docsSelectedTable, 0, len(tables))
+		for i, table := range tables {
+			selected = append(selected, docsSelectedTable{tableWithIndex: table, index: i + 1})
+		}
+		return selected, nil
+	}
+	if index, err := strconv.Atoi(syntax); err == nil {
+		if index == 0 {
+			return nil, usage("--table index cannot be 0")
+		}
+		resolved := index
+		if resolved < 0 {
+			resolved = len(tables) + resolved + 1
+		}
+		if resolved < 1 || resolved > len(tables) {
+			return nil, usagef("table %d out of range (document has %d tables)", index, len(tables))
+		}
+		return []docsSelectedTable{{tableWithIndex: tables[resolved-1], index: resolved}}, nil
+	} else if docsTableSelectorLooksNumeric(syntax) {
+		return nil, usagef("invalid table index %q", syntax)
+	}
+
+	return resolveDocsTableHeaderText(tables, raw)
+}
+
+func docsTableSelectorLooksNumeric(value string) bool {
+	if value == "" {
+		return false
+	}
+	if value[0] == '+' || value[0] == '-' {
+		value = value[1:]
+	}
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func resolveDocsTableHeaderText(tables []tableWithIndex, selector string) ([]docsSelectedTable, error) {
+	var matches []docsSelectedTable
+	for i, table := range tables {
+		if docsTableFirstCellText(table.table) == selector {
+			matches = append(matches, docsSelectedTable{tableWithIndex: table, index: i + 1})
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return nil, usagef("no table has first-cell text %q", selector)
+	case 1:
+		return matches, nil
+	default:
+		return nil, usagef("first-cell text %q matches %d tables; use a numeric --table index", selector, len(matches))
+	}
+}
+
+func docsTableFirstCellText(table *docs.Table) string {
+	if table == nil || len(table.TableRows) == 0 || len(table.TableRows[0].TableCells) == 0 {
+		return ""
+	}
+	text, _, _ := getCellText(table.TableRows[0].TableCells[0])
+	return strings.TrimSuffix(text, "\n")
+}
+
+func parseDocsTableInsertAt(raw, dimension string) (int, bool, error) {
+	value := strings.TrimSpace(raw)
+	if strings.EqualFold(value, "end") {
+		return 0, true, nil
+	}
+	index, err := strconv.Atoi(value)
+	if err != nil || index == 0 {
+		return 0, false, usagef("--at must be a non-zero %s index or end", dimension)
+	}
+	return index, false, nil
+}
+
+func parseDocsTableRowValues(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var encoded []json.RawMessage
+	if err := json.Unmarshal([]byte(raw), &encoded); err != nil {
+		return nil, usagef("--values-json must be a JSON string array: %v", err)
+	}
+	if encoded == nil {
+		return nil, usage("--values-json must be a JSON string array")
+	}
+	values := make([]string, len(encoded))
+	for i, value := range encoded {
+		value = json.RawMessage(strings.TrimSpace(string(value)))
+		if len(value) == 0 || value[0] != '"' {
+			return nil, usagef("--values-json element %d must be a string", i)
+		}
+		if err := json.Unmarshal(value, &values[i]); err != nil {
+			return nil, usagef("--values-json element %d must be a string: %v", i, err)
+		}
+	}
+	return values, nil
+}
+
+func buildDocsTableDimensionRequest(
+	target tableWithIndex,
+	dimension docsTableDimension,
+	action string,
+	requested int,
+	appendAtEnd bool,
+	tabID string,
+) (*docs.Request, int, error) {
+	if target.table == nil {
+		return nil, 0, usage("target table is empty")
+	}
+	count := len(target.table.TableRows)
+	if dimension == docsTableDimensionColumn {
+		count = docsTableColumnCount(target.table)
+	}
+	if count < 1 {
+		return nil, 0, usagef("target table has no %ss", dimension)
+	}
+
+	resolved := requested
+	if appendAtEnd {
+		resolved = count + 1
+	} else if resolved < 0 {
+		resolved = count + resolved + 1
+	}
+	switch action {
+	case opDelete:
+		if resolved < 1 || resolved > count {
+			return nil, 0, usagef("%s %d out of range (table has %d %ss)", dimension, requested, count, dimension)
+		}
+		if count == 1 {
+			return nil, 0, usagef("cannot delete the only %s in a table", dimension)
+		}
+	case opInsert:
+		if !appendAtEnd && (resolved < 1 || resolved > count) {
+			return nil, 0, usagef("%s %d out of range for insert (table has %d %ss)", dimension, requested, count, dimension)
+		}
+	default:
+		return nil, 0, usagef("unsupported table %s action %q", dimension, action)
+	}
+
+	rowIndex, columnIndex, err := docsTableDimensionReference(
+		target.table, dimension, action, resolved, appendAtEnd,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	cellLocation := &docs.TableCellLocation{
+		TableStartLocation: &docs.Location{Index: target.startIdx, TabId: tabID},
+		RowIndex:           int64(rowIndex),
+		ColumnIndex:        int64(columnIndex),
+		ForceSendFields:    []string{"RowIndex", "ColumnIndex"},
+	}
+	if dimension == docsTableDimensionRow {
+		if action == opDelete {
+			return &docs.Request{DeleteTableRow: &docs.DeleteTableRowRequest{
+				TableCellLocation: cellLocation,
+			}}, resolved, nil
+		}
+		return &docs.Request{InsertTableRow: &docs.InsertTableRowRequest{
+			TableCellLocation: cellLocation,
+			InsertBelow:       appendAtEnd,
+		}}, resolved, nil
+	}
+
+	if action == opDelete {
+		return &docs.Request{DeleteTableColumn: &docs.DeleteTableColumnRequest{
+			TableCellLocation: cellLocation,
+		}}, resolved, nil
+	}
+	return &docs.Request{InsertTableColumn: &docs.InsertTableColumnRequest{
+		TableCellLocation: cellLocation,
+		InsertRight:       appendAtEnd,
+	}}, resolved, nil
+}
+
+func docsTableDimensionReference(
+	table *docs.Table,
+	dimension docsTableDimension,
+	action string,
+	resolved int,
+	appendAtEnd bool,
+) (int, int, error) {
+	if !docsTableHasRectangularRows(table) {
+		return 0, 0, usagef(
+			"cannot %s table %s on a non-rectangular table; merge/unmerge cells or normalize the table first",
+			action, dimension,
+		)
+	}
+	placements := docsTableCellPlacements(table)
+	if dimension == docsTableDimensionColumn {
+		for _, placement := range placements {
+			switch {
+			case action == opDelete && placement.columnSpan == 1 && placement.columnStart == resolved:
+				return placement.rowStart - 1, resolved - 1, nil
+			case action == opInsert && !appendAtEnd && placement.columnStart == resolved:
+				return placement.rowStart - 1, resolved - 1, nil
+			case action == opInsert && appendAtEnd && placement.columnEnd() == resolved-1:
+				return placement.rowStart - 1, resolved - 2, nil
+			}
+		}
+		if action == opDelete {
+			return 0, 0, usagef("cannot delete column %d because every reference cell spanning it is merged", resolved)
+		}
+		return 0, 0, usagef("cannot insert at column %d because the boundary is inside merged cells", resolved)
+	}
+
+	for _, placement := range placements {
+		switch {
+		case action == opDelete && placement.rowSpan == 1 && placement.rowStart == resolved:
+			return resolved - 1, placement.columnStart - 1, nil
+		case action == opInsert && !appendAtEnd && placement.rowStart == resolved:
+			return resolved - 1, placement.columnStart - 1, nil
+		case action == opInsert && appendAtEnd && placement.rowEnd() == resolved-1:
+			return resolved - 2, placement.columnStart - 1, nil
+		}
+	}
+	if action == opDelete {
+		return 0, 0, usagef("cannot delete row %d because every reference cell spanning it is merged", resolved)
+	}
+	return 0, 0, usagef("cannot insert at row %d because the boundary is inside merged cells", resolved)
+}
+
+func docsTableCellColumnSpan(cell *docs.TableCell) int {
+	if cell != nil && cell.TableCellStyle != nil && cell.TableCellStyle.ColumnSpan > 0 {
+		return int(cell.TableCellStyle.ColumnSpan)
+	}
+	return 1
+}
+
+func docsTableCellRowSpan(cell *docs.TableCell) int {
+	if cell != nil && cell.TableCellStyle != nil && cell.TableCellStyle.RowSpan > 0 {
+		return int(cell.TableCellStyle.RowSpan)
+	}
+	return 1
+}
+
+type docsTableCellPlacement struct {
+	rowStart    int
+	columnStart int
+	rowSpan     int
+	columnSpan  int
+}
+
+func (p docsTableCellPlacement) rowEnd() int {
+	return p.rowStart + p.rowSpan - 1
+}
+
+func (p docsTableCellPlacement) columnEnd() int {
+	return p.columnStart + p.columnSpan - 1
+}
+
+func docsTableCellPlacements(table *docs.Table) []docsTableCellPlacement {
+	if table == nil {
+		return nil
+	}
+	covered := map[[2]int]bool{}
+	placements := make([]docsTableCellPlacement, 0)
+	for rowIndex, row := range table.TableRows {
+		for columnIndex, cell := range row.TableCells {
+			position := [2]int{rowIndex + 1, columnIndex + 1}
+			if covered[position] {
+				continue
+			}
+			placement := docsTableCellPlacement{
+				rowStart:    position[0],
+				columnStart: position[1],
+				rowSpan:     docsTableCellRowSpan(cell),
+				columnSpan:  docsTableCellColumnSpan(cell),
+			}
+			placements = append(placements, placement)
+			for coveredRow := placement.rowStart; coveredRow <= placement.rowEnd(); coveredRow++ {
+				for coveredColumn := placement.columnStart; coveredColumn <= placement.columnEnd(); coveredColumn++ {
+					if coveredRow == placement.rowStart && coveredColumn == placement.columnStart {
+						continue
+					}
+					covered[[2]int{coveredRow, coveredColumn}] = true
+				}
+			}
+		}
+	}
+	return placements
+}
+
+func docsTableHasRectangularRows(table *docs.Table) bool {
+	columns := docsTableColumnCount(table)
+	if table == nil || columns < 1 || len(table.TableRows) == 0 {
+		return false
+	}
+	for _, row := range table.TableRows {
+		if row == nil || len(row.TableCells) != columns {
+			return false
+		}
+	}
+	return true
+}
+
+func docsTableRowBoundaryCrossesMerge(table *docs.Table, row int) bool {
+	for _, placement := range docsTableCellPlacements(table) {
+		if placement.rowStart < row && placement.rowEnd() >= row {
+			return true
+		}
+	}
+	return false
+}
+
+func parseDocsTableRange(raw string) (int, int, int, int, error) {
+	parts := strings.Split(strings.TrimSpace(raw), ":")
+	if len(parts) != 2 {
+		return 0, 0, 0, 0, usage("--range must use r1,c1:r2,c2")
+	}
+	startRow, startCol, err := parseDocsTableCell(parts[0], "--range")
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	endRow, endCol, err := parseDocsTableCell(parts[1], "--range")
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	if endRow < startRow || endCol < startCol {
+		return 0, 0, 0, 0, usage("--range end must not precede its start")
+	}
+	return startRow, startCol, endRow, endCol, nil
+}
+
+func parseDocsTableCell(raw, flag string) (int, int, error) {
+	parts := strings.Split(strings.TrimSpace(raw), ",")
+	if len(parts) != 2 {
+		return 0, 0, usagef("%s must use r,c", flag)
+	}
+	row, rowErr := strconv.Atoi(strings.TrimSpace(parts[0]))
+	col, colErr := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if rowErr != nil || colErr != nil || row < 1 || col < 1 {
+		return 0, 0, usagef("%s coordinates must be positive integers", flag)
+	}
+	return row, col, nil
+}
+
+func buildDocsTableMergeRequest(
+	target tableWithIndex,
+	action string,
+	startRow, startCol, endRow, endCol int,
+	tabID string,
+) (*docs.Request, error) {
+	if err := validateDocsTableRange(target.table, startRow, startCol, endRow, endCol); err != nil {
+		return nil, err
+	}
+	tableRange := &docs.TableRange{
+		TableCellLocation: &docs.TableCellLocation{
+			TableStartLocation: &docs.Location{Index: target.startIdx, TabId: tabID},
+			RowIndex:           int64(startRow - 1),
+			ColumnIndex:        int64(startCol - 1),
+			ForceSendFields:    []string{"RowIndex", "ColumnIndex"},
+		},
+		RowSpan:    int64(endRow - startRow + 1),
+		ColumnSpan: int64(endCol - startCol + 1),
+	}
+	switch action {
+	case mergeOp:
+		return &docs.Request{MergeTableCells: &docs.MergeTableCellsRequest{TableRange: tableRange}}, nil
+	case unmergeOp, splitOp:
+		tableRange.RowSpan = 1
+		tableRange.ColumnSpan = 1
+		return &docs.Request{UnmergeTableCells: &docs.UnmergeTableCellsRequest{TableRange: tableRange}}, nil
+	default:
+		return nil, usagef("unsupported table merge action %q", action)
+	}
+}
+
+func validateDocsTableRange(table *docs.Table, startRow, startCol, endRow, endCol int) error {
+	rows := 0
+	if table != nil {
+		rows = len(table.TableRows)
+	}
+	if startRow < 1 || startRow > rows {
+		return usagef("row %d out of range (table has %d rows)", startRow, rows)
+	}
+	if endRow < startRow || endRow > rows {
+		return usagef("row %d out of range (table has %d rows)", endRow, rows)
+	}
+	columns := docsTableColumnCount(table)
+	if columns == 0 {
+		for _, placement := range docsTableCellPlacements(table) {
+			if placement.columnEnd() > columns {
+				columns = placement.columnEnd()
+			}
+		}
+	}
+	if startCol < 1 || startCol > columns {
+		return usagef("col %d out of range (table has %d columns)", startCol, columns)
+	}
+	if endCol < startCol || endCol > columns {
+		return usagef("col %d out of range (table has %d columns)", endCol, columns)
+	}
+	return nil
+}
+
+func executeDocsTableRequests(
+	ctx context.Context,
+	svc *docs.Service,
+	docID, revisionID string,
+	requests []*docs.Request,
+) (string, error) {
+	_, updatedRevisionID, err := submitBatchedDocsRequestsWithRevision(
+		ctx, svc, docID, requests, &docs.WriteControl{RequiredRevisionId: revisionID},
+	)
+	return updatedRevisionID, err
+}
+
+func populateDocsTableRow(
+	ctx context.Context,
+	svc *docs.Service,
+	docID, tabID, expectedRevisionID string,
+	tableIndex, rowIndex int,
+	values []string,
+) error {
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, tabID)
+	if err != nil {
+		return fmt.Errorf("reload inserted table row: %w", err)
+	}
+	if loaded.full.RevisionId != expectedRevisionID {
+		return fmt.Errorf(
+			"populate inserted table row: document revision changed after row insertion (expected %s, got %s)",
+			expectedRevisionID, loaded.full.RevisionId,
+		)
+	}
+	target, _, err := resolveDocsTableWithIndex(loaded.target, tableIndex)
+	if err != nil {
+		return err
+	}
+	if rowIndex < 1 || rowIndex > len(target.table.TableRows) {
+		return fmt.Errorf("inserted row %d not found after mutation", rowIndex)
+	}
+	row := target.table.TableRows[rowIndex-1]
+	if len(values) != len(row.TableCells) {
+		return fmt.Errorf("inserted row has %d cells, want %d", len(row.TableCells), len(values))
+	}
+	requests := make([]*docs.Request, 0, len(values))
+	for col := len(values) - 1; col >= 0; col-- {
+		if values[col] == "" {
+			continue
+		}
+		cell := row.TableCells[col]
+		if len(cell.Content) == 0 {
+			return fmt.Errorf("inserted row cell %d has no content location", col+1)
+		}
+		requests = append(requests, &docs.Request{InsertText: &docs.InsertTextRequest{
+			Location: &docs.Location{Index: cell.Content[0].StartIndex, TabId: tabID},
+			Text:     values[col],
+		}})
+	}
+	if len(requests) == 0 {
+		return nil
+	}
+	if _, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests); err != nil {
+		return fmt.Errorf("populate inserted table row: %w", err)
+	}
+	return nil
+}
+
+func writeDocsTableMutationResult(
+	ctx context.Context,
+	docID, tabID, action, target string,
+	results []docsTableMutationResult,
+) error {
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].TableIndex < results[j].TableIndex
+	})
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": docID,
+			"action":     action,
+			"target":     target,
+			"updated":    true,
+			"tables":     results,
+		}
+		if len(results) == 1 {
+			payload["tableIndex"] = results[0].TableIndex
+			if results[0].Index > 0 {
+				payload[target] = results[0].Index
+			}
+			if results[0].Range != "" {
+				payload["range"] = results[0].Range
+			}
+		}
+		if tabID != "" {
+			payload["tabId"] = tabID
+		}
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", docID)
+	u.Out().Linef("action\t%s", action)
+	u.Out().Linef("target\t%s", target)
+	for _, result := range results {
+		if result.Range != "" {
+			u.Out().Linef("table\t%d\t%s\t%s", result.TableIndex, target, result.Range)
+		} else {
+			u.Out().Linef("table\t%d\t%s\t%d", result.TableIndex, target, result.Index)
+		}
+	}
+	u.Out().Linef("updated\ttrue")
+	if tabID != "" {
+		u.Out().Linef("tabId\t%s", tabID)
+	}
+	return nil
+}
+
+func formatDocsTableRange(startRow, startCol, endRow, endCol int) string {
+	return fmt.Sprintf("%d,%d:%d,%d", startRow, startCol, endRow, endCol)
+}

--- a/internal/cmd/docs_table_ops_test.go
+++ b/internal/cmd/docs_table_ops_test.go
@@ -1,0 +1,563 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestResolveDocsTableSelector(t *testing.T) {
+	doc := docsTableOpsTestDocument(
+		docsTableOpsTestElement(5, "First", 2, 2),
+		docsTableOpsTestElement(40, "Second", 3, 2),
+	)
+
+	tests := []struct {
+		name      string
+		selector  string
+		wantIndex []int
+	}{
+		{name: "positive", selector: "1", wantIndex: []int{1}},
+		{name: "negative", selector: "-1", wantIndex: []int{2}},
+		{name: "header", selector: "Second", wantIndex: []int{2}},
+		{name: "all", selector: "*", wantIndex: []int{1, 2}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			selected, err := resolveDocsTableSelector(doc, tt.selector)
+			if err != nil {
+				t.Fatalf("resolveDocsTableSelector: %v", err)
+			}
+			if len(selected) != len(tt.wantIndex) {
+				t.Fatalf("selected = %d, want %d", len(selected), len(tt.wantIndex))
+			}
+			for i, want := range tt.wantIndex {
+				if selected[i].index != want {
+					t.Fatalf("selected[%d].index = %d, want %d", i, selected[i].index, want)
+				}
+			}
+		})
+	}
+}
+
+func TestResolveDocsTableSelectorRejectsAmbiguousHeader(t *testing.T) {
+	doc := docsTableOpsTestDocument(
+		docsTableOpsTestElement(5, "Same", 2, 2),
+		docsTableOpsTestElement(40, "Same", 2, 2),
+	)
+	_, err := resolveDocsTableSelector(doc, "Same")
+	if err == nil || !strings.Contains(err.Error(), "matches 2 tables") {
+		t.Fatalf("expected ambiguity error, got %v", err)
+	}
+}
+
+func TestResolveDocsTableSelectorPreservesHeaderWhitespace(t *testing.T) {
+	doc := docsTableOpsTestDocument(docsTableOpsTestElement(5, " Status ", 2, 2))
+	selected, err := resolveDocsTableSelector(doc, " Status ")
+	if err != nil {
+		t.Fatalf("resolve exact whitespace: %v", err)
+	}
+	if len(selected) != 1 || selected[0].index != 1 {
+		t.Fatalf("selected = %#v", selected)
+	}
+	if _, err := resolveDocsTableSelector(doc, "Status"); err == nil {
+		t.Fatal("expected trimmed selector not to match")
+	}
+}
+
+func TestResolveDocsTableSelectorSupportsNumericHeaderText(t *testing.T) {
+	doc := docsTableOpsTestDocument(
+		docsTableOpsTestElement(5, "First", 2, 2),
+		docsTableOpsTestElement(40, "2026", 2, 2),
+	)
+	selected, err := resolveDocsTableSelector(doc, "text:2026")
+	if err != nil {
+		t.Fatalf("resolve numeric header: %v", err)
+	}
+	if len(selected) != 1 || selected[0].index != 2 {
+		t.Fatalf("selected = %#v", selected)
+	}
+}
+
+func TestResolveDocsTableSelectorRejectsNumericOverflow(t *testing.T) {
+	const overflow = "999999999999999999999999999999"
+	doc := docsTableOpsTestDocument(docsTableOpsTestElement(5, overflow, 2, 2))
+	_, err := resolveDocsTableSelector(doc, overflow)
+	if err == nil || !strings.Contains(err.Error(), "invalid table index") {
+		t.Fatalf("expected numeric overflow error, got %v", err)
+	}
+}
+
+func TestBuildDocsTableDimensionRequest(t *testing.T) {
+	target := tableWithIndex{
+		table:    docsTableOpsTestElement(5, "Header", 3, 2).Table,
+		startIdx: 5,
+	}
+
+	rowReq, rowIndex, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionRow, opInsert, 0, true, "tab-1",
+	)
+	if err != nil {
+		t.Fatalf("append row: %v", err)
+	}
+	if rowIndex != 4 {
+		t.Fatalf("row index = %d, want 4", rowIndex)
+	}
+	row := rowReq.InsertTableRow
+	if row == nil || !row.InsertBelow {
+		t.Fatalf("unexpected row request: %#v", rowReq)
+	}
+	if got := row.TableCellLocation; got.RowIndex != 2 || got.ColumnIndex != 0 ||
+		got.TableStartLocation.Index != 5 || got.TableStartLocation.TabId != "tab-1" {
+		t.Fatalf("row location = %#v", got)
+	}
+
+	colReq, colIndex, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionColumn, opDelete, -1, false, "",
+	)
+	if err != nil {
+		t.Fatalf("delete column: %v", err)
+	}
+	if colIndex != 2 {
+		t.Fatalf("column index = %d, want 2", colIndex)
+	}
+	col := colReq.DeleteTableColumn
+	if col == nil || col.TableCellLocation.ColumnIndex != 1 {
+		t.Fatalf("unexpected column request: %#v", colReq)
+	}
+}
+
+func TestBuildDocsTableDimensionRequestAvoidsMergedDeleteAnchor(t *testing.T) {
+	table := docsTableOpsTestElement(5, "Header", 2, 3).Table
+	table.TableRows[0].TableCells[0].TableCellStyle = &docs.TableCellStyle{ColumnSpan: 2}
+	target := tableWithIndex{table: table, startIdx: 5}
+
+	req, _, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionColumn, opDelete, 1, false, "",
+	)
+	if err != nil {
+		t.Fatalf("delete with safe lower-row anchor: %v", err)
+	}
+	if got := req.DeleteTableColumn.TableCellLocation.RowIndex; got != 1 {
+		t.Fatalf("row index = %d, want safe unmerged row 1", got)
+	}
+}
+
+func TestBuildDocsTableDimensionRequestRejectsMergedDeleteAndInsertBoundary(t *testing.T) {
+	table := docsTableOpsTestElement(5, "Header", 2, 3).Table
+	for _, row := range table.TableRows {
+		row.TableCells[0].TableCellStyle = &docs.TableCellStyle{ColumnSpan: 2}
+	}
+	target := tableWithIndex{table: table, startIdx: 5}
+
+	if _, _, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionColumn, opDelete, 1, false, "",
+	); err == nil || !strings.Contains(err.Error(), "every reference cell") {
+		t.Fatalf("expected merged delete rejection, got %v", err)
+	}
+	if _, _, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionColumn, opInsert, 2, false, "",
+	); err == nil || !strings.Contains(err.Error(), "inside merged cells") {
+		t.Fatalf("expected merged insert-boundary rejection, got %v", err)
+	}
+}
+
+func TestBuildDocsTableDimensionRequestRejectsVerticallyMergedRow(t *testing.T) {
+	table := docsTableOpsTestElement(5, "Header", 3, 2).Table
+	for _, cell := range table.TableRows[0].TableCells {
+		cell.TableCellStyle = &docs.TableCellStyle{RowSpan: 2}
+	}
+	target := tableWithIndex{table: table, startIdx: 5}
+
+	if _, _, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionRow, opDelete, 2, false, "",
+	); err == nil || !strings.Contains(err.Error(), "every reference cell") {
+		t.Fatalf("expected merged row delete rejection, got %v", err)
+	}
+	if _, _, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionRow, opInsert, 2, false, "",
+	); err == nil || !strings.Contains(err.Error(), "inside merged cells") {
+		t.Fatalf("expected merged row insert rejection, got %v", err)
+	}
+}
+
+func TestDocsTableCellPlacementsSupportRetainedCoveredCells(t *testing.T) {
+	retained := docsTableOpsTestElement(5, "Header", 1, 3).Table
+	retained.TableRows[0].TableCells[0].TableCellStyle = &docs.TableCellStyle{ColumnSpan: 2}
+	retainedPlacements := docsTableCellPlacements(retained)
+	if len(retainedPlacements) != 2 ||
+		retainedPlacements[0].columnStart != 1 ||
+		retainedPlacements[1].columnStart != 3 {
+		t.Fatalf("retained placements = %#v", retainedPlacements)
+	}
+}
+
+func TestBuildDocsTableDimensionRequestRejectsNonRectangularRows(t *testing.T) {
+	omitted := docsTableOpsTestElement(5, "Header", 1, 3).Table
+	omitted.TableRows[0].TableCells[0].TableCellStyle = &docs.TableCellStyle{ColumnSpan: 2}
+	omitted.TableRows[0].TableCells = []*docs.TableCell{
+		omitted.TableRows[0].TableCells[0],
+		omitted.TableRows[0].TableCells[2],
+	}
+	target := tableWithIndex{table: omitted, startIdx: 5}
+	if _, _, err := buildDocsTableDimensionRequest(
+		target, docsTableDimensionColumn, opDelete, 3, false, "",
+	); err == nil || !strings.Contains(err.Error(), "non-rectangular") {
+		t.Fatalf("expected non-rectangular rejection, got %v", err)
+	}
+}
+
+func TestBuildDocsTableDimensionRequestPreflightsOnlyDimension(t *testing.T) {
+	rowTarget := tableWithIndex{table: docsTableOpsTestElement(5, "Header", 1, 2).Table, startIdx: 5}
+	if _, _, err := buildDocsTableDimensionRequest(
+		rowTarget, docsTableDimensionRow, opDelete, 1, false, "",
+	); err == nil || !strings.Contains(err.Error(), "only row") {
+		t.Fatalf("expected only-row error, got %v", err)
+	}
+
+	colTarget := tableWithIndex{table: docsTableOpsTestElement(5, "Header", 2, 1).Table, startIdx: 5}
+	if _, _, err := buildDocsTableDimensionRequest(
+		colTarget, docsTableDimensionColumn, opDelete, 1, false, "",
+	); err == nil || !strings.Contains(err.Error(), "only column") {
+		t.Fatalf("expected only-column error, got %v", err)
+	}
+}
+
+func TestBuildDocsTableMergeRequestValidatesLogicalColumnCount(t *testing.T) {
+	element := docsTableOpsTestElement(5, "Header", 2, 2)
+	element.Table.Columns = 1
+	target := tableWithIndex{table: element.Table, startIdx: 5}
+
+	_, err := buildDocsTableMergeRequest(target, mergeOp, 1, 1, 2, 2, "")
+	if err == nil || !strings.Contains(err.Error(), "table has 1 columns") {
+		t.Fatalf("expected logical-column validation error, got %v", err)
+	}
+}
+
+func TestValidateDocsTableRangeCountsMergedCellSpans(t *testing.T) {
+	table := docsTableOpsTestElement(5, "Header", 2, 3).Table
+	table.TableRows[1].TableCells[0].TableCellStyle = &docs.TableCellStyle{ColumnSpan: 2}
+
+	if err := validateDocsTableRange(table, 2, 3, 2, 3); err != nil {
+		t.Fatalf("validate logical third column: %v", err)
+	}
+}
+
+func TestDocsTableColumnDeleteAllUsesDescendingDocumentOrder(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsTableOpsTestDocument(
+		docsTableOpsTestElement(5, "First", 2, 2),
+		docsTableOpsTestElement(40, "Second", 2, 2),
+	)
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(&docs.BatchUpdateDocumentResponse{DocumentId: "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsTableColumnDeleteCmd{}
+	err := runKong(t, cmd, []string{"doc1", "--table", "*", "--col=-1"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.WriteControl == nil || got.WriteControl.RequiredRevisionId != "rev-1" {
+		t.Fatalf("write control = %#v", got.WriteControl)
+	}
+	if len(got.Requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(got.Requests))
+	}
+	if first := got.Requests[0].DeleteTableColumn.TableCellLocation.TableStartLocation.Index; first != 40 {
+		t.Fatalf("first table start = %d, want 40", first)
+	}
+	if second := got.Requests[1].DeleteTableColumn.TableCellLocation.TableStartLocation.Index; second != 5 {
+		t.Fatalf("second table start = %d, want 5", second)
+	}
+}
+
+func TestDocsTableRowInsertPopulatesValues(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	before := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 2, 2))
+	after := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 3, 2))
+	after.RevisionId = "rev-2"
+	var batches []docs.BatchUpdateDocumentRequest
+	gets := 0
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			gets++
+			if gets == 1 {
+				_ = json.NewEncoder(w).Encode(before)
+			} else {
+				_ = json.NewEncoder(w).Encode(after)
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			var batch docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			batches = append(batches, batch)
+			revisionID := "rev-2"
+			if len(batches) > 1 {
+				revisionID = "rev-3"
+			}
+			_ = json.NewEncoder(w).Encode(&docs.BatchUpdateDocumentResponse{
+				DocumentId:   "doc1",
+				WriteControl: &docs.WriteControl{RequiredRevisionId: revisionID},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsTableRowInsertCmd{}
+	err := runKong(t, cmd, []string{
+		"doc1", "--table", "*", "--at", "end", "--values-json", `["left","right"]`,
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(batches) != 2 {
+		t.Fatalf("batches = %d, want 2", len(batches))
+	}
+	if batches[0].Requests[0].InsertTableRow == nil {
+		t.Fatalf("first batch = %#v", batches[0].Requests)
+	}
+	if len(batches[1].Requests) != 2 {
+		t.Fatalf("fill requests = %d, want 2", len(batches[1].Requests))
+	}
+	if batches[1].Requests[0].InsertText.Text != "right" || batches[1].Requests[1].InsertText.Text != "left" {
+		t.Fatalf("fill request order = %#v", batches[1].Requests)
+	}
+	if batches[1].WriteControl == nil || batches[1].WriteControl.RequiredRevisionId != "rev-2" {
+		t.Fatalf("fill write control = %#v", batches[1].WriteControl)
+	}
+}
+
+func TestDocsTableRowInsertValuesRejectsMultipleSelectedTables(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsTableOpsTestDocument(
+		docsTableOpsTestElement(5, "First", 2, 2),
+		docsTableOpsTestElement(40, "Second", 2, 2),
+	)
+	postCount := 0
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(doc)
+			return
+		}
+		if r.Method == http.MethodPost {
+			postCount++
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsTableRowInsertCmd{}
+	err := runKong(t, cmd, []string{
+		"doc1", "--table", "*", "--at", "end", "--values-json", `["left","right"]`,
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "exactly one selected table") {
+		t.Fatalf("expected selection-count error, got %v", err)
+	}
+	if postCount != 0 {
+		t.Fatalf("post count = %d, want 0", postCount)
+	}
+}
+
+func TestDocsTableRowInsertValuesRejectsVerticalMergeBoundary(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	doc := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 3, 2))
+	doc.Body.Content[0].Table.TableRows[0].TableCells[0].TableCellStyle = &docs.TableCellStyle{RowSpan: 2}
+	postCount := 0
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(doc)
+			return
+		}
+		if r.Method == http.MethodPost {
+			postCount++
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsTableRowInsertCmd{}
+	err := runKong(t, cmd, []string{
+		"doc1", "--table", "1", "--at", "2", "--values-json", `["left","right"]`,
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "vertically merged cell") {
+		t.Fatalf("expected vertical merge boundary error, got %v", err)
+	}
+	if postCount != 0 {
+		t.Fatalf("post count = %d, want 0", postCount)
+	}
+}
+
+func TestDocsTableRowInsertValuesRejectsConcurrentRevision(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	before := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 2, 2))
+	after := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 3, 2))
+	after.RevisionId = "rev-collaborator"
+	batchCount := 0
+	gets := 0
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			gets++
+			if gets == 1 {
+				_ = json.NewEncoder(w).Encode(before)
+			} else {
+				_ = json.NewEncoder(w).Encode(after)
+			}
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			batchCount++
+			_ = json.NewEncoder(w).Encode(&docs.BatchUpdateDocumentResponse{
+				DocumentId:   "doc1",
+				WriteControl: &docs.WriteControl{RequiredRevisionId: "rev-2"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsTableRowInsertCmd{}
+	err := runKong(t, cmd, []string{
+		"doc1", "--table", "1", "--at", "end", "--values-json", `["left","right"]`,
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "document revision changed") {
+		t.Fatalf("expected concurrent revision error, got %v", err)
+	}
+	if batchCount != 1 {
+		t.Fatalf("batch count = %d, want structural batch only", batchCount)
+	}
+}
+
+func TestParseDocsTableRowValuesRejectsNull(t *testing.T) {
+	if _, err := parseDocsTableRowValues("null"); err == nil {
+		t.Fatal("expected null rejection")
+	}
+	if _, err := parseDocsTableRowValues(`["left",null]`); err == nil || !strings.Contains(err.Error(), "element 1") {
+		t.Fatalf("expected null element rejection, got %v", err)
+	}
+	if _, err := parseDocsTableRowValues(`["left",2]`); err == nil || !strings.Contains(err.Error(), "element 1") {
+		t.Fatalf("expected numeric element rejection, got %v", err)
+	}
+}
+
+func TestExecuteDocsTableRequestsSplitsAtAPICap(t *testing.T) {
+	var batches []docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		var batch docs.BatchUpdateDocumentRequest
+		if err := json.NewDecoder(r.Body).Decode(&batch); err != nil {
+			t.Fatalf("decode batch: %v", err)
+		}
+		batches = append(batches, batch)
+		revisionID := "rev-2"
+		if len(batches) > 1 {
+			revisionID = "rev-3"
+		}
+		_ = json.NewEncoder(w).Encode(&docs.BatchUpdateDocumentResponse{
+			DocumentId:   "doc1",
+			WriteControl: &docs.WriteControl{RequiredRevisionId: revisionID},
+		})
+	})
+	defer cleanup()
+
+	requests := make([]*docs.Request, docsBatchUpdateRequestCap+1)
+	for i := range requests {
+		requests[i] = &docs.Request{InsertTableRow: &docs.InsertTableRowRequest{}}
+	}
+	if _, err := executeDocsTableRequests(context.Background(), docSvc, "doc1", "rev-1", requests); err != nil {
+		t.Fatalf("executeDocsTableRequests: %v", err)
+	}
+	if len(batches) != 2 || len(batches[0].Requests) != docsBatchUpdateRequestCap || len(batches[1].Requests) != 1 {
+		t.Fatalf("batch sizes = %d/%d/%d", len(batches), len(batches[0].Requests), len(batches[1].Requests))
+	}
+	if batches[0].WriteControl == nil || batches[0].WriteControl.RequiredRevisionId != "rev-1" {
+		t.Fatalf("first write control = %#v", batches[0].WriteControl)
+	}
+	if batches[1].WriteControl == nil || batches[1].WriteControl.RequiredRevisionId != "rev-2" {
+		t.Fatalf("second write control = %#v, want rev-2", batches[1].WriteControl)
+	}
+}
+
+func docsTableOpsTestDocument(elements ...*docs.StructuralElement) *docs.Document {
+	return &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev-1",
+		Body:       &docs.Body{Content: elements},
+	}
+}
+
+func docsTableOpsTestElement(start int64, header string, rows, cols int) *docs.StructuralElement {
+	next := start + 1
+	tableRows := make([]*docs.TableRow, rows)
+	for row := 0; row < rows; row++ {
+		cells := make([]*docs.TableCell, cols)
+		for col := 0; col < cols; col++ {
+			text := ""
+			if row == 0 && col == 0 {
+				text = header
+			}
+			cellStart := next
+			cellEnd := cellStart + int64(len(text)) + 1
+			cells[col] = &docs.TableCell{Content: []*docs.StructuralElement{{
+				StartIndex: cellStart,
+				EndIndex:   cellEnd,
+				Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{{
+					StartIndex: cellStart,
+					EndIndex:   cellEnd,
+					TextRun:    &docs.TextRun{Content: text + "\n"},
+				}}},
+			}}}
+			next = cellEnd
+		}
+		tableRows[row] = &docs.TableRow{TableCells: cells}
+	}
+	return &docs.StructuralElement{
+		StartIndex: start,
+		EndIndex:   next,
+		Table: &docs.Table{
+			Rows:      int64(rows),
+			Columns:   int64(cols),
+			TableRows: tableRows,
+		},
+	}
+}

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -152,6 +152,14 @@ docs:
   edit: false
   sed: false
   clear: false
+  table-row:
+    insert: false
+    delete: false
+  table-column:
+    insert: false
+    delete: false
+  table-merge: false
+  table-unmerge: false
   structure: true
   named-range:
     list: true

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -157,6 +157,14 @@ docs:
   edit: false
   sed: false
   clear: false
+  table-row:
+    insert: false
+    delete: false
+  table-column:
+    insert: false
+    delete: false
+  table-merge: false
+  table-unmerge: false
   structure: true
   named-range:
     list: true


### PR DESCRIPTION
## Summary

- add direct Docs table row/column insert/delete and merge/unmerge commands
- support index, negative index, exact first-cell text, `text:` disambiguation, `*`, and tab selection
- share request builders with `docs sed`, remove duplicate mutation paths, and preserve revision control across capped batches
- reject unsafe merged/non-rectangular references before mutation

## Proof

- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make ci`
- autoreview clean: no accepted/actionable findings
- disposable live Docs proof on `clawdbot@gmail.com`:
  - exact-header and all-table row/column mutations
  - row values with raw readback and revision binding
  - merge/unmerge provider span readback
  - safe horizontal/vertical merged-cell anchors
  - destructive merged-cell and valued vertical-boundary rejection
  - tab-local mutation
  - whitespace, numeric, and ambiguous header selection
  - all test Docs moved to trash

Closes #686
