### PR TITLE
test(docs): lock table inline code styling

### DIFF
--- a/internal/cmd/docs_cell_update_test.go
+++ b/internal/cmd/docs_cell_update_test.go
@@ -150,6 +150,52 @@ func TestDocsCellUpdate_ReplacesWithNativeMarkdownList(t *testing.T) {
 	}
 }
 
+func TestDocsCellUpdate_ReplacesPlainCellWithInlineCodeStyle(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(cellUpdateTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--row", "1", "--col", "2", "--content", "`doThing()`"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("docs cell-update inline code: %v", err)
+	}
+	if len(got.Requests) != 3 {
+		t.Fatalf("expected delete+insert+code style, got %d requests", len(got.Requests))
+	}
+	ins := got.Requests[1].InsertText
+	if ins == nil || ins.Location.Index != 10 || ins.Text != "doThing()" {
+		t.Fatalf("unexpected inline-code insert: %#v", ins)
+	}
+	style := got.Requests[2].UpdateTextStyle
+	if style == nil || style.Range == nil || style.TextStyle == nil || style.TextStyle.WeightedFontFamily == nil {
+		t.Fatalf("missing inline-code style request: %#v", got.Requests[2])
+	}
+	if style.Range.StartIndex != 10 || style.Range.EndIndex != 19 {
+		t.Fatalf("inline-code style range = %#v, want [10,19)", style.Range)
+	}
+	font := style.TextStyle.WeightedFontFamily
+	if font.FontFamily != "Courier New" || font.Weight != 400 || style.Fields != "weightedFontFamily" {
+		t.Fatalf("inline-code style = %#v fields=%q", font, style.Fields)
+	}
+}
+
 func TestDocsCellUpdate_AppendMarkdownWithTab(t *testing.T) {
 	origDocs := newDocsService
 	t.Cleanup(func() { newDocsService = origDocs })

--- a/internal/cmd/docs_table_inserter_inline_test.go
+++ b/internal/cmd/docs_table_inserter_inline_test.go
@@ -70,8 +70,11 @@ func TestBuildTableCellRequests_AppliesInlineItalicAndCode(t *testing.T) {
 			if tt.wantItalic && !style.TextStyle.Italic {
 				t.Fatalf("expected Italic, got %#v", style.TextStyle)
 			}
-			if tt.wantCode && style.TextStyle.WeightedFontFamily == nil {
-				t.Fatalf("expected code styling (WeightedFontFamily), got %#v", style.TextStyle)
+			if tt.wantCode {
+				font := style.TextStyle.WeightedFontFamily
+				if font == nil || font.FontFamily != "Courier New" || font.Weight != 400 {
+					t.Fatalf("expected Courier New 400 code styling, got %#v", style.TextStyle)
+				}
 			}
 		})
 	}

--- a/internal/cmd/docs_write_markdown_test.go
+++ b/internal/cmd/docs_write_markdown_test.go
@@ -77,7 +77,7 @@ func TestDocsWrite_MarkdownReplaceUsesDriveUpdate(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	mdFile := filepath.Join(tmpDir, "test.md")
-	markdown := "# Hello\n\n- item\n"
+	markdown := "# Hello\n\n- item\n\n| label | content |\n|---|---|\n| code | `doThing()` |\n"
 	if err := os.WriteFile(mdFile, []byte(markdown), 0o600); err != nil {
 		t.Fatalf("write markdown temp file: %v", err)
 	}
@@ -90,6 +90,9 @@ func TestDocsWrite_MarkdownReplaceUsesDriveUpdate(t *testing.T) {
 	}
 	if !strings.Contains(uploadBody, "# Hello") {
 		t.Fatalf("expected upload body to contain markdown content, got: %q", uploadBody)
+	}
+	if !strings.Contains(uploadBody, "| code | `doThing()` |") {
+		t.Fatalf("expected upload body to preserve table-cell inline code, got: %q", uploadBody)
 	}
 }
 


### PR DESCRIPTION
## Summary

- lock the whole-document Drive import path to preserve inline-code markers inside Markdown table cells
- verify native table insertion emits exact Courier New weight 400 styling
- verify `docs cell-update` applies the same style when replacing a genuinely plain cell

## Finding

The reported bug does not reproduce on current `main`. Both exact paths render monospace in Google Docs, so this PR adds regression coverage instead of changing working production code.

## Verification

- focused Docs tests passed
- Codex autoreview: no actionable findings
- `make ci`
- live with `clawdbot@gmail.com`:
  - whole-document Markdown import read back `doThing()` as Roboto Mono weight 400 and rendered visibly monospace in Google Docs
  - a plain table cell read back with no font override, then `docs cell-update` with backticked `freshCode()` read back Courier New weight 400 and rendered visibly monospace
  - Chrome verification used the existing signed-in profile with temporary reader access to the disposable Doc
  - screenshots: `/tmp/gog732-doc-before.png`, `/tmp/gog732-cell-plain-before.png`; `gh image` is unavailable in this environment

Closes #732.
