### PR TITLE
feat(agent): add safe capability discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It is built for terminals, shell scripts, CI, and coding agents:
 - runtime command allowlists/denylists and baked safety-profile binaries
 - typed [MCP server](docs/mcp.md) for agent clients, read-only by default and
   without a generic command runner
+- offline-by-default [agent capability discovery](docs/agent-capabilities.md)
+  for runtime safety and MCP tool exposure
 - read-only audit/reporting commands for risky surfaces like Drive and Contacts
 - [generated docs](docs/commands/README.md) for every command
 
@@ -25,6 +27,7 @@ Start here:
 - [Install](docs/install.md)
 - [Quickstart](docs/quickstart.md)
 - [Auth clients and service accounts](docs/auth-clients.md)
+- [Agent capabilities](docs/agent-capabilities.md)
 - [MCP server](docs/mcp.md)
 - [Command index](docs/commands/README.md)
 - [Gmail watch / Pub/Sub push](docs/watch.md) (<https://gogcli.sh/watch.html>)

--- a/docs/agent-capabilities.md
+++ b/docs/agent-capabilities.md
@@ -1,0 +1,69 @@
+---
+title: Agent capabilities
+description: "Inspect gog authentication disclosure, runtime safety rules, and MCP tool exposure before calling Google APIs."
+---
+
+# Agent capabilities
+
+`gog agent capabilities` emits a local runtime snapshot for agents, CI jobs,
+and MCP clients. The default command is offline: it does not open the keyring,
+inspect stored credentials, or print an account identity.
+
+```bash
+gog agent capabilities --json
+```
+
+The response includes:
+
+- supported authentication methods
+- active dry-run and Gmail no-send state
+- runtime command allow and deny rules
+- baked safety-profile name and status
+- the command for retrieving the full visible CLI schema
+
+The snapshot reports configured command rules rather than claiming a single
+global read/write state. Different commands can have different safety and OAuth
+requirements.
+
+## Credential metadata
+
+Credential inspection is explicit because it can access the configured keyring:
+
+```bash
+gog --account you@example.com agent capabilities --include-auth --json
+```
+
+`--include-auth` may add the active authentication method, OAuth client,
+granted services and scopes, and cached access-token expiry. It never returns
+access tokens, refresh tokens, client secrets, service-account keys, or
+credential paths.
+
+Account identity remains omitted unless separately requested:
+
+```bash
+gog --account you@example.com agent capabilities \
+  --include-auth \
+  --include-account \
+  --json
+```
+
+Use `--include-account` only when the output destination is allowed to receive
+that identity.
+
+## MCP discovery
+
+`gog mcp` registers a read-only `gog_capabilities` tool. Its response includes
+the tools actually enabled by the server's `--allow-tool` and `--allow-write`
+flags.
+
+The MCP tool accepts two optional booleans:
+
+- `include_auth`: inspect selected credential metadata; may access the keyring
+- `include_account`: include the selected account identity
+
+Both default to false. The tool runs in the MCP server process so it can report
+the actual filtered tool set without invoking a generic command bridge.
+
+This capability document is gog-specific. It does not claim conformance with
+the `auth.md` agent-registration protocol, and it does not add HTTP or
+well-known endpoints.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -23,6 +23,7 @@ Generated from `gog schema --json`.
       - [`gog admin users list (ls) [flags]`](commands/gog-admin-users-list.md) - List users in a domain
       - [`gog admin users suspend <userEmail>`](commands/gog-admin-users-suspend.md) - Suspend a user account
   - [`gog agent <command> [flags]`](commands/gog-agent.md) - Agent-friendly helpers
+    - [`gog agent capabilities (auth-info) [flags]`](commands/gog-agent-capabilities.md) - Print runtime auth and safety capabilities
     - [`gog agent exit-codes (exitcodes,exit-code)`](commands/gog-agent-exit-codes.md) - Print stable exit codes for automation
   - [`gog analytics (ga) <command> [flags]`](commands/gog-analytics.md) - Google Analytics
     - [`gog analytics (ga) accounts (list,ls) [flags]`](commands/gog-analytics-accounts.md) - List GA4 account summaries

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 618.
+Generated pages: 619.
 
 ## Top-level Commands
 
@@ -75,6 +75,7 @@ Generated pages: 618.
       - [gog admin users list](gog-admin-users-list.md) - List users in a domain
       - [gog admin users suspend](gog-admin-users-suspend.md) - Suspend a user account
   - [gog agent](gog-agent.md) - Agent-friendly helpers
+    - [gog agent capabilities](gog-agent-capabilities.md) - Print runtime auth and safety capabilities
     - [gog agent exit-codes](gog-agent-exit-codes.md) - Print stable exit codes for automation
   - [gog analytics](gog-analytics.md) - Google Analytics
     - [gog analytics accounts](gog-analytics-accounts.md) - List GA4 account summaries

--- a/docs/commands/gog-agent-capabilities.md
+++ b/docs/commands/gog-agent-capabilities.md
@@ -1,23 +1,18 @@
-# `gog agent`
+# `gog agent capabilities`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Agent-friendly helpers
+Print runtime auth and safety capabilities
 
 ## Usage
 
 ```bash
-gog agent <command> [flags]
+gog agent capabilities (auth-info) [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog agent capabilities](gog-agent-capabilities.md) - Print runtime auth and safety capabilities
-- [gog agent exit-codes](gog-agent-exit-codes.md) - Print stable exit codes for automation
+- [gog agent](gog-agent.md)
 
 ## Flags
 
@@ -35,6 +30,8 @@ gog agent <command> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-account` | `bool` |  | Include the selected account identity in output |
+| `--include-auth` | `bool` |  | Inspect the selected credential and include granted services, scopes, and token expiry |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
@@ -46,5 +43,5 @@ gog agent <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog agent](gog-agent.md)
 - [Command index](README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 
 - **Trying it.** [Install](install.md) → [Quickstart](quickstart.md). Five minutes from `brew install` to your first authenticated query.
 - **Wiring up an agent.** [Safety Profiles](safety-profiles.md) and the bundled [`gog` agent skill](https://github.com/openclaw/gogcli/blob/main/.agents/skills/gog/SKILL.md). Lock the binary down before handing it to a model.
+- **Discovering runtime access.** [Agent capabilities](agent-capabilities.md) reports auth disclosure, active safety rules, and the filtered MCP tool surface without opening the keyring by default.
 - **Serving MCP tools.** [MCP server](mcp.md) exposes typed, allowlisted tools for agent clients without a generic command bridge.
 - **Persisting auth and state.** [Paths and State](paths.md) covers `GOG_HOME`, per-kind directories, XDG paths, and legacy compatibility.
 - **Running Workspace at scale.** [Auth Clients](auth-clients.md) for service accounts, named OAuth clients, and domain-wide delegation.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -14,6 +14,11 @@ The server registers a small set of typed tools such as `gmail_search`,
 specific `gog` operation, and returns a structured result containing the tool
 name, service, risk level, exit code, parsed stdout, and stderr.
 
+The read-only `gog_capabilities` tool is handled inside the server process. It
+reports runtime safety state and the tools actually enabled for that server.
+Credential metadata and account identity remain separate opt-ins. See
+[Agent capabilities](agent-capabilities.md).
+
 ## Quick start
 
 Start a read-only server for one account:
@@ -110,6 +115,7 @@ Read tools:
 
 | Tool | Purpose |
 | --- | --- |
+| `gog_capabilities` | Inspect runtime safety and the enabled MCP tool surface without opening the keyring by default. |
 | `gmail_search` | Search Gmail messages with Gmail query syntax. |
 | `gmail_get_message` | Read one Gmail message by ID. Sanitized content is on by default. |
 | `gmail_get_thread` | Read one Gmail thread by ID. Sanitized content is on by default. |

--- a/internal/cmd/agent.go
+++ b/internal/cmd/agent.go
@@ -2,5 +2,6 @@ package cmd
 
 // AgentCmd contains helper commands intended to make gog easier to consume from LLM agents.
 type AgentCmd struct {
-	ExitCodes AgentExitCodesCmd `cmd:"" name:"exit-codes" aliases:"exitcodes,exit-code" help:"Print stable exit codes for automation"`
+	Capabilities AgentCapabilitiesCmd `cmd:"" name:"capabilities" aliases:"auth-info" help:"Print runtime auth and safety capabilities"`
+	ExitCodes    AgentExitCodesCmd    `cmd:"" name:"exit-codes" aliases:"exitcodes,exit-code" help:"Print stable exit codes for automation"`
 }

--- a/internal/cmd/agent_capabilities.go
+++ b/internal/cmd/agent_capabilities.go
@@ -1,0 +1,311 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const (
+	agentCapabilitiesSchemaVersion = 1
+	authMethodADC                  = "adc"
+)
+
+type AgentCapabilitiesCmd struct {
+	IncludeAuth    bool `name:"include-auth" help:"Inspect the selected credential and include granted services, scopes, and token expiry"`
+	IncludeAccount bool `name:"include-account" help:"Include the selected account identity in output"`
+}
+
+type agentCapabilitiesSnapshot struct {
+	SchemaVersion int                       `json:"schema_version"`
+	Build         string                    `json:"build"`
+	Disclosure    agentCapabilityDisclosure `json:"disclosure"`
+	Auth          agentCapabilityAuth       `json:"auth"`
+	Safety        agentCapabilitySafety     `json:"safety"`
+	Commands      agentCapabilityCommands   `json:"commands"`
+	MCP           *agentCapabilityMCP       `json:"mcp,omitempty"`
+}
+
+type agentCapabilityDisclosure struct {
+	AuthInspected   bool `json:"auth_inspected"`
+	AccountIncluded bool `json:"account_included"`
+}
+
+type agentCapabilityAuth struct {
+	SupportedMethods     []string `json:"supported_methods"`
+	Method               string   `json:"method,omitempty"`
+	Account              string   `json:"account,omitempty"`
+	Client               string   `json:"client,omitempty"`
+	Services             []string `json:"services,omitempty"`
+	Scopes               []string `json:"scopes,omitempty"`
+	AccessTokenExpiresAt string   `json:"access_token_expires_at,omitempty"`
+}
+
+type agentCapabilitySafety struct {
+	DryRun       bool                        `json:"dry_run"`
+	GmailNoSend  bool                        `json:"gmail_no_send"`
+	BakedProfile agentCapabilityBakedProfile `json:"baked_profile"`
+	CommandRules agentCapabilityCommandRules `json:"command_rules"`
+}
+
+type agentCapabilityBakedProfile struct {
+	Enabled bool   `json:"enabled"`
+	Name    string `json:"name,omitempty"`
+}
+
+type agentCapabilityCommandRules struct {
+	EnabledPrefixes []string `json:"enabled_prefixes"`
+	EnabledExact    []string `json:"enabled_exact"`
+	Disabled        []string `json:"disabled"`
+}
+
+type agentCapabilityCommands struct {
+	SchemaCommand string `json:"schema_command"`
+}
+
+type agentCapabilityMCP struct {
+	Tools             []agentCapabilityMCPTool `json:"tools"`
+	WriteToolsExposed bool                     `json:"write_tools_exposed"`
+}
+
+type agentCapabilityMCPTool struct {
+	Name    string `json:"name"`
+	Service string `json:"service"`
+	Risk    string `json:"risk"`
+}
+
+type agentCapabilitiesOptions struct {
+	IncludeAuth    bool
+	IncludeAccount bool
+	MCPTools       []mcpToolSpec
+}
+
+func (c *AgentCapabilitiesCmd) Run(ctx context.Context, flags *RootFlags) error {
+	snapshot, err := buildAgentCapabilities(flags, agentCapabilitiesOptions{
+		IncludeAuth:    c.IncludeAuth,
+		IncludeAccount: c.IncludeAccount,
+	})
+	if err != nil {
+		return err
+	}
+	return writeAgentCapabilities(ctx, snapshot)
+}
+
+func buildAgentCapabilities(flags *RootFlags, opts agentCapabilitiesOptions) (agentCapabilitiesSnapshot, error) {
+	profile, err := loadBakedSafetyProfile()
+	if err != nil {
+		return agentCapabilitiesSnapshot{}, usagef("invalid baked safety profile: %v", err)
+	}
+
+	snapshot := agentCapabilitiesSnapshot{
+		SchemaVersion: agentCapabilitiesSchemaVersion,
+		Build:         VersionString(),
+		Disclosure: agentCapabilityDisclosure{
+			AuthInspected: opts.IncludeAuth,
+		},
+		Auth: agentCapabilityAuth{
+			SupportedMethods: []string{"oauth", authTypeServiceAccount, authMethodADC, "access_token"},
+		},
+		Safety: agentCapabilitySafety{
+			BakedProfile: agentCapabilityBakedProfile{
+				Enabled: profile.enabled,
+				Name:    profile.name,
+			},
+			CommandRules: agentCapabilityCommandRules{
+				EnabledPrefixes: capabilityRuleValues(flags, func(f *RootFlags) string { return f.EnableCommands }),
+				EnabledExact:    capabilityRuleValues(flags, func(f *RootFlags) string { return f.EnableCommandsExact }),
+				Disabled:        capabilityRuleValues(flags, func(f *RootFlags) string { return f.DisableCommands }),
+			},
+		},
+		Commands: agentCapabilityCommands{SchemaCommand: "gog schema --json"},
+	}
+	if flags != nil {
+		snapshot.Safety.DryRun = flags.DryRun
+		snapshot.Safety.GmailNoSend = flags.GmailNoSend
+	}
+
+	account, accountKnown, err := configuredCapabilityAccount(flags)
+	if err != nil {
+		return agentCapabilitiesSnapshot{}, err
+	}
+	if opts.IncludeAuth {
+		account, err = requireAccount(flags)
+		if err != nil {
+			return agentCapabilitiesSnapshot{}, err
+		}
+		accountKnown = account != ""
+		if err := inspectCapabilityAuth(flags, account, &snapshot.Auth); err != nil {
+			return agentCapabilitiesSnapshot{}, err
+		}
+	}
+	if accountKnown {
+		noSend, noSendErr := config.IsNoSendAccount(account)
+		if noSendErr != nil {
+			return agentCapabilitiesSnapshot{}, noSendErr
+		}
+		snapshot.Safety.GmailNoSend = snapshot.Safety.GmailNoSend || noSend
+	}
+	if opts.IncludeAccount && accountKnown && capabilityAccountIsIdentity(account) {
+		snapshot.Auth.Account = account
+		snapshot.Disclosure.AccountIncluded = true
+	}
+
+	if opts.MCPTools != nil {
+		snapshot.MCP = buildCapabilityMCP(opts.MCPTools)
+	}
+	return snapshot, nil
+}
+
+func capabilityAccountIsIdentity(account string) bool {
+	account = strings.TrimSpace(account)
+	if account == "" || account == accessTokenPlaceholderAccount {
+		return false
+	}
+	return !googleapi.IsADCMode() || account != authMethodADC
+}
+
+func configuredCapabilityAccount(flags *RootFlags) (string, bool, error) {
+	account, ok, err := configuredAccount(flags)
+	if err != nil {
+		return "", false, err
+	}
+	return strings.TrimSpace(account), ok, nil
+}
+
+func inspectCapabilityAuth(flags *RootFlags, account string, auth *agentCapabilityAuth) error {
+	if auth == nil {
+		return nil
+	}
+	if googleapi.IsADCMode() {
+		auth.Method = authMethodADC
+		return nil
+	}
+	if hasDirectAccessToken(flags) {
+		auth.Method = "access_token"
+		return nil
+	}
+	if _, _, ok := bestServiceAccountPathAndMtime(normalizeEmail(account)); ok {
+		auth.Method = authTypeServiceAccount
+		return nil
+	}
+
+	client, err := resolveClientForEmail(account, flags)
+	if err != nil {
+		return err
+	}
+	store, err := openSecretsStore()
+	if err != nil {
+		return fmt.Errorf("open secrets store: %w", err)
+	}
+	token, err := store.GetToken(client, account)
+	if err != nil {
+		return fmt.Errorf("read token metadata: %w", err)
+	}
+	auth.Method = authTypeOAuth
+	auth.Client = client
+	auth.Services = sortedUniqueStrings(token.Services)
+	auth.Scopes = sortedUniqueStrings(token.Scopes)
+	if !token.AccessTokenExpiresAt.IsZero() {
+		auth.AccessTokenExpiresAt = token.AccessTokenExpiresAt.UTC().Format(time.RFC3339)
+	}
+	return nil
+}
+
+func capabilityRuleValues(flags *RootFlags, value func(*RootFlags) string) []string {
+	if flags == nil {
+		return []string{}
+	}
+	return sortedUniqueStrings(splitCommaValues([]string{value(flags)}))
+}
+
+func sortedUniqueStrings(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func buildCapabilityMCP(tools []mcpToolSpec) *agentCapabilityMCP {
+	out := &agentCapabilityMCP{Tools: make([]agentCapabilityMCPTool, 0, len(tools))}
+	for _, tool := range tools {
+		out.Tools = append(out.Tools, agentCapabilityMCPTool{
+			Name:    tool.Name,
+			Service: tool.Service,
+			Risk:    string(tool.Risk),
+		})
+		if tool.Risk == mcpRiskWrite {
+			out.WriteToolsExposed = true
+		}
+	}
+	return out
+}
+
+func writeAgentCapabilities(ctx context.Context, snapshot agentCapabilitiesSnapshot) error {
+	// This is local process metadata, not fetched Google content.
+	ctx = outfmt.WithJSONTransform(ctx, outfmt.JSONTransform{})
+	ctx = outfmt.WithUntrustedWrapper(ctx, outfmt.UntrustedWrapOptions{})
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, snapshot)
+	}
+
+	lines := [][2]string{
+		{"schema_version", fmt.Sprintf("%d", snapshot.SchemaVersion)},
+		{"build", snapshot.Build},
+		{"auth_inspected", fmt.Sprintf("%t", snapshot.Disclosure.AuthInspected)},
+		{"account_included", fmt.Sprintf("%t", snapshot.Disclosure.AccountIncluded)},
+		{"auth_supported_methods", strings.Join(snapshot.Auth.SupportedMethods, ",")},
+		{"auth_method", snapshot.Auth.Method},
+		{"account", snapshot.Auth.Account},
+		{"client", snapshot.Auth.Client},
+		{"services", strings.Join(snapshot.Auth.Services, ",")},
+		{"scopes", strings.Join(snapshot.Auth.Scopes, ",")},
+		{"access_token_expires_at", snapshot.Auth.AccessTokenExpiresAt},
+		{"dry_run", fmt.Sprintf("%t", snapshot.Safety.DryRun)},
+		{"gmail_no_send", fmt.Sprintf("%t", snapshot.Safety.GmailNoSend)},
+		{"baked_profile_enabled", fmt.Sprintf("%t", snapshot.Safety.BakedProfile.Enabled)},
+		{"baked_profile_name", snapshot.Safety.BakedProfile.Name},
+		{"enabled_command_prefixes", strings.Join(snapshot.Safety.CommandRules.EnabledPrefixes, ",")},
+		{"enabled_commands_exact", strings.Join(snapshot.Safety.CommandRules.EnabledExact, ",")},
+		{"disabled_commands", strings.Join(snapshot.Safety.CommandRules.Disabled, ",")},
+		{"schema_command", snapshot.Commands.SchemaCommand},
+	}
+	if snapshot.MCP != nil {
+		lines = append(lines,
+			[2]string{"mcp_tools", strings.Join(capabilityMCPToolNames(snapshot.MCP.Tools), ",")},
+			[2]string{"mcp_write_tools_exposed", fmt.Sprintf("%t", snapshot.MCP.WriteToolsExposed)},
+		)
+	}
+	for _, line := range lines {
+		if line[1] == "" {
+			continue
+		}
+		_, _ = fmt.Fprintf(os.Stdout, "%s\t%s\n", line[0], line[1])
+	}
+	return nil
+}
+
+func capabilityMCPToolNames(tools []agentCapabilityMCPTool) []string {
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}

--- a/internal/cmd/agent_capabilities_test.go
+++ b/internal/cmd/agent_capabilities_test.go
@@ -1,0 +1,144 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/secrets"
+)
+
+func TestAgentCapabilitiesDefaultDoesNotOpenSecretsStore(t *testing.T) {
+	withCapabilityTestHome(t)
+	originalOpen := openSecretsStore
+	t.Cleanup(func() { openSecretsStore = originalOpen })
+	openSecretsStore = func() (secrets.Store, error) {
+		t.Fatal("default capability discovery must not open the secrets store")
+		return nil, errors.New("unreachable")
+	}
+
+	snapshot, err := buildAgentCapabilities(&RootFlags{
+		Account:             "private@example.com",
+		EnableCommandsExact: "docs.cat,mcp",
+		DisableCommands:     "gmail.send",
+		GmailNoSend:         true,
+	}, agentCapabilitiesOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Disclosure.AuthInspected {
+		t.Fatal("auth should not be inspected by default")
+	}
+	if snapshot.Auth.Account != "" {
+		t.Fatalf("account leaked by default: %q", snapshot.Auth.Account)
+	}
+	if !snapshot.Safety.GmailNoSend {
+		t.Fatal("gmail no-send state missing")
+	}
+	if got := snapshot.Safety.CommandRules.EnabledExact; len(got) != 2 || got[0] != "docs.cat" || got[1] != "mcp" {
+		t.Fatalf("enabled exact = %#v", got)
+	}
+	if got := snapshot.Safety.CommandRules.Disabled; len(got) != 1 || got[0] != "gmail.send" {
+		t.Fatalf("disabled = %#v", got)
+	}
+}
+
+func TestAgentCapabilitiesIncludeOAuthMetadata(t *testing.T) {
+	withCapabilityTestHome(t)
+	store := newMemSecretsStore()
+	expiry := time.Date(2026, 6, 11, 12, 0, 0, 0, time.FixedZone("offset", 2*60*60))
+	if err := store.SetToken(config.DefaultClientName, "user@example.com", secrets.Token{
+		Email:                "user@example.com",
+		RefreshToken:         "secret-refresh-token",
+		AccessToken:          "secret-access-token",
+		AccessTokenExpiresAt: expiry,
+		Services:             []string{"drive", "gmail", "drive"},
+		Scopes:               []string{"scope:z", "scope:a", "scope:z"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	originalOpen := openSecretsStore
+	t.Cleanup(func() { openSecretsStore = originalOpen })
+	openSecretsStore = func() (secrets.Store, error) { return store, nil }
+
+	snapshot, err := buildAgentCapabilities(&RootFlags{Account: "user@example.com"}, agentCapabilitiesOptions{
+		IncludeAuth:    true,
+		IncludeAccount: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Auth.Method != authTypeOAuth {
+		t.Fatalf("method = %q", snapshot.Auth.Method)
+	}
+	if snapshot.Auth.Account != "user@example.com" {
+		t.Fatalf("account = %q", snapshot.Auth.Account)
+	}
+	if got := snapshot.Auth.Services; len(got) != 2 || got[0] != "drive" || got[1] != "gmail" {
+		t.Fatalf("services = %#v", got)
+	}
+	if got := snapshot.Auth.Scopes; len(got) != 2 || got[0] != "scope:a" || got[1] != "scope:z" {
+		t.Fatalf("scopes = %#v", got)
+	}
+	if snapshot.Auth.AccessTokenExpiresAt != "2026-06-11T10:00:00Z" {
+		t.Fatalf("expiry = %q", snapshot.Auth.AccessTokenExpiresAt)
+	}
+}
+
+func TestAgentCapabilitiesJSONIsNotWrappedAsUntrusted(t *testing.T) {
+	withCapabilityTestHome(t)
+	ctx := outfmt.WithMode(context.Background(), outfmt.Mode{JSON: true})
+	ctx = outfmt.WithUntrustedWrapper(ctx, outfmt.UntrustedWrapOptions{Enabled: true})
+
+	out := captureStdout(t, func() {
+		if err := (&AgentCapabilitiesCmd{}).Run(ctx, &RootFlags{}); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if strings.Contains(out, `"external_untrusted_content"`) {
+		t.Fatalf("local capability output was wrapped as untrusted: %s", out)
+	}
+	if !strings.Contains(out, `"schema_version": 1`) {
+		t.Fatalf("missing capability schema: %s", out)
+	}
+}
+
+func TestMCPCapabilitiesReportsFilteredToolSurface(t *testing.T) {
+	withCapabilityTestHome(t)
+	tools := mcpEnabledTools(McpCmd{AllowTool: []string{"agent"}})
+	if len(tools) != 1 || tools[0].Name != "gog_capabilities" {
+		t.Fatalf("tools = %#v", toolNames(tools))
+	}
+
+	result := mcpRunCapabilitiesTool(context.Background(), mcp.CallToolRequest{}, &RootFlags{}, tools)
+	if result.IsError {
+		t.Fatal("capabilities tool returned an error")
+	}
+	snapshot, ok := result.StructuredContent.(agentCapabilitiesSnapshot)
+	if !ok {
+		t.Fatalf("structured content type = %T", result.StructuredContent)
+	}
+	if snapshot.MCP == nil || len(snapshot.MCP.Tools) != 1 || snapshot.MCP.Tools[0].Name != "gog_capabilities" {
+		t.Fatalf("mcp snapshot = %#v", snapshot.MCP)
+	}
+	if snapshot.MCP.WriteToolsExposed {
+		t.Fatal("write tools should not be exposed")
+	}
+}
+
+func withCapabilityTestHome(t *testing.T) {
+	t.Helper()
+	restore, err := config.SetHomeOverride(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(restore)
+	t.Setenv("GOG_ACCOUNT", "")
+	t.Setenv("GOG_AUTH_MODE", "")
+}

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -38,7 +38,10 @@ type mcpToolSpec struct {
 	Description string
 	Options     []mcp.ToolOption
 	BuildArgs   func(mcp.CallToolRequest) ([]string, error)
+	Handle      mcpInProcessHandler
 }
+
+type mcpInProcessHandler func(context.Context, mcp.CallToolRequest, *RootFlags, []mcpToolSpec) *mcp.CallToolResult
 
 type mcpCommandResult struct {
 	Tool     string `json:"tool"`
@@ -86,6 +89,9 @@ func (c *McpCmd) Run(_ context.Context, flags *RootFlags) error {
 			mcp.WithSchemaAdditionalProperties(false),
 		}, tool.Options...)
 		s.AddTool(mcp.NewTool(tool.Name, opts...), func(reqCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			if tool.Handle != nil {
+				return tool.Handle(reqCtx, req, flags, tools), nil
+			}
 			childCommandArgs, buildErr := tool.BuildArgs(req)
 			if buildErr != nil {
 				result := mcp.NewToolResultError(buildErr.Error())
@@ -105,6 +111,20 @@ func (c *McpCmd) Run(_ context.Context, flags *RootFlags) error {
 		})
 	}
 	return server.ServeStdio(s)
+}
+
+func mcpRunCapabilitiesTool(_ context.Context, req mcp.CallToolRequest, flags *RootFlags, tools []mcpToolSpec) *mcp.CallToolResult {
+	snapshot, err := buildAgentCapabilities(flags, agentCapabilitiesOptions{
+		IncludeAuth:    req.GetBool("include_auth", false),
+		IncludeAccount: req.GetBool("include_account", false),
+		MCPTools:       tools,
+	})
+	if err != nil {
+		result := mcp.NewToolResultError(err.Error())
+		result.IsError = true
+		return result
+	}
+	return mcp.NewToolResultStructuredOnly(snapshot)
 }
 
 type mcpRunOptions struct {

--- a/internal/cmd/mcp_tools.go
+++ b/internal/cmd/mcp_tools.go
@@ -13,6 +13,7 @@ import (
 
 func mcpAllTools() []mcpToolSpec {
 	return []mcpToolSpec{
+		mcpCapabilitiesTool(),
 		mcpGmailSearchTool(),
 		mcpGmailGetMessageTool(),
 		mcpGmailGetThreadTool(),
@@ -23,6 +24,20 @@ func mcpAllTools() []mcpToolSpec {
 		mcpCalendarEventsTool(),
 		mcpDocsWriteTool(),
 		mcpSheetsUpdateRangeTool(),
+	}
+}
+
+func mcpCapabilitiesTool() mcpToolSpec {
+	return mcpToolSpec{
+		Name:        "gog_capabilities",
+		Service:     "agent",
+		Risk:        mcpRiskRead,
+		Description: "Inspect this gog process's auth disclosure, safety rules, and enabled MCP tool surface.",
+		Options: []mcp.ToolOption{
+			mcp.WithBoolean("include_auth", mcp.Description("Inspect selected credential metadata; may access the configured keyring"), mcp.DefaultBool(false)),
+			mcp.WithBoolean("include_account", mcp.Description("Include the selected account identity"), mcp.DefaultBool(false)),
+		},
+		Handle: mcpRunCapabilitiesTool,
 	}
 }
 

--- a/internal/cmd/open.go
+++ b/internal/cmd/open.go
@@ -61,7 +61,7 @@ func bestEffortWebURL(kind string, input string) string {
 	id := openGoogleID(input)
 
 	switch kind {
-	case "drive", colorAuto:
+	case backupServiceDrive, colorAuto:
 		// If it's a known Google URL already, prefer canonicalized forms.
 		if u := parseMaybeURL(input); u != nil {
 			host := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(u.Host), "www."))


### PR DESCRIPTION
## Summary

- add `gog agent capabilities` (`auth-info`) with a versioned runtime capability snapshot
- keep default discovery offline, account-redacted, and keyring-free
- add read-only `gog_capabilities` MCP discovery for the server's actual filtered tool surface
- make credential metadata and account identity separate explicit opt-ins
- document that this is gog-specific capability discovery, not auth.md protocol conformance or an HTTP endpoint

## Safety decisions

- no token, client-secret, service-account-key, or credential-path fields
- `--include-auth` is the only path that may open the configured keyring
- `--include-account` controls identity disclosure independently
- report configured command rules instead of claiming a misleading global read/write state

## Proof

- `make ci`
- `go test ./internal/cmd -run 'TestAgentCapabilities|TestMCPCapabilities|TestMCPEnabledTools|TestOpen' -count=1`
- offline live smoke: default JSON, explicit account disclosure, and filtered `mcp --list-tools`
- structured autoreview: clean, no accepted/actionable findings

Closes #677
