### PR TITLE
fix(docs): reset markdown replacement styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixed
 
+- Docs: reset inherited text styles before applying Markdown find-replace formatting so leading bold spans and later inline styles stay paired correctly. (#735) — thanks @sebsnyk.
 - Docs: accept leading-dash Markdown list values in `docs cell-update --content` and reject nonempty Markdown that produces no editable cell text. (#733) — thanks @sebsnyk.
 - Docs: keep inline Markdown find-replace fragments inside their existing paragraph unless the replacement explicitly ends with a newline. (#736) — thanks @sebsnyk.
 - Docs: render HTML `<br>` variants as line breaks inside Markdown table cells while preserving protected literals. (#730) — thanks @sebsnyk.

--- a/internal/cmd/docs_find_replace_test.go
+++ b/internal/cmd/docs_find_replace_test.go
@@ -444,6 +444,57 @@ func TestDocsFindReplace_MarkdownExplicitTrailingNewlinePreserved(t *testing.T) 
 	}
 }
 
+func TestDocsFindReplace_MarkdownResetsInheritedStylesBeforeLeadingBold(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(docBodyWithText("PLACEHOLDER\n"))
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	replacement := "**Alpha** keeps text. The **Bravo** keeps text."
+	err := runKong(t, &DocsFindReplaceCmd{}, []string{
+		"doc1", "PLACEHOLDER", replacement, "--format", "markdown", "--first",
+	}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("docs find-replace leading bold: %v", err)
+	}
+	if len(got.Requests) != 5 {
+		t.Fatalf("expected delete, insert, reset, and two bold requests, got %#v", got.Requests)
+	}
+	inserted := "Alpha keeps text. The Bravo keeps text."
+	if got.Requests[1].InsertText == nil || got.Requests[1].InsertText.Text != inserted {
+		t.Fatalf("unexpected insert request: %#v", got.Requests[1])
+	}
+	reset := got.Requests[2].UpdateTextStyle
+	if reset == nil || reset.Range.StartIndex != 1 || reset.Range.EndIndex != 1+utf16Len(inserted) ||
+		reset.Fields != docsTextStyleResetFields || reset.TextStyle == nil {
+		t.Fatalf("unexpected reset request: %#v", reset)
+	}
+	alpha := got.Requests[3].UpdateTextStyle
+	if alpha == nil || alpha.Range.StartIndex != 1 || alpha.Range.EndIndex != 6 || !alpha.TextStyle.Bold {
+		t.Fatalf("unexpected Alpha bold request: %#v", alpha)
+	}
+	bravo := got.Requests[4].UpdateTextStyle
+	if bravo == nil || bravo.Range.StartIndex != 23 || bravo.Range.EndIndex != 28 || !bravo.TextStyle.Bold {
+		t.Fatalf("unexpected Bravo bold request: %#v", bravo)
+	}
+}
+
 func TestDocsFindReplace_MarkdownCodeBlockStartsFreshParagraphWhenInline(t *testing.T) {
 	origDocs := newDocsService
 	t.Cleanup(func() { newDocsService = origDocs })
@@ -484,13 +535,13 @@ func TestDocsFindReplace_MarkdownCodeBlockStartsFreshParagraphWhenInline(t *test
 		t.Fatalf("expected 1 batchUpdate call, got %d", len(batchCalls))
 	}
 	reqs := batchCalls[0].Requests
-	if len(reqs) != 4 {
-		t.Fatalf("expected delete, insert, code font, and code shading requests, got %#v", reqs)
+	if len(reqs) != 5 {
+		t.Fatalf("expected delete, insert, reset, code font, and code shading requests, got %#v", reqs)
 	}
 	if got := reqs[1].InsertText; got == nil || got.Location.Index != 7 || got.Text != "\nline1"+docsSoftLineBreak+"line2\n" {
 		t.Fatalf("unexpected insert request: %#v", got)
 	}
-	if got := reqs[3].UpdateParagraphStyle; got == nil || got.Range.StartIndex != 8 || got.Range.EndIndex != 20 {
+	if got := reqs[4].UpdateParagraphStyle; got == nil || got.Range.StartIndex != 8 || got.Range.EndIndex != 20 {
 		t.Fatalf("unexpected code shading request: %#v", got)
 	}
 }

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -160,6 +160,7 @@ func replaceDocsMarkdownRange(ctx context.Context, svc *docs.Service, doc *docs.
 				Text:     prefix + textToInsert,
 			},
 		})
+		requests = append(requests, resetDocsTextStyleRequest(baseIndex, baseIndex+utf16Len(textToInsert), tabID))
 		requests = append(requests, formattingRequests...)
 	}
 

--- a/internal/cmd/docs_sed_brace_format.go
+++ b/internal/cmd/docs_sed_brace_format.go
@@ -119,25 +119,11 @@ func buildBraceTextStyleRequests(be *braceExpr, start, end int64) []*docs.Reques
 	}
 }
 
-// resetFieldsStr is the pre-joined field mask for resetting all text formatting.
-// Package-level to avoid per-call allocation and string joining.
-var resetFieldsStr = strings.Join([]string{
-	"bold", "italic", "underline", "strikethrough", "smallCaps",
-	"baselineOffset", "foregroundColor", "backgroundColor",
-	"fontSize", "weightedFontFamily", "link",
-}, ",")
-
 // buildResetTextStyleRequests builds requests to clear all formatting, then apply any
 // additional flags specified after the reset (e.g., {0 b} = reset then bold).
 func buildResetTextStyleRequests(be *braceExpr, start, end int64) []*docs.Request {
 	requests := []*docs.Request{
-		{
-			UpdateTextStyle: &docs.UpdateTextStyleRequest{
-				Range:     &docs.Range{StartIndex: start, EndIndex: end},
-				TextStyle: &docs.TextStyle{}, // Empty style = reset
-				Fields:    resetFieldsStr,
-			},
-		},
+		resetDocsTextStyleRequest(start, end, ""),
 	}
 
 	// Now apply any flags that were set alongside the reset

--- a/internal/cmd/docs_text_style.go
+++ b/internal/cmd/docs_text_style.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "google.golang.org/api/docs/v1"
+
+const docsTextStyleResetFields = "bold,italic,underline,strikethrough,smallCaps,baselineOffset,foregroundColor,backgroundColor,fontSize,weightedFontFamily,link"
+
+func resetDocsTextStyleRequest(startIdx, endIdx int64, tabID string) *docs.Request {
+	return &docs.Request{
+		UpdateTextStyle: &docs.UpdateTextStyleRequest{
+			Range: &docs.Range{
+				StartIndex: startIdx,
+				EndIndex:   endIdx,
+				TabId:      tabID,
+			},
+			TextStyle: &docs.TextStyle{},
+			Fields:    docsTextStyleResetFields,
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- reset inherited text styles across the inserted Markdown replacement range
- apply generated Markdown styles after the reset
- keep synthetic paragraph prefixes and surrounding document text outside the reset
- share the existing deterministic Docs text-style reset helper

## Verification

- focused find-replace, Markdown, inline, and brace reset tests
- autoreview clean
- `make ci`
- live exact reporter case and leading-plain control
- live styled-boundary matrix confirmed only `Alpha` and `Bravo` bold while surrounding text retained its prior style
- disposable documents trashed

Closes #735

Thanks @sebsnyk.
