### PR TITLE
fix(docs): accept cell list content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Docs: accept leading-dash Markdown list values in `docs cell-update --content` and reject nonempty Markdown that produces no editable cell text. (#733) — thanks @sebsnyk.
 - Docs: keep inline Markdown find-replace fragments inside their existing paragraph unless the replacement explicitly ends with a newline. (#736) — thanks @sebsnyk.
 - Docs: render HTML `<br>` variants as line breaks inside Markdown table cells while preserving protected literals. (#730) — thanks @sebsnyk.
 - Docs: avoid duplicate empty paragraphs adjacent to Markdown headings while preserving body paragraph spacing. (#717, #720) — thanks @TurboTheTurtle.

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -138,10 +138,13 @@ Update one existing table cell without round-tripping the surrounding document:
 ```bash
 gog docs cell-update <docId> --table-index 1 --row 2 --col 3 \
   --content "**Ready**" --format markdown
+gog docs cell-update <docId> --table-index 1 --row 2 --col 3 \
+  --content $'- First\n- Second'
 ```
 
 Coordinates are 1-based. `--tab` targets a specific tab, and `--append` inserts
-at the end of the cell instead of replacing its current content.
+at the end of the cell instead of replacing its current content. Markdown list
+content creates native Google Docs bullets or numbering inside the cell.
 
 Set or reset native table column widths after inserting or importing tables:
 

--- a/internal/cmd/docs_cell_update.go
+++ b/internal/cmd/docs_cell_update.go
@@ -145,6 +145,26 @@ func (c *DocsCellUpdateCmd) resolveContent() (string, error) {
 	return string(data), nil
 }
 
+func rewriteDocsCellUpdateContentArgs(args []string) []string {
+	tokens := commandTokens(args, 2)
+	if len(tokens) < 2 ||
+		(tokens[0] != "docs" && tokens[0] != "doc") ||
+		(tokens[1] != "cell-update" && tokens[1] != "update-cell") {
+		return args
+	}
+
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] != "--content" || !strings.HasPrefix(args[i+1], "- ") {
+			continue
+		}
+		out := append([]string(nil), args[:i]...)
+		out = append(out, "--content="+args[i+1])
+		out = append(out, args[i+2:]...)
+		return out
+	}
+	return args
+}
+
 func updateDocsCellContent(ctx context.Context, svc *docs.Service, doc *docs.Document, startIdx, endIdx int64, content, format string, appendOnly bool, prefixBoundary bool, tabID string) error {
 	var requests []*docs.Request
 	if !appendOnly && startIdx < endIdx {
@@ -167,16 +187,17 @@ func updateDocsCellContent(ctx context.Context, svc *docs.Service, doc *docs.Doc
 				return usage("markdown tables are not supported inside table cells")
 			}
 			textToInsert = strings.TrimSuffix(textToInsert, "\n")
-			formatReqs = clampDocsCellFormatRequests(formatReqs, baseIndex+utf16Len(textToInsert))
-			if textToInsert != "" {
-				requests = append(requests, &docs.Request{
-					InsertText: &docs.InsertTextRequest{
-						Location: &docs.Location{Index: startIdx, TabId: tabID},
-						Text:     prefix + textToInsert,
-					},
-				})
-				requests = append(requests, formatReqs...)
+			if textToInsert == "" {
+				return usage("markdown content produced no editable cell text")
 			}
+			formatReqs = clampDocsCellFormatRequests(formatReqs, baseIndex+utf16Len(textToInsert))
+			requests = append(requests, &docs.Request{
+				InsertText: &docs.InsertTextRequest{
+					Location: &docs.Location{Index: startIdx, TabId: tabID},
+					Text:     prefix + textToInsert,
+				},
+			})
+			requests = append(requests, formatReqs...)
 		} else {
 			requests = append(requests, &docs.Request{
 				InsertText: &docs.InsertTextRequest{

--- a/internal/cmd/docs_cell_update_test.go
+++ b/internal/cmd/docs_cell_update_test.go
@@ -4,11 +4,70 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
 	"google.golang.org/api/docs/v1"
 )
+
+func TestRewriteDocsCellUpdateContentArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "bullet list",
+			args: []string{"docs", "cell-update", "doc1", "--content", "- one\n- two", "--row", "1", "--col", "1"},
+			want: []string{"docs", "cell-update", "doc1", "--content=- one\n- two", "--row", "1", "--col", "1"},
+		},
+		{
+			name: "aliases and global flag",
+			args: []string{"--account", "a@b.com", "doc", "update-cell", "doc1", "--content", "- one"},
+			want: []string{"--account", "a@b.com", "doc", "update-cell", "doc1", "--content=- one"},
+		},
+		{
+			name: "existing equals form",
+			args: []string{"docs", "cell-update", "doc1", "--content=- one"},
+			want: []string{"docs", "cell-update", "doc1", "--content=- one"},
+		},
+		{
+			name: "missing content value",
+			args: []string{"docs", "cell-update", "doc1", "--content", "--append"},
+			want: []string{"docs", "cell-update", "doc1", "--content", "--append"},
+		},
+		{
+			name: "other command",
+			args: []string{"docs", "write", "doc1", "--content", "- one"},
+			want: []string{"docs", "write", "doc1", "--content", "- one"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rewriteDocsCellUpdateContentArgs(tt.args); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("rewriteDocsCellUpdateContentArgs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecuteDocsCellUpdateLeadingDashContentDryRun(t *testing.T) {
+	out := captureStdout(t, func() {
+		err := Execute([]string{
+			"--json", "--dry-run", "--no-input",
+			"docs", "cell-update", "doc1",
+			"--row", "1", "--col", "1",
+			"--content", "- one\n- two",
+		})
+		if err != nil && ExitCode(err) != 0 {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+	if !strings.Contains(out, `"op": "docs.cell-update"`) {
+		t.Fatalf("unexpected dry-run output: %s", out)
+	}
+}
 
 func TestDocsCellUpdate_ReplacesTargetCellOnly(t *testing.T) {
 	origDocs := newDocsService
@@ -49,6 +108,45 @@ func TestDocsCellUpdate_ReplacesTargetCellOnly(t *testing.T) {
 	ins := got.Requests[1].InsertText
 	if ins == nil || ins.Location.Index != 10 || ins.Text != "New" {
 		t.Fatalf("unexpected insert: %#v", ins)
+	}
+}
+
+func TestDocsCellUpdate_ReplacesWithNativeMarkdownList(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(cellUpdateTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--row", "1", "--col", "2", "--content=- Alpha\n- Beta"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("docs cell-update list: %v", err)
+	}
+	if len(got.Requests) != 3 {
+		t.Fatalf("expected delete+insert+bullets, got %d requests", len(got.Requests))
+	}
+	ins := got.Requests[1].InsertText
+	if ins == nil || ins.Location.Index != 10 || ins.Text != "Alpha\nBeta" {
+		t.Fatalf("unexpected list insert: %#v", ins)
+	}
+	bullets := got.Requests[2].CreateParagraphBullets
+	if bullets == nil || bullets.Range.StartIndex != 10 || bullets.Range.EndIndex != 20 || bullets.BulletPreset != bulletPresetDisc {
+		t.Fatalf("unexpected bullet request: %#v", bullets)
 	}
 }
 
@@ -132,6 +230,36 @@ func TestDocsCellUpdate_AppendBlockMarkdownStartsNewParagraph(t *testing.T) {
 	para := got.Requests[1].UpdateParagraphStyle
 	if para == nil || para.Range.StartIndex != 9 || para.Range.EndIndex != 14 {
 		t.Fatalf("heading style should start after inserted boundary: %#v", para)
+	}
+}
+
+func TestDocsCellUpdate_RejectsMarkdownWithoutEditableText(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var posted bool
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(cellUpdateTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			posted = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	err := runKong(t, cmd, []string{"doc1", "--row", "1", "--col", "2", "--content", "```\n```"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "no editable cell text") {
+		t.Fatalf("expected no editable text error, got %v", err)
+	}
+	if posted {
+		t.Fatal("unexpected batch update for ineffective markdown")
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -110,6 +110,7 @@ func Execute(args []string) (err error) {
 		args = []string{"--help"}
 	}
 	args = rewriteDesirePathArgs(args)
+	args = rewriteDocsCellUpdateContentArgs(args)
 
 	preHomeApplied := false
 	if home, ok := preScanHomeArg(args); ok {


### PR DESCRIPTION
## Summary

- accept Markdown bullet-list values passed as `--content $'- one\n- two'`
- preserve existing argument behavior outside `docs cell-update`
- reject nonempty Markdown that produces no editable cell text
- document native bullet and numbered list support

## Verification

- focused cell-update and full CLI parser tests
- autoreview clean
- `make ci`
- live disposable Google Doc verified bullet and numbered replace and append behavior from raw Docs metadata
- live ineffective-Markdown check returned nonzero and preserved the cell; document trashed afterward

Closes #733

Thanks @sebsnyk.
