### PR TITLE
fix(docs): preserve inline replacement paragraphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Docs: keep inline Markdown find-replace fragments inside their existing paragraph unless the replacement explicitly ends with a newline. (#736) — thanks @sebsnyk.
 - Docs: render HTML `<br>` variants as line breaks inside Markdown table cells while preserving protected literals. (#730) — thanks @sebsnyk.
 - Docs: avoid duplicate empty paragraphs adjacent to Markdown headings while preserving body paragraph spacing. (#717, #720) — thanks @TurboTheTurtle.
 - Auth: repair duplicate macOS Keychain writes for legacy and subject token aliases without weakening primary token persistence. (#718, #721) — thanks @TurboTheTurtle.

--- a/internal/cmd/docs_find_replace_test.go
+++ b/internal/cmd/docs_find_replace_test.go
@@ -391,7 +391,7 @@ func TestDocsFindReplace_MarkdownMode(t *testing.T) {
 	if reqs[1].InsertText == nil {
 		t.Fatal("second request should be InsertText")
 	}
-	if got := reqs[1].InsertText.Text; got != "bold text and italic and code and bold and italic\n" {
+	if got := reqs[1].InsertText.Text; got != "bold text and italic and code and bold and italic" {
 		t.Fatalf("insert text = %q", got)
 	}
 	if strings.Contains(reqs[1].InsertText.Text, "**") || strings.Contains(reqs[1].InsertText.Text, "_italic_") || strings.Contains(reqs[1].InsertText.Text, "`") {
@@ -405,6 +405,42 @@ func TestDocsFindReplace_MarkdownMode(t *testing.T) {
 	}
 	if !hasTextStyleRequest(reqs, func(style *docs.TextStyle) bool { return style.WeightedFontFamily != nil }) {
 		t.Fatal("expected code text style request")
+	}
+}
+
+func TestDocsFindReplace_MarkdownExplicitTrailingNewlinePreserved(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(docBodyWithText("Before PLACEHOLDER after\n"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	err := runKong(t, &DocsFindReplaceCmd{}, []string{
+		"doc1", "PLACEHOLDER", "**bold**\n", "--format", "markdown", "--first",
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("docs find-replace explicit newline: %v", err)
+	}
+	if len(got.Requests) < 2 || got.Requests[1].InsertText == nil {
+		t.Fatalf("expected delete and insert requests, got %#v", got.Requests)
+	}
+	if text := got.Requests[1].InsertText.Text; text != "bold\n" {
+		t.Fatalf("insert text = %q, want explicit terminal newline", text)
 	}
 }
 

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -136,6 +136,9 @@ func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.
 		baseIndex++
 	}
 	formattingRequests, textToInsert, tables := MarkdownToDocsRequests(elements, baseIndex, tabID)
+	if markdownRangeReplacementIsInline(cleaned, elements) {
+		textToInsert = strings.TrimSuffix(textToInsert, "\n")
+	}
 
 	applyTabIDToFormattingRequests(formattingRequests, tabID)
 
@@ -198,6 +201,12 @@ func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.
 	}
 
 	return requestCount, len(prefix) + len(textToInsert), nil
+}
+
+func markdownRangeReplacementIsInline(markdown string, elements []MarkdownElement) bool {
+	return !strings.HasSuffix(markdown, "\n") &&
+		len(elements) == 1 &&
+		elements[0].Type == MDParagraph
 }
 
 func markdownReplaceNeedsParagraphBoundary(doc *docs.Document, startIdx int64, tabID string, elements []MarkdownElement) bool {


### PR DESCRIPTION
## Summary

- keep single-paragraph Markdown find-replace fragments inside the existing paragraph
- preserve explicit terminal newlines and block Markdown behavior
- add regression coverage for inline and explicit-newline replacements

## Verification

- focused Docs find-replace tests
- autoreview clean
- `make ci`
- live disposable Google Doc: two successive Markdown replacements produced exact paragraph spacing on raw readback; document trashed afterward

Closes #736

Thanks @sebsnyk.
