### PR TITLE
fix(docs): render table cell HTML breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Docs: render HTML `<br>` variants as line breaks inside Markdown table cells while preserving protected literals. (#730) — thanks @sebsnyk.
 - Docs: avoid duplicate empty paragraphs adjacent to Markdown headings while preserving body paragraph spacing. (#717, #720) — thanks @TurboTheTurtle.
 - Auth: repair duplicate macOS Keychain writes for legacy and subject token aliases without weakening primary token persistence. (#718, #721) — thanks @TurboTheTurtle.
 

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -262,6 +262,9 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 	}
 
 	cleaned, images := extractMarkdownImages(content)
+	if markdownHasTableCellBreaks(cleaned) {
+		return c.replaceMarkdownInTab(ctx, flags, docID, content)
+	}
 	cleaned = normalizeMarkdownTablesForDriveImport(cleaned)
 	explicitHeadingAnchors := markdownImportExplicitHeadingAnchors(cleaned)
 	cleaned = stripMarkdownHeadingAnchors(cleaned)

--- a/internal/cmd/docs_markdown.go
+++ b/internal/cmd/docs_markdown.go
@@ -396,10 +396,64 @@ func parseTableRow(line string) []string {
 	cells := make([]string, 0, len(parts))
 	for _, part := range parts {
 		cell := strings.TrimSpace(part)
+		cell = normalizeMarkdownTableBreaks(cell)
 		cells = append(cells, cell)
 	}
 
 	return cells
+}
+
+func normalizeMarkdownTableBreaks(cell string) string {
+	var out strings.Builder
+	changed := false
+	for i := 0; i < len(cell); {
+		if cell[i] == '\\' && i+1 < len(cell) {
+			out.WriteString(cell[i : i+2])
+			i += 2
+			continue
+		}
+		if cell[i] == '`' {
+			if _, end, ok := parseInlineCodeSpan(cell, i); ok {
+				out.WriteString(cell[i:end])
+				i = end
+				continue
+			}
+		}
+		if breakLen := markdownTableBreakPrefixLen(cell[i:]); breakLen > 0 {
+			out.WriteByte('\n')
+			i += breakLen
+			changed = true
+			continue
+		}
+		out.WriteByte(cell[i])
+		i++
+	}
+	if !changed {
+		return cell
+	}
+	return out.String()
+}
+
+func markdownTableBreakPrefixLen(text string) int {
+	if len(text) < len("<br>") || text[0] != '<' ||
+		(text[1] != 'b' && text[1] != 'B') ||
+		(text[2] != 'r' && text[2] != 'R') {
+		return 0
+	}
+	i := 3
+	for i < len(text) && (text[i] == ' ' || text[i] == '\t') {
+		i++
+	}
+	if i < len(text) && text[i] == '/' {
+		i++
+		for i < len(text) && (text[i] == ' ' || text[i] == '\t') {
+			i++
+		}
+	}
+	if i >= len(text) || text[i] != '>' {
+		return 0
+	}
+	return i + 1
 }
 
 func isEmptyMarkdownTableRow(cells []string) bool {
@@ -473,6 +527,41 @@ func isMarkdownTableCandidateLine(line string) bool {
 
 func isIndentedMarkdownCodeLine(line string) bool {
 	return strings.HasPrefix(line, "\t") || strings.HasPrefix(line, "    ")
+}
+
+func markdownHasTableCellBreaks(markdown string) bool {
+	lines := strings.Split(markdown, "\n")
+	inFence := false
+	fenceMarker := ""
+	for i := 0; i < len(lines); i++ {
+		line := lines[i]
+		if marker := docsMarkdownFenceMarker(line); marker != "" {
+			if !inFence {
+				inFence = true
+				fenceMarker = marker
+			} else if marker == fenceMarker {
+				inFence = false
+				fenceMarker = ""
+			}
+			continue
+		}
+		if inFence || !isMarkdownTableCandidateLine(line) || i+1 >= len(lines) || !isTableSeparator(lines[i+1]) {
+			continue
+		}
+		if normalizeMarkdownTableBreaks(line) != line {
+			return true
+		}
+		for j := i + 2; j < len(lines); j++ {
+			row := lines[j]
+			if strings.TrimSpace(row) == "" || !isMarkdownTableCandidateLine(row) {
+				break
+			}
+			if normalizeMarkdownTableBreaks(row) != row {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 const inlineTypeCode = "code"

--- a/internal/cmd/docs_markdown_test.go
+++ b/internal/cmd/docs_markdown_test.go
@@ -523,6 +523,37 @@ func TestParseMarkdown_TableDoesNotSkipFollowingLine(t *testing.T) {
 	}
 }
 
+func TestParseMarkdown_TableNormalizesHTMLBreaksInCells(t *testing.T) {
+	input := "| Name | Notes |\n| --- | --- |\n| Alice<br>Bob<BR/>Carol<Br / >Dana | Keep <break> literal |"
+	got := ParseMarkdown(input)
+	if len(got) != 1 || got[0].Type != MDTable {
+		t.Fatalf("ParseMarkdown() = %#v, want one table", got)
+	}
+	want := []string{"Alice\nBob\nCarol\nDana", "Keep <break> literal"}
+	if rows := got[0].TableCells; len(rows) != 2 || len(rows[1]) != 2 || rows[1][0] != want[0] || rows[1][1] != want[1] {
+		t.Fatalf("table rows = %#v, want second row %#v", rows, want)
+	}
+}
+
+func TestParseMarkdown_TableBreaksPreserveProtectedLiterals(t *testing.T) {
+	input := "| Code | Escaped |\n| --- | --- |\n| `<br>` and ``<BR/>`` | \\<br> and \\<br/> |"
+	got := ParseMarkdown(input)
+	if len(got) != 1 || got[0].Type != MDTable {
+		t.Fatalf("ParseMarkdown() = %#v, want one table", got)
+	}
+	want := []string{"`<br>` and ``<BR/>``", "\\<br> and \\<br/>"}
+	if rows := got[0].TableCells; len(rows) != 2 || len(rows[1]) != 2 || rows[1][0] != want[0] || rows[1][1] != want[1] {
+		t.Fatalf("table rows = %#v, want second row %#v", rows, want)
+	}
+}
+
+func TestParseMarkdown_NonTableHTMLBreakUnchanged(t *testing.T) {
+	got := ParseMarkdown("Alice<br>Bob")
+	if len(got) != 1 || got[0].Type != MDParagraph || got[0].Content != "Alice<br>Bob" {
+		t.Fatalf("ParseMarkdown() = %#v, want unchanged paragraph", got)
+	}
+}
+
 func TestIsTableSeparator_EmptyPipeRowRejected(t *testing.T) {
 	// Regression for #609: a row of empty pipe cells (e.g. an empty markdown
 	// table header) must not be classified as a separator line. Otherwise the
@@ -583,6 +614,27 @@ func TestNormalizeMarkdownTablesForDriveImport_PromotesFirstDataRow(t *testing.T
 	want := "| Label A | Value A |\n|-----|-----|\n| Label B | Value B |\n\nAfter"
 	if got != want {
 		t.Fatalf("normalized markdown = %q, want %q", got, want)
+	}
+}
+
+func TestMarkdownHasTableCellBreaks(t *testing.T) {
+	tests := []struct {
+		name     string
+		markdown string
+		want     bool
+	}{
+		{"prose break", "| Name | Notes |\n| --- | --- |\n| Alice<br>Bob | ok |", true},
+		{"code literal", "| Name | Notes |\n| --- | --- |\n| `<br>` | ok |", false},
+		{"escaped literal", "| Name | Notes |\n| --- | --- |\n| \\<br> | ok |", false},
+		{"outside table", "Alice<br>Bob", false},
+		{"fenced table", "```\n| Name | Notes |\n| --- | --- |\n| Alice<br>Bob | ok |\n```", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := markdownHasTableCellBreaks(tt.markdown); got != tt.want {
+				t.Fatalf("markdownHasTableCellBreaks() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/docs_table_inserter_inline_test.go
+++ b/internal/cmd/docs_table_inserter_inline_test.go
@@ -77,6 +77,38 @@ func TestBuildTableCellRequests_AppliesInlineItalicAndCode(t *testing.T) {
 	}
 }
 
+func TestBuildTableCellRequests_TableBreaksPreserveInlineStyleRanges(t *testing.T) {
+	rows := parseTableRow("| Alice<br>**Bob** and `<br>` |")
+	if len(rows) != 1 {
+		t.Fatalf("parseTableRow() = %#v, want one cell", rows)
+	}
+
+	reqs, inserted := buildTableCellRequests(rows[0], 100, false, "")
+	if inserted != utf16Len("Alice\nBob and <br>") {
+		t.Fatalf("inserted = %d, want %d", inserted, utf16Len("Alice\nBob and <br>"))
+	}
+	if len(reqs) != 3 {
+		t.Fatalf("expected insert, bold, and code requests, got %d: %#v", len(reqs), reqs)
+	}
+	if got := reqs[0].InsertText; got == nil || got.Text != "Alice\nBob and <br>" {
+		t.Fatalf("InsertText = %#v, want text %q", got, "Alice\nBob and <br>")
+	}
+	bold := reqs[1].UpdateTextStyle
+	if bold == nil || bold.TextStyle == nil || !bold.TextStyle.Bold {
+		t.Fatalf("expected bold UpdateTextStyle, got %#v", reqs[1])
+	}
+	if bold.Range == nil || bold.Range.StartIndex != 106 || bold.Range.EndIndex != 109 {
+		t.Fatalf("bold range = %#v, want [106,109]", bold.Range)
+	}
+	code := reqs[2].UpdateTextStyle
+	if code == nil || code.TextStyle == nil || code.TextStyle.WeightedFontFamily == nil {
+		t.Fatalf("expected code UpdateTextStyle, got %#v", reqs[2])
+	}
+	if code.Range == nil || code.Range.StartIndex != 114 || code.Range.EndIndex != 118 {
+		t.Fatalf("code range = %#v, want [114,118]", code.Range)
+	}
+}
+
 func TestBuildTableCellRequests_HeaderRowAppliesBoldOverWholeCell(t *testing.T) {
 	reqs, inserted := buildTableCellRequests("Field", 10, true, "")
 

--- a/internal/cmd/docs_write_markdown_tab_test.go
+++ b/internal/cmd/docs_write_markdown_tab_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 
@@ -122,6 +123,86 @@ func TestDocsWrite_MarkdownReplaceWithTab(t *testing.T) {
 		if r.TabId != "t.second" {
 			t.Fatalf("formatting request %d range tab = %q, want t.second", i+1, r.TabId)
 		}
+	}
+}
+
+func TestDocsWrite_MarkdownReplaceTableBreaksUsesLocalRenderer(t *testing.T) {
+	origDocs := newDocsService
+	origDrive := newDriveService
+	t.Cleanup(func() {
+		newDocsService = origDocs
+		newDriveService = origDrive
+	})
+
+	getCalls := 0
+	var batches []docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			getCalls++
+			w.Header().Set("Content-Type", "application/json")
+			if getCalls == 1 {
+				_ = json.NewEncoder(w).Encode(&docs.Document{
+					DocumentId: "doc1",
+					RevisionId: "rev-1",
+					Body: &docs.Body{Content: []*docs.StructuralElement{{
+						StartIndex: 1,
+						EndIndex:   2,
+						Paragraph:  &docs.Paragraph{},
+					}}},
+				})
+			} else {
+				_ = json.NewEncoder(w).Encode(docsTableOpsTestDocument(docsTableOpsTestElement(1, "", 2, 2)))
+			}
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode batch request: %v", err)
+			}
+			batches = append(batches, req)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+	newDriveService = func(context.Context, string) (*drive.Service, error) {
+		t.Fatal("table-cell breaks must use the local Docs renderer")
+		return nil, errors.New("unexpected Drive service call")
+	}
+
+	markdown := "| Value | Literal |\n| --- | --- |\n| Alice<br>Bob | `<br>` |"
+	if err := runKong(t, &DocsWriteCmd{}, []string{
+		"doc1", "--text", markdown, "--replace", "--markdown",
+	}, newDocsJSONContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("markdown replace with table breaks: %v", err)
+	}
+
+	if getCalls != 2 {
+		t.Fatalf("GET calls = %d, want 2", getCalls)
+	}
+	if len(batches) != 3 {
+		t.Fatalf("batch calls = %d, want placeholder, table, and cells", len(batches))
+	}
+	var inserted []string
+	var sawCodeStyle bool
+	for _, req := range batches[2].Requests {
+		if req.InsertText != nil {
+			inserted = append(inserted, req.InsertText.Text)
+		}
+		if req.UpdateTextStyle != nil && req.UpdateTextStyle.TextStyle != nil &&
+			req.UpdateTextStyle.TextStyle.WeightedFontFamily != nil {
+			sawCodeStyle = true
+		}
+	}
+	if !slices.Contains(inserted, "Alice\nBob") {
+		t.Fatalf("cell inserts = %#v, missing converted line break", inserted)
+	}
+	if !slices.Contains(inserted, "<br>") || !sawCodeStyle {
+		t.Fatalf("cell inserts = %#v, protected code literal/style missing", inserted)
 	}
 }
 


### PR DESCRIPTION
## Summary

- render case-insensitive HTML break variants as line breaks inside Markdown table cells
- preserve break-tag literals protected by backticks or backslash escaping
- use the existing local Docs renderer for whole-document replacements containing real table-cell breaks
- keep ordinary whole-document Markdown on the existing Drive import path

Closes #730.
Supersedes #737, whose raw replacement changed protected code-span literals.

## Verification

- focused parser, request-generation, and command-routing tests
- autoreview clean with no accepted/actionable findings
- `DEVELOPER_DIR=/Library/Developer/CommandLineTools make ci`

## Live proof

Tested the exact built branch binary against a disposable Google Doc owned by `clawdbot@gmail.com`:

- wrote a Markdown table containing `Alice<br>Bob<BR/>Carol`
- Docs API readback returned `Alice`, `Bob`, and `Carol` on separate lines in one cell
- a backticked `<br>` remained literal and retained a monospace text style
- moved the disposable document to trash

Thanks @sebsnyk for the report and reproduction.
