### PR TITLE
feat(docs): expose paragraph run metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Docs: add tab-aware table, image, heading, and paragraph enumerators with structured and plain output. (#719) — thanks @sebsnyk.
 - Docs: style locally rendered fenced Markdown blocks with Roboto Mono, dark-green text, and existing paragraph shading. (#676, #724) — thanks @TurboTheTurtle.
 - Docs: add `docs insert-image --url` for inserting public HTTPS images directly without Drive upload or temporary public sharing. (#675) — thanks @sebsnyk.
+- Docs: expose paragraph emptiness and text-run ranges, styles, and links in `docs paragraphs list --json`. (#734) — thanks @sebsnyk.
 
 ### Fixed
 

--- a/internal/cmd/docs_enumerators.go
+++ b/internal/cmd/docs_enumerators.go
@@ -78,6 +78,34 @@ type docsParagraphListItem struct {
 	Text       string `json:"text"`
 }
 
+type docsParagraphInspectItem struct {
+	Index      int                `json:"index"`
+	StartIndex int64              `json:"startIndex"`
+	EndIndex   int64              `json:"endIndex"`
+	Style      string             `json:"style"`
+	Text       string             `json:"text"`
+	IsEmpty    bool               `json:"isEmpty"`
+	Runs       []docsParagraphRun `json:"runs"`
+}
+
+type docsParagraphRun struct {
+	StartIndex    int64                 `json:"startIndex"`
+	EndIndex      int64                 `json:"endIndex"`
+	Text          string                `json:"text"`
+	Bold          bool                  `json:"bold"`
+	Italic        bool                  `json:"italic"`
+	Underline     bool                  `json:"underline"`
+	Strikethrough bool                  `json:"strikethrough"`
+	Link          *docsParagraphRunLink `json:"link"`
+}
+
+type docsParagraphRunLink struct {
+	URL        string `json:"url,omitempty"`
+	BookmarkID string `json:"bookmarkId,omitempty"`
+	HeadingID  string `json:"headingId,omitempty"`
+	TabID      string `json:"tabId,omitempty"`
+}
+
 func (c *DocsTablesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	doc, tabID, err := loadDocsEnumeratorDocument(ctx, flags, c.DocID, c.Tab)
 	if err != nil {
@@ -188,7 +216,7 @@ func (c *DocsHeadingsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 			Text:       paragraph.Text,
 		})
 	}
-	return writeDocsParagraphEnumerator(ctx, doc.DocumentId, tabID, "headings", items)
+	return writeDocsParagraphEnumerator(ctx, doc.DocumentId, tabID, "headings", items, nil)
 }
 
 func (c *DocsParagraphsListCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -199,19 +227,30 @@ func (c *DocsParagraphsListCmd) Run(ctx context.Context, flags *RootFlags) error
 	style := strings.ToUpper(strings.TrimSpace(c.Style))
 	paragraphs := enumerateDocsParagraphs(doc)
 	items := make([]docsParagraphListItem, 0)
+	inspectItems := make([]docsParagraphInspectItem, 0)
 	for i, paragraph := range paragraphs {
 		if style != "" && paragraph.Style != style {
 			continue
 		}
-		items = append(items, docsParagraphListItem{
+		item := docsParagraphListItem{
 			Index:      i + 1,
 			StartIndex: paragraph.StartIndex,
 			EndIndex:   paragraph.EndIndex,
 			Style:      paragraph.Style,
 			Text:       paragraph.Text,
+		}
+		items = append(items, item)
+		inspectItems = append(inspectItems, docsParagraphInspectItem{
+			Index:      item.Index,
+			StartIndex: item.StartIndex,
+			EndIndex:   item.EndIndex,
+			Style:      item.Style,
+			Text:       item.Text,
+			IsEmpty:    paragraph.IsEmpty,
+			Runs:       paragraph.Runs,
 		})
 	}
-	return writeDocsParagraphEnumerator(ctx, doc.DocumentId, tabID, "paragraphs", items)
+	return writeDocsParagraphEnumerator(ctx, doc.DocumentId, tabID, "paragraphs", items, inspectItems)
 }
 
 func loadDocsEnumeratorDocument(
@@ -267,12 +306,16 @@ func writeDocsParagraphEnumerator(
 	tabID string,
 	key string,
 	items []docsParagraphListItem,
+	jsonItems any,
 ) error {
 	if outfmt.IsJSON(ctx) {
+		if jsonItems == nil {
+			jsonItems = items
+		}
 		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
 			"documentId": documentID,
 			"tabId":      tabID,
-			key:          items,
+			key:          jsonItems,
 		})
 	}
 	w, flush := tableWriter(ctx)
@@ -447,6 +490,8 @@ type docsEnumeratedParagraph struct {
 	EndIndex   int64
 	Style      string
 	Text       string
+	IsEmpty    bool
+	Runs       []docsParagraphRun
 }
 
 func enumerateDocsParagraphs(doc *docs.Document) []docsEnumeratedParagraph {
@@ -466,11 +511,14 @@ func enumerateDocsParagraphs(doc *docs.Document) []docsEnumeratedParagraph {
 					element.Paragraph.ParagraphStyle.NamedStyleType != "" {
 					style = element.Paragraph.ParagraphStyle.NamedStyleType
 				}
+				isEmpty, runs := inspectDocsParagraph(element.Paragraph)
 				paragraphs = append(paragraphs, docsEnumeratedParagraph{
 					StartIndex: element.StartIndex,
 					EndIndex:   element.EndIndex,
 					Style:      style,
 					Text:       paragraphText(element.Paragraph),
+					IsEmpty:    isEmpty,
+					Runs:       runs,
 				})
 			}
 			if element.Table != nil {
@@ -487,6 +535,79 @@ func enumerateDocsParagraphs(doc *docs.Document) []docsEnumeratedParagraph {
 	}
 	walk(doc.Body.Content)
 	return paragraphs
+}
+
+func inspectDocsParagraph(paragraph *docs.Paragraph) (bool, []docsParagraphRun) {
+	if paragraph == nil {
+		return true, []docsParagraphRun{}
+	}
+	runs := make([]docsParagraphRun, 0, len(paragraph.Elements))
+	hasContent := len(paragraph.PositionedObjectIds) > 0
+	for _, element := range paragraph.Elements {
+		if element == nil {
+			continue
+		}
+		if element.TextRun == nil {
+			hasContent = hasContent || docsParagraphElementHasNonTextContent(element)
+			continue
+		}
+
+		textRun := element.TextRun
+		if strings.TrimSpace(textRun.Content) != "" {
+			hasContent = true
+		}
+		run := docsParagraphRun{
+			StartIndex: element.StartIndex,
+			EndIndex:   element.EndIndex,
+			Text:       textRun.Content,
+		}
+		if textRun.TextStyle != nil {
+			run.Bold = textRun.TextStyle.Bold
+			run.Italic = textRun.TextStyle.Italic
+			run.Underline = textRun.TextStyle.Underline
+			run.Strikethrough = textRun.TextStyle.Strikethrough
+			run.Link = docsParagraphRunLinkFrom(textRun.TextStyle.Link)
+		}
+		runs = append(runs, run)
+	}
+	return !hasContent, runs
+}
+
+func docsParagraphElementHasNonTextContent(element *docs.ParagraphElement) bool {
+	return element.AutoText != nil ||
+		element.ColumnBreak != nil ||
+		element.DateElement != nil ||
+		element.Equation != nil ||
+		element.FootnoteReference != nil ||
+		element.HorizontalRule != nil ||
+		element.InlineObjectElement != nil ||
+		element.PageBreak != nil ||
+		element.Person != nil ||
+		element.RichLink != nil
+}
+
+func docsParagraphRunLinkFrom(link *docs.Link) *docsParagraphRunLink {
+	if link == nil {
+		return nil
+	}
+	result := &docsParagraphRunLink{
+		URL:        link.Url,
+		BookmarkID: link.BookmarkId,
+		HeadingID:  link.HeadingId,
+		TabID:      link.TabId,
+	}
+	if link.Bookmark != nil {
+		result.BookmarkID = link.Bookmark.Id
+		result.TabID = link.Bookmark.TabId
+	}
+	if link.Heading != nil {
+		result.HeadingID = link.Heading.Id
+		result.TabID = link.Heading.TabId
+	}
+	if result.URL == "" && result.BookmarkID == "" && result.HeadingID == "" && result.TabID == "" {
+		return nil
+	}
+	return result
 }
 
 func docsTSVField(value string) string {

--- a/internal/cmd/docs_enumerators_test.go
+++ b/internal/cmd/docs_enumerators_test.go
@@ -177,6 +177,8 @@ func TestDocsHeadingsAndParagraphsFilters(t *testing.T) {
 	})
 	if !strings.Contains(headingsOut, `"index": 2`) ||
 		!strings.Contains(headingsOut, `"text": "Section"`) ||
+		strings.Contains(headingsOut, `"isEmpty"`) ||
+		strings.Contains(headingsOut, `"runs"`) ||
 		strings.Contains(headingsOut, `"text": "Title"`) {
 		t.Fatalf("headings output: %s", headingsOut)
 	}
@@ -190,6 +192,157 @@ func TestDocsHeadingsAndParagraphsFilters(t *testing.T) {
 		!strings.Contains(paragraphsOut, `"text": "Body"`) ||
 		strings.Contains(paragraphsOut, `"text": "Section"`) {
 		t.Fatalf("paragraphs output: %s", paragraphsOut)
+	}
+}
+
+func TestDocsParagraphsJSONIncludesRunsAndEmptiness(t *testing.T) {
+	response := map[string]any{
+		"documentId": "doc1",
+		"body": map[string]any{"content": []any{
+			map[string]any{
+				"startIndex": 1,
+				"endIndex":   15,
+				"paragraph": map[string]any{
+					"paragraphStyle": map[string]any{"namedStyleType": "NORMAL_TEXT"},
+					"elements": []any{
+						map[string]any{
+							"startIndex": 1,
+							"endIndex":   7,
+							"textRun": map[string]any{
+								"content":   "Alpha ",
+								"textStyle": map[string]any{"bold": true},
+							},
+						},
+						map[string]any{
+							"startIndex": 7,
+							"endIndex":   11,
+							"textRun": map[string]any{
+								"content": "link",
+								"textStyle": map[string]any{
+									"italic":        true,
+									"underline":     true,
+									"strikethrough": true,
+									"link":          map[string]any{"url": "https://example.com"},
+								},
+							},
+						},
+						map[string]any{
+							"startIndex": 11,
+							"endIndex":   14,
+							"textRun":    map[string]any{"content": "🐢\n"},
+						},
+					},
+				},
+			},
+			map[string]any{
+				"startIndex": 15,
+				"endIndex":   16,
+				"paragraph": map[string]any{
+					"elements": []any{
+						map[string]any{
+							"startIndex": 15,
+							"endIndex":   16,
+							"textRun":    map[string]any{"content": "\n"},
+						},
+					},
+				},
+			},
+			map[string]any{
+				"startIndex": 16,
+				"endIndex":   17,
+				"paragraph": map[string]any{
+					"elements": []any{
+						map[string]any{
+							"startIndex":          16,
+							"endIndex":            17,
+							"inlineObjectElement": map[string]any{"inlineObjectId": "image1"},
+						},
+					},
+				},
+			},
+		}},
+	}
+	srv := newDocsRawTestServer(t, 0, response)
+	defer srv.Close()
+	installMockDocsService(t, srv)
+
+	ctx := outfmt.WithMode(rawTestContext(t), outfmt.Mode{JSON: true})
+	out := captureStdout(t, func() {
+		if err := runKong(t, &DocsParagraphsListCmd{}, []string{"doc1"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	var got struct {
+		Paragraphs []docsParagraphInspectItem `json:"paragraphs"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, out)
+	}
+	if len(got.Paragraphs) != 3 {
+		t.Fatalf("paragraphs = %#v", got.Paragraphs)
+	}
+
+	first := got.Paragraphs[0]
+	if first.IsEmpty || first.Text != "Alpha link🐢" || len(first.Runs) != 3 {
+		t.Fatalf("first paragraph = %#v", first)
+	}
+	if !first.Runs[0].Bold || first.Runs[0].Italic || first.Runs[0].Link != nil {
+		t.Fatalf("bold run = %#v", first.Runs[0])
+	}
+	linkRun := first.Runs[1]
+	if linkRun.Bold || !linkRun.Italic || !linkRun.Underline || !linkRun.Strikethrough ||
+		linkRun.Link == nil || linkRun.Link.URL != "https://example.com" {
+		t.Fatalf("link run = %#v", linkRun)
+	}
+	if first.Runs[2].StartIndex != 11 || first.Runs[2].EndIndex != 14 || first.Runs[2].Text != "🐢\n" {
+		t.Fatalf("UTF-16 run = %#v", first.Runs[2])
+	}
+	if !got.Paragraphs[1].IsEmpty || len(got.Paragraphs[1].Runs) != 1 {
+		t.Fatalf("blank paragraph = %#v", got.Paragraphs[1])
+	}
+	if got.Paragraphs[2].IsEmpty || len(got.Paragraphs[2].Runs) != 0 {
+		t.Fatalf("inline-object paragraph = %#v", got.Paragraphs[2])
+	}
+}
+
+func TestDocsParagraphRunLinkFrom(t *testing.T) {
+	tests := []struct {
+		name string
+		link *docs.Link
+		want docsParagraphRunLink
+	}{
+		{
+			name: "legacy bookmark",
+			link: &docs.Link{BookmarkId: "bookmark1"},
+			want: docsParagraphRunLink{BookmarkID: "bookmark1"},
+		},
+		{
+			name: "tab-aware bookmark",
+			link: &docs.Link{Bookmark: &docs.BookmarkLink{Id: "bookmark2", TabId: "tab1"}},
+			want: docsParagraphRunLink{BookmarkID: "bookmark2", TabID: "tab1"},
+		},
+		{
+			name: "tab-aware heading",
+			link: &docs.Link{Heading: &docs.HeadingLink{Id: "heading1", TabId: "tab2"}},
+			want: docsParagraphRunLink{HeadingID: "heading1", TabID: "tab2"},
+		},
+		{
+			name: "tab",
+			link: &docs.Link{TabId: "tab3"},
+			want: docsParagraphRunLink{TabID: "tab3"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := docsParagraphRunLinkFrom(test.link)
+			if got == nil || *got != test.want {
+				t.Fatalf("link = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+	if got := docsParagraphRunLinkFrom(&docs.Link{}); got != nil {
+		t.Fatalf("empty link = %#v, want nil", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- extend `docs paragraphs list --json` with explicit `isEmpty`
- expose API-native UTF-16 text-run ranges and bold/italic/underline/strikethrough state
- expose external, bookmark, heading, and tab link destinations
- preserve existing headings JSON and paragraph plain/TSV output

Closes #734.

## Validation

- `go test ./internal/cmd -run 'TestDocs(HeadingsAndParagraphsFilters|ParagraphsJSONIncludesRunsAndEmptiness|ParagraphRunLinkFrom|ParagraphsPlainHasNoHeader)|TestEnumerateDocsParagraphsRecursesIntoTablesAndTOC'`
- `make ci`
- autoreview: clean, no accepted/actionable findings
- exact-head push CI: Linux, macOS, Windows, worker green

## Live proof

Authenticated disposable Google Doc using `clawdbot@gmail.com`:

- wrote mixed plain, bold, italic, underline, strikethrough, hyperlink, Unicode, and empty paragraphs
- verified every run range length against UTF-16 code units
- verified `isEmpty` and run/link JSON fields
- verified plain output remains five-column TSV

Result: `live734:ok paragraphs=3 runs=7 empty=2`
