### PR TITLE
feat(poll): add persisted Drive and Docs polling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Docs: prevent multi-paragraph Markdown range replacements from inheriting the matched paragraph's heading or list style. (#756) — thanks @sebsnyk.
 - Docs: preserve nested Markdown list levels as native bullets inside imported and updated table cells. (#749) — thanks @sebsnyk.
 - Gmail: add explicit `gmail archive --thread` semantics so IDs from thread search can archive every message in each thread. (#752) — thanks @sebsnyk.
+- Drive/Docs: add persisted polling for Drive changes and Docs comments, with bounded runs, filters, retry-safe cursors, and sequential JSON hooks. (#690, #751)
 
 ## 0.24.0 - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,8 @@ gog calendar appointments
 
 ### Drive
 
-Docs: [Drive audits](docs/drive-audits.md), [raw API dumps](docs/raw-api.md),
+Docs: [Drive audits](docs/drive-audits.md), [polling](docs/polling.md),
+[raw API dumps](docs/raw-api.md),
 [`gog drive`](docs/commands/gog-drive.md),
 [`drive changes`](docs/commands/gog-drive-changes.md),
 [`drive revisions`](docs/commands/gog-drive-revisions.md),
@@ -209,6 +210,7 @@ gog drive get <fileId> --fields 'id,name,mimeType,size,owners,emailAddress' --js
 # Track changes and audit activity.
 gog drive changes start-token
 gog drive changes list --token <token> --json
+gog drive changes poll --state-file ~/.local/state/gog/drive-changes.json --json
 gog drive revisions list <fileId> --all --json
 gog drive revisions get <fileId> <revisionId> --json
 gog drive activity query --file <fileId> --actions edit,share --from 2026-01-01T00:00:00Z --json
@@ -285,6 +287,7 @@ gog contacts dedupe --match email,phone,name --dry-run
 
 Docs: [Google Docs editing](docs/docs-editing.md),
 [atomic Docs request batches](docs/docs-batch.md),
+[polling](docs/polling.md),
 [sed-style document edits](docs/sedmat.md),
 [`gog docs`](docs/commands/gog-docs.md).
 
@@ -297,6 +300,7 @@ gog docs named-range create <docId> --name Status --at "Ready"
 gog docs insert-image <docId> --url https://example.com/chart.png --at end
 gog docs add-tab <docId> --title "Notes"
 gog docs tabs add <docId> --title "Notes"
+gog docs comments poll <docId> --state-file ~/.local/state/gog/doc-comments.json --json
 gog docs find-replace <docId> old new --tab "Notes" --dry-run
 gog docs raw <docId> --pretty
 ```

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -234,6 +234,7 @@ Generated from `gog schema --json`.
       - [`gog docs (doc) comments get (info,show) <docId> <commentId>`](commands/gog-docs-comments-get.md) - Get a comment by ID
       - [`gog docs (doc) comments list (ls) <docId> [flags]`](commands/gog-docs-comments-list.md) - List comments on a Google Doc
       - [`gog docs (doc) comments locate <docId> <commentId> [flags]`](commands/gog-docs-comments-locate.md) - Resolve a comment quote to Docs API index ranges
+      - [`gog docs (doc) comments poll --state-file=STRING <docId> [flags]`](commands/gog-docs-comments-poll.md) - Poll new and modified comments with persisted state
       - [`gog docs (doc) comments reopen <docId> <commentId> [flags]`](commands/gog-docs-comments-reopen.md) - Reopen a previously resolved comment
       - [`gog docs (doc) comments reply (respond) <docId> <commentId> <content> [flags]`](commands/gog-docs-comments-reply.md) - Reply to a comment
       - [`gog docs (doc) comments resolve <docId> <commentId> [flags]`](commands/gog-docs-comments-resolve.md) - Resolve a comment (mark as done)
@@ -301,6 +302,7 @@ Generated from `gog schema --json`.
       - [`gog drive (drv) bulk update-role [flags]`](commands/gog-drive-bulk-update-role.md) - Change matching Drive permission roles across files
     - [`gog drive (drv) changes <command>`](commands/gog-drive-changes.md) - Track Drive changes for sync and automation
       - [`gog drive (drv) changes list (ls) --token=STRING [flags]`](commands/gog-drive-changes-list.md) - List Drive changes since a page token
+      - [`gog drive (drv) changes poll --state-file=STRING [flags]`](commands/gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
       - [`gog drive (drv) changes start-token (token) [flags]`](commands/gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [`gog drive (drv) changes stop <channelId> <resourceId>`](commands/gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [`gog drive (drv) changes watch --token=STRING --webhook-url=STRING [flags]`](commands/gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 629.
+Generated pages: 631.
 
 ## Top-level Commands
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -285,6 +285,7 @@ Generated pages: 629.
       - [gog docs comments get](gog-docs-comments-get.md) - Get a comment by ID
       - [gog docs comments list](gog-docs-comments-list.md) - List comments on a Google Doc
       - [gog docs comments locate](gog-docs-comments-locate.md) - Resolve a comment quote to Docs API index ranges
+      - [gog docs comments poll](gog-docs-comments-poll.md) - Poll new and modified comments with persisted state
       - [gog docs comments reopen](gog-docs-comments-reopen.md) - Reopen a previously resolved comment
       - [gog docs comments reply](gog-docs-comments-reply.md) - Reply to a comment
       - [gog docs comments resolve](gog-docs-comments-resolve.md) - Resolve a comment (mark as done)
@@ -352,6 +353,7 @@ Generated pages: 629.
       - [gog drive bulk update-role](gog-drive-bulk-update-role.md) - Change matching Drive permission roles across files
     - [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
       - [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
+      - [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
       - [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/gog-docs-comments-poll.md
+++ b/docs/commands/gog-docs-comments-poll.md
@@ -1,26 +1,18 @@
-# `gog drive changes`
+# `gog docs comments poll`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Track Drive changes for sync and automation
+Poll new and modified comments with persisted state
 
 ## Usage
 
 ```bash
-gog drive (drv) changes <command>
+gog docs (doc) comments poll --state-file=STRING <docId> [flags]
 ```
 
 ## Parent
 
-- [gog drive](gog-drive.md)
-
-## Subcommands
-
-- [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
-- [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-- [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
-- [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
-- [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel
+- [gog docs comments](gog-docs-comments.md)
 
 ## Flags
 
@@ -38,16 +30,22 @@ gog drive (drv) changes <command>
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-resolved`<br>`--resolved` | `bool` |  | Include resolved comments |
+| `--interval` | `time.Duration` | 60s | Delay between polls |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max comments per API page |
+| `--max-iterations` | `int` | 0 | Stop after N polls; 0 runs until interrupted |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--on-new` | `string` |  | Trusted local shell command run for each comment; comment event JSON is provided on stdin |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--state-file` | `string` |  | JSON file that stores the comment time watermark |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog drive](gog-drive.md)
+- [gog docs comments](gog-docs-comments.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-comments.md
+++ b/docs/commands/gog-docs-comments.md
@@ -21,6 +21,7 @@ gog docs (doc) comments <command>
 - [gog docs comments get](gog-docs-comments-get.md) - Get a comment by ID
 - [gog docs comments list](gog-docs-comments-list.md) - List comments on a Google Doc
 - [gog docs comments locate](gog-docs-comments-locate.md) - Resolve a comment quote to Docs API index ranges
+- [gog docs comments poll](gog-docs-comments-poll.md) - Poll new and modified comments with persisted state
 - [gog docs comments reopen](gog-docs-comments-reopen.md) - Reopen a previously resolved comment
 - [gog docs comments reply](gog-docs-comments-reply.md) - Reply to a comment
 - [gog docs comments resolve](gog-docs-comments-resolve.md) - Resolve a comment (mark as done)

--- a/docs/commands/gog-drive-changes-poll.md
+++ b/docs/commands/gog-drive-changes-poll.md
@@ -1,26 +1,18 @@
-# `gog drive changes`
+# `gog drive changes poll`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Track Drive changes for sync and automation
+Poll Drive changes with a persisted page token
 
 ## Usage
 
 ```bash
-gog drive (drv) changes <command>
+gog drive (drv) changes poll --state-file=STRING [flags]
 ```
 
 ## Parent
 
-- [gog drive](gog-drive.md)
-
-## Subcommands
-
-- [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
-- [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-- [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
-- [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
-- [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel
+- [gog drive changes](gog-drive-changes.md)
 
 ## Flags
 
@@ -31,23 +23,31 @@ gog drive (drv) changes <command>
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `--drive`<br>`--drive-id` | `string` |  | Shared drive ID for a shared-drive change log |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--filter-file` | `string` |  | Only emit and invoke the hook for changes to this file ID |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-removed` | `bool` | true | Include removed changes |
+| `--interval` | `time.Duration` | 60s | Delay between polls |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max changes per API page |
+| `--max-iterations` | `int` | 0 | Stop after N polls; 0 runs until interrupted |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--on-change` | `string` |  | Trusted local shell command run for each non-empty batch; batch JSON is provided on stdin |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--state-file` | `string` |  | JSON file that stores the current Drive page token |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog drive](gog-drive.md)
+- [gog drive changes](gog-drive-changes.md)
 - [Command index](README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Wiring up automation.** [Automation](automation.md), [Safety Profiles](safety-profiles.md), and the bundled [`gog` skill](https://github.com/openclaw/gogcli/blob/main/.agents/skills/gog/SKILL.md). Discover the active contract and lock the binary down before handing it to an untrusted caller.
 - **Serving MCP tools.** [MCP server](mcp.md) exposes typed, allowlisted tools for agent clients without a generic command bridge.
 - **Discovering runtime contracts.** [Automation](automation.md) explains root help, schema metadata, safety controls, and stable exit codes.
+- **Polling local events.** [Drive and Docs polling](polling.md) persists cursors and optionally invokes trusted shell hooks.
 - **Persisting auth and state.** [Paths and State](paths.md) covers `GOG_HOME`, per-kind directories, XDG paths, and legacy compatibility.
 - **Running Workspace at scale.** [Auth Clients](auth-clients.md) for service accounts, named OAuth clients, and domain-wide delegation.
 - **Managing Workspace.** [Workspace Admin](workspace-admin.md) covers user creation, cleanup, organizational units, and group administration.

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -1,0 +1,84 @@
+---
+summary: "Persisted Drive changes and Docs comment polling"
+read_when:
+  - Running gog as a local Drive or Docs event poller
+  - Wiring Drive changes or Docs comments to shell hooks
+---
+
+# Drive and Docs polling
+
+`gog` can poll Drive changes or Google Docs comments while persisting the API
+cursor in a local JSON file:
+
+```bash
+gog drive changes poll \
+  --state-file ~/.local/state/gog/drive-changes.json \
+  --interval 30s \
+  --json
+
+gog docs comments poll <docId> \
+  --state-file ~/.local/state/gog/doc-comments.json \
+  --interval 30s \
+  --json
+```
+
+Both commands poll immediately, then wait for `--interval`. Use
+`--max-iterations N` for bounded jobs and tests. `SIGINT` and `SIGTERM` stop the
+poller; completed iterations have already persisted their cursor.
+
+## State
+
+State files are written atomically with mode `0600`. Missing and empty state
+files initialize without replaying existing history:
+
+- Drive stores a fresh start page token before its first changes request.
+- Docs stores the current time as its initial comment watermark.
+
+Drive state is scoped to `--drive`. Docs state is scoped to the document and
+the `--include-resolved` setting. Delete the state file or choose a new path to
+start a new stream.
+
+The Docs API time filter is inclusive. State therefore records both the latest
+timestamp and comment IDs already delivered at that timestamp. Comments that
+share a modified time are delivered once without moving the watermark past an
+unseen peer.
+
+## Output
+
+With `--json`, stdout is newline-delimited JSON: one object per non-empty Drive
+batch or Docs comment. Plain and human modes emit one tab-separated line per
+change or comment. Empty polls produce no stdout.
+
+`drive changes poll --filter-file <fileId>` filters emitted changes and hook
+payloads, while the underlying Drive page token still advances.
+
+## Shell hooks
+
+Hooks are explicit trusted local shell commands:
+
+```bash
+gog drive changes poll \
+  --state-file drive.json \
+  --on-change './handle-drive-batch'
+
+gog docs comments poll <docId> \
+  --state-file comments.json \
+  --on-new './handle-comment'
+```
+
+Payload JSON is passed on stdin. Google-provided text is never interpolated
+into the command string. Hook stdout and stderr go to `gog` stderr so event
+stdout remains parseable.
+
+Drive invokes `--on-change` once per non-empty filtered batch. Docs invokes
+`--on-new` once per comment, in modified-time and comment-ID order. Hooks run
+sequentially.
+
+State advances only after output and all hooks succeed. Output or hook failure
+returns an error and retains the previous cursor, so the event is retried on
+the next run. Consumers must tolerate duplicate delivery.
+
+Command pages:
+
+- [`gog drive changes poll`](commands/gog-drive-changes-poll.md)
+- [`gog docs comments poll`](commands/gog-docs-comments-poll.md)

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -36,12 +36,13 @@ files initialize without replaying existing history:
 
 Drive state is scoped to `--drive`. Docs state is scoped to the document and
 the `--include-resolved` setting. Delete the state file or choose a new path to
-start a new stream.
+start a new stream. Run only one poller against a state file; concurrent writers
+can overwrite each other's cursor.
 
-The Docs API time filter is inclusive. State therefore records both the latest
-timestamp and comment IDs already delivered at that timestamp. Comments that
-share a modified time are delivered once without moving the watermark past an
-unseen peer.
+The Drive comments API time filter is inclusive. State therefore records both
+the latest timestamp and comment IDs already delivered at that timestamp.
+Comments that share a modified time are delivered once without moving the
+watermark past an unseen peer.
 
 ## Output
 
@@ -69,6 +70,9 @@ gog docs comments poll <docId> \
 Payload JSON is passed on stdin. Google-provided text is never interpolated
 into the command string. Hook stdout and stderr go to `gog` stderr so event
 stdout remains parseable.
+
+Hooks run through the platform shell and are not sandboxed. Use only fixed,
+operator-controlled commands; do not build the hook string from Google content.
 
 Drive invokes `--on-change` once per non-empty filtered batch. Docs invokes
 `--on-new` once per comment, in modified-time and comment-ID order. Hooks run

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -230,6 +230,7 @@ Flag aliases:
 - `gog drive drives [--max N] [--page TOKEN] [--query Q]`
 - `gog drive changes start-token [--drive DRIVE_ID]`
 - `gog drive changes list --token TOKEN [--max N] [--all] [--drive DRIVE_ID]`
+- `gog drive changes poll --state-file PATH [--interval DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--drive DRIVE_ID]`
 - `gog drive changes watch --token TOKEN --webhook-url URL [--channel-id ID] [--channel-token TOKEN]`
 - `gog drive changes stop <channelId> <resourceId>`
 - `gog drive activity query [--file FILE_ID|--folder FOLDER_ID] [--actions edit,share] [--from RFC3339] [--to RFC3339] [--filter FILTER]`

--- a/internal/cmd/docs_comments.go
+++ b/internal/cmd/docs_comments.go
@@ -12,6 +12,7 @@ import (
 // DocsCommentsCmd is the parent command for comment operations on a Google Doc.
 type DocsCommentsCmd struct {
 	List    DocsCommentsListCmd    `cmd:"" name:"list" aliases:"ls" help:"List comments on a Google Doc"`
+	Poll    DocsCommentsPollCmd    `cmd:"" name:"poll" help:"Poll new and modified comments with persisted state"`
 	Get     DocsCommentsGetCmd     `cmd:"" name:"get" aliases:"info,show" help:"Get a comment by ID"`
 	Add     DocsCommentsAddCmd     `cmd:"" name:"add" aliases:"create,new" help:"Add a comment to a Google Doc"`
 	Locate  DocsCommentsLocateCmd  `cmd:"" name:"locate" help:"Resolve a comment quote to Docs API index ranges"`

--- a/internal/cmd/docs_comments_poll.go
+++ b/internal/cmd/docs_comments_poll.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type DocsCommentsPollCmd struct {
+	DocID           string        `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	StateFile       string        `name:"state-file" required:"" help:"JSON file that stores the comment time watermark"`
+	Interval        time.Duration `name:"interval" help:"Delay between polls" default:"60s"`
+	IncludeResolved bool          `name:"include-resolved" aliases:"resolved" help:"Include resolved comments"`
+	OnNew           string        `name:"on-new" help:"Trusted local shell command run for each comment; comment event JSON is provided on stdin"`
+	MaxIterations   int           `name:"max-iterations" help:"Stop after N polls; 0 runs until interrupted" default:"0"`
+	Max             int64         `name:"max" aliases:"limit" help:"Max comments per API page" default:"100"`
+}
+
+type docsCommentsPollState struct {
+	Version         int      `json:"version"`
+	DocID           string   `json:"doc_id"`
+	Watermark       string   `json:"watermark"`
+	SeenIDs         []string `json:"seen_ids,omitempty"`
+	IncludeResolved bool     `json:"include_resolved"`
+	UpdatedAt       string   `json:"updated_at"`
+}
+
+type docsCommentPollEvent struct {
+	Kind    string         `json:"kind"`
+	DocID   string         `json:"docId"`
+	Comment *drive.Comment `json:"comment"`
+}
+
+type timedDriveComment struct {
+	comment *drive.Comment
+	at      time.Time
+}
+
+func (c *DocsCommentsPollCmd) Run(ctx context.Context, flags *RootFlags) error {
+	pollCtx, stop := pollSignalContext(ctx)
+	defer stop()
+	return c.run(pollCtx, flags, defaultPollRuntime())
+}
+
+func (c *DocsCommentsPollCmd) run(ctx context.Context, flags *RootFlags, runtime pollRuntime) error {
+	runtime = runtime.withDefaults()
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	statePath, err := expandPollStatePath(c.StateFile)
+	if err != nil {
+		return err
+	}
+	if c.Interval <= 0 {
+		return usage("--interval must be greater than zero")
+	}
+	if c.MaxIterations < 0 {
+		return usage("--max-iterations must be >= 0")
+	}
+	if c.Max <= 0 {
+		return usage("--max must be greater than zero")
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "docs.comments.poll", map[string]any{
+		"doc_id":           docID,
+		"state_file":       statePath,
+		"interval":         c.Interval.String(),
+		"include_resolved": c.IncludeResolved,
+		"max_iterations":   c.MaxIterations,
+		"max":              c.Max,
+		"hook_configured":  strings.TrimSpace(c.OnNew) != "",
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	state, exists, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if state.DocID != docID {
+			return usagef("poll state doc_id %q does not match docId %q", state.DocID, docID)
+		}
+		if state.IncludeResolved != c.IncludeResolved {
+			return usage("poll state --include-resolved setting does not match")
+		}
+	} else {
+		now := runtime.now().UTC()
+		state = docsCommentsPollState{
+			Version:         pollStateVersion,
+			DocID:           docID,
+			Watermark:       now.Format(time.RFC3339Nano),
+			IncludeResolved: c.IncludeResolved,
+			UpdatedAt:       now.Format(time.RFC3339Nano),
+		}
+		if err := writePollState(statePath, state); err != nil {
+			return err
+		}
+	}
+
+	for iteration := 1; ; iteration++ {
+		comments, _, listErr := listDriveComments(ctx, svc, docID, driveCommentListOptions{
+			resourceKey:     "docId",
+			resourceID:      docID,
+			includeResolved: true,
+			since:           state.Watermark,
+			all:             true,
+			max:             c.Max,
+			mode:            driveCommentListModeExpanded,
+		})
+		if listErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return listErr
+		}
+
+		allFresh, filterErr := filterPolledDriveComments(comments, state)
+		if filterErr != nil {
+			return filterErr
+		}
+		fresh := filterPolledCommentsByResolved(allFresh, c.IncludeResolved)
+		for _, item := range fresh {
+			event := docsCommentPollEvent{
+				Kind:    "docs_comment",
+				DocID:   docID,
+				Comment: item.comment,
+			}
+			if err := writeDocsCommentPollEvent(ctx, event, item.at); err != nil {
+				return err
+			}
+			if err := runtime.runHook(ctx, c.OnNew, event); err != nil {
+				return err
+			}
+		}
+
+		nextState := advanceDocsCommentsPollState(state, allFresh, runtime.now().UTC())
+		if err := writePollState(statePath, nextState); err != nil {
+			return err
+		}
+		state = nextState
+
+		if c.MaxIterations > 0 && iteration >= c.MaxIterations {
+			return nil
+		}
+		if err := runtime.wait(ctx, c.Interval); err != nil {
+			return err
+		}
+	}
+}
+
+func readDocsCommentsPollState(path string) (docsCommentsPollState, bool, error) {
+	var state docsCommentsPollState
+	exists, err := readPollState(path, &state)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if state.Version != pollStateVersion {
+		return docsCommentsPollState{}, false, fmt.Errorf("unsupported docs comments poll state version %d", state.Version)
+	}
+	state.DocID = strings.TrimSpace(state.DocID)
+	if state.DocID == "" {
+		return docsCommentsPollState{}, false, fmt.Errorf("docs comments poll state has empty doc_id")
+	}
+	watermark, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(state.Watermark))
+	if err != nil {
+		return docsCommentsPollState{}, false, fmt.Errorf("docs comments poll state has invalid watermark: %w", err)
+	}
+	state.Watermark = watermark.UTC().Format(time.RFC3339Nano)
+	state.SeenIDs = normalizedPollIDs(state.SeenIDs)
+	return state, true, nil
+}
+
+func filterPolledDriveComments(comments []*drive.Comment, state docsCommentsPollState) ([]timedDriveComment, error) {
+	watermark, err := time.Parse(time.RFC3339Nano, state.Watermark)
+	if err != nil {
+		return nil, fmt.Errorf("parse docs comments poll watermark: %w", err)
+	}
+	seen := make(map[string]struct{}, len(state.SeenIDs))
+	for _, id := range state.SeenIDs {
+		seen[id] = struct{}{}
+	}
+
+	fresh := make([]timedDriveComment, 0, len(comments))
+	for _, comment := range comments {
+		if comment == nil {
+			continue
+		}
+		at, timeErr := driveCommentPollTime(comment)
+		if timeErr != nil {
+			return nil, timeErr
+		}
+		if at.Before(watermark) {
+			continue
+		}
+		if at.Equal(watermark) {
+			if _, ok := seen[comment.Id]; ok {
+				continue
+			}
+		}
+		fresh = append(fresh, timedDriveComment{comment: comment, at: at})
+	}
+	sort.SliceStable(fresh, func(i, j int) bool {
+		if fresh[i].at.Equal(fresh[j].at) {
+			return fresh[i].comment.Id < fresh[j].comment.Id
+		}
+		return fresh[i].at.Before(fresh[j].at)
+	})
+	return fresh, nil
+}
+
+func filterPolledCommentsByResolved(comments []timedDriveComment, includeResolved bool) []timedDriveComment {
+	if includeResolved {
+		return comments
+	}
+	filtered := make([]timedDriveComment, 0, len(comments))
+	for _, item := range comments {
+		if !item.comment.Resolved {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func driveCommentPollTime(comment *drive.Comment) (time.Time, error) {
+	raw := strings.TrimSpace(comment.ModifiedTime)
+	if raw == "" {
+		raw = strings.TrimSpace(comment.CreatedTime)
+	}
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("drive comment %q has no modifiedTime or createdTime", comment.Id)
+	}
+	at, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("drive comment %q has invalid timestamp %q: %w", comment.Id, raw, err)
+	}
+	return at.UTC(), nil
+}
+
+func advanceDocsCommentsPollState(state docsCommentsPollState, fresh []timedDriveComment, updatedAt time.Time) docsCommentsPollState {
+	watermark, _ := time.Parse(time.RFC3339Nano, state.Watermark)
+	seen := make(map[string]struct{}, len(state.SeenIDs))
+	for _, id := range state.SeenIDs {
+		seen[id] = struct{}{}
+	}
+	for _, item := range fresh {
+		switch {
+		case item.at.After(watermark):
+			watermark = item.at
+			clear(seen)
+			seen[item.comment.Id] = struct{}{}
+		case item.at.Equal(watermark):
+			seen[item.comment.Id] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	state.Watermark = watermark.UTC().Format(time.RFC3339Nano)
+	state.SeenIDs = ids
+	state.UpdatedAt = updatedAt.Format(time.RFC3339Nano)
+	return state
+}
+
+func normalizedPollIDs(ids []string) []string {
+	unique := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			unique[id] = struct{}{}
+		}
+	}
+	normalized := make([]string, 0, len(unique))
+	for id := range unique {
+		normalized = append(normalized, id)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func writeDocsCommentPollEvent(ctx context.Context, event docsCommentPollEvent, at time.Time) error {
+	if outfmt.IsJSON(ctx) {
+		return writePollJSON(ctx, event)
+	}
+	author := ""
+	if event.Comment.Author != nil {
+		author = event.Comment.Author.DisplayName
+	}
+	if _, err := fmt.Fprintf(
+		os.Stdout,
+		"comment\t%s\t%s\t%s\t%s\t%t\n",
+		event.Comment.Id,
+		oneLineTSV(author),
+		oneLineTSV(event.Comment.Content),
+		at.Format(time.RFC3339Nano),
+		event.Comment.Resolved,
+	); err != nil {
+		return fmt.Errorf("write poll output: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/drive_changes.go
+++ b/internal/cmd/drive_changes.go
@@ -21,6 +21,7 @@ const driveChangesFields = "nextPageToken,newStartPageToken,changes(kind,type,re
 type DriveChangesCmd struct {
 	StartToken DriveChangesStartTokenCmd `cmd:"" name:"start-token" aliases:"token" help:"Get a Drive changes start page token"`
 	List       DriveChangesListCmd       `cmd:"" name:"list" aliases:"ls" help:"List Drive changes since a page token"`
+	Poll       DriveChangesPollCmd       `cmd:"" name:"poll" help:"Poll Drive changes with a persisted page token"`
 	Watch      DriveChangesWatchCmd      `cmd:"" name:"watch" help:"Watch Drive changes with a webhook channel"`
 	Stop       DriveChangesStopCmd       `cmd:"" name:"stop" help:"Stop a Drive changes webhook channel"`
 }
@@ -36,19 +37,15 @@ func (c *DriveChangesStartTokenCmd) Run(ctx context.Context, flags *RootFlags) e
 		return err
 	}
 
-	call := svc.Changes.GetStartPageToken().SupportsAllDrives(true).Context(ctx)
-	if driveID := strings.TrimSpace(c.DriveID); driveID != "" {
-		call = call.DriveId(driveID)
-	}
-	resp, err := call.Do()
+	startPageToken, err := getDriveChangesStartToken(ctx, svc, c.DriveID)
 	if err != nil {
 		return err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"startPageToken": resp.StartPageToken})
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"startPageToken": startPageToken})
 	}
-	u.Out().Linef("startPageToken\t%s", resp.StartPageToken)
+	u.Out().Linef("startPageToken\t%s", startPageToken)
 	return nil
 }
 
@@ -80,29 +77,12 @@ func (c *DriveChangesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	fetch := func(pageToken string) ([]*drive.Change, string, error) {
-		call := svc.Changes.List(pageToken).
-			PageSize(c.Max).
-			IncludeItemsFromAllDrives(true).
-			SupportsAllDrives(true).
-			IncludeRemoved(c.IncludeRemoved).
-			Fields(gapi.Field(driveChangesFields)).
-			Context(ctx)
-		if driveID := strings.TrimSpace(c.DriveID); driveID != "" {
-			call = call.DriveId(driveID)
-		}
-		resp, callErr := call.Do()
-		if callErr != nil {
-			return nil, "", callErr
-		}
-		next := resp.NextPageToken
-		if next == "" {
-			next = resp.NewStartPageToken
-		}
-		return resp.Changes, next, nil
-	}
-
-	changes, nextPageToken, err := loadPagedItems(token, c.All, fetch)
+	changes, nextPageToken, err := loadDriveChanges(ctx, svc, token, driveChangesLoadOptions{
+		max:            c.Max,
+		includeRemoved: c.IncludeRemoved,
+		driveID:        c.DriveID,
+		all:            c.All,
+	})
 	if err != nil {
 		return err
 	}
@@ -130,6 +110,98 @@ func (c *DriveChangesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	printNextPageHint(u, nextPageToken)
 	return nil
+}
+
+type driveChangesLoadOptions struct {
+	max            int64
+	includeRemoved bool
+	driveID        string
+	all            bool
+}
+
+type driveChangesPage struct {
+	changes           []*drive.Change
+	nextPageToken     string
+	newStartPageToken string
+}
+
+func getDriveChangesStartToken(ctx context.Context, svc *drive.Service, driveID string) (string, error) {
+	call := svc.Changes.GetStartPageToken().SupportsAllDrives(true).Context(ctx)
+	if driveID = strings.TrimSpace(driveID); driveID != "" {
+		call = call.DriveId(driveID)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(resp.StartPageToken) == "" {
+		return "", fmt.Errorf("drive changes start-token response was empty")
+	}
+	return resp.StartPageToken, nil
+}
+
+func fetchDriveChangesPage(ctx context.Context, svc *drive.Service, pageToken string, opts driveChangesLoadOptions) (driveChangesPage, error) {
+	call := svc.Changes.List(pageToken).
+		PageSize(opts.max).
+		IncludeItemsFromAllDrives(true).
+		SupportsAllDrives(true).
+		IncludeRemoved(opts.includeRemoved).
+		Fields(gapi.Field(driveChangesFields)).
+		Context(ctx)
+	if driveID := strings.TrimSpace(opts.driveID); driveID != "" {
+		call = call.DriveId(driveID)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return driveChangesPage{}, err
+	}
+	return driveChangesPage{
+		changes:           resp.Changes,
+		nextPageToken:     strings.TrimSpace(resp.NextPageToken),
+		newStartPageToken: strings.TrimSpace(resp.NewStartPageToken),
+	}, nil
+}
+
+func loadDriveChanges(ctx context.Context, svc *drive.Service, pageToken string, opts driveChangesLoadOptions) ([]*drive.Change, string, error) {
+	pageToken = strings.TrimSpace(pageToken)
+	if pageToken == "" {
+		return nil, "", usage("missing --token")
+	}
+	if !opts.all {
+		page, err := fetchDriveChangesPage(ctx, svc, pageToken, opts)
+		if err != nil {
+			return nil, "", err
+		}
+		next := page.nextPageToken
+		if next == "" {
+			next = page.newStartPageToken
+		}
+		return page.changes, next, nil
+	}
+
+	seen := make(map[string]struct{})
+	var changes []*drive.Change
+	for range 10_000 {
+		if _, ok := seen[pageToken]; ok {
+			return nil, "", fmt.Errorf("pagination loop: repeated page token %q", pageToken)
+		}
+		seen[pageToken] = struct{}{}
+
+		page, err := fetchDriveChangesPage(ctx, svc, pageToken, opts)
+		if err != nil {
+			return nil, "", err
+		}
+		changes = append(changes, page.changes...)
+		if page.nextPageToken != "" {
+			pageToken = page.nextPageToken
+			continue
+		}
+		if page.newStartPageToken == "" {
+			return nil, "", fmt.Errorf("drive changes response ended without newStartPageToken")
+		}
+		return changes, page.newStartPageToken, nil
+	}
+	return nil, "", fmt.Errorf("pagination exceeded max pages")
 }
 
 type DriveChangesWatchCmd struct {

--- a/internal/cmd/drive_changes_poll.go
+++ b/internal/cmd/drive_changes_poll.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type DriveChangesPollCmd struct {
+	StateFile      string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token"`
+	Interval       time.Duration `name:"interval" help:"Delay between polls" default:"60s"`
+	OnChange       string        `name:"on-change" help:"Trusted local shell command run for each non-empty batch; batch JSON is provided on stdin"`
+	FilterFile     string        `name:"filter-file" help:"Only emit and invoke the hook for changes to this file ID"`
+	DriveID        string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
+	MaxIterations  int           `name:"max-iterations" help:"Stop after N polls; 0 runs until interrupted" default:"0"`
+	Max            int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
+	IncludeRemoved bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
+}
+
+type driveChangesPollState struct {
+	Version   int    `json:"version"`
+	PageToken string `json:"page_token"`
+	DriveID   string `json:"drive_id,omitempty"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type driveChangesPollEvent struct {
+	Kind          string          `json:"kind"`
+	DriveID       string          `json:"driveId,omitempty"`
+	PageToken     string          `json:"pageToken"`
+	NextPageToken string          `json:"nextPageToken"`
+	Changes       []*drive.Change `json:"changes"`
+}
+
+func (c *DriveChangesPollCmd) Run(ctx context.Context, flags *RootFlags) error {
+	pollCtx, stop := pollSignalContext(ctx)
+	defer stop()
+	return c.run(pollCtx, flags, defaultPollRuntime())
+}
+
+func (c *DriveChangesPollCmd) run(ctx context.Context, flags *RootFlags, runtime pollRuntime) error {
+	runtime = runtime.withDefaults()
+	statePath, err := expandPollStatePath(c.StateFile)
+	if err != nil {
+		return err
+	}
+	if c.Interval <= 0 {
+		return usage("--interval must be greater than zero")
+	}
+	if c.MaxIterations < 0 {
+		return usage("--max-iterations must be >= 0")
+	}
+	if c.Max <= 0 {
+		return usage("--max must be greater than zero")
+	}
+
+	driveID := strings.TrimSpace(c.DriveID)
+	filterFile := normalizeGoogleID(strings.TrimSpace(c.FilterFile))
+	if dryRunErr := dryRunExit(ctx, flags, "drive.changes.poll", map[string]any{
+		"state_file":      statePath,
+		"interval":        c.Interval.String(),
+		"drive_id":        driveID,
+		"filter_file":     filterFile,
+		"max_iterations":  c.MaxIterations,
+		"max":             c.Max,
+		"include_removed": c.IncludeRemoved,
+		"hook_configured": strings.TrimSpace(c.OnChange) != "",
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	state, exists, err := readDriveChangesPollState(statePath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if driveID != "" && driveID != state.DriveID {
+			return usagef("poll state drive_id %q does not match --drive %q", state.DriveID, driveID)
+		}
+		if driveID == "" {
+			driveID = state.DriveID
+		}
+	} else {
+		startPageToken, startErr := getDriveChangesStartToken(ctx, svc, driveID)
+		if startErr != nil {
+			return startErr
+		}
+		state = driveChangesPollState{
+			Version:   pollStateVersion,
+			PageToken: startPageToken,
+			DriveID:   driveID,
+			UpdatedAt: runtime.now().UTC().Format(time.RFC3339Nano),
+		}
+		if err := writePollState(statePath, state); err != nil {
+			return err
+		}
+	}
+
+	for iteration := 1; ; iteration++ {
+		changes, nextPageToken, loadErr := loadDriveChanges(ctx, svc, state.PageToken, driveChangesLoadOptions{
+			max:            c.Max,
+			includeRemoved: c.IncludeRemoved,
+			driveID:        driveID,
+			all:            true,
+		})
+		if loadErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return loadErr
+		}
+		filtered := filterDriveChangesByFile(changes, filterFile)
+		if len(filtered) > 0 {
+			event := driveChangesPollEvent{
+				Kind:          "drive_changes",
+				DriveID:       driveID,
+				PageToken:     state.PageToken,
+				NextPageToken: nextPageToken,
+				Changes:       filtered,
+			}
+			if err := writeDriveChangesPollEvent(ctx, event); err != nil {
+				return err
+			}
+			if err := runtime.runHook(ctx, c.OnChange, event); err != nil {
+				return err
+			}
+		}
+
+		nextState := driveChangesPollState{
+			Version:   pollStateVersion,
+			PageToken: nextPageToken,
+			DriveID:   driveID,
+			UpdatedAt: runtime.now().UTC().Format(time.RFC3339Nano),
+		}
+		if err := writePollState(statePath, nextState); err != nil {
+			return err
+		}
+		state = nextState
+
+		if c.MaxIterations > 0 && iteration >= c.MaxIterations {
+			return nil
+		}
+		if err := runtime.wait(ctx, c.Interval); err != nil {
+			return err
+		}
+	}
+}
+
+func readDriveChangesPollState(path string) (driveChangesPollState, bool, error) {
+	var state driveChangesPollState
+	exists, err := readPollState(path, &state)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if state.Version != pollStateVersion {
+		return driveChangesPollState{}, false, fmt.Errorf("unsupported Drive changes poll state version %d", state.Version)
+	}
+	if strings.TrimSpace(state.PageToken) == "" {
+		return driveChangesPollState{}, false, fmt.Errorf("drive changes poll state has empty page_token")
+	}
+	state.PageToken = strings.TrimSpace(state.PageToken)
+	state.DriveID = strings.TrimSpace(state.DriveID)
+	return state, true, nil
+}
+
+func filterDriveChangesByFile(changes []*drive.Change, fileID string) []*drive.Change {
+	if strings.TrimSpace(fileID) == "" {
+		return changes
+	}
+	filtered := make([]*drive.Change, 0, len(changes))
+	for _, change := range changes {
+		if change != nil && change.FileId == fileID {
+			filtered = append(filtered, change)
+		}
+	}
+	return filtered
+}
+
+func writeDriveChangesPollEvent(ctx context.Context, event driveChangesPollEvent) error {
+	if outfmt.IsJSON(ctx) {
+		return writePollJSON(ctx, event)
+	}
+	for _, change := range event.Changes {
+		if change == nil {
+			continue
+		}
+		name := ""
+		if change.File != nil {
+			name = change.File.Name
+		}
+		if _, err := fmt.Fprintf(
+			os.Stdout,
+			"change\t%s\t%s\t%s\t%s\t%t\n",
+			change.Time,
+			change.Type,
+			change.FileId,
+			sanitizeTab(name),
+			change.Removed,
+		); err != nil {
+			return fmt.Errorf("write poll output: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/poll_helpers.go
+++ b/internal/cmd/poll_helpers.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const pollStateVersion = 1
+
+type pollRuntime struct {
+	now     func() time.Time
+	runHook func(context.Context, string, any) error
+	wait    func(context.Context, time.Duration) error
+}
+
+func defaultPollRuntime() pollRuntime {
+	return pollRuntime{
+		now:     time.Now,
+		runHook: runPollHook,
+		wait:    waitForPollInterval,
+	}
+}
+
+func (r pollRuntime) withDefaults() pollRuntime {
+	defaults := defaultPollRuntime()
+	if r.now == nil {
+		r.now = defaults.now
+	}
+	if r.runHook == nil {
+		r.runHook = defaults.runHook
+	}
+	if r.wait == nil {
+		r.wait = defaults.wait
+	}
+	return r
+}
+
+func pollSignalContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+}
+
+func waitForPollInterval(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func runPollHook(ctx context.Context, command string, payload any) error {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode poll hook payload: %w", err)
+	}
+	data = append(data, '\n')
+
+	var cmd *exec.Cmd
+	if os.PathSeparator == '\\' {
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/D", "/S", "/C", command) //nolint:gosec // command is an explicit local operator-provided hook.
+	} else {
+		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec // command is an explicit local operator-provided hook.
+	}
+	cmd.Stdin = bytes.NewReader(data)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("poll hook failed: %w", err)
+	}
+	return nil
+}
+
+func expandPollStatePath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", usage("missing --state-file")
+	}
+	path, err := config.ExpandPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(path) == "" {
+		return "", usage("empty --state-file")
+	}
+	return path, nil
+}
+
+func readPollState(path string, dst any) (bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // explicit user-provided state path.
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read poll state %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return false, nil
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return false, fmt.Errorf("decode poll state %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func writePollState(path string, state any) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode poll state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create poll state directory: %w", err)
+	}
+	if err := config.WriteFileAtomic(path, data, 0o600); err != nil {
+		return fmt.Errorf("write poll state %s: %w", path, err)
+	}
+	return nil
+}
+
+func writePollJSON(ctx context.Context, payload any) error {
+	var rendered bytes.Buffer
+	if err := outfmt.WriteJSON(ctx, &rendered, payload); err != nil {
+		return err
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, rendered.Bytes()); err != nil {
+		return fmt.Errorf("compact poll json: %w", err)
+	}
+	if err := compact.WriteByte('\n'); err != nil {
+		return err
+	}
+	if _, err := os.Stdout.Write(compact.Bytes()); err != nil {
+		return fmt.Errorf("write poll output: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/poll_test.go
+++ b/internal/cmd/poll_test.go
@@ -1,0 +1,432 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const pollTestStartToken = "start"
+
+func TestDriveChangesListAllStopsAtNewStartPageToken(t *testing.T) {
+	var tokens []string
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		token := r.URL.Query().Get("pageToken")
+		tokens = append(tokens, token)
+		switch token {
+		case pollTestStartToken:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"nextPageToken": "page-2",
+				"changes":       []map[string]any{{"fileId": "file-1"}},
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"newStartPageToken": "next-start",
+				"changes":           []map[string]any{{"fileId": "file-2"}},
+			})
+		default:
+			t.Fatalf("unexpected page token %q", token)
+		}
+	}))
+	defer closeSrv()
+
+	changes, next, err := loadDriveChanges(context.Background(), svc, pollTestStartToken, driveChangesLoadOptions{
+		max:            10,
+		includeRemoved: true,
+		all:            true,
+	})
+	if err != nil {
+		t.Fatalf("loadDriveChanges: %v", err)
+	}
+	if next != "next-start" {
+		t.Fatalf("next = %q, want next-start", next)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("changes = %d, want 2", len(changes))
+	}
+	if got := strings.Join(tokens, ","); got != "start,page-2" {
+		t.Fatalf("tokens = %q", got)
+	}
+}
+
+func TestDriveChangesPollPersistsFilteredBatch(t *testing.T) {
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/changes/startPageToken":
+			_ = json.NewEncoder(w).Encode(map[string]any{"startPageToken": pollTestStartToken})
+		case "/changes":
+			requireQuery(t, r, "pageToken", pollTestStartToken)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"newStartPageToken": "next",
+				"changes": []map[string]any{
+					{"fileId": "wanted", "type": "file", "file": map[string]any{"name": "Wanted"}},
+					{"fileId": "other", "type": "file", "file": map[string]any{"name": "Other"}},
+				},
+			})
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "nested", "drive-state.json")
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	var hooked driveChangesPollEvent
+	hookCalls := 0
+	cmd := DriveChangesPollCmd{
+		StateFile:      statePath,
+		Interval:       time.Second,
+		FilterFile:     "wanted",
+		MaxIterations:  1,
+		Max:            10,
+		IncludeRemoved: true,
+	}
+	out := captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				now: func() time.Time { return now },
+				runHook: func(_ context.Context, _ string, payload any) error {
+					hookCalls++
+					hooked = payload.(driveChangesPollEvent)
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if hookCalls != 1 || len(hooked.Changes) != 1 || hooked.Changes[0].FileId != "wanted" {
+		t.Fatalf("hooked = %#v, calls=%d", hooked, hookCalls)
+	}
+	if strings.Count(out, "\n") != 1 || !json.Valid([]byte(out)) {
+		t.Fatalf("expected one NDJSON event, got %q", out)
+	}
+	state, exists, err := readDriveChangesPollState(statePath)
+	if err != nil || !exists {
+		t.Fatalf("read state: exists=%t err=%v", exists, err)
+	}
+	if state.PageToken != "next" {
+		t.Fatalf("page token = %q, want next", state.PageToken)
+	}
+	if os.PathSeparator != '\\' {
+		info, statErr := os.Stat(statePath)
+		if statErr != nil {
+			t.Fatalf("stat state: %v", statErr)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("state mode = %o, want 600", info.Mode().Perm())
+		}
+	}
+	leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(statePath), ".drive-state.json.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("temporary state files remain: %v", leftovers)
+	}
+}
+
+func TestDriveChangesPollHookFailureRetainsToken(t *testing.T) {
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next",
+			"changes":           []map[string]any{{"fileId": "file-1", "type": "file"}},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "drive-state.json")
+	initial := driveChangesPollState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		UpdatedAt: "2026-06-11T10:00:00Z",
+	}
+	if err := writePollState(statePath, initial); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	cmd := DriveChangesPollCmd{
+		StateFile:      statePath,
+		Interval:       time.Second,
+		MaxIterations:  1,
+		Max:            10,
+		IncludeRemoved: true,
+	}
+	hookErr := errors.New("hook failed")
+	_ = captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{runHook: func(context.Context, string, any) error { return hookErr }},
+		)
+		if !errors.Is(err, hookErr) {
+			t.Fatalf("run error = %v, want hook error", err)
+		}
+	})
+	state, _, err := readDriveChangesPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.PageToken != pollTestStartToken {
+		t.Fatalf("page token = %q, want start", state.PageToken)
+	}
+}
+
+func TestDocsCommentsPollPersistsWatermarkAndSeenIDs(t *testing.T) {
+	const baseline = "2026-06-11T10:00:00Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files/doc-1/comments" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		requireQuery(t, r, "startModifiedTime", baseline)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{
+				{"id": "c2", "content": "Second", "modifiedTime": "2026-06-11T10:00:01Z"},
+				{"id": "c1", "content": "First", "modifiedTime": "2026-06-11T10:00:01Z"},
+			},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	var hooked []string
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	out := captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				now: func() time.Time { return now },
+				runHook: func(_ context.Context, _ string, payload any) error {
+					hooked = append(hooked, payload.(docsCommentPollEvent).Comment.Id)
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if got := strings.Join(hooked, ","); got != "c1,c2" {
+		t.Fatalf("hook order = %q, want c1,c2", got)
+	}
+	if strings.Count(out, "\n") != 2 {
+		t.Fatalf("expected two NDJSON events, got %q", out)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if !json.Valid([]byte(line)) {
+			t.Fatalf("invalid NDJSON line %q", line)
+		}
+	}
+	state, exists, err := readDocsCommentsPollState(statePath)
+	if err != nil || !exists {
+		t.Fatalf("read state: exists=%t err=%v", exists, err)
+	}
+	if state.Watermark != "2026-06-11T10:00:01Z" {
+		t.Fatalf("watermark = %q", state.Watermark)
+	}
+	if got := strings.Join(state.SeenIDs, ","); got != "c1,c2" {
+		t.Fatalf("seen IDs = %q", got)
+	}
+}
+
+func TestDocsCommentsPollSkipsSeenAtInclusiveWatermark(t *testing.T) {
+	const watermark = "2026-06-11T10:00:01Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireQuery(t, r, "startModifiedTime", watermark)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{
+				{"id": "seen", "modifiedTime": watermark},
+				{"id": "new-same-time", "modifiedTime": watermark},
+				{"id": "new-later", "modifiedTime": "2026-06-11T10:00:02Z"},
+			},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	if err := writePollState(statePath, docsCommentsPollState{
+		Version:   pollStateVersion,
+		DocID:     "doc-1",
+		Watermark: watermark,
+		SeenIDs:   []string{"seen"},
+		UpdatedAt: watermark,
+	}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	var hooked []string
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	_ = captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				runHook: func(_ context.Context, _ string, payload any) error {
+					hooked = append(hooked, payload.(docsCommentPollEvent).Comment.Id)
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if got := strings.Join(hooked, ","); got != "new-same-time,new-later" {
+		t.Fatalf("hooked = %q", got)
+	}
+	state, _, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.Watermark != "2026-06-11T10:00:02Z" || strings.Join(state.SeenIDs, ",") != "new-later" {
+		t.Fatalf("unexpected state: %#v", state)
+	}
+}
+
+func TestDocsCommentsPollAdvancesPastExcludedResolvedComments(t *testing.T) {
+	const watermark = "2026-06-11T10:00:00Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{{
+				"id":           "resolved",
+				"modifiedTime": "2026-06-11T10:00:01Z",
+				"resolved":     true,
+			}},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	if err := writePollState(statePath, docsCommentsPollState{
+		Version:   pollStateVersion,
+		DocID:     "doc-1",
+		Watermark: watermark,
+		UpdatedAt: watermark,
+	}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	hookCalls := 0
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	out := captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				runHook: func(context.Context, string, any) error {
+					hookCalls++
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if out != "" || hookCalls != 0 {
+		t.Fatalf("excluded comment emitted output=%q hooks=%d", out, hookCalls)
+	}
+	state, _, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.Watermark != "2026-06-11T10:00:01Z" || strings.Join(state.SeenIDs, ",") != "resolved" {
+		t.Fatalf("unexpected state: %#v", state)
+	}
+}
+
+func TestDocsCommentsPollHookFailureRetainsWatermark(t *testing.T) {
+	const watermark = "2026-06-11T10:00:00Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{{"id": "c1", "modifiedTime": "2026-06-11T10:00:01Z"}},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	initial := docsCommentsPollState{
+		Version:   pollStateVersion,
+		DocID:     "doc-1",
+		Watermark: watermark,
+		UpdatedAt: watermark,
+	}
+	if err := writePollState(statePath, initial); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	hookErr := errors.New("hook failed")
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	_ = captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{runHook: func(context.Context, string, any) error { return hookErr }},
+		)
+		if !errors.Is(err, hookErr) {
+			t.Fatalf("run error = %v, want hook error", err)
+		}
+	})
+	state, _, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.Watermark != watermark {
+		t.Fatalf("watermark = %q, want %q", state.Watermark, watermark)
+	}
+}
+
+func TestWaitForPollIntervalCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := waitForPollInterval(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+}


### PR DESCRIPTION
Closes #690.

## Summary

- add `gog drive changes poll` with atomic persisted page-token state, optional file filtering, bounded iterations, and sequential batch hooks
- add `gog docs comments poll` with an inclusive-safe modified-time watermark, sequential per-comment hooks, and resolved-comment filtering
- emit NDJSON in JSON mode, keep hook output on stderr, and advance state only after output/hooks succeed
- document polling state, hook trust, retry semantics, generated command references, and examples
- fix `drive changes list --all` so terminal `newStartPageToken` is returned instead of followed as another page

## Behavior decisions

- missing/empty Drive state starts from `changes.startPageToken`; missing/empty Docs state starts at the current time, avoiding existing-history replay
- hook payloads are JSON on stdin; Google content is never interpolated into the trusted local shell command
- hook/output failure retains the prior cursor, giving at-least-once delivery
- Docs state tracks IDs delivered at the inclusive timestamp watermark, preserving comments that share a modified time
- excluded resolved comments still advance the Docs watermark, avoiding repeated refetches

## Verification

- `make ci`
- focused polling/API tests covering pagination termination, atomic state, mode `0600`, filtering, NDJSON, deterministic hook order, inclusive timestamps, excluded resolved comments, hook retry, and cancellation
- autoreview: clean after fixing its resolved-comment cursor finding
- built binary dry-run smoke for both new command surfaces

A real Google smoke with `clawdbot@gmail.com` was attempted using the configured file keyring and `--no-input`. The account could not be unlocked because `GOG_KEYRING_PASSWORD` is unavailable in this shell. No GUI/keychain prompt was triggered. The local HTTP API tests exercise the real Drive client request/response path and hook/state behavior.
