### PR TITLE
feat(sheets): add table-aware dimension deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Sheets: add `sheets validation` get/set/clear commands for dropdown, checkbox, number, date, range, and custom-formula rules, and preserve table-managed dropdowns during validation-only copy/paste. (#710) — thanks @chrischall.
+- Sheets: add table-aware `sheets delete-dimension` for deleting row or column spans while preserving intersecting table objects and remaining data. (#711) — thanks @chrischall.
 - Docs: add direct `docs table-row`, `docs table-column`, `docs table-merge`, and `docs table-unmerge` commands with index, header-text, all-table, and tab-aware selection. (#686) — thanks @sebsnyk.
 - Docs: add `docs named-range` create/list/delete/replace commands for durable, tab-aware document anchors. (#692) — thanks @sebsnyk.
 - Gmail: report attached filenames and byte sizes in JSON results for send and draft create/update. (#716) — thanks @chrischall.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -517,6 +517,7 @@ Generated from `gog schema --json`.
     - [`gog sheets (sheet) copy (cp,duplicate) <spreadsheetId> <title> [flags]`](commands/gog-sheets-copy.md) - Copy a Google Sheet
     - [`gog sheets (sheet) copy-paste (fill,copy-range) <spreadsheetId> <source> <dest> [flags]`](commands/gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
     - [`gog sheets (sheet) create (new) <title> [flags]`](commands/gog-sheets-create.md) - Create a new spreadsheet
+    - [`gog sheets (sheet) delete-dimension (delete-dim) --dimension=STRING <spreadsheetId> <rangeOrSheet> [flags]`](commands/gog-sheets-delete-dimension.md) - Delete rows or columns while preserving intersecting tables
     - [`gog sheets (sheet) delete-tab (delete-sheet) <spreadsheetId> <tabName>`](commands/gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
     - [`gog sheets (sheet) export (download,dl) <spreadsheetId> [flags]`](commands/gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive
     - [`gog sheets (sheet) find-replace <spreadsheetId> <find> <replace> [flags]`](commands/gog-sheets-find-replace.md) - Find and replace text across a spreadsheet

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 614.
+Generated pages: 615.
 
 ## Top-level Commands
 
@@ -569,6 +569,7 @@ Generated pages: 614.
     - [gog sheets copy](gog-sheets-copy.md) - Copy a Google Sheet
     - [gog sheets copy-paste](gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
     - [gog sheets create](gog-sheets-create.md) - Create a new spreadsheet
+    - [gog sheets delete-dimension](gog-sheets-delete-dimension.md) - Delete rows or columns while preserving intersecting tables
     - [gog sheets delete-tab](gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
     - [gog sheets export](gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive
     - [gog sheets find-replace](gog-sheets-find-replace.md) - Find and replace text across a spreadsheet

--- a/docs/commands/gog-sheets-delete-dimension.md
+++ b/docs/commands/gog-sheets-delete-dimension.md
@@ -1,0 +1,48 @@
+# `gog sheets delete-dimension`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Delete rows or columns while preserving intersecting tables
+
+## Usage
+
+```bash
+gog sheets (sheet) delete-dimension (delete-dim) --dimension=STRING <spreadsheetId> <rangeOrSheet> [flags]
+```
+
+## Parent
+
+- [gog sheets](gog-sheets.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--dimension` | `string` |  | Dimension to delete: ROWS or COLUMNS |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--end` | `int64` |  | Last row/column to delete (1-based, inclusive; required with a sheet target) |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--start` | `int64` |  | First row/column to delete (1-based, inclusive; required with a sheet target) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog sheets](gog-sheets.md)
+- [Command index](README.md)

--- a/docs/commands/gog-sheets.md
+++ b/docs/commands/gog-sheets.md
@@ -26,6 +26,7 @@ gog sheets (sheet) <command> [flags]
 - [gog sheets copy](gog-sheets-copy.md) - Copy a Google Sheet
 - [gog sheets copy-paste](gog-sheets-copy-paste.md) - Copy a range's values/formulas/format to another range (tiles to fill down/across)
 - [gog sheets create](gog-sheets-create.md) - Create a new spreadsheet
+- [gog sheets delete-dimension](gog-sheets-delete-dimension.md) - Delete rows or columns while preserving intersecting tables
 - [gog sheets delete-tab](gog-sheets-delete-tab.md) - Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)
 - [gog sheets export](gog-sheets-export.md) - Export a Google Sheet (pdf|xlsx|csv) via Drive
 - [gog sheets find-replace](gog-sheets-find-replace.md) - Find and replace text across a spreadsheet

--- a/docs/sheets-tables.md
+++ b/docs/sheets-tables.md
@@ -121,6 +121,24 @@ clear without touching auth or the Sheets API:
 gog sheets table clear "$spreadsheet_id" Tasks --dry-run --json
 ```
 
+## Delete Rows Or Columns
+
+Use `sheets delete-dimension` to remove rows or columns without deleting an
+intersecting structured table:
+
+```bash
+gog sheets delete-dimension "$spreadsheet_id" Sheet1 \
+  --dimension ROWS --start 2 --end 4 --force
+gog sheets delete-dimension "$spreadsheet_id" 'Sheet1!B:C' \
+  --dimension COLUMNS --force
+```
+
+Indexes are 1-based and inclusive. A sheet target requires both `--start` and
+`--end`; an explicitly sheet-qualified row or column range supplies them
+directly. Intersecting table ranges are resized in the same atomic Sheets batch,
+preserving the table object and remaining data. The command refuses a deletion
+that would remove a table's entire row or column extent.
+
 ## Delete A Table
 
 The Sheets API deletes both the table object and every cell in its range. There
@@ -157,3 +175,4 @@ used blindly.
 - [`gog sheets table append`](commands/gog-sheets-table-append.md)
 - [`gog sheets table clear`](commands/gog-sheets-table-clear.md)
 - [`gog sheets table delete`](commands/gog-sheets-table-delete.md)
+- [`gog sheets delete-dimension`](commands/gog-sheets-delete-dimension.md)

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -23,6 +23,8 @@ const (
 	sheetsConditionOneOfList      = "ONE_OF_LIST"
 	sheetsTypeDropdown            = "DROPDOWN"
 	sheetsTypeText                = "TEXT"
+	sheetsDimensionRows           = "ROWS"
+	sheetsDimensionColumns        = "COLUMNS"
 )
 
 // cleanRange removes shell escape sequences from range arguments.
@@ -32,40 +34,41 @@ func cleanRange(r string) string {
 }
 
 type SheetsCmd struct {
-	Get           SheetsGetCmd           `cmd:"" name:"get" aliases:"read,show" help:"Get values from a range"`
-	Update        SheetsUpdateCmd        `cmd:"" name:"update" aliases:"edit,set" help:"Update values in a range"`
-	BatchUpdate   SheetsBatchUpdateCmd   `cmd:"" name:"batch-update" aliases:"batch" help:"Update values in multiple ranges with one API request"`
-	Append        SheetsAppendCmd        `cmd:"" name:"append" aliases:"add" help:"Append values to a range"`
-	Insert        SheetsInsertCmd        `cmd:"" name:"insert" help:"Insert empty rows or columns into a sheet"`
-	Clear         SheetsClearCmd         `cmd:"" name:"clear" help:"Clear values in a range"`
-	Format        SheetsFormatCmd        `cmd:"" name:"format" help:"Apply cell formatting to a range"`
-	Conditional   SheetsConditionalCmd   `cmd:"" name:"conditional-format" aliases:"cf,conditional-formats" help:"Manage conditional formatting rules"`
-	Validation    SheetsValidationCmd    `cmd:"" name:"validation" aliases:"data-validation,validations" help:"Manage cell data validation rules"`
-	Banding       SheetsBandingCmd       `cmd:"" name:"banding" aliases:"banded-ranges" help:"Manage alternating color banding"`
-	Merge         SheetsMergeCmd         `cmd:"" name:"merge" help:"Merge cells in a range"`
-	Unmerge       SheetsUnmergeCmd       `cmd:"" name:"unmerge" help:"Unmerge cells in a range"`
-	CopyPaste     SheetsCopyPasteCmd     `cmd:"" name:"copy-paste" aliases:"fill,copy-range" help:"Copy a range's values/formulas/format to another range (tiles to fill down/across)"`
-	NumberFormat  SheetsNumberFormatCmd  `cmd:"" name:"number-format" help:"Apply number format to a range"`
-	Freeze        SheetsFreezeCmd        `cmd:"" name:"freeze" help:"Freeze rows and columns on a sheet"`
-	ResizeColumns SheetsResizeColumnsCmd `cmd:"" name:"resize-columns" help:"Resize sheet columns"`
-	ResizeRows    SheetsResizeRowsCmd    `cmd:"" name:"resize-rows" help:"Resize sheet rows"`
-	ReadFormat    SheetsReadFormatCmd    `cmd:"" name:"read-format" aliases:"get-format,format-read" help:"Read cell formatting from a range"`
-	Notes         SheetsNotesCmd         `cmd:"" name:"notes" help:"Get cell notes from a range"`
-	UpdateNote    SheetsUpdateNoteCmd    `cmd:"" name:"update-note" aliases:"set-note" help:"Set or clear a cell note"`
-	FindReplace   SheetsFindReplaceCmd   `cmd:"" name:"find-replace" help:"Find and replace text across a spreadsheet"`
-	Links         SheetsLinksCmd         `cmd:"" name:"links" aliases:"hyperlinks" help:"Get or set cell hyperlinks"`
-	Named         SheetsNamedRangesCmd   `cmd:"" name:"named-ranges" aliases:"namedranges,nr" help:"Manage named ranges"`
-	Table         SheetsTableCmd         `cmd:"" name:"table" aliases:"tables" help:"Manage Google Sheets tables"`
-	Metadata      SheetsMetadataCmd      `cmd:"" name:"metadata" aliases:"info" help:"Get spreadsheet metadata"`
-	Raw           SheetsRawCmd           `cmd:"" name:"raw" help:"Dump raw Google Sheets API response as JSON (Spreadsheets.Get; lossless; for scripting and LLM consumption)"`
-	Create        SheetsCreateCmd        `cmd:"" name:"create" aliases:"new" help:"Create a new spreadsheet"`
-	Copy          SheetsCopyCmd          `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Sheet"`
-	Export        SheetsExportCmd        `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Sheet (pdf|xlsx|csv) via Drive"`
-	Chart         SheetsChartCmd         `cmd:"" name:"chart" aliases:"charts" help:"Manage spreadsheet charts"`
-	AddTab        SheetsAddTabCmd        `cmd:"" name:"add-tab" aliases:"add-sheet" help:"Add a new tab/sheet to a spreadsheet"`
-	RenameTab     SheetsRenameTabCmd     `cmd:"" name:"rename-tab" aliases:"rename-sheet" help:"Rename a tab/sheet in a spreadsheet"`
-	DeleteTab     SheetsDeleteTabCmd     `cmd:"" name:"delete-tab" aliases:"delete-sheet" help:"Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)"`
-	ReorderTab    SheetsReorderTabCmd    `cmd:"" name:"reorder-tab" aliases:"move-tab,reorder-sheet,move-sheet" help:"Move a tab/sheet to a specific 0-based position in the spreadsheet"`
+	Get           SheetsGetCmd             `cmd:"" name:"get" aliases:"read,show" help:"Get values from a range"`
+	Update        SheetsUpdateCmd          `cmd:"" name:"update" aliases:"edit,set" help:"Update values in a range"`
+	BatchUpdate   SheetsBatchUpdateCmd     `cmd:"" name:"batch-update" aliases:"batch" help:"Update values in multiple ranges with one API request"`
+	Append        SheetsAppendCmd          `cmd:"" name:"append" aliases:"add" help:"Append values to a range"`
+	Insert        SheetsInsertCmd          `cmd:"" name:"insert" help:"Insert empty rows or columns into a sheet"`
+	DeleteDim     SheetsDeleteDimensionCmd `cmd:"" name:"delete-dimension" aliases:"delete-dim" help:"Delete rows or columns while preserving intersecting tables"`
+	Clear         SheetsClearCmd           `cmd:"" name:"clear" help:"Clear values in a range"`
+	Format        SheetsFormatCmd          `cmd:"" name:"format" help:"Apply cell formatting to a range"`
+	Conditional   SheetsConditionalCmd     `cmd:"" name:"conditional-format" aliases:"cf,conditional-formats" help:"Manage conditional formatting rules"`
+	Validation    SheetsValidationCmd      `cmd:"" name:"validation" aliases:"data-validation,validations" help:"Manage cell data validation rules"`
+	Banding       SheetsBandingCmd         `cmd:"" name:"banding" aliases:"banded-ranges" help:"Manage alternating color banding"`
+	Merge         SheetsMergeCmd           `cmd:"" name:"merge" help:"Merge cells in a range"`
+	Unmerge       SheetsUnmergeCmd         `cmd:"" name:"unmerge" help:"Unmerge cells in a range"`
+	CopyPaste     SheetsCopyPasteCmd       `cmd:"" name:"copy-paste" aliases:"fill,copy-range" help:"Copy a range's values/formulas/format to another range (tiles to fill down/across)"`
+	NumberFormat  SheetsNumberFormatCmd    `cmd:"" name:"number-format" help:"Apply number format to a range"`
+	Freeze        SheetsFreezeCmd          `cmd:"" name:"freeze" help:"Freeze rows and columns on a sheet"`
+	ResizeColumns SheetsResizeColumnsCmd   `cmd:"" name:"resize-columns" help:"Resize sheet columns"`
+	ResizeRows    SheetsResizeRowsCmd      `cmd:"" name:"resize-rows" help:"Resize sheet rows"`
+	ReadFormat    SheetsReadFormatCmd      `cmd:"" name:"read-format" aliases:"get-format,format-read" help:"Read cell formatting from a range"`
+	Notes         SheetsNotesCmd           `cmd:"" name:"notes" help:"Get cell notes from a range"`
+	UpdateNote    SheetsUpdateNoteCmd      `cmd:"" name:"update-note" aliases:"set-note" help:"Set or clear a cell note"`
+	FindReplace   SheetsFindReplaceCmd     `cmd:"" name:"find-replace" help:"Find and replace text across a spreadsheet"`
+	Links         SheetsLinksCmd           `cmd:"" name:"links" aliases:"hyperlinks" help:"Get or set cell hyperlinks"`
+	Named         SheetsNamedRangesCmd     `cmd:"" name:"named-ranges" aliases:"namedranges,nr" help:"Manage named ranges"`
+	Table         SheetsTableCmd           `cmd:"" name:"table" aliases:"tables" help:"Manage Google Sheets tables"`
+	Metadata      SheetsMetadataCmd        `cmd:"" name:"metadata" aliases:"info" help:"Get spreadsheet metadata"`
+	Raw           SheetsRawCmd             `cmd:"" name:"raw" help:"Dump raw Google Sheets API response as JSON (Spreadsheets.Get; lossless; for scripting and LLM consumption)"`
+	Create        SheetsCreateCmd          `cmd:"" name:"create" aliases:"new" help:"Create a new spreadsheet"`
+	Copy          SheetsCopyCmd            `cmd:"" name:"copy" aliases:"cp,duplicate" help:"Copy a Google Sheet"`
+	Export        SheetsExportCmd          `cmd:"" name:"export" aliases:"download,dl" help:"Export a Google Sheet (pdf|xlsx|csv) via Drive"`
+	Chart         SheetsChartCmd           `cmd:"" name:"chart" aliases:"charts" help:"Manage spreadsheet charts"`
+	AddTab        SheetsAddTabCmd          `cmd:"" name:"add-tab" aliases:"add-sheet" help:"Add a new tab/sheet to a spreadsheet"`
+	RenameTab     SheetsRenameTabCmd       `cmd:"" name:"rename-tab" aliases:"rename-sheet" help:"Rename a tab/sheet in a spreadsheet"`
+	DeleteTab     SheetsDeleteTabCmd       `cmd:"" name:"delete-tab" aliases:"delete-sheet" help:"Delete a tab/sheet from a spreadsheet (use --force to skip confirmation)"`
+	ReorderTab    SheetsReorderTabCmd      `cmd:"" name:"reorder-tab" aliases:"move-tab,reorder-sheet,move-sheet" help:"Move a tab/sheet to a specific 0-based position in the spreadsheet"`
 }
 
 type SheetsExportCmd struct {

--- a/internal/cmd/sheets_a1.go
+++ b/internal/cmd/sheets_a1.go
@@ -189,12 +189,17 @@ func colLettersToIndex(letters string) (int, error) {
 	}
 
 	col := 0
+	maxInt := int(^uint(0) >> 1)
 	for i := 0; i < len(letters); i++ {
 		ch := letters[i]
 		if ch < 'A' || ch > 'Z' {
 			return 0, fmt.Errorf("invalid column %q", letters)
 		}
-		col = col*26 + int(ch-'A'+1)
+		digit := int(ch - 'A' + 1)
+		if col > (maxInt-digit)/26 {
+			return 0, fmt.Errorf("column %q is too large", letters)
+		}
+		col = col*26 + digit
 	}
 	return col, nil
 }

--- a/internal/cmd/sheets_a1_test.go
+++ b/internal/cmd/sheets_a1_test.go
@@ -78,4 +78,10 @@ func TestParseA1Range(t *testing.T) {
 			t.Fatalf("unexpected range: %#v", r)
 		}
 	})
+
+	t.Run("column overflow", func(t *testing.T) {
+		if _, err := parseA1Range("Sheet1!GKGWBYLWRXTLPQ1"); err == nil {
+			t.Fatal("expected oversized column error")
+		}
+	})
 }

--- a/internal/cmd/sheets_delete_dimension.go
+++ b/internal/cmd/sheets_delete_dimension.go
@@ -1,0 +1,366 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"google.golang.org/api/sheets/v4"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type SheetsDeleteDimensionCmd struct {
+	SpreadsheetID string `arg:"" name:"spreadsheetId" help:"Spreadsheet ID"`
+	Target        string `arg:"" name:"rangeOrSheet" help:"Sheet name, or row/column range such as Sheet1!2:4 or Sheet1!B:C"`
+	Dimension     string `name:"dimension" help:"Dimension to delete: ROWS or COLUMNS" required:""`
+	Start         int64  `name:"start" help:"First row/column to delete (1-based, inclusive; required with a sheet target)"`
+	End           int64  `name:"end" help:"Last row/column to delete (1-based, inclusive; required with a sheet target)"`
+}
+
+type sheetsDeleteDimensionSpec struct {
+	SheetName  string
+	Dimension  string
+	Label      string
+	StartIndex int64
+	EndIndex   int64
+}
+
+type sheetsDeleteDimensionTable struct {
+	TableID  string            `json:"tableId"`
+	Name     string            `json:"name,omitempty"`
+	BeforeA1 string            `json:"beforeA1"`
+	AfterA1  string            `json:"afterA1"`
+	Range    *sheets.GridRange `json:"range"`
+}
+
+func (c *SheetsDeleteDimensionCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	spreadsheetID := normalizeGoogleID(strings.TrimSpace(c.SpreadsheetID))
+	if spreadsheetID == "" {
+		return usage("empty spreadsheetId")
+	}
+
+	spec, err := parseSheetsDeleteDimensionSpec(c.Target, c.Dimension, c.Start, c.End)
+	if err != nil {
+		return err
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "sheets.delete-dimension", map[string]any{
+		"spreadsheet_id": spreadsheetID,
+		"target":         strings.TrimSpace(c.Target),
+		"sheet":          spec.SheetName,
+		"dimension":      spec.Dimension,
+		"start":          spec.StartIndex + 1,
+		"end":            spec.EndIndex,
+		"start_index":    spec.StartIndex,
+		"end_index":      spec.EndIndex,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := newSheetsService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	catalog, tables, err := fetchSheetsDeleteDimensionMetadata(ctx, svc, spreadsheetID)
+	if err != nil {
+		return err
+	}
+	sheetID, sheetTitle, err := resolveSheetIDByNameOrFirstWithCatalog(catalog, spec.SheetName)
+	if err != nil {
+		return err
+	}
+	props := findSheetPropertiesByID(catalog, sheetID)
+	if props == nil {
+		return fmt.Errorf("sheet metadata disappeared (id=%d)", sheetID)
+	}
+	if boundsErr := validateSheetsDeleteDimensionBounds(spec, props); boundsErr != nil {
+		return boundsErr
+	}
+
+	tableUpdates, err := planSheetsDeleteDimensionTables(tables, sheetID, sheetTitle, spec)
+	if err != nil {
+		return err
+	}
+	if err := confirmDestructiveChecked(
+		ctx,
+		flagsWithoutDryRun(flags),
+		fmt.Sprintf("delete %s %d-%d from sheet %q", spec.Label, spec.StartIndex+1, spec.EndIndex, sheetTitle),
+	); err != nil {
+		return err
+	}
+
+	dimRange := &sheets.DimensionRange{
+		SheetId:    sheetID,
+		Dimension:  spec.Dimension,
+		StartIndex: spec.StartIndex,
+		EndIndex:   spec.EndIndex,
+	}
+	forceSendDimensionRangeZeroes(dimRange)
+	requests := []*sheets.Request{{
+		DeleteDimension: &sheets.DeleteDimensionRequest{Range: dimRange},
+	}}
+	for _, table := range tableUpdates {
+		requests = append(requests, &sheets.Request{
+			UpdateTable: &sheets.UpdateTableRequest{
+				Table: &sheets.Table{
+					TableId: table.TableID,
+					Range:   table.Range,
+				},
+				Fields: "range",
+			},
+		})
+	}
+
+	if _, err := svc.Spreadsheets.BatchUpdate(spreadsheetID, &sheets.BatchUpdateSpreadsheetRequest{
+		Requests: requests,
+	}).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("delete sheet dimension: %w", err)
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"spreadsheetId": spreadsheetID,
+			"sheet":         sheetTitle,
+			"sheetId":       sheetID,
+			"dimension":     spec.Dimension,
+			"start":         spec.StartIndex + 1,
+			"end":           spec.EndIndex,
+			"startIndex":    spec.StartIndex,
+			"endIndex":      spec.EndIndex,
+			"tables":        tableUpdates,
+		})
+	}
+
+	count := spec.EndIndex - spec.StartIndex
+	u.Out().Linef("Deleted %d %s from %q (%d-%d); resized %d table(s)",
+		count, spec.Label, sheetTitle, spec.StartIndex+1, spec.EndIndex, len(tableUpdates))
+	return nil
+}
+
+func parseSheetsDeleteDimensionSpec(target, dimension string, start, end int64) (sheetsDeleteDimensionSpec, error) {
+	target = cleanRange(strings.TrimSpace(target))
+	if target == "" {
+		return sheetsDeleteDimensionSpec{}, usage("empty rangeOrSheet")
+	}
+
+	spec := sheetsDeleteDimensionSpec{}
+	switch strings.ToUpper(strings.TrimSpace(dimension)) {
+	case "ROW", "ROWS":
+		spec.Dimension = sheetsDimensionRows
+		spec.Label = "rows"
+	case "COL", "COLS", "COLUMN", "COLUMNS":
+		spec.Dimension = sheetsDimensionColumns
+		spec.Label = "columns"
+	default:
+		return sheetsDeleteDimensionSpec{}, usagef("dimension must be ROWS or COLUMNS, got %q", dimension)
+	}
+
+	if start == 0 && end == 0 {
+		if !strings.Contains(target, "!") {
+			return sheetsDeleteDimensionSpec{}, usage("sheet targets require both --start and --end; range targets must include a sheet name")
+		}
+		var span dimensionSpan
+		var err error
+		if spec.Dimension == sheetsDimensionRows {
+			span, err = parseRowsSpan(target, "delete-dimension")
+		} else {
+			span, err = parseColumnsSpan(target, "delete-dimension")
+		}
+		if err != nil {
+			return sheetsDeleteDimensionSpec{}, usagef(
+				"sheet targets require both --start and --end; otherwise provide a matching row/column range: %v",
+				err,
+			)
+		}
+		spec.SheetName = span.SheetName
+		spec.StartIndex = span.StartIndex
+		spec.EndIndex = span.EndIndex
+		return spec, nil
+	}
+	if start == 0 || end == 0 {
+		return sheetsDeleteDimensionSpec{}, usage("provide both --start and --end")
+	}
+	if start < 1 {
+		return sheetsDeleteDimensionSpec{}, usage("start must be >= 1")
+	}
+	if end < start {
+		return sheetsDeleteDimensionSpec{}, usage("end must be >= start")
+	}
+
+	spec.SheetName = target
+	spec.StartIndex = start - 1
+	spec.EndIndex = end
+	return spec, nil
+}
+
+func fetchSheetsDeleteDimensionMetadata(
+	ctx context.Context,
+	svc *sheets.Service,
+	spreadsheetID string,
+) (*spreadsheetRangeCatalog, []*sheets.Table, error) {
+	call := svc.Spreadsheets.Get(spreadsheetID).
+		Fields("sheets(properties(sheetId,title,index,gridProperties(rowCount,columnCount)),tables(tableId,name,range))")
+	if ctx != nil {
+		call = call.Context(ctx)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return nil, nil, fmt.Errorf("get spreadsheet dimensions and tables: %w", err)
+	}
+
+	catalog := &spreadsheetRangeCatalog{
+		SheetIDsByTitle: make(map[string]int64, len(resp.Sheets)),
+		SheetTitlesByID: make(map[int64]string, len(resp.Sheets)),
+		Sheets:          make([]*sheets.SheetProperties, 0, len(resp.Sheets)),
+	}
+	tables := make([]*sheets.Table, 0)
+	for _, sheet := range resp.Sheets {
+		if sheet == nil || sheet.Properties == nil {
+			continue
+		}
+		props := sheet.Properties
+		catalog.Sheets = append(catalog.Sheets, props)
+		if props.Title != "" {
+			catalog.SheetIDsByTitle[props.Title] = props.SheetId
+			catalog.SheetTitlesByID[props.SheetId] = props.Title
+		}
+		tables = append(tables, sheet.Tables...)
+	}
+	return catalog, tables, nil
+}
+
+func findSheetPropertiesByID(catalog *spreadsheetRangeCatalog, sheetID int64) *sheets.SheetProperties {
+	if catalog == nil {
+		return nil
+	}
+	for _, props := range catalog.Sheets {
+		if props != nil && props.SheetId == sheetID {
+			return props
+		}
+	}
+	return nil
+}
+
+func validateSheetsDeleteDimensionBounds(spec sheetsDeleteDimensionSpec, props *sheets.SheetProperties) error {
+	if props == nil || props.GridProperties == nil {
+		return nil
+	}
+	var size int64
+	if spec.Dimension == sheetsDimensionRows {
+		size = props.GridProperties.RowCount
+	} else {
+		size = props.GridProperties.ColumnCount
+	}
+	if size <= 0 {
+		return nil
+	}
+	if spec.EndIndex > size {
+		return usagef("%s end %d exceeds sheet size %d", spec.Label, spec.EndIndex, size)
+	}
+	if spec.StartIndex == 0 && spec.EndIndex == size {
+		return usagef("cannot delete every %s in a sheet", spec.Label[:len(spec.Label)-1])
+	}
+	return nil
+}
+
+func planSheetsDeleteDimensionTables(
+	tables []*sheets.Table,
+	sheetID int64,
+	sheetTitle string,
+	spec sheetsDeleteDimensionSpec,
+) ([]sheetsDeleteDimensionTable, error) {
+	updates := make([]sheetsDeleteDimensionTable, 0)
+	for _, table := range tables {
+		if table == nil || table.Range == nil || table.Range.SheetId != sheetID {
+			continue
+		}
+		after, intersects, err := resizeTableRangeAfterDimensionDelete(table.Range, spec)
+		if err != nil {
+			label := strings.TrimSpace(table.Name)
+			if label == "" {
+				label = strings.TrimSpace(table.TableId)
+			}
+			return nil, usagef("cannot delete %s %d-%d: table %q would lose its entire %s extent",
+				spec.Label, spec.StartIndex+1, spec.EndIndex, label, spec.Label[:len(spec.Label)-1])
+		}
+		if !intersects {
+			continue
+		}
+		if after.SheetId == 0 {
+			after.ForceSendFields = append(after.ForceSendFields, "SheetId")
+		}
+		updates = append(updates, sheetsDeleteDimensionTable{
+			TableID:  strings.TrimSpace(table.TableId),
+			Name:     strings.TrimSpace(table.Name),
+			BeforeA1: gridRangeToA1(sheetTitle, table.Range),
+			AfterA1:  gridRangeToA1(sheetTitle, after),
+			Range:    after,
+		})
+	}
+	sort.Slice(updates, func(i, j int) bool {
+		if updates[i].TableID == updates[j].TableID {
+			return updates[i].Name < updates[j].Name
+		}
+		return updates[i].TableID < updates[j].TableID
+	})
+	return updates, nil
+}
+
+func resizeTableRangeAfterDimensionDelete(
+	tableRange *sheets.GridRange,
+	spec sheetsDeleteDimensionSpec,
+) (*sheets.GridRange, bool, error) {
+	if tableRange == nil {
+		return nil, false, nil
+	}
+	var tableStart, tableEnd int64
+	if spec.Dimension == sheetsDimensionRows {
+		tableStart, tableEnd = tableRange.StartRowIndex, tableRange.EndRowIndex
+	} else {
+		tableStart, tableEnd = tableRange.StartColumnIndex, tableRange.EndColumnIndex
+	}
+	if tableEnd <= tableStart {
+		return nil, false, fmt.Errorf("invalid bounded table range")
+	}
+	if spec.EndIndex <= tableStart || spec.StartIndex >= tableEnd {
+		return nil, false, nil
+	}
+
+	afterStart := dimensionBoundaryAfterDelete(tableStart, spec.StartIndex, spec.EndIndex)
+	afterEnd := dimensionBoundaryAfterDelete(tableEnd, spec.StartIndex, spec.EndIndex)
+	if afterEnd <= afterStart {
+		return nil, true, fmt.Errorf("empty table range")
+	}
+
+	after := *tableRange
+	after.ForceSendFields = append([]string(nil), tableRange.ForceSendFields...)
+	if spec.Dimension == sheetsDimensionRows {
+		after.StartRowIndex = afterStart
+		after.EndRowIndex = afterEnd
+	} else {
+		after.StartColumnIndex = afterStart
+		after.EndColumnIndex = afterEnd
+	}
+	return &after, true, nil
+}
+
+func dimensionBoundaryAfterDelete(boundary, deleteStart, deleteEnd int64) int64 {
+	switch {
+	case boundary <= deleteStart:
+		return boundary
+	case boundary >= deleteEnd:
+		return boundary - (deleteEnd - deleteStart)
+	default:
+		return deleteStart
+	}
+}

--- a/internal/cmd/sheets_delete_dimension_test.go
+++ b/internal/cmd/sheets_delete_dimension_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/sheets/v4"
+)
+
+func TestSheetsDeleteDimensionCmdTableAwareRows(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+
+	var got sheets.BatchUpdateSpreadsheetRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/spreadsheets/s1"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "s1",
+				"sheets": []map[string]any{{
+					"properties": map[string]any{
+						"sheetId": 7,
+						"title":   "Data",
+						"gridProperties": map[string]any{
+							"rowCount":    100,
+							"columnCount": 20,
+						},
+					},
+					"tables": []map[string]any{{
+						"tableId": "tbl1",
+						"name":    "Tasks",
+						"range": map[string]any{
+							"sheetId":          7,
+							"startRowIndex":    0,
+							"endRowIndex":      5,
+							"startColumnIndex": 0,
+							"endColumnIndex":   3,
+						},
+					}},
+				}},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/spreadsheets/s1:batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batch update: %v", err)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	svc, err := sheets.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) { return svc, nil }
+
+	out := captureStdout(t, func() {
+		cmd := &SheetsDeleteDimensionCmd{}
+		err = runKong(t, cmd, []string{
+			"s1", "Data", "--dimension", "ROWS", "--start", "2", "--end", "3",
+		}, newCmdJSONContext(t), &RootFlags{Account: "a@b.com", Force: true})
+	})
+	if err != nil {
+		t.Fatalf("delete rows: %v", err)
+	}
+	if len(got.Requests) != 2 || got.Requests[0].DeleteDimension == nil || got.Requests[1].UpdateTable == nil {
+		t.Fatalf("requests = %#v", got.Requests)
+	}
+	dim := got.Requests[0].DeleteDimension.Range
+	if dim.SheetId != 7 || dim.Dimension != "ROWS" || dim.StartIndex != 1 || dim.EndIndex != 3 {
+		t.Fatalf("delete range = %#v", dim)
+	}
+	update := got.Requests[1].UpdateTable
+	if update.Fields != "range" || update.Table.TableId != "tbl1" {
+		t.Fatalf("update table = %#v", update)
+	}
+	if gotRange := update.Table.Range; gotRange.StartRowIndex != 0 || gotRange.EndRowIndex != 3 ||
+		gotRange.StartColumnIndex != 0 || gotRange.EndColumnIndex != 3 {
+		t.Fatalf("updated table range = %#v", gotRange)
+	}
+	if !strings.Contains(out, `"beforeA1": "Data!A1:C5"`) || !strings.Contains(out, `"afterA1": "Data!A1:C3"`) {
+		t.Fatalf("output = %s", out)
+	}
+}
+
+func TestSheetsDeleteDimensionCmdRangeTargetColumns(t *testing.T) {
+	literalSheet, err := parseSheetsDeleteDimensionSpec("Q1!Q2", "columns", 2, 4)
+	if err != nil {
+		t.Fatalf("parse literal sheet target: %v", err)
+	}
+	if literalSheet.SheetName != "Q1!Q2" || literalSheet.StartIndex != 1 || literalSheet.EndIndex != 4 {
+		t.Fatalf("literal sheet spec = %#v", literalSheet)
+	}
+
+	spec, err := parseSheetsDeleteDimensionSpec("'Data Sheet'!B:C", "columns", 0, 0)
+	if err != nil {
+		t.Fatalf("parse range target: %v", err)
+	}
+	if spec.SheetName != "Data Sheet" || spec.Dimension != "COLUMNS" || spec.StartIndex != 1 || spec.EndIndex != 3 {
+		t.Fatalf("spec = %#v", spec)
+	}
+}
+
+func TestSheetsDeleteDimensionPlanning(t *testing.T) {
+	table := &sheets.Table{
+		TableId: "tbl1",
+		Name:    "Tasks",
+		Range: &sheets.GridRange{
+			SheetId:          7,
+			StartRowIndex:    2,
+			EndRowIndex:      8,
+			StartColumnIndex: 1,
+			EndColumnIndex:   5,
+		},
+	}
+
+	updates, err := planSheetsDeleteDimensionTables([]*sheets.Table{table}, 7, "Data", sheetsDeleteDimensionSpec{
+		Dimension:  "COLUMNS",
+		Label:      "columns",
+		StartIndex: 2,
+		EndIndex:   4,
+	})
+	if err != nil {
+		t.Fatalf("plan columns: %v", err)
+	}
+	if len(updates) != 1 || updates[0].AfterA1 != "Data!B3:C8" {
+		t.Fatalf("updates = %#v", updates)
+	}
+
+	_, err = planSheetsDeleteDimensionTables([]*sheets.Table{table}, 7, "Data", sheetsDeleteDimensionSpec{
+		Dimension:  "COLUMNS",
+		Label:      "columns",
+		StartIndex: 0,
+		EndIndex:   5,
+	})
+	if err == nil || !strings.Contains(err.Error(), "entire column extent") {
+		t.Fatalf("expected whole-table guard, got %v", err)
+	}
+}
+
+func TestSheetsDeleteDimensionValidation(t *testing.T) {
+	spec, err := parseSheetsDeleteDimensionSpec("Data", "rows", 2, 4)
+	if err != nil {
+		t.Fatalf("parse sheet target: %v", err)
+	}
+	if spec.StartIndex != 1 || spec.EndIndex != 4 {
+		t.Fatalf("spec = %#v", spec)
+	}
+
+	for _, tc := range []struct {
+		name      string
+		target    string
+		dimension string
+		start     int64
+		end       int64
+		want      string
+	}{
+		{name: "missing spans", target: "Data", dimension: "ROWS", want: "require both --start and --end"},
+		{name: "ambiguous bare column", target: "B", dimension: "COLUMNS", want: "must include a sheet name"},
+		{name: "ambiguous bare row", target: "2025", dimension: "ROWS", want: "must include a sheet name"},
+		{name: "column overflow", target: "Data!GKGWBYLWRXTLPQ", dimension: "COLUMNS", want: "too large"},
+		{name: "one bound", target: "Data", dimension: "ROWS", start: 2, want: "provide both"},
+		{name: "bad dimension", target: "Data", dimension: "CELLS", start: 2, end: 4, want: "ROWS or COLUMNS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, gotErr := parseSheetsDeleteDimensionSpec(tc.target, tc.dimension, tc.start, tc.end)
+			if gotErr == nil || !strings.Contains(gotErr.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", gotErr, tc.want)
+			}
+		})
+	}
+
+	err = validateSheetsDeleteDimensionBounds(spec, &sheets.SheetProperties{
+		GridProperties: &sheets.GridProperties{RowCount: 3, ColumnCount: 10},
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeds sheet size") {
+		t.Fatalf("expected bounds error, got %v", err)
+	}
+}
+
+func TestSheetsDeleteDimensionDryRunIsOffline(t *testing.T) {
+	origNew := newSheetsService
+	t.Cleanup(func() { newSheetsService = origNew })
+	newSheetsService = func(context.Context, string) (*sheets.Service, error) {
+		t.Fatal("dry-run must not create Sheets service")
+		return nil, errors.New("unexpected Sheets service creation")
+	}
+
+	out := captureStdout(t, func() {
+		err := (&SheetsDeleteDimensionCmd{
+			SpreadsheetID: "s1",
+			Target:        "Data!2:4",
+			Dimension:     "ROWS",
+		}).Run(newCmdJSONContext(t), &RootFlags{DryRun: true})
+		if ExitCode(err) != 0 {
+			t.Fatalf("dry-run exit: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"op": "sheets.delete-dimension"`) ||
+		!strings.Contains(out, `"start_index": 1`) ||
+		!strings.Contains(out, `"end_index": 4`) {
+		t.Fatalf("dry-run output = %s", out)
+	}
+}

--- a/internal/cmd/sheets_insert.go
+++ b/internal/cmd/sheets_insert.go
@@ -39,10 +39,10 @@ func (c *SheetsInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
 	var apiDimension, dimLabel string
 	switch dim {
 	case "rows", "row":
-		apiDimension = "ROWS"
+		apiDimension = sheetsDimensionRows
 		dimLabel = "row"
 	case "cols", "col", "columns", "column":
-		apiDimension = "COLUMNS"
+		apiDimension = sheetsDimensionColumns
 		dimLabel = "column"
 	default:
 		return usagef("dimension must be rows or cols, got %q", c.Dimension)

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -196,6 +196,7 @@ sheets:
   batch-update: false
   append: false
   insert: false
+  delete-dimension: false
   clear: false
   format: false
   merge: false

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -201,6 +201,7 @@ sheets:
   batch-update: false
   append: false
   insert: false
+  delete-dimension: false
   clear: false
   format: false
   merge: false


### PR DESCRIPTION
## Summary

- add `sheets delete-dimension` / `delete-dim` for row or column deletion
- accept either a literal sheet with inclusive `--start`/`--end` bounds or an explicitly sheet-qualified range
- preserve intersecting structured tables atomically by updating their ranges in the same batch
- fail closed for ambiguous targets, numeric overflow, whole-sheet deletion, and deletion of an entire table extent
- document the command and include it in safety profiles

Closes #711.

## Verification

- focused command, A1 parser, and insert regression tests
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make ci`
- autoreview clean after addressing all accepted findings

## Live proof

Tested the exact built binary against disposable Sheets owned by `clawdbot@gmail.com`:

- created a 5x5 structured table
- dry-run completed without mutation
- deleted column C; table identity was preserved and range changed from `A1:E5` to `A1:D5`
- deleted row 3; table identity was preserved and range changed from `A1:D5` to `A1:D4`
- attempted deletion of the table's complete column extent; command rejected it before mutation
- verified remaining cell values after each mutation
- moved every disposable spreadsheet to trash
