### PR TITLE
feat(drive): add secure changes push receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ gog drive get <fileId> --fields 'id,name,mimeType,size,owners,emailAddress' --js
 gog drive changes start-token
 gog drive changes list --token <token> --json
 gog drive changes poll --state-file ~/.local/state/gog/drive-changes.json --json
+gog drive changes serve --state-file ~/.local/state/gog/drive-serve.json \
+  --channel-token "$CHANNEL_TOKEN" --auto-renew \
+  --webhook-url https://example.com/drive-changes
 gog drive revisions list <fileId> --all --json
 gog drive revisions get <fileId> <revisionId> --json
 gog drive activity query --file <fileId> --actions edit,share --from 2026-01-01T00:00:00Z --json

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ gog calendar appointments
 
 ### Drive
 
-Docs: [Drive audits](docs/drive-audits.md), [raw API dumps](docs/raw-api.md),
+Docs: [Drive audits](docs/drive-audits.md), [polling](docs/polling.md),
+[raw API dumps](docs/raw-api.md),
 [`gog drive`](docs/commands/gog-drive.md),
 [`drive changes`](docs/commands/gog-drive-changes.md),
 [`drive revisions`](docs/commands/gog-drive-revisions.md),
@@ -208,6 +209,7 @@ gog drive get <fileId> --fields 'id,name,mimeType,size,owners,emailAddress' --js
 # Track changes and audit activity.
 gog drive changes start-token
 gog drive changes list --token <token> --json
+gog drive changes poll --state-file ~/.local/state/gog/drive-changes.json --json
 gog drive revisions list <fileId> --all --json
 gog drive revisions get <fileId> <revisionId> --json
 gog drive activity query --file <fileId> --actions edit,share --from 2026-01-01T00:00:00Z --json
@@ -268,7 +270,7 @@ gog contacts dedupe --match email,phone,name --dry-run
 
 ### Docs
 
-Docs: [Google Docs editing](docs/docs-editing.md),
+Docs: [Google Docs editing](docs/docs-editing.md), [polling](docs/polling.md),
 [sed-style document edits](docs/sedmat.md),
 [`gog docs`](docs/commands/gog-docs.md).
 
@@ -281,6 +283,7 @@ gog docs named-range create <docId> --name Status --at "Ready"
 gog docs insert-image <docId> --url https://example.com/chart.png --at end
 gog docs add-tab <docId> --title "Notes"
 gog docs tabs add <docId> --title "Notes"
+gog docs comments poll <docId> --state-file ~/.local/state/gog/doc-comments.json --json
 gog docs find-replace <docId> old new --tab "Notes" --dry-run
 gog docs raw <docId> --pretty
 ```

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -229,6 +229,7 @@ Generated from `gog schema --json`.
       - [`gog docs (doc) comments get (info,show) <docId> <commentId>`](commands/gog-docs-comments-get.md) - Get a comment by ID
       - [`gog docs (doc) comments list (ls) <docId> [flags]`](commands/gog-docs-comments-list.md) - List comments on a Google Doc
       - [`gog docs (doc) comments locate <docId> <commentId> [flags]`](commands/gog-docs-comments-locate.md) - Resolve a comment quote to Docs API index ranges
+      - [`gog docs (doc) comments poll --state-file=STRING <docId> [flags]`](commands/gog-docs-comments-poll.md) - Poll new and modified comments with persisted state
       - [`gog docs (doc) comments reopen <docId> <commentId> [flags]`](commands/gog-docs-comments-reopen.md) - Reopen a previously resolved comment
       - [`gog docs (doc) comments reply (respond) <docId> <commentId> <content> [flags]`](commands/gog-docs-comments-reply.md) - Reply to a comment
       - [`gog docs (doc) comments resolve <docId> <commentId> [flags]`](commands/gog-docs-comments-resolve.md) - Resolve a comment (mark as done)
@@ -296,6 +297,7 @@ Generated from `gog schema --json`.
       - [`gog drive (drv) bulk update-role [flags]`](commands/gog-drive-bulk-update-role.md) - Change matching Drive permission roles across files
     - [`gog drive (drv) changes <command>`](commands/gog-drive-changes.md) - Track Drive changes for sync and automation
       - [`gog drive (drv) changes list (ls) --token=STRING [flags]`](commands/gog-drive-changes-list.md) - List Drive changes since a page token
+      - [`gog drive (drv) changes poll --state-file=STRING [flags]`](commands/gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
       - [`gog drive (drv) changes start-token (token) [flags]`](commands/gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [`gog drive (drv) changes stop <channelId> <resourceId>`](commands/gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [`gog drive (drv) changes watch --token=STRING --webhook-url=STRING [flags]`](commands/gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -298,6 +298,7 @@ Generated from `gog schema --json`.
     - [`gog drive (drv) changes <command>`](commands/gog-drive-changes.md) - Track Drive changes for sync and automation
       - [`gog drive (drv) changes list (ls) --token=STRING [flags]`](commands/gog-drive-changes-list.md) - List Drive changes since a page token
       - [`gog drive (drv) changes poll --state-file=STRING [flags]`](commands/gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
+      - [`gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]`](commands/gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
       - [`gog drive (drv) changes start-token (token) [flags]`](commands/gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [`gog drive (drv) changes stop <channelId> <resourceId>`](commands/gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [`gog drive (drv) changes watch --token=STRING --webhook-url=STRING [flags]`](commands/gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 620.
+Generated pages: 621.
 
 ## Top-level Commands
 
@@ -350,6 +350,7 @@ Generated pages: 620.
     - [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
       - [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
       - [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
+      - [gog drive changes serve](gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
       - [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 618.
+Generated pages: 620.
 
 ## Top-level Commands
 
@@ -281,6 +281,7 @@ Generated pages: 618.
       - [gog docs comments get](gog-docs-comments-get.md) - Get a comment by ID
       - [gog docs comments list](gog-docs-comments-list.md) - List comments on a Google Doc
       - [gog docs comments locate](gog-docs-comments-locate.md) - Resolve a comment quote to Docs API index ranges
+      - [gog docs comments poll](gog-docs-comments-poll.md) - Poll new and modified comments with persisted state
       - [gog docs comments reopen](gog-docs-comments-reopen.md) - Reopen a previously resolved comment
       - [gog docs comments reply](gog-docs-comments-reply.md) - Reply to a comment
       - [gog docs comments resolve](gog-docs-comments-resolve.md) - Resolve a comment (mark as done)
@@ -348,6 +349,7 @@ Generated pages: 618.
       - [gog drive bulk update-role](gog-drive-bulk-update-role.md) - Change matching Drive permission roles across files
     - [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
       - [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
+      - [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
       - [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/gog-docs-comments-poll.md
+++ b/docs/commands/gog-docs-comments-poll.md
@@ -1,26 +1,18 @@
-# `gog drive changes`
+# `gog docs comments poll`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Track Drive changes for sync and automation
+Poll new and modified comments with persisted state
 
 ## Usage
 
 ```bash
