### PR TITLE
feat(docs): guard markdown writes against orphaned comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Docs: style locally rendered fenced Markdown blocks with Roboto Mono, dark-green text, and existing paragraph shading. (#676, #724) — thanks @TurboTheTurtle.
 - Docs: add `docs insert-image --url` for inserting public HTTPS images directly without Drive upload or temporary public sharing. (#675) — thanks @sebsnyk.
 - Docs: expose paragraph emptiness and text-run ranges, styles, and links in `docs paragraphs list --json`. (#734) — thanks @sebsnyk.
+- Docs: add opt-in `--check-orphans` to Markdown replacement writes so open comments whose quoted text would disappear block the mutation with orphaned exit code 11. (#691) — thanks @sebsnyk.
 
 ### Fixed
 

--- a/docs/commands/gog-docs-write.md
+++ b/docs/commands/gog-docs-write.md
@@ -24,6 +24,7 @@ gog docs (doc) write <docId> [flags]
 | `--append` | `bool` |  | Append instead of replacing the document body |
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
+| `--check-orphans` | `bool` |  | Block markdown replacement when open comment quotes would disappear |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--code` | `bool` |  | Apply code style (Courier New + grey background) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -21,6 +21,19 @@ Replace the document body with Markdown from a file:
 gog docs write <docId> --replace --markdown --content-file README.md
 ```
 
+Add `--check-orphans` to block the replacement when an open, currently
+located comment quote would disappear:
+
+```bash
+gog docs write <docId> --replace --markdown --file README.md --check-orphans
+```
+
+The preflight uses the same entity and whitespace matching as
+`docs comments locate`, skips resolved, unquoted, and already-orphaned
+comments, and exits with code 11 before mutation. With `--tab`, only comments
+located in the replaced tab are checked. JSON output includes the comments in
+`wouldOrphan`; human output is written to stderr.
+
 Command pages:
 
 - [`gog docs write`](commands/gog-docs-write.md)

--- a/internal/cmd/docs_comments_locate.go
+++ b/internal/cmd/docs_comments_locate.go
@@ -94,10 +94,14 @@ func (c *DocsCommentsLocateCmd) findQuoteMatches(ctx context.Context, svc *docs.
 		return nil, err
 	}
 
+	return c.findQuoteMatchesAcrossDocument(doc, quote), nil
+}
+
+func (c *DocsCommentsLocateCmd) findQuoteMatchesAcrossDocument(doc *docs.Document, quote string) []docsTextRangeMatch {
 	var matches []docsTextRangeMatch
 	tabs := flattenTabs(doc.Tabs)
 	if len(tabs) == 0 {
-		return c.findQuoteMatchesInDoc(doc, quote, ""), nil
+		return c.findQuoteMatchesInDoc(doc, quote, "")
 	}
 	for _, tab := range tabs {
 		if tab == nil || tab.DocumentTab == nil {
@@ -110,7 +114,7 @@ func (c *DocsCommentsLocateCmd) findQuoteMatches(ctx context.Context, svc *docs.
 		tabDoc := &docs.Document{Body: tab.DocumentTab.Body}
 		matches = append(matches, c.findQuoteMatchesInDoc(tabDoc, quote, tabID)...)
 	}
-	return matches, nil
+	return matches
 }
 
 func (c *DocsCommentsLocateCmd) findQuoteMatchesInDoc(doc *docs.Document, quote string, tabID string) []docsTextRangeMatch {

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -34,17 +34,18 @@ func resolveTabArg(ctx context.Context, tab, tabID string) (string, error) {
 }
 
 type DocsWriteCmd struct {
-	DocID    string          `arg:"" name:"docId" help:"Doc ID"`
-	Text     string          `name:"text" help:"Text to write"`
-	File     string          `name:"file" help:"Text file path ('-' for stdin)"`
-	Replace  bool            `name:"replace" help:"Replace all content explicitly (required with --markdown unless --append is set)"`
-	Markdown bool            `name:"markdown" help:"Convert markdown to Google Docs formatting (requires --replace or --append)"`
-	Append   bool            `name:"append" help:"Append instead of replacing the document body"`
-	Pageless bool            `name:"pageless" help:"Set document to pageless mode"`
-	Layout   DocsLayoutFlags `embed:""`
-	Tab      string          `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
-	TabID    string          `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
-	Format   DocsFormatFlags `embed:""`
+	DocID        string          `arg:"" name:"docId" help:"Doc ID"`
+	Text         string          `name:"text" help:"Text to write"`
+	File         string          `name:"file" help:"Text file path ('-' for stdin)"`
+	Replace      bool            `name:"replace" help:"Replace all content explicitly (required with --markdown unless --append is set)"`
+	Markdown     bool            `name:"markdown" help:"Convert markdown to Google Docs formatting (requires --replace or --append)"`
+	Append       bool            `name:"append" help:"Append instead of replacing the document body"`
+	CheckOrphans bool            `name:"check-orphans" help:"Block markdown replacement when open comment quotes would disappear"`
+	Pageless     bool            `name:"pageless" help:"Set document to pageless mode"`
+	Layout       DocsLayoutFlags `embed:""`
+	Tab          string          `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	TabID        string          `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+	Format       DocsFormatFlags `embed:""`
 }
 
 func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -59,6 +60,9 @@ func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootF
 	}
 	if c.Append && c.Replace {
 		return usage("--append cannot be combined with --replace")
+	}
+	if c.CheckOrphans && (!c.Markdown || !c.Replace || c.Append) {
+		return usage("--check-orphans requires --replace --markdown")
 	}
 
 	tab, tabErr := resolveTabArg(ctx, c.Tab, c.TabID)
@@ -269,13 +273,14 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 	explicitHeadingAnchors := markdownImportExplicitHeadingAnchors(cleaned)
 	cleaned = stripMarkdownHeadingAnchors(cleaned)
 	dryRunPayload := map[string]any{
-		"document_id": docID,
-		"written":     len(content),
-		"append":      false,
-		"replace":     true,
-		"markdown":    true,
-		"pageless":    c.Pageless,
-		"images":      len(images),
+		"document_id":   docID,
+		"written":       len(content),
+		"append":        false,
+		"replace":       true,
+		"markdown":      true,
+		"pageless":      c.Pageless,
+		"images":        len(images),
+		"check_orphans": c.CheckOrphans,
 	}
 	for k, v := range c.Layout.dryRunPayload() {
 		dryRunPayload[k] = v
@@ -289,6 +294,21 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 		return err
 	}
 
+	var docsSvc *docs.Service
+	if c.CheckOrphans {
+		docsSvc, err = newDocsService(ctx, account)
+		if err != nil {
+			return err
+		}
+		orphans, tabID, orphanErr := findDocsWriteMarkdownOrphans(ctx, driveSvc, docsSvc, docID, content, "", true)
+		if orphanErr != nil {
+			return orphanErr
+		}
+		if resultErr := writeDocsWriteOrphanResult(ctx, docID, tabID, orphans); resultErr != nil {
+			return resultErr
+		}
+	}
+
 	updated, err := driveSvc.Files.Update(docID, &drive.File{}).
 		Media(strings.NewReader(cleaned), gapi.ContentType(mimeTextMarkdown)).
 		SupportsAllDrives(true).
@@ -299,9 +319,8 @@ func (c *DocsWriteCmd) writeMarkdown(ctx context.Context, flags *RootFlags, docI
 		return fmt.Errorf("writing markdown to document: %w", err)
 	}
 
-	var docsSvc *docs.Service
 	needsDocsSvc := len(images) > 0 || c.Pageless || c.Layout.any() || markdownMayContainHeadingLinks(cleaned)
-	if needsDocsSvc {
+	if needsDocsSvc && docsSvc == nil {
 		var svcErr error
 		docsSvc, svcErr = newDocsService(ctx, account)
 		if svcErr != nil {
@@ -461,14 +480,15 @@ func (c *DocsWriteCmd) replaceMarkdownInTab(ctx context.Context, flags *RootFlag
 	cleaned, images := extractMarkdownImages(content)
 	explicitHeadingAnchors := markdownExplicitHeadingAnchors(cleaned)
 	dryRunPayload := map[string]any{
-		"document_id": docID,
-		"written":     len(cleaned),
-		"append":      false,
-		"replace":     true,
-		"markdown":    true,
-		"pageless":    c.Pageless,
-		"tab":         c.Tab,
-		"images":      len(images),
+		"document_id":   docID,
+		"written":       len(cleaned),
+		"append":        false,
+		"replace":       true,
+		"markdown":      true,
+		"pageless":      c.Pageless,
+		"tab":           c.Tab,
+		"images":        len(images),
+		"check_orphans": c.CheckOrphans,
 	}
 	for k, v := range c.Layout.dryRunPayload() {
 		dryRunPayload[k] = v
@@ -477,7 +497,28 @@ func (c *DocsWriteCmd) replaceMarkdownInTab(ctx context.Context, flags *RootFlag
 		return err
 	}
 
-	svc, err := requireDocsService(ctx, flags)
+	var svc *docs.Service
+	var err error
+	if c.CheckOrphans {
+		account, driveSvc, driveErr := requireDriveService(ctx, flags)
+		if driveErr != nil {
+			return driveErr
+		}
+		svc, err = newDocsService(ctx, account)
+		if err != nil {
+			return err
+		}
+		orphans, resolvedTabID, orphanErr := findDocsWriteMarkdownOrphans(ctx, driveSvc, svc, docID, content, c.Tab, false)
+		if orphanErr != nil {
+			return orphanErr
+		}
+		if resultErr := writeDocsWriteOrphanResult(ctx, docID, resolvedTabID, orphans); resultErr != nil {
+			return resultErr
+		}
+		c.Tab = resolvedTabID
+	} else {
+		svc, err = requireDocsService(ctx, flags)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/docs_write_orphans.go
+++ b/internal/cmd/docs_write_orphans.go
@@ -1,0 +1,249 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type docsWriteOrphanComment struct {
+	CommentID   string `json:"commentId"`
+	Author      string `json:"author,omitempty"`
+	AuthorEmail string `json:"authorEmail,omitempty"`
+	Content     string `json:"content"`
+	Quote       string `json:"quote"`
+}
+
+type docsWriteOrphanResult struct {
+	DocumentID  string                   `json:"documentId"`
+	TabID       string                   `json:"tabId,omitempty"`
+	WouldOrphan []docsWriteOrphanComment `json:"wouldOrphan"`
+}
+
+func findDocsWriteMarkdownOrphans(
+	ctx context.Context,
+	driveSvc *drive.Service,
+	docsSvc *docs.Service,
+	docID string,
+	content string,
+	tabQuery string,
+	wholeDocument bool,
+) ([]docsWriteOrphanComment, string, error) {
+	doc, err := docsSvc.Documents.Get(docID).Context(ctx).IncludeTabsContent(true).Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return nil, "", fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return nil, "", err
+	}
+	doc, err = requireRawResponse(doc, "doc not found")
+	if err != nil {
+		return nil, "", err
+	}
+
+	targetTabID, err := docsWriteOrphanTargetTabID(doc, tabQuery, wholeDocument)
+	if err != nil {
+		return nil, "", err
+	}
+	comments, _, err := listDriveComments(ctx, driveSvc, docID, driveCommentListOptions{
+		includeQuoted: true,
+		all:           true,
+		max:           100,
+		mode:          driveCommentListModeExpanded,
+	})
+	if err != nil {
+		return nil, "", fmt.Errorf("list document comments: %w", err)
+	}
+
+	outgoing := docsWriteMarkdownDocument(content)
+	locator := DocsCommentsLocateCmd{NormalizeWhitespace: true}
+	var orphans []docsWriteOrphanComment
+	for _, comment := range comments {
+		quote := strings.TrimSpace(docsCommentQuote(comment))
+		if quote == "" {
+			continue
+		}
+
+		currentMatches := locator.findQuoteMatchesAcrossDocument(doc, quote)
+		if len(currentMatches) == 0 || !docsWriteCommentTouchesTarget(currentMatches, targetTabID, wholeDocument) {
+			continue
+		}
+		if len(locator.findQuoteMatchesInDoc(outgoing, quote, targetTabID)) > 0 {
+			continue
+		}
+
+		orphan := docsWriteOrphanComment{
+			CommentID: comment.Id,
+			Content:   comment.Content,
+			Quote:     docsCommentQuote(comment),
+		}
+		if comment.Author != nil {
+			orphan.Author = comment.Author.DisplayName
+			orphan.AuthorEmail = comment.Author.EmailAddress
+		}
+		orphans = append(orphans, orphan)
+	}
+	sort.SliceStable(orphans, func(i, j int) bool {
+		left := strings.ToLower(orphans[i].Author + "\x00" + orphans[i].AuthorEmail + "\x00" + orphans[i].CommentID)
+		right := strings.ToLower(orphans[j].Author + "\x00" + orphans[j].AuthorEmail + "\x00" + orphans[j].CommentID)
+		return left < right
+	})
+	return orphans, targetTabID, nil
+}
+
+func docsWriteOrphanTargetTabID(doc *docs.Document, tabQuery string, wholeDocument bool) (string, error) {
+	if wholeDocument {
+		return "", nil
+	}
+	tabs := flattenTabs(doc.Tabs)
+	if strings.TrimSpace(tabQuery) == "" {
+		if len(tabs) == 0 {
+			return "", nil
+		}
+		if tabs[0].TabProperties == nil || strings.TrimSpace(tabs[0].TabProperties.TabId) == "" {
+			return "", fmt.Errorf("first tab has no ID")
+		}
+		return tabs[0].TabProperties.TabId, nil
+	}
+	tab, err := findTab(tabs, tabQuery)
+	if err != nil {
+		return "", err
+	}
+	if tab.TabProperties == nil || strings.TrimSpace(tab.TabProperties.TabId) == "" {
+		return "", fmt.Errorf("tab has no ID: %s", tabQuery)
+	}
+	return tab.TabProperties.TabId, nil
+}
+
+func docsWriteCommentTouchesTarget(matches []docsTextRangeMatch, targetTabID string, wholeDocument bool) bool {
+	if wholeDocument {
+		return len(matches) > 0
+	}
+	for _, match := range matches {
+		if match.TabID == targetTabID {
+			return true
+		}
+	}
+	return false
+}
+
+func docsWriteMarkdownDocument(content string) *docs.Document {
+	cleaned, images := extractMarkdownImages(content)
+	for _, image := range images {
+		cleaned = strings.ReplaceAll(cleaned, image.placeholder(), "")
+	}
+
+	doc := &docs.Document{Body: &docs.Body{}}
+	index := int64(1)
+	elements := ParseMarkdown(cleaned)
+	stripMarkdownElementHeadingAnchors(elements)
+	for _, element := range elements {
+		if element.Type == MDTable {
+			table, next := docsWriteMarkdownTable(element.TableCells, index)
+			if table != nil {
+				doc.Body.Content = append(doc.Body.Content, table)
+				index = next
+			}
+			continue
+		}
+		_, text, _ := MarkdownToDocsRequests([]MarkdownElement{element}, index, "")
+		if text == "" {
+			continue
+		}
+		doc.Body.Content = append(doc.Body.Content, docsWriteMarkdownParagraph(index, text))
+		index += utf16Len(text)
+	}
+	return doc
+}
+
+func docsWriteMarkdownTable(cells [][]string, index int64) (*docs.StructuralElement, int64) {
+	if len(cells) == 0 {
+		return nil, index
+	}
+	start := index
+	table := &docs.Table{}
+	for _, rowCells := range cells {
+		row := &docs.TableRow{}
+		for _, cellMarkdown := range rowCells {
+			elements := ParseMarkdown(cellMarkdown)
+			stripMarkdownElementHeadingAnchors(elements)
+			_, text, _ := MarkdownToDocsRequests(elements, index, "")
+			if text == "" {
+				text = "\n"
+			}
+			paragraph := docsWriteMarkdownParagraph(index, text)
+			cell := &docs.TableCell{
+				Content:    []*docs.StructuralElement{paragraph},
+				StartIndex: index,
+				EndIndex:   index + utf16Len(text),
+			}
+			index = cell.EndIndex
+			row.TableCells = append(row.TableCells, cell)
+		}
+		table.TableRows = append(table.TableRows, row)
+	}
+	return &docs.StructuralElement{StartIndex: start, EndIndex: index, Table: table}, index
+}
+
+func docsWriteMarkdownParagraph(index int64, text string) *docs.StructuralElement {
+	end := index + utf16Len(text)
+	return &docs.StructuralElement{
+		StartIndex: index,
+		EndIndex:   end,
+		Paragraph: &docs.Paragraph{
+			Elements: []*docs.ParagraphElement{{
+				StartIndex: index,
+				EndIndex:   end,
+				TextRun:    &docs.TextRun{Content: text},
+			}},
+		},
+	}
+}
+
+func writeDocsWriteOrphanResult(ctx context.Context, docID, tabID string, orphans []docsWriteOrphanComment) error {
+	if len(orphans) == 0 {
+		return nil
+	}
+	result := docsWriteOrphanResult{
+		DocumentID:  docID,
+		TabID:       tabID,
+		WouldOrphan: orphans,
+	}
+	if outfmt.IsJSON(ctx) {
+		if err := outfmt.WriteJSON(ctx, os.Stdout, result); err != nil {
+			return err
+		}
+		return &ExitError{Code: exitCodeOrphaned, Err: nil}
+	}
+
+	u := ui.FromContext(ctx)
+	u.Err().Linef("docs write blocked: %d open comment(s) would become orphaned", len(orphans))
+	lastAuthor := ""
+	for _, orphan := range orphans {
+		author := strings.TrimSpace(orphan.Author)
+		if author == "" {
+			author = strings.TrimSpace(orphan.AuthorEmail)
+		}
+		if author == "" {
+			author = "(unknown author)"
+		}
+		if author != lastAuthor {
+			u.Err().Linef("%s", author)
+			lastAuthor = author
+		}
+		u.Err().Linef("  %s\t%s\t%s",
+			orphan.CommentID,
+			truncateString(oneLineTSV(orphan.Content), 80),
+			truncateString(oneLineTSV(orphan.Quote), 60),
+		)
+	}
+	return &ExitError{Code: exitCodeOrphaned, Err: nil}
+}

--- a/internal/cmd/docs_write_orphans_test.go
+++ b/internal/cmd/docs_write_orphans_test.go
@@ -1,0 +1,253 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+)
+
+func TestDocsWriteCheckOrphansValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "plain", args: []string{"doc1", "--text", "text", "--replace", "--check-orphans"}},
+		{name: "markdown without replace", args: []string{"doc1", "--text", "text", "--markdown", "--check-orphans"}},
+		{name: "append", args: []string{"doc1", "--text", "text", "--markdown", "--append", "--check-orphans"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := runKong(t, &DocsWriteCmd{}, tt.args, newDocsCmdContext(t), &RootFlags{Account: "a@b.com", DryRun: true})
+			if err == nil || !strings.Contains(err.Error(), "--check-orphans requires --replace --markdown") {
+				t.Fatalf("err = %v", err)
+			}
+		})
+	}
+}
+
+func TestDocsWriteCheckOrphansDryRunSkipsServices(t *testing.T) {
+	origDrive := newDriveService
+	origDocs := newDocsService
+	t.Cleanup(func() {
+		newDriveService = origDrive
+		newDocsService = origDocs
+	})
+	newDriveService = func(context.Context, string) (*drive.Service, error) {
+		t.Fatal("dry-run must not create Drive service")
+		return nil, errors.New("unexpected Drive service creation")
+	}
+	newDocsService = func(context.Context, string) (*docs.Service, error) {
+		t.Fatal("dry-run must not create Docs service")
+		return nil, errors.New("unexpected Docs service creation")
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runKong(t, &DocsWriteCmd{},
+			[]string{"doc1", "--text", "replacement", "--markdown", "--replace", "--check-orphans"},
+			newDocsJSONContext(t),
+			&RootFlags{Account: "a@b.com", DryRun: true},
+		)
+	})
+	var exitErr *ExitError
+	if !errors.As(runErr, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("err = %#v, want dry-run exit 0", runErr)
+	}
+	var got struct {
+		Request struct {
+			CheckOrphans bool `json:"check_orphans"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(out), &got); err != nil {
+		t.Fatalf("json: %v\n%s", err, out)
+	}
+	if !got.Request.CheckOrphans {
+		t.Fatalf("dry-run request = %#v, want check_orphans", got.Request)
+	}
+}
+
+func TestFindDocsWriteMarkdownOrphansFiltersAndMatchesRenderedText(t *testing.T) {
+	doc := docsFindRangeDoc(
+		docsFindRangeParagraph(1, "Tom & Jerry\n"),
+		docsFindRangeParagraph(13, "kept phrase\n"),
+	)
+	comments := []*drive.Comment{
+		{
+			Id:      "c1",
+			Content: "entity quote",
+			Author:  &drive.User{DisplayName: "Alice", EmailAddress: "alice@example.com"},
+			QuotedFileContent: &drive.CommentQuotedFileContent{
+				Value: "Tom &amp; Jerry",
+			},
+		},
+		{
+			Id:       "c2",
+			Resolved: true,
+			QuotedFileContent: &drive.CommentQuotedFileContent{
+				Value: "Tom &amp; Jerry",
+			},
+		},
+		{Id: "c3", Content: "unanchored"},
+		{
+			Id: "c4",
+			QuotedFileContent: &drive.CommentQuotedFileContent{
+				Value: "already orphaned",
+			},
+		},
+		{
+			Id: "c5",
+			QuotedFileContent: &drive.CommentQuotedFileContent{
+				Value: "kept phrase",
+			},
+		},
+	}
+	driveSvc, docsSvc := newDocsWriteOrphanServices(t, doc, comments)
+
+	orphans, tabID, err := findDocsWriteMarkdownOrphans(
+		context.Background(),
+		driveSvc,
+		docsSvc,
+		"doc1",
+		"# Replacement\n\nkept phrase",
+		"",
+		true,
+	)
+	if err != nil {
+		t.Fatalf("find orphans: %v", err)
+	}
+	if tabID != "" {
+		t.Fatalf("tabID = %q, want whole document", tabID)
+	}
+	if len(orphans) != 1 || orphans[0].CommentID != "c1" || orphans[0].AuthorEmail != "alice@example.com" {
+		t.Fatalf("orphans = %#v, want c1", orphans)
+	}
+}
+
+func TestFindDocsWriteMarkdownOrphansScopesToTargetTab(t *testing.T) {
+	doc := &docs.Document{
+		DocumentId: "doc1",
+		Tabs: []*docs.Tab{
+			{
+				TabProperties: &docs.TabProperties{TabId: "t.first", Title: "First"},
+				DocumentTab:   &docs.DocumentTab{Body: docsFindRangeDoc(docsFindRangeParagraph(1, "outside quote\n")).Body},
+			},
+			{
+				TabProperties: &docs.TabProperties{TabId: "t.second", Title: "Second"},
+				DocumentTab:   &docs.DocumentTab{Body: docsFindRangeDoc(docsFindRangeParagraph(1, "inside quote\n")).Body},
+			},
+		},
+	}
+	comments := []*drive.Comment{
+		{Id: "outside", QuotedFileContent: &drive.CommentQuotedFileContent{Value: "outside quote"}},
+		{Id: "inside", QuotedFileContent: &drive.CommentQuotedFileContent{Value: "inside quote"}},
+	}
+	driveSvc, docsSvc := newDocsWriteOrphanServices(t, doc, comments)
+
+	orphans, tabID, err := findDocsWriteMarkdownOrphans(
+		context.Background(),
+		driveSvc,
+		docsSvc,
+		"doc1",
+		"replacement",
+		"Second",
+		false,
+	)
+	if err != nil {
+		t.Fatalf("find orphans: %v", err)
+	}
+	if tabID != "t.second" {
+		t.Fatalf("tabID = %q, want t.second", tabID)
+	}
+	if len(orphans) != 1 || orphans[0].CommentID != "inside" {
+		t.Fatalf("orphans = %#v, want inside only", orphans)
+	}
+}
+
+func TestDocsWriteMarkdownDocumentIncludesTableCellText(t *testing.T) {
+	doc := docsWriteMarkdownDocument("| Name | Note |\n| --- | --- |\n| Ada | **cell phrase** |")
+	locator := DocsCommentsLocateCmd{NormalizeWhitespace: true}
+	matches := locator.findQuoteMatchesInDoc(doc, "cell phrase", "")
+	if len(matches) != 1 || !matches[0].InTable {
+		t.Fatalf("matches = %#v, want one table match", matches)
+	}
+}
+
+func TestDocsWriteMarkdownDocumentStripsHeadingAnchors(t *testing.T) {
+	doc := docsWriteMarkdownDocument("## Files {#attachments}")
+	locator := DocsCommentsLocateCmd{NormalizeWhitespace: true}
+	if matches := locator.findQuoteMatchesInDoc(doc, "{#attachments}", ""); len(matches) != 0 {
+		t.Fatalf("matches = %#v, want explicit heading anchor stripped", matches)
+	}
+	if matches := locator.findQuoteMatchesInDoc(doc, "Files", ""); len(matches) != 1 {
+		t.Fatalf("matches = %#v, want rendered heading text", matches)
+	}
+}
+
+func TestWriteDocsWriteOrphanResultJSONAndPlain(t *testing.T) {
+	orphans := []docsWriteOrphanComment{
+		{
+			CommentID: "c1",
+			Author:    "Alice",
+			Content:   strings.Repeat("comment ", 20),
+			Quote:     strings.Repeat("quoted ", 20),
+		},
+	}
+
+	var jsonErr error
+	jsonOut := captureStdout(t, func() {
+		jsonErr = writeDocsWriteOrphanResult(newDocsJSONContext(t), "doc1", "t.second", orphans)
+	})
+	var exitErr *ExitError
+	if !errors.As(jsonErr, &exitErr) || exitErr.Code != exitCodeOrphaned {
+		t.Fatalf("json err = %#v, want exit %d", jsonErr, exitCodeOrphaned)
+	}
+	var result docsWriteOrphanResult
+	if err := json.Unmarshal([]byte(jsonOut), &result); err != nil {
+		t.Fatalf("json: %v\n%s", err, jsonOut)
+	}
+	if result.DocumentID != "doc1" || result.TabID != "t.second" || len(result.WouldOrphan) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+
+	var stdout, stderr bytes.Buffer
+	plainErr := writeDocsWriteOrphanResult(newCmdOutputContext(t, &stdout, &stderr), "doc1", "", orphans)
+	if !errors.As(plainErr, &exitErr) || exitErr.Code != exitCodeOrphaned {
+		t.Fatalf("plain err = %#v, want exit %d", plainErr, exitCodeOrphaned)
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	for _, want := range []string{"blocked: 1", "Alice", "c1"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr = %q, want %q", stderr.String(), want)
+		}
+	}
+}
+
+func newDocsWriteOrphanServices(t *testing.T, doc *docs.Document, comments []*drive.Comment) (*drive.Service, *docs.Service) {
+	t.Helper()
+	driveSvc, _ := newDriveServiceForCommentsLocateTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || strings.TrimPrefix(r.URL.Path, "/drive/v3") != "/files/doc1/comments" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(&drive.CommentList{Comments: comments})
+	}))
+	docsSvc, _ := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/documents/doc1" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(doc)
+	}))
+	return driveSvc, docsSvc
+}


### PR DESCRIPTION
## Summary

- add opt-in `--check-orphans` to `docs write --replace --markdown`
- reuse `docs comments locate` entity and whitespace matching to identify currently anchored open comments whose quotes would disappear
- scope tab replacements to comments located in the target tab and skip resolved, unquoted, and already-orphaned comments
- block before mutation with exit code 11 and structured JSON or grouped human output
- document the behavior and add the changelog credit

## Verification

- `make ci`
- autoreview: clean, no actionable findings
- exact-head push CI: green on Linux, Windows, Darwin, and worker
- live Docs smoke with `clawdbot@gmail.com`: preserving replacement succeeded; dropping `DROP PHRASE` returned exit 11; JSON identified the exact comment; readback confirmed the blocked write left the document unchanged

Closes #691
