### PR TITLE
feat(calendar): update event attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Calendar: add repeatable `--attachment` to `calendar update` for replacing or clearing event attachments. (#738) — thanks @TreyLawrence.
 - Sheets: add `sheets validation` get/set/clear commands for dropdown, checkbox, number, date, range, and custom-formula rules, and preserve table-managed dropdowns during validation-only copy/paste. (#710) — thanks @chrischall.
 - Sheets: add table-aware `sheets delete-dimension` for deleting row or column spans while preserving intersecting table objects and remaining data. (#711) — thanks @chrischall.
 - Docs: add direct `docs table-row`, `docs table-column`, `docs table-merge`, and `docs table-unmerge` commands with index, header-text, all-table, and tab-aware selection. (#686) — thanks @sebsnyk.

--- a/docs/commands/gog-calendar-update.md
+++ b/docs/commands/gog-calendar-update.md
@@ -22,6 +22,7 @@ gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--add-attendee` | `string` |  | Comma-separated attendee emails to add (preserves existing attendees) |
 | `--all-day` | `bool` |  | All-day event (use date-only in --from/--to) |
+| `--attachment` | `[]string` |  | File attachment URL (can be repeated; replaces all; set empty to clear) |
 | `--attendees` | `string` |  | Comma-separated attendee emails (replaces all; set empty to clear) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -246,7 +246,7 @@ Flag aliases:
 - `gog calendar event|get <calendarId> <eventId>`
 - `GOG_CALENDAR_WEEKDAY=1` defaults `--weekday` for `gog calendar events`
 - `gog calendar create <calendarId> --summary S --from DT --to DT [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees a@b.com,c@d.com] [--all-day] [--event-type TYPE]`
-- `gog calendar update <calendarId> <eventId> [--summary S] [--from DT] [--to DT] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees ...] [--add-attendee ...] [--all-day] [--with-meet|--regenerate-meet] [--event-type TYPE]`
+- `gog calendar update <calendarId> <eventId> [--summary S] [--from DT] [--to DT] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees ...] [--add-attendee ...] [--attachment URL ...] [--all-day] [--with-meet|--regenerate-meet] [--event-type TYPE]`
 - `gog calendar delete <calendarId> <eventId>`
 - `gog calendar freebusy [calendarIds] [--cal ID_OR_NAME] [--calendars CSV] [--all] --from RFC3339 --to RFC3339`
 - `gog calendar conflicts [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339|date|relative] [--to RFC3339|date|relative] [--today|--week|--days N]`

--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -335,6 +335,103 @@ func TestCalendarUpdateCmd_RunJSON(t *testing.T) {
 	}
 }
 
+func TestCalendarUpdateCmd_AttachmentsReplaceAndClear(t *testing.T) {
+	origNew := newCalendarService
+	t.Cleanup(func() { newCalendarService = origNew })
+
+	var patchCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if r.Method != http.MethodPatch || path != "/calendars/cal@example.com/events/ev" {
+			http.NotFound(w, r)
+			return
+		}
+		patchCalls++
+		if got := r.URL.Query().Get("supportsAttachments"); got != "true" {
+			t.Fatalf("supportsAttachments = %q, want true", got)
+		}
+		var body map[string]json.RawMessage
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode patch body: %v", err)
+		}
+		raw, ok := body["attachments"]
+		if !ok {
+			t.Fatalf("patch %d missing attachments: %#v", patchCalls, body)
+		}
+		var attachments []*calendar.EventAttachment
+		if err := json.Unmarshal(raw, &attachments); err != nil {
+			t.Fatalf("decode attachments: %v", err)
+		}
+		switch patchCalls {
+		case 1:
+			if len(attachments) != 2 ||
+				attachments[0].FileUrl != "https://drive.google.com/file/d/one" ||
+				attachments[1].FileUrl != "https://drive.google.com/file/d/two" {
+				t.Fatalf("unexpected replacement attachments: %#v", attachments)
+			}
+		case 2:
+			if attachments == nil || len(attachments) != 0 {
+				t.Fatalf("expected explicit empty attachments array, got %#v", attachments)
+			}
+		default:
+			t.Fatalf("unexpected patch call %d", patchCalls)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "ev"})
+	}))
+	defer srv.Close()
+
+	svc := newCalendarServiceFromServer(t, srv)
+	newCalendarService = func(context.Context, string) (*calendar.Service, error) { return svc, nil }
+	ctx := newCalendarJSONOutputContext(t, os.Stdout, os.Stderr)
+
+	if err := runKong(t, &CalendarUpdateCmd{}, []string{
+		"cal@example.com", "ev",
+		"--attachment", "https://drive.google.com/file/d/one",
+		"--attachment", "https://drive.google.com/file/d/two",
+	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("replace attachments: %v", err)
+	}
+	if err := runKong(t, &CalendarUpdateCmd{}, []string{
+		"cal@example.com", "ev", "--attachment=",
+	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("clear attachments: %v", err)
+	}
+	if patchCalls != 2 {
+		t.Fatalf("patch calls = %d, want 2", patchCalls)
+	}
+}
+
+func TestCalendarUpdateCmd_AttachmentClearDryRunReportsSupport(t *testing.T) {
+	ctx := newCalendarJSONContext(t)
+	out := captureStdout(t, func() {
+		err := runKong(t, &CalendarUpdateCmd{}, []string{
+			"primary", "ev", "--attachment=",
+		}, ctx, &RootFlags{Account: "a@b.com", DryRun: true})
+		if err != nil && ExitCode(err) != 0 {
+			t.Fatalf("dry-run: %v", err)
+		}
+	})
+
+	var payload struct {
+		Request struct {
+			SupportsAttachments bool `json:"supports_attachments"`
+			Patch               struct {
+				Attachments []*calendar.EventAttachment `json:"attachments"`
+			} `json:"patch"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(out), &payload); err != nil {
+		t.Fatalf("unmarshal dry-run: %v\n%s", err, out)
+	}
+	if !payload.Request.SupportsAttachments {
+		t.Fatal("expected supports_attachments for clear")
+	}
+	if payload.Request.Patch.Attachments == nil || len(payload.Request.Patch.Attachments) != 0 {
+		t.Fatalf("expected explicit empty attachment list: %#v", payload.Request.Patch.Attachments)
+	}
+}
+
 func TestCalendarUpdateCmd_WithMeet(t *testing.T) {
 	origNew := newCalendarService
 	t.Cleanup(func() { newCalendarService = origNew })

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -294,6 +294,7 @@ type CalendarUpdateCmd struct {
 	PlaceRegion           string   `name:"place-region" help:"Places API region code for location lookup"`
 	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails (replaces all; set empty to clear)"`
 	AddAttendee           string   `name:"add-attendee" help:"Comma-separated attendee emails to add (preserves existing attendees)"`
+	Attachments           []string `name:"attachment" help:"File attachment URL (can be repeated; replaces all; set empty to clear)"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
 	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear." sep:"none"`
 	Reminders             []string `name:"reminder" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5). Set empty to clear."`
@@ -412,7 +413,7 @@ func (c *CalendarUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		"patch":                patch,
 		"wants_add_attendee":   wantsAddAttendee,
 		"conference_version_1": patchHasConferenceDataMutation(patch),
-		"supports_attachments": len(patch.Attachments) > 0,
+		"supports_attachments": patchHasAttachmentsMutation(patch),
 	}
 	if placeLookup != nil {
 		request["place_lookup"] = placeLookup.dryRunPayload()
@@ -530,6 +531,10 @@ func (c *CalendarUpdateCmd) buildUpdatePatch(kctx *kong.Context) (*calendar.Even
 	}
 
 	if c.applyAttendees(kctx, patch) {
+		changed = true
+	}
+
+	if c.applyAttachments(kctx, patch) {
 		changed = true
 	}
 
@@ -672,6 +677,18 @@ func (c *CalendarUpdateCmd) applyAttendees(kctx *kong.Context, patch *calendar.E
 		return false
 	}
 	patch.Attendees = buildAttendees(c.Attendees)
+	return true
+}
+
+func (c *CalendarUpdateCmd) applyAttachments(kctx *kong.Context, patch *calendar.Event) bool {
+	if !flagProvided(kctx, "attachment") {
+		return false
+	}
+	patch.Attachments = buildAttachments(c.Attachments)
+	if len(patch.Attachments) == 0 {
+		patch.Attachments = []*calendar.EventAttachment{}
+		patch.ForceSendFields = appendForceSendField(patch.ForceSendFields, "Attachments")
+	}
 	return true
 }
 

--- a/internal/cmd/calendar_edit_patch_test.go
+++ b/internal/cmd/calendar_edit_patch_test.go
@@ -82,3 +82,63 @@ func TestCalendarUpdateBuildPatch_ClearFields(t *testing.T) {
 		t.Fatalf("expected force send fields")
 	}
 }
+
+func TestCalendarUpdateBuildPatch_Attachments(t *testing.T) {
+	t.Run("replace", func(t *testing.T) {
+		cmd := &CalendarUpdateCmd{}
+		parser, err := kong.New(cmd, kong.Writers(io.Discard, io.Discard))
+		if err != nil {
+			t.Fatalf("kong.New: %v", err)
+		}
+		kctx, err := parser.Parse([]string{
+			"cal1",
+			"evt1",
+			"--attachment", " https://drive.google.com/file/d/one ",
+			"--attachment", "https://drive.google.com/file/d/two",
+		})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		patch, changed, err := cmd.buildUpdatePatch(kctx)
+		if err != nil {
+			t.Fatalf("buildUpdatePatch: %v", err)
+		}
+		if !changed || len(patch.Attachments) != 2 {
+			t.Fatalf("unexpected attachment patch: %#v", patch)
+		}
+		if patch.Attachments[0].FileUrl != "https://drive.google.com/file/d/one" ||
+			patch.Attachments[1].FileUrl != "https://drive.google.com/file/d/two" {
+			t.Fatalf("unexpected attachments: %#v", patch.Attachments)
+		}
+		if !patchHasAttachmentsMutation(patch) {
+			t.Fatal("expected attachment mutation")
+		}
+	})
+
+	t.Run("clear", func(t *testing.T) {
+		cmd := &CalendarUpdateCmd{}
+		parser, err := kong.New(cmd, kong.Writers(io.Discard, io.Discard))
+		if err != nil {
+			t.Fatalf("kong.New: %v", err)
+		}
+		kctx, err := parser.Parse([]string{"cal1", "evt1", "--attachment="})
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+
+		patch, changed, err := cmd.buildUpdatePatch(kctx)
+		if err != nil {
+			t.Fatalf("buildUpdatePatch: %v", err)
+		}
+		if !changed || patch.Attachments == nil || len(patch.Attachments) != 0 {
+			t.Fatalf("unexpected clear patch: %#v", patch)
+		}
+		if !hasForceSendField(patch.ForceSendFields, "Attachments") {
+			t.Fatalf("expected Attachments force-send field: %#v", patch.ForceSendFields)
+		}
+		if !patchHasAttachmentsMutation(patch) {
+			t.Fatal("expected clear attachment mutation")
+		}
+	})
+}

--- a/internal/cmd/calendar_mutation_helpers.go
+++ b/internal/cmd/calendar_mutation_helpers.go
@@ -60,7 +60,25 @@ func (m *calendarMutationContext) patchEvent(ctx context.Context, eventID string
 	if patchHasConferenceDataMutation(patch) {
 		call = call.ConferenceDataVersion(1)
 	}
+	if patchHasAttachmentsMutation(patch) {
+		call = call.SupportsAttachments(true)
+	}
 	return call.Do()
+}
+
+func patchHasAttachmentsMutation(patch *calendar.Event) bool {
+	if patch == nil {
+		return false
+	}
+	if len(patch.Attachments) > 0 {
+		return true
+	}
+	for _, field := range patch.ForceSendFields {
+		if field == "Attachments" {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *calendarMutationContext) deleteEvent(ctx context.Context, eventID, sendUpdates string) error {


### PR DESCRIPTION
## Summary

- add repeatable `--attachment` to `calendar update`
- replace the complete attachment array when URLs are supplied
- clear attachments with `--attachment=`
- send `supportsAttachments=true` for replacement and clear
- expose attachment support accurately in dry-run output

## Verification

- patch construction, empty-array serialization, query parameter, and dry-run tests
- generated command docs
- autoreview clean
- `make ci`
- live owned Drive Doc attached to a disposable Calendar event, read back, cleared, and read back again
- event deleted and Drive file trashed

Closes #738

Thanks @TreyLawrence.