-gog drive (drv) changes <command>
+gog docs (doc) comments poll --state-file=STRING <docId> [flags]
 ```
 
 ## Parent
 
-- [gog drive](gog-drive.md)
-
-## Subcommands
-
-- [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
-- [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-- [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
-- [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
-- [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel
+- [gog docs comments](gog-docs-comments.md)
 
 ## Flags
 
@@ -38,16 +30,22 @@ gog drive (drv) changes <command>
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-resolved`<br>`--resolved` | `bool` |  | Include resolved comments |
+| `--interval` | `time.Duration` | 60s | Delay between polls |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max comments per API page |
+| `--max-iterations` | `int` | 0 | Stop after N polls; 0 runs until interrupted |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--on-new` | `string` |  | Trusted local shell command run for each comment; comment event JSON is provided on stdin |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--state-file` | `string` |  | JSON file that stores the comment time watermark |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog drive](gog-drive.md)
+- [gog docs comments](gog-docs-comments.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-comments.md
+++ b/docs/commands/gog-docs-comments.md
@@ -21,6 +21,7 @@ gog docs (doc) comments <command>
 - [gog docs comments get](gog-docs-comments-get.md) - Get a comment by ID
 - [gog docs comments list](gog-docs-comments-list.md) - List comments on a Google Doc
 - [gog docs comments locate](gog-docs-comments-locate.md) - Resolve a comment quote to Docs API index ranges
+- [gog docs comments poll](gog-docs-comments-poll.md) - Poll new and modified comments with persisted state
 - [gog docs comments reopen](gog-docs-comments-reopen.md) - Reopen a previously resolved comment
 - [gog docs comments reply](gog-docs-comments-reply.md) - Reply to a comment
 - [gog docs comments resolve](gog-docs-comments-resolve.md) - Resolve a comment (mark as done)

--- a/docs/commands/gog-drive-changes-poll.md
+++ b/docs/commands/gog-drive-changes-poll.md
@@ -1,26 +1,18 @@
-# `gog drive changes`
+# `gog drive changes poll`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Track Drive changes for sync and automation
+Poll Drive changes with a persisted page token
 
 ## Usage
 
 ```bash
-gog drive (drv) changes <command>
+gog drive (drv) changes poll --state-file=STRING [flags]
 ```
 
 ## Parent
 
-- [gog drive](gog-drive.md)
-
-## Subcommands
-
-- [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
-- [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-- [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
-- [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
-- [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel
+- [gog drive changes](gog-drive-changes.md)
 
 ## Flags
 
@@ -31,23 +23,31 @@ gog drive (drv) changes <command>
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `--drive`<br>`--drive-id` | `string` |  | Shared drive ID for a shared-drive change log |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--filter-file` | `string` |  | Only emit and invoke the hook for changes to this file ID |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-removed` | `bool` | true | Include removed changes |
+| `--interval` | `time.Duration` | 60s | Delay between polls |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--max`<br>`--limit` | `int64` | 100 | Max changes per API page |
+| `--max-iterations` | `int` | 0 | Stop after N polls; 0 runs until interrupted |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--on-change` | `string` |  | Trusted local shell command run for each non-empty batch; batch JSON is provided on stdin |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--state-file` | `string` |  | JSON file that stores the current Drive page token |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog drive](gog-drive.md)
+- [gog drive changes](gog-drive-changes.md)
 - [Command index](README.md)

--- a/docs/commands/gog-drive-changes-serve.md
+++ b/docs/commands/gog-drive-changes-serve.md
@@ -1,27 +1,18 @@
-# `gog drive changes`
+# `gog drive changes serve`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Track Drive changes for sync and automation
+Receive Drive change notifications and run a local hook
 
 ## Usage
 
 ```bash
-gog drive (drv) changes <command>
+gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]
 ```
 
 ## Parent
 
-- [gog drive](gog-drive.md)
-
-## Subcommands
-
-- [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
-- [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-- [gog drive changes serve](gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
-- [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
-- [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
-- [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel
+- [gog drive changes](gog-drive-changes.md)
 
 ## Flags
 
@@ -29,26 +20,42 @@ gog drive (drv) changes <command>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--auto-renew` | `bool` |  | Create and renew the Drive notification channel |
+| `--cert` | `string` |  | TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy) |
+| `--channel-token` | `string` |  | Expected X-Goog-Channel-Token value |
+| `--channel-ttl` | `time.Duration` | 24h | Requested channel lifetime |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `--drive`<br>`--drive-id` | `string` |  | Shared drive ID for a shared-drive change log |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--filter-file` | `string` |  | Only invoke the hook for changes to this file ID |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-removed` | `bool` | true | Include removed changes |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--key` | `string` |  | TLS private key path; pair with --cert |
+| `--listen` | `string` | 127.0.0.1:8443 | Listen address |
+| `--max`<br>`--limit` | `int64` | 100 | Max changes per API page |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--on-change` | `string` |  | Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin |
+| `--path` | `string` | /drive-changes | Notification handler path |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--renew-before` | `time.Duration` | 10m | Renew this long before channel expiration |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--state-file` | `string` |  | JSON file that stores the current Drive page token and channel state |
+| `--token` | `string` |  | Initial Drive page token when creating a new state file |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--webhook-url` | `string` |  | Public HTTPS callback URL used by --auto-renew |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog drive](gog-drive.md)
+- [gog drive changes](gog-drive-changes.md)
 - [Command index](README.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -47,6 +47,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Trying it.** [Install](install.md) → [Quickstart](quickstart.md). Five minutes from `brew install` to your first authenticated query.
 - **Wiring up an agent.** [Safety Profiles](safety-profiles.md) and the bundled [`gog` agent skill](https://github.com/openclaw/gogcli/blob/main/.agents/skills/gog/SKILL.md). Lock the binary down before handing it to a model.
 - **Serving MCP tools.** [MCP server](mcp.md) exposes typed, allowlisted tools for agent clients without a generic command bridge.
+- **Polling local events.** [Drive and Docs polling](polling.md) persists cursors and optionally invokes trusted shell hooks.
 - **Persisting auth and state.** [Paths and State](paths.md) covers `GOG_HOME`, per-kind directories, XDG paths, and legacy compatibility.
 - **Running Workspace at scale.** [Auth Clients](auth-clients.md) for service accounts, named OAuth clients, and domain-wide delegation.
 - **Managing Workspace.** [Workspace Admin](workspace-admin.md) covers user creation, cleanup, organizational units, and group administration.

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -1,0 +1,84 @@
+---
+summary: "Persisted Drive changes and Docs comment polling"
+read_when:
+  - Running gog as a local Drive or Docs event poller
+  - Wiring Drive changes or Docs comments to shell hooks
+---
+
+# Drive and Docs polling
+
+`gog` can poll Drive changes or Google Docs comments while persisting the API
+cursor in a local JSON file:
+
+```bash
+gog drive changes poll \
+  --state-file ~/.local/state/gog/drive-changes.json \
+  --interval 30s \
+  --json
+
+gog docs comments poll <docId> \
+  --state-file ~/.local/state/gog/doc-comments.json \
+  --interval 30s \
+  --json
+```
+
+Both commands poll immediately, then wait for `--interval`. Use
+`--max-iterations N` for bounded jobs and tests. `SIGINT` and `SIGTERM` stop the
+poller; completed iterations have already persisted their cursor.
+
+## State
+
+State files are written atomically with mode `0600`. Missing and empty state
+files initialize without replaying existing history:
+
+- Drive stores a fresh start page token before its first changes request.
+- Docs stores the current time as its initial comment watermark.
+
+Drive state is scoped to `--drive`. Docs state is scoped to the document and
+the `--include-resolved` setting. Delete the state file or choose a new path to
+start a new stream.
+
+The Docs API time filter is inclusive. State therefore records both the latest
+timestamp and comment IDs already delivered at that timestamp. Comments that
+share a modified time are delivered once without moving the watermark past an
+unseen peer.
+
+## Output
+
+With `--json`, stdout is newline-delimited JSON: one object per non-empty Drive
+batch or Docs comment. Plain and human modes emit one tab-separated line per
+change or comment. Empty polls produce no stdout.
+
+`drive changes poll --filter-file <fileId>` filters emitted changes and hook
+payloads, while the underlying Drive page token still advances.
+
+## Shell hooks
+
+Hooks are explicit trusted local shell commands:
+
+```bash
+gog drive changes poll \
+  --state-file drive.json \
+  --on-change './handle-drive-batch'
+
+gog docs comments poll <docId> \
+  --state-file comments.json \
+  --on-new './handle-comment'
+```
+
+Payload JSON is passed on stdin. Google-provided text is never interpolated
+into the command string. Hook stdout and stderr go to `gog` stderr so event
+stdout remains parseable.
+
+Drive invokes `--on-change` once per non-empty filtered batch. Docs invokes
+`--on-new` once per comment, in modified-time and comment-ID order. Hooks run
+sequentially.
+
+State advances only after output and all hooks succeed. Output or hook failure
+returns an error and retains the previous cursor, so the event is retried on
+the next run. Consumers must tolerate duplicate delivery.
+
+Command pages:
+
+- [`gog drive changes poll`](commands/gog-drive-changes-poll.md)
+- [`gog docs comments poll`](commands/gog-docs-comments-poll.md)

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -82,3 +82,73 @@ Command pages:
 
 - [`gog drive changes poll`](commands/gog-drive-changes-poll.md)
 - [`gog docs comments poll`](commands/gog-docs-comments-poll.md)
+
+## Drive push receiver
+
+`gog drive changes serve` receives Drive push notifications, lists the actual
+changes from the persisted page token, and optionally runs the same JSON-stdin
+hook shape as polling:
+
+```bash
+gog drive changes serve \
+  --listen 127.0.0.1:8443 \
+  --state-file ~/.local/state/gog/drive-serve.json \
+  --channel-token "$CHANNEL_TOKEN" \
+  --on-change './handle-drive-batch'
+```
+
+The default listener is loopback-only. Expose it through an HTTPS reverse proxy
+or tunnel whose public route ends at `/drive-changes`. Google requires a public
+HTTPS callback with a valid certificate. To terminate TLS in `gog` instead,
+provide both `--cert` and `--key`.
+
+The channel token is required and compared before notification headers are
+parsed or any Drive API request or hook runs. Use a random value; do not put
+OAuth credentials or other sensitive data in it.
+
+To let `gog` create and renew the channel after the listener is bound:
+
+```bash
+gog drive changes serve \
+  --listen 127.0.0.1:8443 \
+  --state-file ~/.local/state/gog/drive-serve.json \
+  --channel-token "$CHANNEL_TOKEN" \
+  --auto-renew \
+  --webhook-url https://example.com/drive-changes \
+  --channel-ttl 24h \
+  --renew-before 10m \
+  --on-change './handle-drive-batch'
+```
+
+Auto-renew creates a unique replacement channel before expiration, persists the
+new channel, then stops the previous channel. If cleanup fails, the state keeps
+the previous channel metadata and retries before creating another replacement.
+The maximum `--channel-ttl` is seven days, matching the Drive Changes API.
+
+Without `--auto-renew`, register the channel separately with `drive changes
+watch`. For a new receiver state file, pass the same initial page token to
+`serve --token` that was used by `watch --token`.
+
+Receiver behavior:
+
+- only `POST` requests to the configured path are accepted
+- mismatched or missing `X-Goog-Channel-Token` returns `401`
+- malformed required `X-Goog-*` headers return `400`
+- `sync`, duplicate, and unknown resource-state notifications are acknowledged
+  without running the hook
+- change notifications are serialized so concurrent deliveries cannot race the
+  page token
+- Drive/API, hook, or state-write failure returns `500`; Google retries these
+  statuses with backoff
+- the page token and message number advance only after the hook succeeds
+- `--filter-file` suppresses hooks for unrelated changes while still advancing
+  state
+
+The state file stores a SHA-256 digest of the channel token, not the token
+itself. Auto-renewed receivers also bind notifications to the persisted current
+or previous channel and resource IDs; manual receivers rely on the channel
+token. Do not run `poll` and `serve` concurrently against the same state file.
+
+Command page:
+
+- [`gog drive changes serve`](commands/gog-drive-changes-serve.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -229,6 +229,7 @@ Flag aliases:
 - `gog drive drives [--max N] [--page TOKEN] [--query Q]`
 - `gog drive changes start-token [--drive DRIVE_ID]`
 - `gog drive changes list --token TOKEN [--max N] [--all] [--drive DRIVE_ID]`
+- `gog drive changes poll --state-file PATH [--interval DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--drive DRIVE_ID]`
 - `gog drive changes watch --token TOKEN --webhook-url URL [--channel-id ID] [--channel-token TOKEN]`
 - `gog drive changes stop <channelId> <resourceId>`
 - `gog drive activity query [--file FILE_ID|--folder FOLDER_ID] [--actions edit,share] [--from RFC3339] [--to RFC3339] [--filter FILTER]`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -230,6 +230,7 @@ Flag aliases:
 - `gog drive changes start-token [--drive DRIVE_ID]`
 - `gog drive changes list --token TOKEN [--max N] [--all] [--drive DRIVE_ID]`
 - `gog drive changes poll --state-file PATH [--interval DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--drive DRIVE_ID]`
+- `gog drive changes serve --state-file PATH --channel-token TOKEN [--listen ADDR] [--on-change COMMAND] [--filter-file FILE_ID] [--auto-renew --webhook-url HTTPS_URL]`
 - `gog drive changes watch --token TOKEN --webhook-url URL [--channel-id ID] [--channel-token TOKEN]`
 - `gog drive changes stop <channelId> <resourceId>`
 - `gog drive activity query [--file FILE_ID|--folder FOLDER_ID] [--actions edit,share] [--from RFC3339] [--to RFC3339] [--filter FILTER]`

--- a/internal/cmd/docs_comments.go
+++ b/internal/cmd/docs_comments.go
@@ -12,6 +12,7 @@ import (
 // DocsCommentsCmd is the parent command for comment operations on a Google Doc.
 type DocsCommentsCmd struct {
 	List    DocsCommentsListCmd    `cmd:"" name:"list" aliases:"ls" help:"List comments on a Google Doc"`
+	Poll    DocsCommentsPollCmd    `cmd:"" name:"poll" help:"Poll new and modified comments with persisted state"`
 	Get     DocsCommentsGetCmd     `cmd:"" name:"get" aliases:"info,show" help:"Get a comment by ID"`
 	Add     DocsCommentsAddCmd     `cmd:"" name:"add" aliases:"create,new" help:"Add a comment to a Google Doc"`
 	Locate  DocsCommentsLocateCmd  `cmd:"" name:"locate" help:"Resolve a comment quote to Docs API index ranges"`

--- a/internal/cmd/docs_comments_poll.go
+++ b/internal/cmd/docs_comments_poll.go
@@ -1,0 +1,315 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type DocsCommentsPollCmd struct {
+	DocID           string        `arg:"" name:"docId" help:"Google Doc ID or URL"`
+	StateFile       string        `name:"state-file" required:"" help:"JSON file that stores the comment time watermark"`
+	Interval        time.Duration `name:"interval" help:"Delay between polls" default:"60s"`
+	IncludeResolved bool          `name:"include-resolved" aliases:"resolved" help:"Include resolved comments"`
+	OnNew           string        `name:"on-new" help:"Trusted local shell command run for each comment; comment event JSON is provided on stdin"`
+	MaxIterations   int           `name:"max-iterations" help:"Stop after N polls; 0 runs until interrupted" default:"0"`
+	Max             int64         `name:"max" aliases:"limit" help:"Max comments per API page" default:"100"`
+}
+
+type docsCommentsPollState struct {
+	Version         int      `json:"version"`
+	DocID           string   `json:"doc_id"`
+	Watermark       string   `json:"watermark"`
+	SeenIDs         []string `json:"seen_ids,omitempty"`
+	IncludeResolved bool     `json:"include_resolved"`
+	UpdatedAt       string   `json:"updated_at"`
+}
+
+type docsCommentPollEvent struct {
+	Kind    string         `json:"kind"`
+	DocID   string         `json:"docId"`
+	Comment *drive.Comment `json:"comment"`
+}
+
+type timedDriveComment struct {
+	comment *drive.Comment
+	at      time.Time
+}
+
+func (c *DocsCommentsPollCmd) Run(ctx context.Context, flags *RootFlags) error {
+	pollCtx, stop := pollSignalContext(ctx)
+	defer stop()
+	return c.run(pollCtx, flags, defaultPollRuntime())
+}
+
+func (c *DocsCommentsPollCmd) run(ctx context.Context, flags *RootFlags, runtime pollRuntime) error {
+	runtime = runtime.withDefaults()
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	statePath, err := expandPollStatePath(c.StateFile)
+	if err != nil {
+		return err
+	}
+	if c.Interval <= 0 {
+		return usage("--interval must be greater than zero")
+	}
+	if c.MaxIterations < 0 {
+		return usage("--max-iterations must be >= 0")
+	}
+	if c.Max <= 0 {
+		return usage("--max must be greater than zero")
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "docs.comments.poll", map[string]any{
+		"doc_id":           docID,
+		"state_file":       statePath,
+		"interval":         c.Interval.String(),
+		"include_resolved": c.IncludeResolved,
+		"max_iterations":   c.MaxIterations,
+		"max":              c.Max,
+		"hook_configured":  strings.TrimSpace(c.OnNew) != "",
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	state, exists, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if state.DocID != docID {
+			return usagef("poll state doc_id %q does not match docId %q", state.DocID, docID)
+		}
+		if state.IncludeResolved != c.IncludeResolved {
+			return usage("poll state --include-resolved setting does not match")
+		}
+	} else {
+		now := runtime.now().UTC()
+		state = docsCommentsPollState{
+			Version:         pollStateVersion,
+			DocID:           docID,
+			Watermark:       now.Format(time.RFC3339Nano),
+			IncludeResolved: c.IncludeResolved,
+			UpdatedAt:       now.Format(time.RFC3339Nano),
+		}
+		if err := writePollState(statePath, state); err != nil {
+			return err
+		}
+	}
+
+	for iteration := 1; ; iteration++ {
+		comments, _, listErr := listDriveComments(ctx, svc, docID, driveCommentListOptions{
+			resourceKey:     "docId",
+			resourceID:      docID,
+			includeResolved: true,
+			since:           state.Watermark,
+			all:             true,
+			max:             c.Max,
+			mode:            driveCommentListModeExpanded,
+		})
+		if listErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return listErr
+		}
+
+		allFresh, filterErr := filterPolledDriveComments(comments, state)
+		if filterErr != nil {
+			return filterErr
+		}
+		fresh := filterPolledCommentsByResolved(allFresh, c.IncludeResolved)
+		for _, item := range fresh {
+			event := docsCommentPollEvent{
+				Kind:    "docs_comment",
+				DocID:   docID,
+				Comment: item.comment,
+			}
+			if err := writeDocsCommentPollEvent(ctx, event, item.at); err != nil {
+				return err
+			}
+			if err := runtime.runHook(ctx, c.OnNew, event); err != nil {
+				return err
+			}
+		}
+
+		nextState := advanceDocsCommentsPollState(state, allFresh, runtime.now().UTC())
+		if err := writePollState(statePath, nextState); err != nil {
+			return err
+		}
+		state = nextState
+
+		if c.MaxIterations > 0 && iteration >= c.MaxIterations {
+			return nil
+		}
+		if err := runtime.wait(ctx, c.Interval); err != nil {
+			return err
+		}
+	}
+}
+
+func readDocsCommentsPollState(path string) (docsCommentsPollState, bool, error) {
+	var state docsCommentsPollState
+	exists, err := readPollState(path, &state)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if state.Version != pollStateVersion {
+		return docsCommentsPollState{}, false, fmt.Errorf("unsupported docs comments poll state version %d", state.Version)
+	}
+	state.DocID = strings.TrimSpace(state.DocID)
+	if state.DocID == "" {
+		return docsCommentsPollState{}, false, fmt.Errorf("docs comments poll state has empty doc_id")
+	}
+	watermark, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(state.Watermark))
+	if err != nil {
+		return docsCommentsPollState{}, false, fmt.Errorf("docs comments poll state has invalid watermark: %w", err)
+	}
+	state.Watermark = watermark.UTC().Format(time.RFC3339Nano)
+	state.SeenIDs = normalizedPollIDs(state.SeenIDs)
+	return state, true, nil
+}
+
+func filterPolledDriveComments(comments []*drive.Comment, state docsCommentsPollState) ([]timedDriveComment, error) {
+	watermark, err := time.Parse(time.RFC3339Nano, state.Watermark)
+	if err != nil {
+		return nil, fmt.Errorf("parse docs comments poll watermark: %w", err)
+	}
+	seen := make(map[string]struct{}, len(state.SeenIDs))
+	for _, id := range state.SeenIDs {
+		seen[id] = struct{}{}
+	}
+
+	fresh := make([]timedDriveComment, 0, len(comments))
+	for _, comment := range comments {
+		if comment == nil {
+			continue
+		}
+		at, timeErr := driveCommentPollTime(comment)
+		if timeErr != nil {
+			return nil, timeErr
+		}
+		if at.Before(watermark) {
+			continue
+		}
+		if at.Equal(watermark) {
+			if _, ok := seen[comment.Id]; ok {
+				continue
+			}
+		}
+		fresh = append(fresh, timedDriveComment{comment: comment, at: at})
+	}
+	sort.SliceStable(fresh, func(i, j int) bool {
+		if fresh[i].at.Equal(fresh[j].at) {
+			return fresh[i].comment.Id < fresh[j].comment.Id
+		}
+		return fresh[i].at.Before(fresh[j].at)
+	})
+	return fresh, nil
+}
+
+func filterPolledCommentsByResolved(comments []timedDriveComment, includeResolved bool) []timedDriveComment {
+	if includeResolved {
+		return comments
+	}
+	filtered := make([]timedDriveComment, 0, len(comments))
+	for _, item := range comments {
+		if !item.comment.Resolved {
+			filtered = append(filtered, item)
+		}
+	}
+	return filtered
+}
+
+func driveCommentPollTime(comment *drive.Comment) (time.Time, error) {
+	raw := strings.TrimSpace(comment.ModifiedTime)
+	if raw == "" {
+		raw = strings.TrimSpace(comment.CreatedTime)
+	}
+	if raw == "" {
+		return time.Time{}, fmt.Errorf("drive comment %q has no modifiedTime or createdTime", comment.Id)
+	}
+	at, err := time.Parse(time.RFC3339Nano, raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("drive comment %q has invalid timestamp %q: %w", comment.Id, raw, err)
+	}
+	return at.UTC(), nil
+}
+
+func advanceDocsCommentsPollState(state docsCommentsPollState, fresh []timedDriveComment, updatedAt time.Time) docsCommentsPollState {
+	watermark, _ := time.Parse(time.RFC3339Nano, state.Watermark)
+	seen := make(map[string]struct{}, len(state.SeenIDs))
+	for _, id := range state.SeenIDs {
+		seen[id] = struct{}{}
+	}
+	for _, item := range fresh {
+		switch {
+		case item.at.After(watermark):
+			watermark = item.at
+			clear(seen)
+			seen[item.comment.Id] = struct{}{}
+		case item.at.Equal(watermark):
+			seen[item.comment.Id] = struct{}{}
+		}
+	}
+	ids := make([]string, 0, len(seen))
+	for id := range seen {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	state.Watermark = watermark.UTC().Format(time.RFC3339Nano)
+	state.SeenIDs = ids
+	state.UpdatedAt = updatedAt.Format(time.RFC3339Nano)
+	return state
+}
+
+func normalizedPollIDs(ids []string) []string {
+	unique := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		if id = strings.TrimSpace(id); id != "" {
+			unique[id] = struct{}{}
+		}
+	}
+	normalized := make([]string, 0, len(unique))
+	for id := range unique {
+		normalized = append(normalized, id)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func writeDocsCommentPollEvent(ctx context.Context, event docsCommentPollEvent, at time.Time) error {
+	if outfmt.IsJSON(ctx) {
+		return writePollJSON(ctx, event)
+	}
+	author := ""
+	if event.Comment.Author != nil {
+		author = event.Comment.Author.DisplayName
+	}
+	if _, err := fmt.Fprintf(
+		os.Stdout,
+		"comment\t%s\t%s\t%s\t%s\t%t\n",
+		event.Comment.Id,
+		oneLineTSV(author),
+		oneLineTSV(event.Comment.Content),
+		at.Format(time.RFC3339Nano),
+		event.Comment.Resolved,
+	); err != nil {
+		return fmt.Errorf("write poll output: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/drive_changes.go
+++ b/internal/cmd/drive_changes.go
@@ -21,6 +21,7 @@ const driveChangesFields = "nextPageToken,newStartPageToken,changes(kind,type,re
 type DriveChangesCmd struct {
 	StartToken DriveChangesStartTokenCmd `cmd:"" name:"start-token" aliases:"token" help:"Get a Drive changes start page token"`
 	List       DriveChangesListCmd       `cmd:"" name:"list" aliases:"ls" help:"List Drive changes since a page token"`
+	Poll       DriveChangesPollCmd       `cmd:"" name:"poll" help:"Poll Drive changes with a persisted page token"`
 	Watch      DriveChangesWatchCmd      `cmd:"" name:"watch" help:"Watch Drive changes with a webhook channel"`
 	Stop       DriveChangesStopCmd       `cmd:"" name:"stop" help:"Stop a Drive changes webhook channel"`
 }
@@ -36,19 +37,15 @@ func (c *DriveChangesStartTokenCmd) Run(ctx context.Context, flags *RootFlags) e
 		return err
 	}
 
-	call := svc.Changes.GetStartPageToken().SupportsAllDrives(true).Context(ctx)
-	if driveID := strings.TrimSpace(c.DriveID); driveID != "" {
-		call = call.DriveId(driveID)
-	}
-	resp, err := call.Do()
+	startPageToken, err := getDriveChangesStartToken(ctx, svc, c.DriveID)
 	if err != nil {
 		return err
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"startPageToken": resp.StartPageToken})
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"startPageToken": startPageToken})
 	}
-	u.Out().Linef("startPageToken\t%s", resp.StartPageToken)
+	u.Out().Linef("startPageToken\t%s", startPageToken)
 	return nil
 }
 
@@ -80,29 +77,12 @@ func (c *DriveChangesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	fetch := func(pageToken string) ([]*drive.Change, string, error) {
-		call := svc.Changes.List(pageToken).
-			PageSize(c.Max).
-			IncludeItemsFromAllDrives(true).
-			SupportsAllDrives(true).
-			IncludeRemoved(c.IncludeRemoved).
-			Fields(gapi.Field(driveChangesFields)).
-			Context(ctx)
-		if driveID := strings.TrimSpace(c.DriveID); driveID != "" {
-			call = call.DriveId(driveID)
-		}
-		resp, callErr := call.Do()
-		if callErr != nil {
-			return nil, "", callErr
-		}
-		next := resp.NextPageToken
-		if next == "" {
-			next = resp.NewStartPageToken
-		}
-		return resp.Changes, next, nil
-	}
-
-	changes, nextPageToken, err := loadPagedItems(token, c.All, fetch)
+	changes, nextPageToken, err := loadDriveChanges(ctx, svc, token, driveChangesLoadOptions{
+		max:            c.Max,
+		includeRemoved: c.IncludeRemoved,
+		driveID:        c.DriveID,
+		all:            c.All,
+	})
 	if err != nil {
 		return err
 	}
@@ -130,6 +110,98 @@ func (c *DriveChangesListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	printNextPageHint(u, nextPageToken)
 	return nil
+}
+
+type driveChangesLoadOptions struct {
+	max            int64
+	includeRemoved bool
+	driveID        string
+	all            bool
+}
+
+type driveChangesPage struct {
+	changes           []*drive.Change
+	nextPageToken     string
+	newStartPageToken string
+}
+
+func getDriveChangesStartToken(ctx context.Context, svc *drive.Service, driveID string) (string, error) {
+	call := svc.Changes.GetStartPageToken().SupportsAllDrives(true).Context(ctx)
+	if driveID = strings.TrimSpace(driveID); driveID != "" {
+		call = call.DriveId(driveID)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(resp.StartPageToken) == "" {
+		return "", fmt.Errorf("drive changes start-token response was empty")
+	}
+	return resp.StartPageToken, nil
+}
+
+func fetchDriveChangesPage(ctx context.Context, svc *drive.Service, pageToken string, opts driveChangesLoadOptions) (driveChangesPage, error) {
+	call := svc.Changes.List(pageToken).
+		PageSize(opts.max).
+		IncludeItemsFromAllDrives(true).
+		SupportsAllDrives(true).
+		IncludeRemoved(opts.includeRemoved).
+		Fields(gapi.Field(driveChangesFields)).
+		Context(ctx)
+	if driveID := strings.TrimSpace(opts.driveID); driveID != "" {
+		call = call.DriveId(driveID)
+	}
+	resp, err := call.Do()
+	if err != nil {
+		return driveChangesPage{}, err
+	}
+	return driveChangesPage{
+		changes:           resp.Changes,
+		nextPageToken:     strings.TrimSpace(resp.NextPageToken),
+		newStartPageToken: strings.TrimSpace(resp.NewStartPageToken),
+	}, nil
+}
+
+func loadDriveChanges(ctx context.Context, svc *drive.Service, pageToken string, opts driveChangesLoadOptions) ([]*drive.Change, string, error) {
+	pageToken = strings.TrimSpace(pageToken)
+	if pageToken == "" {
+		return nil, "", usage("missing --token")
+	}
+	if !opts.all {
+		page, err := fetchDriveChangesPage(ctx, svc, pageToken, opts)
+		if err != nil {
+			return nil, "", err
+		}
+		next := page.nextPageToken
+		if next == "" {
+			next = page.newStartPageToken
+		}
+		return page.changes, next, nil
+	}
+
+	seen := make(map[string]struct{})
+	var changes []*drive.Change
+	for range 10_000 {
+		if _, ok := seen[pageToken]; ok {
+			return nil, "", fmt.Errorf("pagination loop: repeated page token %q", pageToken)
+		}
+		seen[pageToken] = struct{}{}
+
+		page, err := fetchDriveChangesPage(ctx, svc, pageToken, opts)
+		if err != nil {
+			return nil, "", err
+		}
+		changes = append(changes, page.changes...)
+		if page.nextPageToken != "" {
+			pageToken = page.nextPageToken
+			continue
+		}
+		if page.newStartPageToken == "" {
+			return nil, "", fmt.Errorf("drive changes response ended without newStartPageToken")
+		}
+		return changes, page.newStartPageToken, nil
+	}
+	return nil, "", fmt.Errorf("pagination exceeded max pages")
 }
 
 type DriveChangesWatchCmd struct {

--- a/internal/cmd/drive_changes.go
+++ b/internal/cmd/drive_changes.go
@@ -16,12 +16,17 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
-const driveChangesFields = "nextPageToken,newStartPageToken,changes(kind,type,removed,time,fileId,driveId,file(id,name,mimeType,modifiedTime,trashed,webViewLink))"
+const (
+	driveChangesFields             = "nextPageToken,newStartPageToken,changes(kind,type,removed,time,fileId,driveId,file(id,name,mimeType,modifiedTime,trashed,webViewLink))"
+	driveChangesWebhookSchemeHTTPS = "https"
+	driveChangesServerSchemeHTTP   = "http"
+)
 
 type DriveChangesCmd struct {
 	StartToken DriveChangesStartTokenCmd `cmd:"" name:"start-token" aliases:"token" help:"Get a Drive changes start page token"`
 	List       DriveChangesListCmd       `cmd:"" name:"list" aliases:"ls" help:"List Drive changes since a page token"`
 	Poll       DriveChangesPollCmd       `cmd:"" name:"poll" help:"Poll Drive changes with a persisted page token"`
+	Serve      DriveChangesServeCmd      `cmd:"" name:"serve" help:"Receive Drive change notifications and run a local hook"`
 	Watch      DriveChangesWatchCmd      `cmd:"" name:"watch" help:"Watch Drive changes with a webhook channel"`
 	Stop       DriveChangesStopCmd       `cmd:"" name:"stop" help:"Stop a Drive changes webhook channel"`
 }
@@ -290,7 +295,7 @@ func (c *DriveChangesWatchCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 func validateDriveChangesWebhookURL(rawURL string) error {
 	u, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil || u.Scheme != "https" || u.Host == "" {
+	if err != nil || u.Scheme != driveChangesWebhookSchemeHTTPS || u.Host == "" {
 		return usage("--webhook-url must be an absolute HTTPS URL")
 	}
 	return nil

--- a/internal/cmd/drive_changes_poll.go
+++ b/internal/cmd/drive_changes_poll.go
@@ -1,0 +1,215 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type DriveChangesPollCmd struct {
+	StateFile      string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token"`
+	Interval       time.Duration `name:"interval" help:"Delay between polls" default:"60s"`
+	OnChange       string        `name:"on-change" help:"Trusted local shell command run for each non-empty batch; batch JSON is provided on stdin"`
+	FilterFile     string        `name:"filter-file" help:"Only emit and invoke the hook for changes to this file ID"`
+	DriveID        string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
+	MaxIterations  int           `name:"max-iterations" help:"Stop after N polls; 0 runs until interrupted" default:"0"`
+	Max            int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
+	IncludeRemoved bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
+}
+
+type driveChangesPollState struct {
+	Version   int    `json:"version"`
+	PageToken string `json:"page_token"`
+	DriveID   string `json:"drive_id,omitempty"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type driveChangesPollEvent struct {
+	Kind          string          `json:"kind"`
+	DriveID       string          `json:"driveId,omitempty"`
+	PageToken     string          `json:"pageToken"`
+	NextPageToken string          `json:"nextPageToken"`
+	Changes       []*drive.Change `json:"changes"`
+}
+
+func (c *DriveChangesPollCmd) Run(ctx context.Context, flags *RootFlags) error {
+	pollCtx, stop := pollSignalContext(ctx)
+	defer stop()
+	return c.run(pollCtx, flags, defaultPollRuntime())
+}
+
+func (c *DriveChangesPollCmd) run(ctx context.Context, flags *RootFlags, runtime pollRuntime) error {
+	runtime = runtime.withDefaults()
+	statePath, err := expandPollStatePath(c.StateFile)
+	if err != nil {
+		return err
+	}
+	if c.Interval <= 0 {
+		return usage("--interval must be greater than zero")
+	}
+	if c.MaxIterations < 0 {
+		return usage("--max-iterations must be >= 0")
+	}
+	if c.Max <= 0 {
+		return usage("--max must be greater than zero")
+	}
+
+	driveID := strings.TrimSpace(c.DriveID)
+	filterFile := normalizeGoogleID(strings.TrimSpace(c.FilterFile))
+	if dryRunErr := dryRunExit(ctx, flags, "drive.changes.poll", map[string]any{
+		"state_file":      statePath,
+		"interval":        c.Interval.String(),
+		"drive_id":        driveID,
+		"filter_file":     filterFile,
+		"max_iterations":  c.MaxIterations,
+		"max":             c.Max,
+		"include_removed": c.IncludeRemoved,
+		"hook_configured": strings.TrimSpace(c.OnChange) != "",
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	state, exists, err := readDriveChangesPollState(statePath)
+	if err != nil {
+		return err
+	}
+	if exists {
+		if driveID != "" && driveID != state.DriveID {
+			return usagef("poll state drive_id %q does not match --drive %q", state.DriveID, driveID)
+		}
+		if driveID == "" {
+			driveID = state.DriveID
+		}
+	} else {
+		startPageToken, startErr := getDriveChangesStartToken(ctx, svc, driveID)
+		if startErr != nil {
+			return startErr
+		}
+		state = driveChangesPollState{
+			Version:   pollStateVersion,
+			PageToken: startPageToken,
+			DriveID:   driveID,
+			UpdatedAt: runtime.now().UTC().Format(time.RFC3339Nano),
+		}
+		if err := writePollState(statePath, state); err != nil {
+			return err
+		}
+	}
+
+	for iteration := 1; ; iteration++ {
+		changes, nextPageToken, loadErr := loadDriveChanges(ctx, svc, state.PageToken, driveChangesLoadOptions{
+			max:            c.Max,
+			includeRemoved: c.IncludeRemoved,
+			driveID:        driveID,
+			all:            true,
+		})
+		if loadErr != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return loadErr
+		}
+		filtered := filterDriveChangesByFile(changes, filterFile)
+		if len(filtered) > 0 {
+			event := driveChangesPollEvent{
+				Kind:          "drive_changes",
+				DriveID:       driveID,
+				PageToken:     state.PageToken,
+				NextPageToken: nextPageToken,
+				Changes:       filtered,
+			}
+			if err := writeDriveChangesPollEvent(ctx, event); err != nil {
+				return err
+			}
+			if err := runtime.runHook(ctx, c.OnChange, event); err != nil {
+				return err
+			}
+		}
+
+		nextState := driveChangesPollState{
+			Version:   pollStateVersion,
+			PageToken: nextPageToken,
+			DriveID:   driveID,
+			UpdatedAt: runtime.now().UTC().Format(time.RFC3339Nano),
+		}
+		if err := writePollState(statePath, nextState); err != nil {
+			return err
+		}
+		state = nextState
+
+		if c.MaxIterations > 0 && iteration >= c.MaxIterations {
+			return nil
+		}
+		if err := runtime.wait(ctx, c.Interval); err != nil {
+			return err
+		}
+	}
+}
+
+func readDriveChangesPollState(path string) (driveChangesPollState, bool, error) {
+	var state driveChangesPollState
+	exists, err := readPollState(path, &state)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if state.Version != pollStateVersion {
+		return driveChangesPollState{}, false, fmt.Errorf("unsupported Drive changes poll state version %d", state.Version)
+	}
+	if strings.TrimSpace(state.PageToken) == "" {
+		return driveChangesPollState{}, false, fmt.Errorf("drive changes poll state has empty page_token")
+	}
+	state.PageToken = strings.TrimSpace(state.PageToken)
+	state.DriveID = strings.TrimSpace(state.DriveID)
+	return state, true, nil
+}
+
+func filterDriveChangesByFile(changes []*drive.Change, fileID string) []*drive.Change {
+	if strings.TrimSpace(fileID) == "" {
+		return changes
+	}
+	filtered := make([]*drive.Change, 0, len(changes))
+	for _, change := range changes {
+		if change != nil && change.FileId == fileID {
+			filtered = append(filtered, change)
+		}
+	}
+	return filtered
+}
+
+func writeDriveChangesPollEvent(ctx context.Context, event driveChangesPollEvent) error {
+	if outfmt.IsJSON(ctx) {
+		return writePollJSON(ctx, event)
+	}
+	for _, change := range event.Changes {
+		if change == nil {
+			continue
+		}
+		name := ""
+		if change.File != nil {
+			name = change.File.Name
+		}
+		if _, err := fmt.Fprintf(
+			os.Stdout,
+			"change\t%s\t%s\t%s\t%s\t%t\n",
+			change.Time,
+			change.Type,
+			change.FileId,
+			sanitizeTab(name),
+			change.Removed,
+		); err != nil {
+			return fmt.Errorf("write poll output: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -1,0 +1,595 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+const (
+	defaultDriveChangesChannelTTL = 24 * time.Hour
+	maxDriveChangesChannelTTL     = 7 * 24 * time.Hour
+	driveChangesRenewRetry        = time.Minute
+)
+
+type DriveChangesServeCmd struct {
+	Listen         string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
+	Path           string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
+	Cert           string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
+	Key            string        `name:"key" help:"TLS private key path; pair with --cert"`
+	ChannelToken   string        `name:"channel-token" required:"" help:"Expected X-Goog-Channel-Token value"`
+	StateFile      string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
+	Token          string        `name:"token" help:"Initial Drive page token when creating a new state file"`
+	OnChange       string        `name:"on-change" help:"Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin"`
+	FilterFile     string        `name:"filter-file" help:"Only invoke the hook for changes to this file ID"`
+	DriveID        string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
+	Max            int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
+	IncludeRemoved bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
+	AutoRenew      bool          `name:"auto-renew" help:"Create and renew the Drive notification channel"`
+	WebhookURL     string        `name:"webhook-url" help:"Public HTTPS callback URL used by --auto-renew"`
+	ChannelTTL     time.Duration `name:"channel-ttl" help:"Requested channel lifetime" default:"24h"`
+	RenewBefore    time.Duration `name:"renew-before" help:"Renew this long before channel expiration" default:"10m"`
+}
+
+type driveChangesServeChannelState struct {
+	ID          string `json:"id"`
+	ResourceID  string `json:"resource_id"`
+	ResourceURI string `json:"resource_uri,omitempty"`
+	Expiration  int64  `json:"expiration_ms"`
+	WebhookURL  string `json:"webhook_url,omitempty"`
+	TokenHash   string `json:"token_sha256,omitempty"`
+}
+
+type driveChangesServeState struct {
+	Version            int                            `json:"version"`
+	PageToken          string                         `json:"page_token"`
+	DriveID            string                         `json:"drive_id,omitempty"`
+	Channel            *driveChangesServeChannelState `json:"channel,omitempty"`
+	PreviousChannel    *driveChangesServeChannelState `json:"previous_channel,omitempty"`
+	LastMessageNumbers map[string]uint64              `json:"last_message_numbers,omitempty"`
+	UpdatedAt          string                         `json:"updated_at"`
+}
+
+type driveChangesServeRuntime struct {
+	now     func() time.Time
+	runHook func(context.Context, string, any) error
+	wait    func(context.Context, time.Duration) error
+	listen  func(context.Context, string, string) (net.Listener, error)
+}
+
+func defaultDriveChangesServeRuntime() driveChangesServeRuntime {
+	var listenConfig net.ListenConfig
+	return driveChangesServeRuntime{
+		now:     time.Now,
+		runHook: runJSONShellHook,
+		wait:    waitForPollInterval,
+		listen:  listenConfig.Listen,
+	}
+}
+
+func (r driveChangesServeRuntime) withDefaults() driveChangesServeRuntime {
+	defaults := defaultDriveChangesServeRuntime()
+	if r.now == nil {
+		r.now = defaults.now
+	}
+	if r.runHook == nil {
+		r.runHook = defaults.runHook
+	}
+	if r.wait == nil {
+		r.wait = defaults.wait
+	}
+	if r.listen == nil {
+		r.listen = defaults.listen
+	}
+	return r
+}
+
+type driveChangesServer struct {
+	mu             sync.Mutex
+	renewMu        sync.Mutex
+	pendingChannel string
+	statePath      string
+	state          driveChangesServeState
+	service        *drive.Service
+	path           string
+	channelToken   string
+	onChange       string
+	filterFile     string
+	max            int64
+	includeRemoved bool
+	autoRenew      bool
+	webhookURL     string
+	channelTTL     time.Duration
+	renewBefore    time.Duration
+	runtime        driveChangesServeRuntime
+	logf           func(string, ...any)
+	warnf          func(string, ...any)
+}
+
+func (c *DriveChangesServeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	serveCtx, stop := pollSignalContext(ctx)
+	defer stop()
+	return c.run(serveCtx, flags, defaultDriveChangesServeRuntime())
+}
+
+func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtime driveChangesServeRuntime) error {
+	runtime = runtime.withDefaults()
+	u := ui.FromContext(ctx)
+	statePath, err := expandPollStatePath(c.StateFile)
+	if err != nil {
+		return err
+	}
+	if validationErr := c.validate(); validationErr != nil {
+		return validationErr
+	}
+
+	driveID := strings.TrimSpace(c.DriveID)
+	filterFile := normalizeGoogleID(strings.TrimSpace(c.FilterFile))
+	if dryRunErr := dryRunExit(ctx, flags, "drive.changes.serve", map[string]any{
+		"listen":           strings.TrimSpace(c.Listen),
+		"path":             strings.TrimSpace(c.Path),
+		"tls":              strings.TrimSpace(c.Cert) != "",
+		"state_file":       statePath,
+		"initial_token":    strings.TrimSpace(c.Token) != "",
+		"drive_id":         driveID,
+		"filter_file":      filterFile,
+		"max":              c.Max,
+		"include_removed":  c.IncludeRemoved,
+		"hook_configured":  strings.TrimSpace(c.OnChange) != "",
+		"auto_renew":       c.AutoRenew,
+		"webhook_url":      strings.TrimSpace(c.WebhookURL),
+		"channel_ttl":      c.ChannelTTL.String(),
+		"renew_before":     c.RenewBefore.String(),
+		"token_configured": true,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	var tlsConfig *tls.Config
+	if strings.TrimSpace(c.Cert) != "" {
+		certificate, certErr := tls.LoadX509KeyPair(c.Cert, c.Key)
+		if certErr != nil {
+			return fmt.Errorf("load TLS certificate: %w", certErr)
+		}
+		tlsConfig = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{certificate},
+		}
+	}
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	state, err := initializeDriveChangesServeState(
+		ctx,
+		svc,
+		statePath,
+		strings.TrimSpace(c.Token),
+		driveID,
+		runtime.now().UTC(),
+	)
+	if err != nil {
+		return err
+	}
+	listener, err := runtime.listen(ctx, "tcp", strings.TrimSpace(c.Listen))
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", c.Listen, err)
+	}
+	if tlsConfig != nil {
+		listener = tls.NewListener(listener, tlsConfig)
+	}
+
+	server := &driveChangesServer{
+		statePath:      statePath,
+		state:          state,
+		service:        svc,
+		path:           strings.TrimSpace(c.Path),
+		channelToken:   strings.TrimSpace(c.ChannelToken),
+		onChange:       strings.TrimSpace(c.OnChange),
+		filterFile:     filterFile,
+		max:            c.Max,
+		includeRemoved: c.IncludeRemoved,
+		autoRenew:      c.AutoRenew,
+		webhookURL:     strings.TrimSpace(c.WebhookURL),
+		channelTTL:     c.ChannelTTL,
+		renewBefore:    c.RenewBefore,
+		runtime:        runtime,
+		logf:           u.Err().Linef,
+		warnf:          u.Err().Linef,
+	}
+	httpServer := &http.Server{
+		Handler:           server,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		MaxHeaderBytes:    64 << 10,
+	}
+	serveErrors := make(chan error, 1)
+	go func() {
+		serveErrors <- httpServer.Serve(listener)
+	}()
+
+	scheme := driveChangesServerSchemeHTTP
+	if tlsConfig != nil {
+		scheme = driveChangesWebhookSchemeHTTPS
+	}
+	u.Err().Linef("drive changes serve: listening on %s://%s%s", scheme, listener.Addr(), server.path)
+
+	if c.AutoRenew {
+		nextRenewal, renewErr := server.ensureChannel(ctx)
+		if renewErr != nil {
+			_ = shutdownHTTPServer(ctx, httpServer)
+			return renewErr
+		}
+		go server.runRenewLoop(ctx, nextRenewal)
+	}
+
+	select {
+	case serveErr := <-serveErrors:
+		if errors.Is(serveErr, http.ErrServerClosed) {
+			return nil
+		}
+		return serveErr
+	case <-ctx.Done():
+		if shutdownErr := shutdownHTTPServer(ctx, httpServer); shutdownErr != nil {
+			return shutdownErr
+		}
+		return ctx.Err()
+	}
+}
+
+func (c *DriveChangesServeCmd) validate() error {
+	if strings.TrimSpace(c.Listen) == "" {
+		return usage("missing --listen")
+	}
+	if path := strings.TrimSpace(c.Path); path == "" || !strings.HasPrefix(path, "/") {
+		return usage("--path must start with '/'")
+	}
+	if (strings.TrimSpace(c.Cert) == "") != (strings.TrimSpace(c.Key) == "") {
+		return usage("--cert and --key must be provided together")
+	}
+	channelToken := strings.TrimSpace(c.ChannelToken)
+	if channelToken == "" {
+		return usage("missing --channel-token")
+	}
+	if len(channelToken) > 256 {
+		return usage("--channel-token must be at most 256 bytes")
+	}
+	if c.Max <= 0 {
+		return usage("--max must be greater than zero")
+	}
+	webhookURL := strings.TrimSpace(c.WebhookURL)
+	if c.AutoRenew {
+		if webhookURL == "" {
+			return usage("--webhook-url is required with --auto-renew")
+		}
+		if err := validateDriveChangesWebhookURL(webhookURL); err != nil {
+			return err
+		}
+		if c.ChannelTTL <= 0 || c.ChannelTTL > maxDriveChangesChannelTTL {
+			return usage("--channel-ttl must be greater than zero and at most 168h")
+		}
+		if c.RenewBefore <= 0 || c.RenewBefore >= c.ChannelTTL {
+			return usage("--renew-before must be greater than zero and less than --channel-ttl")
+		}
+	} else if webhookURL != "" {
+		return usage("--webhook-url requires --auto-renew")
+	}
+	return nil
+}
+
+func initializeDriveChangesServeState(
+	ctx context.Context,
+	svc *drive.Service,
+	path string,
+	initialToken string,
+	driveID string,
+	now time.Time,
+) (driveChangesServeState, error) {
+	state, exists, err := readDriveChangesServeState(path)
+	if err != nil {
+		return driveChangesServeState{}, err
+	}
+	if exists {
+		if initialToken != "" && initialToken != state.PageToken {
+			return driveChangesServeState{}, usage("--token does not match the persisted page token")
+		}
+		if driveID != "" && driveID != state.DriveID {
+			return driveChangesServeState{}, usagef("serve state drive_id %q does not match --drive %q", state.DriveID, driveID)
+		}
+		return state, nil
+	}
+	if initialToken == "" {
+		initialToken, err = getDriveChangesStartToken(ctx, svc, driveID)
+		if err != nil {
+			return driveChangesServeState{}, err
+		}
+	}
+	state = driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: initialToken,
+		DriveID:   driveID,
+		UpdatedAt: now.Format(time.RFC3339Nano),
+	}
+	if err := writePollState(path, state); err != nil {
+		return driveChangesServeState{}, err
+	}
+	return state, nil
+}
+
+func readDriveChangesServeState(path string) (driveChangesServeState, bool, error) {
+	var state driveChangesServeState
+	exists, err := readPollState(path, &state)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if state.Version != pollStateVersion {
+		return driveChangesServeState{}, false, fmt.Errorf("unsupported drive changes serve state version %d", state.Version)
+	}
+	state.PageToken = strings.TrimSpace(state.PageToken)
+	state.DriveID = strings.TrimSpace(state.DriveID)
+	if state.PageToken == "" {
+		return driveChangesServeState{}, false, fmt.Errorf("drive changes serve state has empty page_token")
+	}
+	normalizeDriveChangesServeChannel(state.Channel)
+	normalizeDriveChangesServeChannel(state.PreviousChannel)
+	return state, true, nil
+}
+
+func normalizeDriveChangesServeChannel(channel *driveChangesServeChannelState) {
+	if channel == nil {
+		return
+	}
+	channel.ID = strings.TrimSpace(channel.ID)
+	channel.ResourceID = strings.TrimSpace(channel.ResourceID)
+	channel.ResourceURI = strings.TrimSpace(channel.ResourceURI)
+	channel.WebhookURL = strings.TrimSpace(channel.WebhookURL)
+	channel.TokenHash = strings.TrimSpace(channel.TokenHash)
+}
+
+func cloneDriveChangesServeState(state driveChangesServeState) driveChangesServeState {
+	cloned := state
+	if state.Channel != nil {
+		channel := *state.Channel
+		cloned.Channel = &channel
+	}
+	if state.PreviousChannel != nil {
+		channel := *state.PreviousChannel
+		cloned.PreviousChannel = &channel
+	}
+	if state.LastMessageNumbers != nil {
+		cloned.LastMessageNumbers = make(map[string]uint64, len(state.LastMessageNumbers))
+		for channelID, messageNumber := range state.LastMessageNumbers {
+			cloned.LastMessageNumbers[channelID] = messageNumber
+		}
+	}
+	return cloned
+}
+
+func channelTokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func shutdownHTTPServer(ctx context.Context, server *http.Server) error {
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shut down Drive changes server: %w", err)
+	}
+	return nil
+}
+
+func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, error) {
+	s.renewMu.Lock()
+	defer s.renewMu.Unlock()
+
+	s.mu.Lock()
+
+	pendingStopFailed := false
+	if s.state.PreviousChannel != nil {
+		if err := s.stopPreviousChannelLocked(ctx); err != nil {
+			pendingStopFailed = true
+			s.warnf("drive changes serve: stop previous channel failed: %v", err)
+		}
+	}
+
+	now := s.runtime.now().UTC()
+	if s.currentChannelMatchesLocked() {
+		delay := s.channelRenewalDelayLocked(now)
+		if delay > 0 {
+			if pendingStopFailed && delay > driveChangesRenewRetry {
+				delay = driveChangesRenewRetry
+			}
+			s.mu.Unlock()
+			return delay, nil
+		}
+	}
+	if s.state.PreviousChannel != nil {
+		s.mu.Unlock()
+		return 0, errors.New("cannot renew Drive changes channel while previous channel cleanup is pending")
+	}
+	pageToken := s.state.PageToken
+	driveID := s.state.DriveID
+	s.mu.Unlock()
+
+	channelID, err := randomChannelID()
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	s.pendingChannel = channelID
+	s.mu.Unlock()
+	requestedExpiration := now.Add(s.channelTTL).UnixMilli()
+	channel := &drive.Channel{
+		Id:         channelID,
+		Type:       "web_hook",
+		Address:    s.webhookURL,
+		Token:      s.channelToken,
+		Expiration: requestedExpiration,
+	}
+	call := s.service.Changes.Watch(pageToken, channel).
+		SupportsAllDrives(true).
+		Context(ctx)
+	if driveID != "" {
+		call = call.DriveId(driveID)
+	}
+	response, err := call.Do()
+	if err != nil {
+		s.clearPendingChannel(channelID)
+		return 0, err
+	}
+	if response == nil || strings.TrimSpace(response.Id) == "" || strings.TrimSpace(response.ResourceId) == "" {
+		s.clearPendingChannel(channelID)
+		return 0, errors.New("drive changes watch response missing channel identifiers")
+	}
+	expiration := response.Expiration
+	if expiration <= 0 {
+		expiration = requestedExpiration
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pendingChannel == channelID {
+		s.pendingChannel = ""
+	}
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.PreviousChannel = nextState.Channel
+	nextState.Channel = &driveChangesServeChannelState{
+		ID:          strings.TrimSpace(response.Id),
+		ResourceID:  strings.TrimSpace(response.ResourceId),
+		ResourceURI: strings.TrimSpace(response.ResourceUri),
+		Expiration:  expiration,
+		WebhookURL:  s.webhookURL,
+		TokenHash:   channelTokenHash(s.channelToken),
+	}
+	nextState.UpdatedAt = now.Format(time.RFC3339Nano)
+	trimDriveChangesMessageNumbers(&nextState, nextState.Channel.ID, channelIDFor(nextState.PreviousChannel))
+	if err := writePollState(s.statePath, nextState); err != nil {
+		_ = s.service.Channels.Stop(&drive.Channel{
+			Id:         nextState.Channel.ID,
+			ResourceId: nextState.Channel.ResourceID,
+		}).Context(ctx).Do()
+		return 0, err
+	}
+	s.state = nextState
+
+	if s.state.PreviousChannel != nil {
+		if err := s.stopPreviousChannelLocked(ctx); err != nil {
+			s.warnf("drive changes serve: stop previous channel failed: %v", err)
+		}
+	}
+	delay := s.channelRenewalDelayLocked(now)
+	if s.state.PreviousChannel != nil && delay > driveChangesRenewRetry {
+		delay = driveChangesRenewRetry
+	}
+	return delay, nil
+}
+
+func (s *driveChangesServer) clearPendingChannel(channelID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pendingChannel == channelID {
+		s.pendingChannel = ""
+	}
+}
+
+func (s *driveChangesServer) currentChannelMatchesLocked() bool {
+	channel := s.state.Channel
+	return channel != nil &&
+		channel.ID != "" &&
+		channel.ResourceID != "" &&
+		channel.WebhookURL == s.webhookURL &&
+		channel.TokenHash == channelTokenHash(s.channelToken)
+}
+
+func (s *driveChangesServer) channelRenewalDelayLocked(now time.Time) time.Duration {
+	if s.state.Channel == nil || s.state.Channel.Expiration <= 0 {
+		return 0
+	}
+	delay := time.UnixMilli(s.state.Channel.Expiration).Sub(now) - s.renewBefore
+	if delay < time.Second {
+		return 0
+	}
+	return delay
+}
+
+func (s *driveChangesServer) stopPreviousChannelLocked(ctx context.Context) error {
+	previous := s.state.PreviousChannel
+	if previous == nil {
+		return nil
+	}
+	if previous.ID != "" && previous.ResourceID != "" {
+		if err := s.service.Channels.Stop(&drive.Channel{
+			Id:         previous.ID,
+			ResourceId: previous.ResourceID,
+		}).Context(ctx).Do(); err != nil && !isNotFoundAPIError(err) {
+			return err
+		}
+	}
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.PreviousChannel = nil
+	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
+	if err := writePollState(s.statePath, nextState); err != nil {
+		return err
+	}
+	s.state = nextState
+	return nil
+}
+
+func (s *driveChangesServer) runRenewLoop(ctx context.Context, delay time.Duration) {
+	for {
+		if delay < time.Second {
+			delay = time.Second
+		}
+		if err := s.runtime.wait(ctx, delay); err != nil {
+			return
+		}
+		nextDelay, err := s.ensureChannel(ctx)
+		if err != nil {
+			s.warnf("drive changes serve: channel renewal failed: %v", err)
+			delay = driveChangesRenewRetry
+			continue
+		}
+		delay = nextDelay
+	}
+}
+
+func channelIDFor(channel *driveChangesServeChannelState) string {
+	if channel == nil {
+		return ""
+	}
+	return channel.ID
+}
+
+func trimDriveChangesMessageNumbers(state *driveChangesServeState, keepChannelIDs ...string) {
+	if len(state.LastMessageNumbers) <= 32 {
+		return
+	}
+	keep := make(map[string]struct{}, len(keepChannelIDs))
+	for _, channelID := range keepChannelIDs {
+		if channelID != "" {
+			keep[channelID] = struct{}{}
+		}
+	}
+	for channelID := range state.LastMessageNumbers {
+		if len(state.LastMessageNumbers) <= 32 {
+			break
+		}
+		if _, ok := keep[channelID]; !ok {
+			delete(state.LastMessageNumbers, channelID)
+		}
+	}
+}

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -1,0 +1,574 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+)
+
+const (
+	driveChangesTestChannelToken = "channel-secret"
+	driveChangesTestStatePath    = "/drive-changes"
+)
+
+func TestDriveChangesServeRejectsWrongTokenBeforeAPI(t *testing.T) {
+	server := newDriveChangesTestReceiver(t, nil, driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	})
+	var hookCalls atomic.Int32
+	server.runtime.runHook = func(context.Context, string, any) error {
+		hookCalls.Add(1)
+		return nil
+	}
+
+	request := newDriveChangesNotificationRequest(t, "wrong", "change", 2)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", response.Code)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("hook calls = %d, want 0", hookCalls.Load())
+	}
+}
+
+func TestDriveChangesServeRejectsUntrackedChannel(t *testing.T) {
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "expected-channel",
+			ResourceID: "expected-resource",
+		},
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	var hookCalls atomic.Int32
+	server.onChange = "./handle-change"
+	server.runtime.runHook = func(context.Context, string, any) error {
+		hookCalls.Add(1)
+		return nil
+	}
+
+	request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 2)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", response.Code)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("hook calls = %d, want 0", hookCalls.Load())
+	}
+	if server.state.PageToken != pollTestStartToken || len(server.state.LastMessageNumbers) != 0 {
+		t.Fatalf("state changed: %#v", server.state)
+	}
+}
+
+func TestDriveChangesServeAcceptsPreviousAndPendingChannels(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "current-channel",
+			ResourceID: "current-resource",
+		},
+		PreviousChannel: &driveChangesServeChannelState{
+			ID:         "channel-1",
+			ResourceID: "resource-1",
+		},
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	server.statePath = statePath
+
+	previous := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "sync", 1)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, previous)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("previous channel status = %d, want 204", response.Code)
+	}
+
+	server.mu.Lock()
+	server.pendingChannel = "pending-channel"
+	server.mu.Unlock()
+	pending := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "sync", 1)
+	pending.Header.Set("X-Goog-Channel-ID", "pending-channel")
+	pending.Header.Set("X-Goog-Resource-ID", "pending-resource")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, pending)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("pending channel status = %d, want 204", response.Code)
+	}
+}
+
+func TestDriveChangesServeAcknowledgesSyncUnknownAndDuplicates(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		UpdatedAt: "2026-06-11T10:00:00Z",
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	server.statePath = statePath
+
+	for _, tc := range []struct {
+		resourceState string
+		messageNumber uint64
+	}{
+		{resourceState: "sync", messageNumber: 1},
+		{resourceState: "future-state", messageNumber: 2},
+		{resourceState: "future-state", messageNumber: 2},
+	} {
+		request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, tc.resourceState, tc.messageNumber)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		if response.Code != http.StatusNoContent {
+			t.Fatalf("%s status = %d, want 204", tc.resourceState, response.Code)
+		}
+	}
+
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != pollTestStartToken {
+		t.Fatalf("page token = %q", persisted.PageToken)
+	}
+	if persisted.LastMessageNumbers["channel-1"] != 2 {
+		t.Fatalf("message number = %d, want 2", persisted.LastMessageNumbers["channel-1"])
+	}
+}
+
+func TestDriveChangesServeProcessesNotificationOverHTTP(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		requireQuery(t, r, "pageToken", pollTestStartToken)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes": []map[string]any{{
+				"fileId": "file-1",
+				"type":   "file",
+				"file":   map[string]any{"name": "Doc"},
+			}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		UpdatedAt: "2026-06-11T10:00:00Z",
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.onChange = "./handle-change"
+	var event driveChangesServeEvent
+	server.runtime.runHook = func(_ context.Context, command string, payload any) error {
+		if command != "./handle-change" {
+			t.Fatalf("command = %q", command)
+		}
+		event = payload.(driveChangesServeEvent)
+		return nil
+	}
+
+	httpServer := httptest.NewServer(server)
+	defer httpServer.Close()
+	request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 7)
+	request.URL.Scheme = "http"
+	request.URL.Host = strings.TrimPrefix(httpServer.URL, "http://")
+	request.RequestURI = ""
+	response, err := httpServer.Client().Do(request)
+	if err != nil {
+		t.Fatalf("notification request: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+	if event.MessageNumber != 7 || event.PageToken != pollTestStartToken || event.NextPageToken != "next-token" {
+		t.Fatalf("unexpected event: %#v", event)
+	}
+	if len(event.Changes) != 1 || event.Changes[0].FileId != "file-1" {
+		t.Fatalf("unexpected changes: %#v", event.Changes)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 7 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeFilterSkipsHookButAdvancesState(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes":           []map[string]any{{"fileId": "other"}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.filterFile = "wanted"
+	server.onChange = "./handle-change"
+	var hookCalls atomic.Int32
+	server.runtime.runHook = func(context.Context, string, any) error {
+		hookCalls.Add(1)
+		return nil
+	}
+
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 3))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.Code)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("hook calls = %d, want 0", hookCalls.Load())
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 3 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeHookFailureRetainsStateForRetry(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes":           []map[string]any{{"fileId": "file-1"}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.onChange = "./handle-change"
+	hookErr := errors.New("hook failed")
+	server.runtime.runHook = func(context.Context, string, any) error { return hookErr }
+
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 4))
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", response.Code)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != pollTestStartToken || persisted.LastMessageNumbers["channel-1"] != 0 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeSerializesConcurrentNotifications(t *testing.T) {
+	firstAPIStarted := make(chan struct{})
+	releaseFirstAPI := make(chan struct{})
+	var apiCalls atomic.Int32
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := apiCalls.Add(1)
+		if call == 1 {
+			close(firstAPIStarted)
+			<-releaseFirstAPI
+			requireQuery(t, r, "pageToken", pollTestStartToken)
+			_ = json.NewEncoder(w).Encode(map[string]any{"newStartPageToken": "next-1"})
+			return
+		}
+		requireQuery(t, r, "pageToken", "next-1")
+		_ = json.NewEncoder(w).Encode(map[string]any{"newStartPageToken": "next-2"})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 2))
+		if response.Code != http.StatusNoContent {
+			t.Errorf("first status = %d", response.Code)
+		}
+	}()
+	<-firstAPIStarted
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 3))
+		if response.Code != http.StatusNoContent {
+			t.Errorf("second status = %d", response.Code)
+		}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	if apiCalls.Load() != 1 {
+		t.Fatalf("API calls before releasing first = %d, want 1", apiCalls.Load())
+	}
+	close(releaseFirstAPI)
+	<-firstDone
+	<-secondDone
+
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-2" || persisted.LastMessageNumbers["channel-1"] != 3 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeRenewsAndStopsPreviousChannel(t *testing.T) {
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	var watched drive.Channel
+	var stopped drive.Channel
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/changes/watch":
+			requireQuery(t, r, "pageToken", pollTestStartToken)
+			if err := json.NewDecoder(r.Body).Decode(&watched); err != nil {
+				t.Fatalf("decode watch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          watched.Id,
+				"resourceId":  "resource-new",
+				"resourceUri": "https://www.googleapis.com/drive/v3/changes",
+				"expiration":  strconv.FormatInt(now.Add(defaultDriveChangesChannelTTL).UnixMilli(), 10),
+			})
+		case "/channels/stop":
+			if err := json.NewDecoder(r.Body).Decode(&stopped); err != nil {
+				t.Fatalf("decode stop: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "channel-old",
+			ResourceID: "resource-old",
+			Expiration: now.Add(time.Minute).UnixMilli(),
+			WebhookURL: "https://old.example/hook",
+			TokenHash:  channelTokenHash(driveChangesTestChannelToken),
+		},
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.autoRenew = true
+	server.webhookURL = "https://example.com/hook"
+	server.channelTTL = defaultDriveChangesChannelTTL
+	server.renewBefore = 10 * time.Minute
+	server.runtime.now = func() time.Time { return now }
+
+	delay, err := server.ensureChannel(context.Background())
+	if err != nil {
+		t.Fatalf("ensureChannel: %v", err)
+	}
+	if delay != defaultDriveChangesChannelTTL-10*time.Minute {
+		t.Fatalf("delay = %v", delay)
+	}
+	if watched.Address != server.webhookURL || watched.Token != driveChangesTestChannelToken {
+		t.Fatalf("unexpected watch request: %#v", watched)
+	}
+	if watched.Expiration != now.Add(defaultDriveChangesChannelTTL).UnixMilli() {
+		t.Fatalf("expiration = %d", watched.Expiration)
+	}
+	if stopped.Id != "channel-old" || stopped.ResourceId != "resource-old" {
+		t.Fatalf("unexpected stopped channel: %#v", stopped)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.Channel == nil || persisted.Channel.ResourceID != "resource-new" || persisted.PreviousChannel != nil {
+		t.Fatalf("unexpected channel state: %#v", persisted)
+	}
+	if persisted.Channel.TokenHash == driveChangesTestChannelToken || persisted.Channel.TokenHash == "" {
+		t.Fatalf("channel token was not hashed")
+	}
+}
+
+func TestDriveChangesServeValidation(t *testing.T) {
+	valid := DriveChangesServeCmd{
+		Listen:         "127.0.0.1:8443",
+		Path:           driveChangesTestStatePath,
+		ChannelToken:   driveChangesTestChannelToken,
+		StateFile:      "state.json",
+		Max:            100,
+		IncludeRemoved: true,
+		ChannelTTL:     defaultDriveChangesChannelTTL,
+		RenewBefore:    10 * time.Minute,
+	}
+	cases := []struct {
+		name   string
+		mutate func(*DriveChangesServeCmd)
+		want   string
+	}{
+		{name: "missing token", mutate: func(c *DriveChangesServeCmd) { c.ChannelToken = "" }, want: "channel-token"},
+		{name: "cert without key", mutate: func(c *DriveChangesServeCmd) { c.Cert = "cert.pem" }, want: "--cert and --key"},
+		{name: "bad path", mutate: func(c *DriveChangesServeCmd) { c.Path = "hook" }, want: "--path"},
+		{name: "renew without url", mutate: func(c *DriveChangesServeCmd) { c.AutoRenew = true }, want: "--webhook-url"},
+		{name: "url without renew", mutate: func(c *DriveChangesServeCmd) { c.WebhookURL = "https://example.com" }, want: "requires --auto-renew"},
+		{
+			name: "ttl too long",
+			mutate: func(c *DriveChangesServeCmd) {
+				c.AutoRenew = true
+				c.WebhookURL = "https://example.com/hook"
+				c.ChannelTTL = maxDriveChangesChannelTTL + time.Second
+			},
+			want: "--channel-ttl",
+		},
+		{
+			name: "renew after expiration",
+			mutate: func(c *DriveChangesServeCmd) {
+				c.AutoRenew = true
+				c.WebhookURL = "https://example.com/hook"
+				c.RenewBefore = c.ChannelTTL
+			},
+			want: "--renew-before",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := valid
+			tc.mutate(&cmd)
+			err := cmd.validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	defer closeDrive()
+	stubDriveServiceForTest(t, svc)
+
+	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
+	listening := make(chan struct{})
+	cmd := DriveChangesServeCmd{
+		Listen:         "127.0.0.1:0",
+		Path:           driveChangesTestStatePath,
+		ChannelToken:   driveChangesTestChannelToken,
+		StateFile:      filepath.Join(t.TempDir(), "state.json"),
+		Token:          pollTestStartToken,
+		Max:            100,
+		IncludeRemoved: true,
+		ChannelTTL:     defaultDriveChangesChannelTTL,
+		RenewBefore:    10 * time.Minute,
+	}
+	runtime := defaultDriveChangesServeRuntime()
+	runtime.listen = func(ctx context.Context, network string, address string) (net.Listener, error) {
+		var listenConfig net.ListenConfig
+		listener, err := listenConfig.Listen(ctx, network, address)
+		if err == nil {
+			close(listening)
+		}
+		return listener, err
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.run(ctx, &RootFlags{Account: "a@example.com"}, runtime)
+	}()
+	<-listening
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error = %v, want context canceled", err)
+	}
+}
+
+func newDriveChangesTestReceiver(t *testing.T, svc *drive.Service, state driveChangesServeState) *driveChangesServer {
+	t.Helper()
+	return &driveChangesServer{
+		state:          state,
+		service:        svc,
+		path:           driveChangesTestStatePath,
+		channelToken:   driveChangesTestChannelToken,
+		max:            100,
+		includeRemoved: true,
+		channelTTL:     defaultDriveChangesChannelTTL,
+		renewBefore:    10 * time.Minute,
+		runtime:        defaultDriveChangesServeRuntime(),
+		logf:           func(string, ...any) {},
+		warnf:          func(string, ...any) {},
+	}
+}
+
+func newDriveChangesNotificationRequest(t *testing.T, token string, resourceState string, messageNumber uint64) *http.Request {
+	t.Helper()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, driveChangesTestStatePath, nil)
+	request.Header.Set("X-Goog-Channel-ID", "channel-1")
+	request.Header.Set("X-Goog-Channel-Token", token)
+	request.Header.Set("X-Goog-Resource-ID", "resource-1")
+	request.Header.Set("X-Goog-Resource-State", resourceState)
+	request.Header.Set("X-Goog-Resource-URI", "https://www.googleapis.com/drive/v3/changes")
+	request.Header.Set("X-Goog-Message-Number", strconv.FormatUint(messageNumber, 10))
+	return request
+}

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+)
+
+var (
+	errDriveChangesDuplicateNotification = errors.New("duplicate drive changes notification")
+	errDriveChangesIgnoredNotification   = errors.New("ignored drive changes notification")
+	errDriveChangesUntrackedNotification = errors.New("untracked drive changes notification channel")
+)
+
+type driveChangesNotification struct {
+	ChannelID         string
+	ResourceID        string
+	ResourceState     string
+	ResourceURI       string
+	Changed           string
+	ChannelExpiration string
+	MessageNumber     uint64
+}
+
+type driveChangesServeEvent struct {
+	Kind              string          `json:"kind"`
+	ChannelID         string          `json:"channelId"`
+	ResourceID        string          `json:"resourceId"`
+	ResourceState     string          `json:"resourceState"`
+	ResourceURI       string          `json:"resourceUri"`
+	Changed           string          `json:"changed,omitempty"`
+	ChannelExpiration string          `json:"channelExpiration,omitempty"`
+	MessageNumber     uint64          `json:"messageNumber"`
+	DriveID           string          `json:"driveId,omitempty"`
+	PageToken         string          `json:"pageToken"`
+	NextPageToken     string          `json:"nextPageToken"`
+	Changes           []*drive.Change `json:"changes"`
+}
+
+func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != s.path {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if !driveChangesChannelTokenMatches(r.Header.Get("X-Goog-Channel-Token"), s.channelToken) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	notification, err := parseDriveChangesNotification(r)
+	if err != nil {
+		s.warnf("drive changes serve: invalid notification: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := s.handleNotification(r.Context(), notification); err != nil {
+		if errors.Is(err, errDriveChangesUntrackedNotification) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if errors.Is(err, errDriveChangesDuplicateNotification) || errors.Is(err, errDriveChangesIgnoredNotification) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		s.warnf("drive changes serve: notification failed: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func driveChangesChannelTokenMatches(got string, expected string) bool {
+	got = strings.TrimSpace(got)
+	expected = strings.TrimSpace(expected)
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}
+
+func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, error) {
+	channelID := strings.TrimSpace(r.Header.Get("X-Goog-Channel-ID"))
+	resourceID := strings.TrimSpace(r.Header.Get("X-Goog-Resource-ID"))
+	resourceState := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Goog-Resource-State")))
+	resourceURI := strings.TrimSpace(r.Header.Get("X-Goog-Resource-URI"))
+	messageNumberRaw := strings.TrimSpace(r.Header.Get("X-Goog-Message-Number"))
+	switch {
+	case channelID == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Channel-ID")
+	case len(channelID) > 128:
+		return driveChangesNotification{}, errors.New("x-goog-channel-id is too long")
+	case resourceID == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Resource-ID")
+	case len(resourceID) > 512:
+		return driveChangesNotification{}, errors.New("x-goog-resource-id is too long")
+	case resourceState == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Resource-State")
+	case len(resourceState) > 64:
+		return driveChangesNotification{}, errors.New("x-goog-resource-state is too long")
+	case resourceURI == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Resource-URI")
+	case len(resourceURI) > 4096:
+		return driveChangesNotification{}, errors.New("x-goog-resource-uri is too long")
+	case messageNumberRaw == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Message-Number")
+	}
+	messageNumber, err := strconv.ParseUint(messageNumberRaw, 10, 64)
+	if err != nil || messageNumber == 0 {
+		return driveChangesNotification{}, errors.New("invalid X-Goog-Message-Number")
+	}
+	return driveChangesNotification{
+		ChannelID:         channelID,
+		ResourceID:        resourceID,
+		ResourceState:     resourceState,
+		ResourceURI:       resourceURI,
+		Changed:           strings.TrimSpace(r.Header.Get("X-Goog-Changed")),
+		ChannelExpiration: strings.TrimSpace(r.Header.Get("X-Goog-Channel-Expiration")),
+		MessageNumber:     messageNumber,
+	}, nil
+}
+
+func (s *driveChangesServer) handleNotification(ctx context.Context, notification driveChangesNotification) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.notificationChannelAllowedLocked(notification) {
+		s.warnf(
+			"drive changes serve: rejecting untracked channel=%s resource=%s",
+			notification.ChannelID,
+			notification.ResourceID,
+		)
+		return errDriveChangesUntrackedNotification
+	}
+	if last := s.state.LastMessageNumbers[notification.ChannelID]; last >= notification.MessageNumber {
+		s.logf(
+			"drive changes serve: ignoring duplicate channel=%s message=%d",
+			notification.ChannelID,
+			notification.MessageNumber,
+		)
+		return errDriveChangesDuplicateNotification
+	}
+	switch notification.ResourceState {
+	case "sync":
+		if err := s.acknowledgeNotificationLocked(notification); err != nil {
+			return err
+		}
+		return errDriveChangesIgnoredNotification
+	case "change", "changed":
+	default:
+		if err := s.acknowledgeNotificationLocked(notification); err != nil {
+			return err
+		}
+		s.logf("drive changes serve: ignoring resource state %q", notification.ResourceState)
+		return errDriveChangesIgnoredNotification
+	}
+
+	changes, nextPageToken, err := loadDriveChanges(ctx, s.service, s.state.PageToken, driveChangesLoadOptions{
+		max:            s.max,
+		includeRemoved: s.includeRemoved,
+		driveID:        s.state.DriveID,
+		all:            true,
+	})
+	if err != nil {
+		return err
+	}
+	filtered := filterDriveChangesByFile(changes, s.filterFile)
+	if len(filtered) > 0 && s.onChange != "" {
+		event := driveChangesServeEvent{
+			Kind:              "drive_changes_notification",
+			ChannelID:         notification.ChannelID,
+			ResourceID:        notification.ResourceID,
+			ResourceState:     notification.ResourceState,
+			ResourceURI:       notification.ResourceURI,
+			Changed:           notification.Changed,
+			ChannelExpiration: notification.ChannelExpiration,
+			MessageNumber:     notification.MessageNumber,
+			DriveID:           s.state.DriveID,
+			PageToken:         s.state.PageToken,
+			NextPageToken:     nextPageToken,
+			Changes:           filtered,
+		}
+		if err := s.runtime.runHook(ctx, s.onChange, event); err != nil {
+			return err
+		}
+	}
+
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.PageToken = nextPageToken
+	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
+	setDriveChangesMessageNumber(&nextState, notification.ChannelID, notification.MessageNumber)
+	if err := writePollState(s.statePath, nextState); err != nil {
+		return err
+	}
+	s.state = nextState
+	return nil
+}
+
+func (s *driveChangesServer) notificationChannelAllowedLocked(notification driveChangesNotification) bool {
+	tracked := false
+	for _, channel := range []*driveChangesServeChannelState{s.state.Channel, s.state.PreviousChannel} {
+		if channel == nil {
+			continue
+		}
+		tracked = true
+		if channel.ID == notification.ChannelID && channel.ResourceID == notification.ResourceID {
+			return true
+		}
+	}
+	if s.pendingChannel != "" {
+		tracked = true
+		if s.pendingChannel == notification.ChannelID {
+			return true
+		}
+	}
+	return !tracked
+}
+
+func (s *driveChangesServer) acknowledgeNotificationLocked(notification driveChangesNotification) error {
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
+	setDriveChangesMessageNumber(&nextState, notification.ChannelID, notification.MessageNumber)
+	if err := writePollState(s.statePath, nextState); err != nil {
+		return err
+	}
+	s.state = nextState
+	return nil
+}
+
+func setDriveChangesMessageNumber(state *driveChangesServeState, channelID string, messageNumber uint64) {
+	if state.LastMessageNumbers == nil {
+		state.LastMessageNumbers = make(map[string]uint64)
+	}
+	state.LastMessageNumbers[channelID] = messageNumber
+	trimDriveChangesMessageNumbers(state, channelIDFor(state.Channel), channelIDFor(state.PreviousChannel), channelID)
+}

--- a/internal/cmd/poll_helpers.go
+++ b/internal/cmd/poll_helpers.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const pollStateVersion = 1
+
+type pollRuntime struct {
+	now     func() time.Time
+	runHook func(context.Context, string, any) error
+	wait    func(context.Context, time.Duration) error
+}
+
+func defaultPollRuntime() pollRuntime {
+	return pollRuntime{
+		now:     time.Now,
+		runHook: runPollHook,
+		wait:    waitForPollInterval,
+	}
+}
+
+func (r pollRuntime) withDefaults() pollRuntime {
+	defaults := defaultPollRuntime()
+	if r.now == nil {
+		r.now = defaults.now
+	}
+	if r.runHook == nil {
+		r.runHook = defaults.runHook
+	}
+	if r.wait == nil {
+		r.wait = defaults.wait
+	}
+	return r
+}
+
+func pollSignalContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+}
+
+func waitForPollInterval(ctx context.Context, interval time.Duration) error {
+	timer := time.NewTimer(interval)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func runPollHook(ctx context.Context, command string, payload any) error {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("encode poll hook payload: %w", err)
+	}
+	data = append(data, '\n')
+
+	var cmd *exec.Cmd
+	if os.PathSeparator == '\\' {
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/D", "/S", "/C", command) //nolint:gosec // command is an explicit local operator-provided hook.
+	} else {
+		cmd = exec.CommandContext(ctx, "/bin/sh", "-c", command) //nolint:gosec // command is an explicit local operator-provided hook.
+	}
+	cmd.Stdin = bytes.NewReader(data)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return fmt.Errorf("poll hook failed: %w", err)
+	}
+	return nil
+}
+
+func expandPollStatePath(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", usage("missing --state-file")
+	}
+	path, err := config.ExpandPath(raw)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(path) == "" {
+		return "", usage("empty --state-file")
+	}
+	return path, nil
+}
+
+func readPollState(path string, dst any) (bool, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // explicit user-provided state path.
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read poll state %s: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return false, nil
+	}
+	if err := json.Unmarshal(data, dst); err != nil {
+		return false, fmt.Errorf("decode poll state %s: %w", path, err)
+	}
+	return true, nil
+}
+
+func writePollState(path string, state any) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode poll state: %w", err)
+	}
+	data = append(data, '\n')
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("create poll state directory: %w", err)
+	}
+	if err := config.WriteFileAtomic(path, data, 0o600); err != nil {
+		return fmt.Errorf("write poll state %s: %w", path, err)
+	}
+	return nil
+}
+
+func writePollJSON(ctx context.Context, payload any) error {
+	var rendered bytes.Buffer
+	if err := outfmt.WriteJSON(ctx, &rendered, payload); err != nil {
+		return err
+	}
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, rendered.Bytes()); err != nil {
+		return fmt.Errorf("compact poll json: %w", err)
+	}
+	if err := compact.WriteByte('\n'); err != nil {
+		return err
+	}
+	if _, err := os.Stdout.Write(compact.Bytes()); err != nil {
+		return fmt.Errorf("write poll output: %w", err)
+	}
+	return nil
+}

--- a/internal/cmd/poll_helpers.go
+++ b/internal/cmd/poll_helpers.go
@@ -29,7 +29,7 @@ type pollRuntime struct {
 func defaultPollRuntime() pollRuntime {
 	return pollRuntime{
 		now:     time.Now,
-		runHook: runPollHook,
+		runHook: runJSONShellHook,
 		wait:    waitForPollInterval,
 	}
 }
@@ -63,7 +63,7 @@ func waitForPollInterval(ctx context.Context, interval time.Duration) error {
 	}
 }
 
-func runPollHook(ctx context.Context, command string, payload any) error {
+func runJSONShellHook(ctx context.Context, command string, payload any) error {
 	command = strings.TrimSpace(command)
 	if command == "" {
 		return nil
@@ -87,7 +87,7 @@ func runPollHook(ctx context.Context, command string, payload any) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		return fmt.Errorf("poll hook failed: %w", err)
+		return fmt.Errorf("shell hook failed: %w", err)
 	}
 	return nil
 }

--- a/internal/cmd/poll_test.go
+++ b/internal/cmd/poll_test.go
@@ -1,0 +1,432 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const pollTestStartToken = "start"
+
+func TestDriveChangesListAllStopsAtNewStartPageToken(t *testing.T) {
+	var tokens []string
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		token := r.URL.Query().Get("pageToken")
+		tokens = append(tokens, token)
+		switch token {
+		case pollTestStartToken:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"nextPageToken": "page-2",
+				"changes":       []map[string]any{{"fileId": "file-1"}},
+			})
+		case "page-2":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"newStartPageToken": "next-start",
+				"changes":           []map[string]any{{"fileId": "file-2"}},
+			})
+		default:
+			t.Fatalf("unexpected page token %q", token)
+		}
+	}))
+	defer closeSrv()
+
+	changes, next, err := loadDriveChanges(context.Background(), svc, pollTestStartToken, driveChangesLoadOptions{
+		max:            10,
+		includeRemoved: true,
+		all:            true,
+	})
+	if err != nil {
+		t.Fatalf("loadDriveChanges: %v", err)
+	}
+	if next != "next-start" {
+		t.Fatalf("next = %q, want next-start", next)
+	}
+	if len(changes) != 2 {
+		t.Fatalf("changes = %d, want 2", len(changes))
+	}
+	if got := strings.Join(tokens, ","); got != "start,page-2" {
+		t.Fatalf("tokens = %q", got)
+	}
+}
+
+func TestDriveChangesPollPersistsFilteredBatch(t *testing.T) {
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/changes/startPageToken":
+			_ = json.NewEncoder(w).Encode(map[string]any{"startPageToken": pollTestStartToken})
+		case "/changes":
+			requireQuery(t, r, "pageToken", pollTestStartToken)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"newStartPageToken": "next",
+				"changes": []map[string]any{
+					{"fileId": "wanted", "type": "file", "file": map[string]any{"name": "Wanted"}},
+					{"fileId": "other", "type": "file", "file": map[string]any{"name": "Other"}},
+				},
+			})
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "nested", "drive-state.json")
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	var hooked driveChangesPollEvent
+	hookCalls := 0
+	cmd := DriveChangesPollCmd{
+		StateFile:      statePath,
+		Interval:       time.Second,
+		FilterFile:     "wanted",
+		MaxIterations:  1,
+		Max:            10,
+		IncludeRemoved: true,
+	}
+	out := captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				now: func() time.Time { return now },
+				runHook: func(_ context.Context, _ string, payload any) error {
+					hookCalls++
+					hooked = payload.(driveChangesPollEvent)
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if hookCalls != 1 || len(hooked.Changes) != 1 || hooked.Changes[0].FileId != "wanted" {
+		t.Fatalf("hooked = %#v, calls=%d", hooked, hookCalls)
+	}
+	if strings.Count(out, "\n") != 1 || !json.Valid([]byte(out)) {
+		t.Fatalf("expected one NDJSON event, got %q", out)
+	}
+	state, exists, err := readDriveChangesPollState(statePath)
+	if err != nil || !exists {
+		t.Fatalf("read state: exists=%t err=%v", exists, err)
+	}
+	if state.PageToken != "next" {
+		t.Fatalf("page token = %q, want next", state.PageToken)
+	}
+	if os.PathSeparator != '\\' {
+		info, statErr := os.Stat(statePath)
+		if statErr != nil {
+			t.Fatalf("stat state: %v", statErr)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("state mode = %o, want 600", info.Mode().Perm())
+		}
+	}
+	leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(statePath), ".drive-state.json.*.tmp"))
+	if err != nil {
+		t.Fatalf("glob temp files: %v", err)
+	}
+	if len(leftovers) != 0 {
+		t.Fatalf("temporary state files remain: %v", leftovers)
+	}
+}
+
+func TestDriveChangesPollHookFailureRetainsToken(t *testing.T) {
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next",
+			"changes":           []map[string]any{{"fileId": "file-1", "type": "file"}},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "drive-state.json")
+	initial := driveChangesPollState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		UpdatedAt: "2026-06-11T10:00:00Z",
+	}
+	if err := writePollState(statePath, initial); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	cmd := DriveChangesPollCmd{
+		StateFile:      statePath,
+		Interval:       time.Second,
+		MaxIterations:  1,
+		Max:            10,
+		IncludeRemoved: true,
+	}
+	hookErr := errors.New("hook failed")
+	_ = captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{runHook: func(context.Context, string, any) error { return hookErr }},
+		)
+		if !errors.Is(err, hookErr) {
+			t.Fatalf("run error = %v, want hook error", err)
+		}
+	})
+	state, _, err := readDriveChangesPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.PageToken != pollTestStartToken {
+		t.Fatalf("page token = %q, want start", state.PageToken)
+	}
+}
+
+func TestDocsCommentsPollPersistsWatermarkAndSeenIDs(t *testing.T) {
+	const baseline = "2026-06-11T10:00:00Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/files/doc-1/comments" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		requireQuery(t, r, "startModifiedTime", baseline)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{
+				{"id": "c2", "content": "Second", "modifiedTime": "2026-06-11T10:00:01Z"},
+				{"id": "c1", "content": "First", "modifiedTime": "2026-06-11T10:00:01Z"},
+			},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	var hooked []string
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	out := captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				now: func() time.Time { return now },
+				runHook: func(_ context.Context, _ string, payload any) error {
+					hooked = append(hooked, payload.(docsCommentPollEvent).Comment.Id)
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+
+	if got := strings.Join(hooked, ","); got != "c1,c2" {
+		t.Fatalf("hook order = %q, want c1,c2", got)
+	}
+	if strings.Count(out, "\n") != 2 {
+		t.Fatalf("expected two NDJSON events, got %q", out)
+	}
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if !json.Valid([]byte(line)) {
+			t.Fatalf("invalid NDJSON line %q", line)
+		}
+	}
+	state, exists, err := readDocsCommentsPollState(statePath)
+	if err != nil || !exists {
+		t.Fatalf("read state: exists=%t err=%v", exists, err)
+	}
+	if state.Watermark != "2026-06-11T10:00:01Z" {
+		t.Fatalf("watermark = %q", state.Watermark)
+	}
+	if got := strings.Join(state.SeenIDs, ","); got != "c1,c2" {
+		t.Fatalf("seen IDs = %q", got)
+	}
+}
+
+func TestDocsCommentsPollSkipsSeenAtInclusiveWatermark(t *testing.T) {
+	const watermark = "2026-06-11T10:00:01Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requireQuery(t, r, "startModifiedTime", watermark)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{
+				{"id": "seen", "modifiedTime": watermark},
+				{"id": "new-same-time", "modifiedTime": watermark},
+				{"id": "new-later", "modifiedTime": "2026-06-11T10:00:02Z"},
+			},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	if err := writePollState(statePath, docsCommentsPollState{
+		Version:   pollStateVersion,
+		DocID:     "doc-1",
+		Watermark: watermark,
+		SeenIDs:   []string{"seen"},
+		UpdatedAt: watermark,
+	}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	var hooked []string
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	_ = captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				runHook: func(_ context.Context, _ string, payload any) error {
+					hooked = append(hooked, payload.(docsCommentPollEvent).Comment.Id)
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if got := strings.Join(hooked, ","); got != "new-same-time,new-later" {
+		t.Fatalf("hooked = %q", got)
+	}
+	state, _, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.Watermark != "2026-06-11T10:00:02Z" || strings.Join(state.SeenIDs, ",") != "new-later" {
+		t.Fatalf("unexpected state: %#v", state)
+	}
+}
+
+func TestDocsCommentsPollAdvancesPastExcludedResolvedComments(t *testing.T) {
+	const watermark = "2026-06-11T10:00:00Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{{
+				"id":           "resolved",
+				"modifiedTime": "2026-06-11T10:00:01Z",
+				"resolved":     true,
+			}},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	if err := writePollState(statePath, docsCommentsPollState{
+		Version:   pollStateVersion,
+		DocID:     "doc-1",
+		Watermark: watermark,
+		UpdatedAt: watermark,
+	}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	hookCalls := 0
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	out := captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{
+				runHook: func(context.Context, string, any) error {
+					hookCalls++
+					return nil
+				},
+			},
+		)
+		if err != nil {
+			t.Fatalf("run: %v", err)
+		}
+	})
+	if out != "" || hookCalls != 0 {
+		t.Fatalf("excluded comment emitted output=%q hooks=%d", out, hookCalls)
+	}
+	state, _, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.Watermark != "2026-06-11T10:00:01Z" || strings.Join(state.SeenIDs, ",") != "resolved" {
+		t.Fatalf("unexpected state: %#v", state)
+	}
+}
+
+func TestDocsCommentsPollHookFailureRetainsWatermark(t *testing.T) {
+	const watermark = "2026-06-11T10:00:00Z"
+	svc, closeSrv := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"comments": []map[string]any{{"id": "c1", "modifiedTime": "2026-06-11T10:00:01Z"}},
+		})
+	}))
+	defer closeSrv()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "comments-state.json")
+	initial := docsCommentsPollState{
+		Version:   pollStateVersion,
+		DocID:     "doc-1",
+		Watermark: watermark,
+		UpdatedAt: watermark,
+	}
+	if err := writePollState(statePath, initial); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	hookErr := errors.New("hook failed")
+	cmd := DocsCommentsPollCmd{
+		DocID:         "doc-1",
+		StateFile:     statePath,
+		Interval:      time.Second,
+		MaxIterations: 1,
+		Max:           10,
+	}
+	_ = captureStdout(t, func() {
+		err := cmd.run(
+			newCmdJSONOutputContext(t, io.Discard, io.Discard),
+			&RootFlags{Account: "a@example.com"},
+			pollRuntime{runHook: func(context.Context, string, any) error { return hookErr }},
+		)
+		if !errors.Is(err, hookErr) {
+			t.Fatalf("run error = %v, want hook error", err)
+		}
+	})
+	state, _, err := readDocsCommentsPollState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if state.Watermark != watermark {
+		t.Fatalf("watermark = %q, want %q", state.Watermark, watermark)
+	}
+}
+
+func TestWaitForPollIntervalCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := waitForPollInterval(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled", err)
+	}
+}


### PR DESCRIPTION
Closes #689.

Stacked on #751 (`feat/poll-state-690`) to reuse its reviewed atomic state, Drive pagination, and JSON hook primitives. Retarget to `main` after #751 lands.

## Summary

- add `gog drive changes serve` with loopback-default HTTP or direct TLS
- validate path, method, channel token, notification headers, message ordering, and tracked channel/resource IDs
- serialize Drive change-log reads and persist page-token/message progress only after hook success
- support optional file filtering plus JSON-on-stdin shell hooks
- create and renew Drive notification channels with overlap-safe replacement and old-channel cleanup
- document reverse-proxy/TLS, manual watch setup, retry semantics, state safety, and channel limits

## Security and reliability

- channel token is checked before header parsing, Drive API access, or hooks
- state stores only the token SHA-256 digest
- auto-renew binds notifications to current, previous, or in-flight channel identity
- hook/API/state failures return `500` without advancing the page token so Google can retry
- listener binds before channel registration; renewal persists replacement state before stopping the old channel

## Proof

- autoreview: clean, no actionable findings
- `go test -race ./internal/cmd -run 'TestDriveChangesServe' -count=1`
- `make lint`
- `make ci`
- `make build`
- local HTTP notification smoke through `httptest.Server`
- CLI dry-run smoke for auto-renew configuration; channel token absent from output

A real Drive watch callback was not created because the `clawdbot@gmail.com` file-keyring password is unavailable noninteractively. The smoke used `--no-input`, so no desktop keyring prompt was triggered.
