### PR TITLE
feat(photos): add explicit Picker workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.24.1 - Unreleased
 
+### Added
+
+- Photos: add an explicit-opt-in Google Photos Picker workflow for creating selection sessions, waiting for completion, listing chosen media, and downloading selected files. (#754)
+
 ## 0.24.0 - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Useful Google setup links:
 - [Places API (New)](https://console.cloud.google.com/apis/api/places.googleapis.com)
 - [Drive Labels API](https://console.cloud.google.com/apis/api/drivelabels.googleapis.com)
 - [Photos Library API](https://console.cloud.google.com/apis/api/photoslibrary.googleapis.com)
+- [Photos Picker API](https://console.cloud.google.com/apis/library/photospicker.googleapis.com)
 - [Google Analytics Admin API](https://console.cloud.google.com/apis/api/analyticsadmin.googleapis.com)
 - [Google Analytics Data API](https://console.cloud.google.com/apis/api/analyticsdata.googleapis.com)
 - [Google Search Console API](https://console.cloud.google.com/apis/api/searchconsole.googleapis.com)
@@ -239,7 +240,8 @@ Place ID/lat,lng value to avoid splitting it.
 
 ### Photos
 
-Docs: [`gog photos`](docs/commands/gog-photos.md).
+Docs: [`gog photos`](docs/commands/gog-photos.md) and
+[Photos Picker workflows](docs/photos-picker.md).
 
 Google Photos Library API access is limited to app-created media through
 `photoslibrary.readonly.appcreateddata`, and the Photos Library API must be
@@ -249,6 +251,19 @@ enabled on the OAuth project used for `gog auth add`.
 gog photos list --json
 gog photos search --media-type PHOTO --from 2026-01-01 --to 2026-01-31 --json
 gog photos download <mediaItemId> --out photo.jpg
+```
+
+For user-selected private media, enable the Photos Picker API and authorize its
+separate explicit-opt-in service. It is not included in the default `user`
+service set.
+
+```bash
+gog auth add you@gmail.com --services photospicker
+gog photos picker create --max-items 20 --open --json
+gog photos picker wait <sessionId> --json
+gog photos picker list <sessionId> --all --json
+gog photos picker download <sessionId> <mediaItemId> --out photo.jpg
+gog photos picker delete <sessionId>
 ```
 
 ### Contacts
@@ -600,6 +615,7 @@ Generated service scope table:
 | admin | no | Admin SDK Directory API | `https://www.googleapis.com/auth/admin.directory.user`<br>`https://www.googleapis.com/auth/admin.directory.group`<br>`https://www.googleapis.com/auth/admin.directory.group.member` | Workspace only; service account with domain-wide delegation required |
 | youtube | yes | YouTube Data API v3 | `https://www.googleapis.com/auth/youtube.readonly` | Most read operations also work with API key only (config youtube_api_key or GOG_YOUTUBE_API_KEY) |
 | photos | yes | Photos Library API | `https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata` | Read-only app-created media only after Google Photos Library API scope changes |
+| photospicker | no | Photos Picker API | `https://www.googleapis.com/auth/photospicker.mediaitems.readonly` | Consumer OAuth; explicit opt-in with --services photospicker; selected media only |
 <!-- auth-services:end -->
 
 Regenerate the table with:
@@ -617,6 +633,7 @@ go run scripts/gen-auth-services-md.go
 - [Gmail workflows](docs/gmail-workflows.md) — <https://gogcli.sh/gmail-workflows.html>
 - [Gmail watch](docs/watch.md) — <https://gogcli.sh/watch.html>
 - [Drive audits](docs/drive-audits.md) — <https://gogcli.sh/drive-audits.html>
+- [Photos Picker](docs/photos-picker.md) — <https://gogcli.sh/photos-picker.html>
 - [Docs editing](docs/docs-editing.md) — <https://gogcli.sh/docs-editing.html>
 - [Sheets tables](docs/sheets-tables.md) and [Sheets formatting](docs/sheets-formatting.md)
 - [Safety profiles](docs/safety-profiles.md) — command guards and baked safe binaries

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -478,10 +478,17 @@ Generated from `gog schema --json`.
     - [`gog people (person) raw <userId> [flags]`](commands/gog-people-raw.md) - Dump raw People API response as JSON (People.Get; lossless; for scripting and LLM consumption)
     - [`gog people (person) relations [<userId>] [flags]`](commands/gog-people-relations.md) - Get user relations
     - [`gog people (person) search (find,query) <query> ... [flags]`](commands/gog-people-search.md) - Search the Workspace directory
-  - [`gog photos (photo) <command> [flags]`](commands/gog-photos.md) - Google Photos Library API (app-created media)
+  - [`gog photos (photo) <command> [flags]`](commands/gog-photos.md) - Google Photos Library and Picker APIs
     - [`gog photos (photo) download (dl) <mediaItemId> [flags]`](commands/gog-photos-download.md) - Download an app-created media item
     - [`gog photos (photo) get (info,show) <mediaItemId>`](commands/gog-photos-get.md) - Get an app-created media item
     - [`gog photos (photo) list (ls) [flags]`](commands/gog-photos-list.md) - List app-created media items
+    - [`gog photos (photo) picker <command>`](commands/gog-photos-picker.md) - Access user-selected media with the Photos Picker API
+      - [`gog photos (photo) picker create (new,start) [flags]`](commands/gog-photos-picker-create.md) - Create a photo-picking session
+      - [`gog photos (photo) picker delete (rm,close) <sessionId>`](commands/gog-photos-picker-delete.md) - Delete a photo-picking session
+      - [`gog photos (photo) picker download (dl) <sessionId> <mediaItemId> [flags]`](commands/gog-photos-picker-download.md) - Download selected media bytes
+      - [`gog photos (photo) picker get (info,show) <sessionId>`](commands/gog-photos-picker-get.md) - Get a photo-picking session
+      - [`gog photos (photo) picker list (ls,items) <sessionId> [flags]`](commands/gog-photos-picker-list.md) - List media selected in a session
+      - [`gog photos (photo) picker wait (poll) <sessionId> [flags]`](commands/gog-photos-picker-wait.md) - Wait until the user finishes picking media
     - [`gog photos (photo) search (find) [flags]`](commands/gog-photos-search.md) - Search app-created media items
   - [`gog schema (help-json,helpjson) [<command> ...] [flags]`](commands/gog-schema.md) - Machine-readable command/flag schema
   - [`gog search (find) <query> ... [flags]`](commands/gog-search.md) - Search Drive files (alias for 'drive search')

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 618.
+Generated pages: 625.
 
 ## Top-level Commands
 
@@ -35,7 +35,7 @@ Generated pages: 618.
 - [gog meet](gog-meet.md) - Google Meet
 - [gog open](gog-open.md) - Print a best-effort web URL for a Google URL/ID (offline)
 - [gog people](gog-people.md) - Google People
-- [gog photos](gog-photos.md) - Google Photos Library API (app-created media)
+- [gog photos](gog-photos.md) - Google Photos Library and Picker APIs
 - [gog schema](gog-schema.md) - Machine-readable command/flag schema
 - [gog search](gog-search.md) - Search Drive files (alias for 'drive search')
 - [gog searchconsole](gog-searchconsole.md) - Google Search Console
@@ -530,10 +530,17 @@ Generated pages: 618.
     - [gog people raw](gog-people-raw.md) - Dump raw People API response as JSON (People.Get; lossless; for scripting and LLM consumption)
     - [gog people relations](gog-people-relations.md) - Get user relations
     - [gog people search](gog-people-search.md) - Search the Workspace directory
-  - [gog photos](gog-photos.md) - Google Photos Library API (app-created media)
+  - [gog photos](gog-photos.md) - Google Photos Library and Picker APIs
     - [gog photos download](gog-photos-download.md) - Download an app-created media item
     - [gog photos get](gog-photos-get.md) - Get an app-created media item
     - [gog photos list](gog-photos-list.md) - List app-created media items
+    - [gog photos picker](gog-photos-picker.md) - Access user-selected media with the Photos Picker API
+      - [gog photos picker create](gog-photos-picker-create.md) - Create a photo-picking session
+      - [gog photos picker delete](gog-photos-picker-delete.md) - Delete a photo-picking session
+      - [gog photos picker download](gog-photos-picker-download.md) - Download selected media bytes
+      - [gog photos picker get](gog-photos-picker-get.md) - Get a photo-picking session
+      - [gog photos picker list](gog-photos-picker-list.md) - List media selected in a session
+      - [gog photos picker wait](gog-photos-picker-wait.md) - Wait until the user finishes picking media
     - [gog photos search](gog-photos-search.md) - Search app-created media items
   - [gog schema](gog-schema.md) - Machine-readable command/flag schema
   - [gog search](gog-search.md) - Search Drive files (alias for 'drive search')

--- a/docs/commands/gog-auth-add.md
+++ b/docs/commands/gog-auth-add.md
@@ -46,7 +46,7 @@ gog auth add <email> [flags]
 | `--remote` | `bool` |  | Remote/server-friendly manual flow (print URL, then exchange code) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; all means all user OAuth services. Workspace service-account-only services: admin, groups, keep |
+| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
 | `--step` | `int` |  | Remote auth step: 1=print URL, 2=exchange code |
 | `--timeout` | `time.Duration` |  | Authorization timeout (manual flows default to 5m) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/commands/gog-login.md
+++ b/docs/commands/gog-login.md
@@ -46,7 +46,7 @@ gog login <email> [flags]
 | `--remote` | `bool` |  | Remote/server-friendly manual flow (print URL, then exchange code) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; all means all user OAuth services. Workspace service-account-only services: admin, groups, keep |
+| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
 | `--step` | `int` |  | Remote auth step: 1=print URL, 2=exchange code |
 | `--timeout` | `time.Duration` |  | Authorization timeout (manual flows default to 5m) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/commands/gog-photos-picker-create.md
+++ b/docs/commands/gog-photos-picker-create.md
@@ -1,18 +1,18 @@
-# `gog auth manage`
+# `gog photos picker create`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Create a photo-picking session
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker create (new,start) [flags]
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 
 ## Flags
 
@@ -27,24 +27,21 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
+| `--max-items` | `int64` | 0 | Maximum items the user may select (max 2000; 0 uses the API default) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--open`<br>`--browser` | `bool` |  | Open the Picker URI in the default browser |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos-picker-delete.md
+++ b/docs/commands/gog-photos-picker-delete.md
@@ -1,18 +1,18 @@
-# `gog auth manage`
+# `gog photos picker delete`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Delete a photo-picking session
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker delete (rm,close) <sessionId>
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 
 ## Flags
 
@@ -27,24 +27,19 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos-picker-download.md
+++ b/docs/commands/gog-photos-picker-download.md
@@ -1,18 +1,18 @@
-# `gog auth manage`
+# `gog photos picker download`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Download selected media bytes
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker download (dl) <sessionId> <mediaItemId> [flags]
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 
 ## Flags
 
@@ -27,24 +27,21 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--out` | `string` |  | Output path, directory, or '-' for stdout |
+| `--overwrite` | `bool` |  | Overwrite an existing output file |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos-picker-get.md
+++ b/docs/commands/gog-photos-picker-get.md
@@ -1,18 +1,18 @@
-# `gog auth manage`
+# `gog photos picker get`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Get a photo-picking session
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker get (info,show) <sessionId>
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 
 ## Flags
 
@@ -27,24 +27,19 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos-picker-list.md
+++ b/docs/commands/gog-photos-picker-list.md
@@ -1,18 +1,18 @@
-# `gog auth manage`
+# `gog photos picker list`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+List media selected in a session
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker list (ls,items) <sessionId> [flags]
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 
 ## Flags
 
@@ -20,6 +20,7 @@ gog auth manage (login) [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--all` | `bool` |  | Fetch all pages |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -27,24 +28,21 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
+| `--max`<br>`--limit` | `int64` | 50 | Max results per page (max 100) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--page`<br>`--cursor` | `string` |  | Page token |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos-picker-wait.md
+++ b/docs/commands/gog-photos-picker-wait.md
@@ -1,18 +1,18 @@
-# `gog auth manage`
+# `gog photos picker wait`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Wait until the user finishes picking media
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker wait (poll) <sessionId> [flags]
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 
 ## Flags
 
@@ -27,24 +27,20 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
+| `--timeout` | `time.Duration` | 0s | Maximum local wait; 0 uses the API-provided timeout |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos picker](gog-photos-picker.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos-picker.md
+++ b/docs/commands/gog-photos-picker.md
@@ -1,18 +1,27 @@
-# `gog auth manage`
+# `gog photos picker`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Access user-selected media with the Photos Picker API
 
 ## Usage
 
 ```bash
-gog auth manage (login) [flags]
+gog photos (photo) picker <command>
 ```
 
 ## Parent
 
-- [gog auth](gog-auth.md)
+- [gog photos](gog-photos.md)
+
+## Subcommands
+
+- [gog photos picker create](gog-photos-picker-create.md) - Create a photo-picking session
+- [gog photos picker delete](gog-photos-picker-delete.md) - Delete a photo-picking session
+- [gog photos picker download](gog-photos-picker-download.md) - Download selected media bytes
+- [gog photos picker get](gog-photos-picker-get.md) - Get a photo-picking session
+- [gog photos picker list](gog-photos-picker-list.md) - List media selected in a session
+- [gog photos picker wait](gog-photos-picker-wait.md) - Wait until the user finishes picking media
 
 ## Flags
 
@@ -27,24 +36,19 @@ gog auth manage (login) [flags]
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
-| `--force-consent` | `bool` |  | Force consent screen when adding accounts |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--listen-addr` | `string` |  | Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--redirect-host` | `string` |  | Hostname for OAuth callback; builds https://{host}/oauth2/callback |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--services` | `string` | user | Services to authorize: user\|all-user or comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep |
-| `--timeout` | `time.Duration` | 10m | Server timeout duration |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog auth](gog-auth.md)
+- [gog photos](gog-photos.md)
 - [Command index](README.md)

--- a/docs/commands/gog-photos.md
+++ b/docs/commands/gog-photos.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Photos Library API (app-created media)
+Google Photos Library and Picker APIs
 
 ## Usage
 
@@ -19,6 +19,7 @@ gog photos (photo) <command> [flags]
 - [gog photos download](gog-photos-download.md) - Download an app-created media item
 - [gog photos get](gog-photos-get.md) - Get an app-created media item
 - [gog photos list](gog-photos-list.md) - List app-created media items
+- [gog photos picker](gog-photos-picker.md) - Access user-selected media with the Photos Picker API
 - [gog photos search](gog-photos-search.md) - Search app-created media items
 
 ## Flags

--- a/docs/commands/gog.md
+++ b/docs/commands/gog.md
@@ -45,7 +45,7 @@ gog <command> [flags]
 - [gog meet](gog-meet.md) - Google Meet
 - [gog open](gog-open.md) - Print a best-effort web URL for a Google URL/ID (offline)
 - [gog people](gog-people.md) - Google People
-- [gog photos](gog-photos.md) - Google Photos Library API (app-created media)
+- [gog photos](gog-photos.md) - Google Photos Library and Picker APIs
 - [gog schema](gog-schema.md) - Machine-readable command/flag schema
 - [gog search](gog-search.md) - Search Drive files (alias for 'drive search')
 - [gog searchconsole](gog-searchconsole.md) - Google Search Console

--- a/docs/index.md
+++ b/docs/index.md
@@ -51,6 +51,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Running Workspace at scale.** [Auth Clients](auth-clients.md) for service accounts, named OAuth clients, and domain-wide delegation.
 - **Managing Workspace.** [Workspace Admin](workspace-admin.md) covers user creation, cleanup, organizational units, and group administration.
 - **Backing up an account.** [Backup](backup.md) before pointing `gog backup push` at a busy mailbox.
+- **Selecting private Photos media.** [Photos Picker](photos-picker.md) keeps access limited to items the user explicitly chooses.
 - **Looking up a flag.** The [Command Index](commands/) has a generated page for every subcommand.
 
 ## Project

--- a/docs/photos-picker.md
+++ b/docs/photos-picker.md
@@ -1,0 +1,88 @@
+---
+title: Photos Picker
+description: "Let a user select private Google Photos media, then list and download only those chosen items."
+---
+
+# Photos Picker
+
+The Photos Picker API is separate from the app-created-only Photos Library API.
+It exposes only media the user explicitly selects for a short-lived picking
+session.
+
+## Setup
+
+Enable the
+[Photos Picker API](https://console.cloud.google.com/apis/library/photospicker.googleapis.com)
+in the OAuth client project, then authorize the dedicated service:
+
+```bash
+gog auth add you@gmail.com --services photospicker
+```
+
+`photospicker` is intentionally excluded from the default `user` and `all-user`
+service sets. It uses only
+`https://www.googleapis.com/auth/photospicker.mediaitems.readonly`.
+
+## Select Media
+
+Create a session and open its Google-hosted picker:
+
+```bash
+gog photos picker create --max-items 20 --open --json
+```
+
+The response contains `session.id`, `session.pickerUri`, the expiration time,
+and Google's recommended polling configuration. The browser must be signed in
+to the same Google account that owns the session.
+
+Wait until the user finishes:
+
+```bash
+gog photos picker wait <sessionId> --json
+```
+
+`wait` follows the API-provided `pollInterval` and `timeoutIn`. An optional
+`--timeout` only shortens that server-provided limit.
+
+## List And Download
+
+List one page or all selected items:
+
+```bash
+gog photos picker list <sessionId> --max 100 --json
+gog photos picker list <sessionId> --all --json
+```
+
+Download an item by its selected-media ID:
+
+```bash
+gog photos picker download <sessionId> <mediaItemId> --out photo.jpg
+```
+
+Downloads use the authenticated Picker client. Image downloads request the
+original media with location metadata removed; video downloads request the
+transcoded video bytes and reject videos that are not ready.
+
+Picker `baseUrl` values are short-lived, currently up to 60 minutes, and require
+an OAuth bearer token. Prefer the download command instead of persisting or
+sharing those URLs.
+
+## Cleanup
+
+Delete the session after retrieving the required bytes:
+
+```bash
+gog photos picker delete <sessionId>
+```
+
+Google recommends deleting completed or timed-out sessions to avoid session
+resource limits. `create` and `delete` support the global `--dry-run` flag.
+
+Command pages:
+
+- [`gog photos picker create`](commands/gog-photos-picker-create.md)
+- [`gog photos picker get`](commands/gog-photos-picker-get.md)
+- [`gog photos picker wait`](commands/gog-photos-picker-wait.md)
+- [`gog photos picker list`](commands/gog-photos-picker-list.md)
+- [`gog photos picker download`](commands/gog-photos-picker-download.md)
+- [`gog photos picker delete`](commands/gog-photos-picker-delete.md)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -15,6 +15,7 @@ Build a single, clean, modern Go CLI that talks to:
 - Google Forms API
 - Google Maps Places API
 - Google Photos Library API
+- Google Photos Picker API
 - Apps Script API
 - Google Tasks API
 - Cloud Identity API (Groups)
@@ -193,7 +194,7 @@ Flag aliases:
 - `gog auth credentials list`
 - `gog auth credentials remove [<client>|all]`
 - `gog --client <name> auth credentials <credentials.json|->`
-- `gog auth add <email> [--services user|all-user|all|gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,photos,appscript,analytics,searchconsole,ads,youtube] [--readonly] [--drive-scope full|readonly|file] [--gmail-scope full|readonly] [--extra-scopes CSV] [--manual] [--remote] [--step 1|2] [--auth-url URL] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--timeout DURATION] [--force-consent]`
+- `gog auth add <email> [--services user|all-user|all|gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,photos,photospicker,appscript,analytics,searchconsole,ads,youtube] [--readonly] [--drive-scope full|readonly|file] [--gmail-scope full|readonly] [--extra-scopes CSV] [--manual] [--remote] [--step 1|2] [--auth-url URL] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--timeout DURATION] [--force-consent]`
 - `gog auth services [--markdown]`
 - `gog auth manage [--services ...] [--listen-addr HOST[:PORT]] [--redirect-host HOST]`
 - `gog auth keep <email> --key <service-account.json>` (Google Keep; Workspace only)
@@ -265,6 +266,12 @@ Flag aliases:
 - `gog photos search [--album ALBUM_ID] [--media-type PHOTO|VIDEO|ALL_MEDIA] [--from YYYY-MM-DD] [--to YYYY-MM-DD] [--include-archived] [--max N] [--page TOKEN]`
 - `gog photos get <mediaItemId>`
 - `gog photos download <mediaItemId> [--out PATH|-] [--video]`
+- `gog photos picker create [--max-items N] [--open]`
+- `gog photos picker get <sessionId>`
+- `gog photos picker wait <sessionId> [--timeout DURATION]`
+- `gog photos picker list <sessionId> [--max N] [--page TOKEN] [--all]`
+- `gog photos picker download <sessionId> <mediaItemId> [--out PATH|-] [--overwrite]`
+- `gog photos picker delete <sessionId>`
 - `gog time now [--timezone TZ]`
 - `gog classroom courses [--state ...] [--max N] [--page TOKEN]`
 - `gog classroom courses get <courseId>`
@@ -453,6 +460,7 @@ We store a single refresh token per Google account email.
 - People:
   - `profile` (OIDC)
 - Photos: `https://www.googleapis.com/auth/photoslibrary.readonly.appcreateddata`
+- Photos Picker: `https://www.googleapis.com/auth/photospicker.mediaitems.readonly` (explicit opt-in)
 
 ## Output formats
 

--- a/internal/cmd/auth_accounts.go
+++ b/internal/cmd/auth_accounts.go
@@ -254,7 +254,7 @@ func (c *AuthRemoveCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 type AuthManageCmd struct {
 	ForceConsent bool          `name:"force-consent" help:"Force consent screen when adding accounts"`
-	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all-user or comma-separated ${auth_services}; all means all user OAuth services. Workspace service-account-only services: admin, groups, keep" default:"user"`
+	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all-user or comma-separated ${auth_services}; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep" default:"user"`
 	Timeout      time.Duration `name:"timeout" help:"Server timeout duration" default:"10m"`
 	ListenAddr   string        `name:"listen-addr" help:"Loopback address to listen on for the accounts manager (for example 127.0.0.1:8080 or [::1]:8080)"`
 	RedirectHost string        `name:"redirect-host" help:"Hostname for OAuth callback; builds https://{host}/oauth2/callback"`

--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -28,7 +28,7 @@ type AuthAddCmd struct {
 	AuthCode     string        `name:"auth-code" hidden:"" help:"UNSAFE: Authorization code from browser (manual flow; skips state check; not valid with --remote)"`
 	Timeout      time.Duration `name:"timeout" help:"Authorization timeout (manual flows default to 5m)"`
 	ForceConsent bool          `name:"force-consent" help:"Force consent screen to obtain a refresh token"`
-	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all-user or comma-separated ${auth_services}; all means all user OAuth services. Workspace service-account-only services: admin, groups, keep" default:"user"`
+	ServicesCSV  string        `name:"services" help:"Services to authorize: user|all-user or comma-separated ${auth_services}; explicit opt-in: photospicker; all means all default user OAuth services. Workspace service-account-only services: admin, groups, keep" default:"user"`
 	Readonly     bool          `name:"readonly" help:"Use read-only scopes where available (still includes OIDC identity scopes)"`
 	DriveScope   string        `name:"drive-scope" help:"Drive scope mode: full|readonly|file" enum:"full,readonly,file" default:"full"`
 	GmailScope   string        `name:"gmail-scope" help:"Gmail scope mode: full|readonly" enum:"full,readonly" default:"full"`

--- a/internal/cmd/calendar_propose_time.go
+++ b/internal/cmd/calendar_propose_time.go
@@ -212,7 +212,7 @@ var openProposeTimeBrowser = func(url string) error {
 	switch runtime.GOOS {
 	case "darwin":
 		cmd = exec.Command("open", url) //nolint:gosec // executable is fixed; arg is generated propose URL
-	case "windows":
+	case "windows": //nolint:goconst // runtime.GOOS value repeated across independent browser helpers
 		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url) //nolint:gosec // executable is fixed; arg is generated propose URL
 	default:
 		cmd = exec.Command("xdg-open", url) //nolint:gosec // executable is fixed; arg is generated propose URL

--- a/internal/cmd/photos.go
+++ b/internal/cmd/photos.go
@@ -25,6 +25,7 @@ type PhotosCmd struct {
 	Search   PhotosSearchCmd   `cmd:"" name:"search" aliases:"find" help:"Search app-created media items"`
 	Get      PhotosGetCmd      `cmd:"" name:"get" aliases:"info,show" help:"Get an app-created media item"`
 	Download PhotosDownloadCmd `cmd:"" name:"download" aliases:"dl" help:"Download an app-created media item"`
+	Picker   PhotosPickerCmd   `cmd:"" name:"picker" help:"Access user-selected media with the Photos Picker API"`
 }
 
 type PhotosListCmd struct {
@@ -301,9 +302,13 @@ func resolvePhotosDownloadDestPath(item *googleapi.PhotosMediaItem, outPathFlag 
 	if item == nil {
 		return "", fmt.Errorf("missing media item metadata")
 	}
-	filename := strings.TrimSpace(item.Filename)
+	return resolvePhotosDownloadDestPathParts(item.ID, item.Filename, outPathFlag)
+}
+
+func resolvePhotosDownloadDestPathParts(itemID string, itemFilename string, outPathFlag string) (string, error) {
+	filename := strings.TrimSpace(itemFilename)
 	if filename == "" {
-		filename = strings.TrimSpace(item.ID)
+		filename = strings.TrimSpace(itemID)
 	}
 	if filename == "" {
 		filename = "media-item"

--- a/internal/cmd/photos_picker.go
+++ b/internal/cmd/photos_picker.go
@@ -313,7 +313,7 @@ func waitForPhotosPickerSession(
 		return nil, err
 	}
 	timeout := apiTimeout
-	if maxWait > 0 && (timeout == 0 || maxWait < timeout) {
+	if maxWait > 0 && timeout > 0 && maxWait < timeout {
 		timeout = maxWait
 	}
 	if timeout <= 0 {

--- a/internal/cmd/photos_picker.go
+++ b/internal/cmd/photos_picker.go
@@ -1,0 +1,476 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+const (
+	maxPhotosPickerPageSize  = 100
+	maxPhotosPickerItemCount = 2000
+)
+
+var (
+	errPhotosPickerWaitTimeout          = errors.New("session wait timed out")
+	errPhotosPickerRepeatedPageToken    = errors.New("repeated page token from Photos Picker")
+	errPhotosPickerPollingConfigMissing = errors.New("response is missing Photos Picker pollingConfig")
+	newPhotosPickerClient               = func(ctx context.Context, email string) (*googleapi.PhotosPickerClient, error) {
+		return googleapi.NewPhotosPickerClientForAccount(
+			ctx,
+			email,
+			googleapi.WithPhotosPickerBaseURL(os.Getenv("GOG_PHOTOS_PICKER_BASE_URL")),
+		)
+	}
+	openPhotosPickerBrowser = func(uri string) error {
+		var command *exec.Cmd
+		switch runtime.GOOS {
+		case "darwin":
+			command = exec.Command("open", uri) //nolint:gosec // executable is fixed; arg is a Google-generated Picker URI
+		case "windows":
+			command = exec.Command("rundll32", "url.dll,FileProtocolHandler", uri) //nolint:gosec // executable is fixed
+		default:
+			command = exec.Command("xdg-open", uri) //nolint:gosec // executable is fixed; arg is a Google-generated Picker URI
+		}
+		return command.Start()
+	}
+)
+
+type PhotosPickerCmd struct {
+	Create   PhotosPickerCreateCmd   `cmd:"" name:"create" aliases:"new,start" help:"Create a photo-picking session"`
+	Get      PhotosPickerGetCmd      `cmd:"" name:"get" aliases:"info,show" help:"Get a photo-picking session"`
+	Wait     PhotosPickerWaitCmd     `cmd:"" name:"wait" aliases:"poll" help:"Wait until the user finishes picking media"`
+	List     PhotosPickerListCmd     `cmd:"" name:"list" aliases:"ls,items" help:"List media selected in a session"`
+	Download PhotosPickerDownloadCmd `cmd:"" name:"download" aliases:"dl" help:"Download selected media bytes"`
+	Delete   PhotosPickerDeleteCmd   `cmd:"" name:"delete" aliases:"rm,close" help:"Delete a photo-picking session"`
+}
+
+type PhotosPickerCreateCmd struct {
+	MaxItems int64 `name:"max-items" help:"Maximum items the user may select (max 2000; 0 uses the API default)" default:"0"`
+	Open     bool  `name:"open" aliases:"browser" help:"Open the Picker URI in the default browser"`
+}
+
+func (c *PhotosPickerCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if err := validatePhotosPickerMaxItems(c.MaxItems); err != nil {
+		return err
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "photos.picker.sessions.create", map[string]any{
+		"max_items": c.MaxItems,
+		"open":      c.Open,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+	client, err := requirePhotosPickerClient(ctx, flags)
+	if err != nil {
+		return err
+	}
+	session, err := client.CreateSession(ctx, c.MaxItems)
+	if err != nil {
+		return err
+	}
+	if err := writePhotosPickerSession(ctx, session); err != nil {
+		return err
+	}
+	if c.Open && strings.TrimSpace(session.PickerURI) != "" {
+		return openPhotosPickerBrowser(session.PickerURI)
+	}
+	return nil
+}
+
+type PhotosPickerGetCmd struct {
+	SessionID string `arg:"" name:"sessionId" help:"Photos Picker session ID"`
+}
+
+func (c *PhotosPickerGetCmd) Run(ctx context.Context, flags *RootFlags) error {
+	sessionID, err := requirePhotosPickerSessionID(c.SessionID)
+	if err != nil {
+		return err
+	}
+	client, err := requirePhotosPickerClient(ctx, flags)
+	if err != nil {
+		return err
+	}
+	session, err := client.GetSession(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	return writePhotosPickerSession(ctx, session)
+}
+
+type PhotosPickerWaitCmd struct {
+	SessionID string        `arg:"" name:"sessionId" help:"Photos Picker session ID"`
+	Timeout   time.Duration `name:"timeout" help:"Maximum local wait; 0 uses the API-provided timeout" default:"0s"`
+}
+
+func (c *PhotosPickerWaitCmd) Run(ctx context.Context, flags *RootFlags) error {
+	sessionID, err := requirePhotosPickerSessionID(c.SessionID)
+	if err != nil {
+		return err
+	}
+	if c.Timeout < 0 {
+		return usage("--timeout must be non-negative")
+	}
+	client, err := requirePhotosPickerClient(ctx, flags)
+	if err != nil {
+		return err
+	}
+	session, err := waitForPhotosPickerSession(
+		ctx,
+		client,
+		sessionID,
+		c.Timeout,
+		defaultPhotosPickerWaitRuntime(),
+	)
+	if err != nil {
+		return err
+	}
+	return writePhotosPickerSession(ctx, session)
+}
+
+type PhotosPickerListCmd struct {
+	SessionID string `arg:"" name:"sessionId" help:"Photos Picker session ID"`
+	Max       int64  `name:"max" aliases:"limit" help:"Max results per page (max 100)" default:"50"`
+	Page      string `name:"page" aliases:"cursor" help:"Page token"`
+	All       bool   `name:"all" help:"Fetch all pages"`
+}
+
+func (c *PhotosPickerListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	sessionID, err := requirePhotosPickerSessionID(c.SessionID)
+	if err != nil {
+		return err
+	}
+	if validationErr := validatePhotosPickerPageSize(c.Max); validationErr != nil {
+		return validationErr
+	}
+	client, err := requirePhotosPickerClient(ctx, flags)
+	if err != nil {
+		return err
+	}
+	items := make([]*googleapi.PhotosPickerMediaItem, 0)
+	pageToken := strings.TrimSpace(c.Page)
+	seenPageTokens := map[string]struct{}{}
+	for {
+		resp, listErr := client.ListMediaItems(ctx, sessionID, c.Max, pageToken)
+		if listErr != nil {
+			return listErr
+		}
+		items = append(items, resp.MediaItems...)
+		nextPageToken := strings.TrimSpace(resp.NextPageToken)
+		if !c.All || nextPageToken == "" {
+			return writePhotosPickerMediaItems(ctx, sessionID, items, nextPageToken)
+		}
+		if _, exists := seenPageTokens[nextPageToken]; exists {
+			return errPhotosPickerRepeatedPageToken
+		}
+		seenPageTokens[nextPageToken] = struct{}{}
+		pageToken = nextPageToken
+	}
+}
+
+type PhotosPickerDownloadCmd struct {
+	SessionID   string `arg:"" name:"sessionId" help:"Photos Picker session ID"`
+	MediaItemID string `arg:"" name:"mediaItemId" help:"Selected media item ID"`
+	Out         string `name:"out" help:"Output path, directory, or '-' for stdout"`
+	Overwrite   bool   `name:"overwrite" help:"Overwrite an existing output file"`
+}
+
+func (c *PhotosPickerDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
+	sessionID, err := requirePhotosPickerSessionID(c.SessionID)
+	if err != nil {
+		return err
+	}
+	mediaItemID := strings.TrimSpace(c.MediaItemID)
+	if mediaItemID == "" {
+		return usage("empty mediaItemId")
+	}
+	client, err := requirePhotosPickerClient(ctx, flags)
+	if err != nil {
+		return err
+	}
+	item, err := client.FindMediaItem(ctx, sessionID, mediaItemID)
+	if err != nil {
+		return err
+	}
+	resp, err := client.DownloadMedia(ctx, item)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if isStdoutPath(c.Out) {
+		_, err = io.Copy(os.Stdout, resp.Body)
+		return err
+	}
+	filename := ""
+	if item.MediaFile != nil {
+		filename = item.MediaFile.Filename
+	}
+	dest, err := resolvePhotosDownloadDestPathParts(item.ID, filename, c.Out)
+	if err != nil {
+		return err
+	}
+	file, actual, err := openUserOutputFile(dest, outputFileOptions{
+		Overwrite: c.Overwrite,
+		FileMode:  0o600,
+		DirMode:   0o700,
+	})
+	if err != nil {
+		return err
+	}
+	written, copyErr := io.Copy(file, resp.Body)
+	closeErr := file.Close()
+	if copyErr != nil {
+		return copyErr
+	}
+	if closeErr != nil {
+		return closeErr
+	}
+	return writeResult(ctx, ui.FromContext(ctx),
+		kv("sessionId", sessionID),
+		kv("mediaItemId", item.ID),
+		kv("path", actual),
+		kv("bytes", written),
+	)
+}
+
+type PhotosPickerDeleteCmd struct {
+	SessionID string `arg:"" name:"sessionId" help:"Photos Picker session ID"`
+}
+
+func (c *PhotosPickerDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	sessionID, err := requirePhotosPickerSessionID(c.SessionID)
+	if err != nil {
+		return err
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "photos.picker.sessions.delete", map[string]any{
+		"session_id": sessionID,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+	client, err := requirePhotosPickerClient(ctx, flags)
+	if err != nil {
+		return err
+	}
+	if err := client.DeleteSession(ctx, sessionID); err != nil {
+		return err
+	}
+	return writeResult(ctx, ui.FromContext(ctx),
+		kv("deleted", true),
+		kv("sessionId", sessionID),
+	)
+}
+
+type photosPickerWaitRuntime struct {
+	now  func() time.Time
+	wait func(context.Context, time.Duration) error
+}
+
+func defaultPhotosPickerWaitRuntime() photosPickerWaitRuntime {
+	return photosPickerWaitRuntime{
+		now: time.Now,
+		wait: func(ctx context.Context, duration time.Duration) error {
+			timer := time.NewTimer(duration)
+			defer timer.Stop()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-timer.C:
+				return nil
+			}
+		},
+	}
+}
+
+func waitForPhotosPickerSession(
+	ctx context.Context,
+	client *googleapi.PhotosPickerClient,
+	sessionID string,
+	maxWait time.Duration,
+	waitRuntime photosPickerWaitRuntime,
+) (*googleapi.PhotosPickerSession, error) {
+	session, err := client.GetSession(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if session.MediaItemsSet {
+		return session, nil
+	}
+	if waitRuntime.now == nil || waitRuntime.wait == nil {
+		waitRuntime = defaultPhotosPickerWaitRuntime()
+	}
+	apiTimeout, err := photosPickerDuration(session.PollingConfig, true)
+	if err != nil {
+		return nil, err
+	}
+	timeout := apiTimeout
+	if maxWait > 0 && (timeout == 0 || maxWait < timeout) {
+		timeout = maxWait
+	}
+	if timeout <= 0 {
+		return nil, fmt.Errorf("%w: session %s", errPhotosPickerWaitTimeout, sessionID)
+	}
+	deadline := waitRuntime.now().Add(timeout)
+
+	for {
+		interval, intervalErr := photosPickerDuration(session.PollingConfig, false)
+		if intervalErr != nil {
+			return nil, intervalErr
+		}
+		remaining := deadline.Sub(waitRuntime.now())
+		if remaining <= 0 {
+			return nil, fmt.Errorf("%w: session %s", errPhotosPickerWaitTimeout, sessionID)
+		}
+		if interval > remaining {
+			interval = remaining
+		}
+		if waitErr := waitRuntime.wait(ctx, interval); waitErr != nil {
+			return nil, waitErr
+		}
+		session, err = client.GetSession(ctx, sessionID)
+		if err != nil {
+			return nil, err
+		}
+		if session.MediaItemsSet {
+			return session, nil
+		}
+	}
+}
+
+func photosPickerDuration(config *googleapi.PhotosPickerPollingConfig, timeout bool) (time.Duration, error) {
+	if config == nil {
+		return 0, errPhotosPickerPollingConfigMissing
+	}
+	raw := strings.TrimSpace(config.PollInterval)
+	field := "pollInterval"
+	if timeout {
+		raw = strings.TrimSpace(config.TimeoutIn)
+		field = "timeoutIn"
+	}
+	duration, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid Photos Picker %s %q: %w", field, raw, err)
+	}
+	if duration < 0 || (!timeout && duration == 0) {
+		return 0, fmt.Errorf("invalid Photos Picker %s %q", field, raw)
+	}
+	return duration, nil
+}
+
+func requirePhotosPickerClient(ctx context.Context, flags *RootFlags) (*googleapi.PhotosPickerClient, error) {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return nil, err
+	}
+	return newPhotosPickerClient(ctx, account)
+}
+
+func requirePhotosPickerSessionID(raw string) (string, error) {
+	sessionID := strings.TrimSpace(raw)
+	if sessionID == "" {
+		return "", usage("empty sessionId")
+	}
+	return sessionID, nil
+}
+
+func validatePhotosPickerMaxItems(maxItems int64) error {
+	if maxItems < 0 {
+		return usage("--max-items must be non-negative")
+	}
+	if maxItems > maxPhotosPickerItemCount {
+		return usage("--max-items must be <= 2000")
+	}
+	return nil
+}
+
+func validatePhotosPickerPageSize(maxResults int64) error {
+	if maxResults <= 0 {
+		return usage("max must be > 0")
+	}
+	if maxResults > maxPhotosPickerPageSize {
+		return usage("max must be <= 100")
+	}
+	return nil
+}
+
+func writePhotosPickerSession(ctx context.Context, session *googleapi.PhotosPickerSession) error {
+	if session == nil {
+		session = &googleapi.PhotosPickerSession{}
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"session": session})
+	}
+	u := ui.FromContext(ctx)
+	u.Out().Linef("id\t%s", session.ID)
+	if session.PickerURI != "" {
+		u.Out().Linef("picker_uri\t%s", session.PickerURI)
+	}
+	if session.ExpireTime != "" {
+		u.Out().Linef("expire_time\t%s", session.ExpireTime)
+	}
+	u.Out().Linef("media_items_set\t%t", session.MediaItemsSet)
+	if session.PollingConfig != nil {
+		u.Out().Linef("poll_interval\t%s", session.PollingConfig.PollInterval)
+		u.Out().Linef("timeout_in\t%s", session.PollingConfig.TimeoutIn)
+	}
+	return nil
+}
+
+func writePhotosPickerMediaItems(
+	ctx context.Context,
+	sessionID string,
+	items []*googleapi.PhotosPickerMediaItem,
+	nextPageToken string,
+) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"sessionId":      sessionID,
+			"mediaItems":     items,
+			"mediaItemCount": len(items),
+			"nextPageToken":  nextPageToken,
+		})
+	}
+	u := ui.FromContext(ctx)
+	if len(items) == 0 {
+		u.Err().Println("No picked media items")
+		return nil
+	}
+	writer, flush := tableWriter(ctx)
+	defer flush()
+	fmt.Fprintln(writer, "ID\tTYPE\tFILENAME\tMIME\tCREATED\tWIDTH\tHEIGHT")
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		filename, mimeType := "", ""
+		var width, height int64
+		if item.MediaFile != nil {
+			filename = item.MediaFile.Filename
+			mimeType = item.MediaFile.MimeType
+			if item.MediaFile.MediaFileMetadata != nil {
+				width = item.MediaFile.MediaFileMetadata.Width
+				height = item.MediaFile.MediaFileMetadata.Height
+			}
+		}
+		fmt.Fprintf(writer, "%s\t%s\t%s\t%s\t%s\t%d\t%d\n",
+			item.ID,
+			item.Type,
+			sanitizeTab(filename),
+			mimeType,
+			item.CreateTime,
+			width,
+			height,
+		)
+	}
+	printNextPageHint(u, nextPageToken)
+	return nil
+}

--- a/internal/cmd/photos_picker_test.go
+++ b/internal/cmd/photos_picker_test.go
@@ -197,6 +197,39 @@ func TestPhotosPickerWaitUsesAPITiming(t *testing.T) {
 	}
 }
 
+func TestPhotosPickerWaitHonorsAPIStopSignalWithLocalTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"session-1",
+			"pollingConfig":{"pollInterval":"1s","timeoutIn":"0s"}
+		}`)
+	}))
+	defer srv.Close()
+	client := googleapi.NewPhotosPickerClient(srv.Client(), googleapi.WithPhotosPickerBaseURL(srv.URL))
+
+	waitCalls := 0
+	_, err := waitForPhotosPickerSession(
+		context.Background(),
+		client,
+		"session-1",
+		time.Minute,
+		photosPickerWaitRuntime{
+			now: time.Now,
+			wait: func(context.Context, time.Duration) error {
+				waitCalls++
+				return nil
+			},
+		},
+	)
+	if !errors.Is(err, errPhotosPickerWaitTimeout) {
+		t.Fatalf("err = %v", err)
+	}
+	if waitCalls != 0 {
+		t.Fatalf("wait calls = %d, want 0", waitCalls)
+	}
+}
+
 func TestPhotosPickerListRejectsRepeatedPageToken(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/cmd/photos_picker_test.go
+++ b/internal/cmd/photos_picker_test.go
@@ -1,0 +1,271 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/steipete/gogcli/internal/googleapi"
+)
+
+func TestPhotosPickerCommandWorkflow(t *testing.T) {
+	var sessionGets atomic.Int32
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sessions":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create: %v", err)
+			}
+			if body["pickingConfig"].(map[string]any)["maxItemCount"] != "2" {
+				t.Fatalf("create body = %#v", body)
+			}
+			_, _ = io.WriteString(w, `{
+				"id":"session-1",
+				"pickerUri":"https://photos.google.com/picker/session-1",
+				"expireTime":"2026-06-11T13:00:00Z",
+				"pollingConfig":{"pollInterval":"0.001s","timeoutIn":"1s"},
+				"pickingConfig":{"maxItemCount":"2"}
+			}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions/session-1":
+			ready := sessionGets.Add(1) > 1
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":            "session-1",
+				"mediaItemsSet": ready,
+				"pollingConfig": map[string]any{
+					"pollInterval": "0.001s",
+					"timeoutIn":    "1s",
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/mediaItems":
+			if r.URL.Query().Get("sessionId") != "session-1" {
+				t.Fatalf("session query = %q", r.URL.Query().Get("sessionId"))
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"mediaItems": []map[string]any{{
+					"id":         "photo-1",
+					"type":       "PHOTO",
+					"createTime": "2026-06-10T12:00:00Z",
+					"mediaFile": map[string]any{
+						"baseUrl":  srv.URL + "/media/photo",
+						"mimeType": "image/jpeg",
+						"filename": "picked.jpg",
+						"mediaFileMetadata": map[string]any{
+							"width":  1200,
+							"height": 800,
+						},
+					},
+				}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/media/photo=d":
+			w.Header().Set("Content-Type", "image/jpeg")
+			_, _ = io.WriteString(w, "picked-photo")
+		case r.Method == http.MethodDelete && r.URL.Path == "/sessions/session-1":
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	originalClient := newPhotosPickerClient
+	originalOpen := openPhotosPickerBrowser
+	t.Cleanup(func() {
+		newPhotosPickerClient = originalClient
+		openPhotosPickerBrowser = originalOpen
+	})
+	newPhotosPickerClient = func(context.Context, string) (*googleapi.PhotosPickerClient, error) {
+		return googleapi.NewPhotosPickerClient(srv.Client(), googleapi.WithPhotosPickerBaseURL(srv.URL)), nil
+	}
+	openedURI := ""
+	openPhotosPickerBrowser = func(uri string) error {
+		openedURI = uri
+		return nil
+	}
+	ctx := newCalendarJSONContext(t)
+	flags := &RootFlags{Account: "a@example.com"}
+
+	createOut := captureStdout(t, func() {
+		cmd := &PhotosPickerCreateCmd{MaxItems: 2, Open: true}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("create: %v", err)
+		}
+	})
+	if !strings.Contains(createOut, `"id": "session-1"`) {
+		t.Fatalf("create output = %s", createOut)
+	}
+	if openedURI != "https://photos.google.com/picker/session-1" {
+		t.Fatalf("opened URI = %q", openedURI)
+	}
+
+	waitOut := captureStdout(t, func() {
+		cmd := &PhotosPickerWaitCmd{SessionID: "session-1", Timeout: time.Second}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("wait: %v", err)
+		}
+	})
+	if !strings.Contains(waitOut, `"mediaItemsSet": true`) {
+		t.Fatalf("wait output = %s", waitOut)
+	}
+
+	listOut := captureStdout(t, func() {
+		cmd := &PhotosPickerListCmd{SessionID: "session-1", Max: 50}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("list: %v", err)
+		}
+	})
+	if !strings.Contains(listOut, `"id": "photo-1"`) {
+		t.Fatalf("list output = %s", listOut)
+	}
+
+	outputPath := filepath.Join(t.TempDir(), "picked.jpg")
+	downloadOut := captureStdout(t, func() {
+		cmd := &PhotosPickerDownloadCmd{
+			SessionID:   "session-1",
+			MediaItemID: "photo-1",
+			Out:         outputPath,
+		}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("download: %v", err)
+		}
+	})
+	if !strings.Contains(downloadOut, `"bytes": 12`) {
+		t.Fatalf("download output = %s", downloadOut)
+	}
+	downloaded, err := os.ReadFile(outputPath)
+	if err != nil {
+		t.Fatalf("read download: %v", err)
+	}
+	if string(downloaded) != "picked-photo" {
+		t.Fatalf("downloaded = %q", downloaded)
+	}
+
+	deleteOut := captureStdout(t, func() {
+		cmd := &PhotosPickerDeleteCmd{SessionID: "session-1"}
+		if err := cmd.Run(ctx, flags); err != nil {
+			t.Fatalf("delete: %v", err)
+		}
+	})
+	if !strings.Contains(deleteOut, `"deleted": true`) {
+		t.Fatalf("delete output = %s", deleteOut)
+	}
+}
+
+func TestPhotosPickerWaitUsesAPITiming(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"session-1",
+			"pollingConfig":{"pollInterval":"1s","timeoutIn":"2s"}
+		}`)
+	}))
+	defer srv.Close()
+	client := googleapi.NewPhotosPickerClient(srv.Client(), googleapi.WithPhotosPickerBaseURL(srv.URL))
+
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	waitCalls := 0
+	_, err := waitForPhotosPickerSession(
+		context.Background(),
+		client,
+		"session-1",
+		0,
+		photosPickerWaitRuntime{
+			now: func() time.Time { return now },
+			wait: func(_ context.Context, duration time.Duration) error {
+				waitCalls++
+				now = now.Add(duration)
+				return nil
+			},
+		},
+	)
+	if !errors.Is(err, errPhotosPickerWaitTimeout) {
+		t.Fatalf("err = %v", err)
+	}
+	if waitCalls != 2 {
+		t.Fatalf("wait calls = %d, want 2", waitCalls)
+	}
+}
+
+func TestPhotosPickerListRejectsRepeatedPageToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"nextPageToken":"repeated"}`)
+	}))
+	defer srv.Close()
+
+	originalClient := newPhotosPickerClient
+	t.Cleanup(func() { newPhotosPickerClient = originalClient })
+	newPhotosPickerClient = func(context.Context, string) (*googleapi.PhotosPickerClient, error) {
+		return googleapi.NewPhotosPickerClient(srv.Client(), googleapi.WithPhotosPickerBaseURL(srv.URL)), nil
+	}
+
+	cmd := &PhotosPickerListCmd{SessionID: "session-1", Max: 50, All: true}
+	err := cmd.Run(newCalendarJSONContext(t), &RootFlags{Account: "a@example.com"})
+	if err == nil || !strings.Contains(err.Error(), "repeated page token") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPhotosPickerValidationFailsBeforeClient(t *testing.T) {
+	originalClient := newPhotosPickerClient
+	t.Cleanup(func() { newPhotosPickerClient = originalClient })
+	newPhotosPickerClient = func(context.Context, string) (*googleapi.PhotosPickerClient, error) {
+		t.Fatalf("expected validation before creating Picker client")
+		return nil, context.Canceled
+	}
+
+	testCases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "negative max items", args: []string{"--account", "a@b.com", "photos", "picker", "create", "--max-items=-1"}, want: "--max-items must be non-negative"},
+		{name: "too many items", args: []string{"--account", "a@b.com", "photos", "picker", "create", "--max-items", "2001"}, want: "--max-items must be <= 2000"},
+		{name: "empty get session", args: []string{"--account", "a@b.com", "photos", "picker", "get", ""}, want: "empty sessionId"},
+		{name: "negative wait", args: []string{"--account", "a@b.com", "photos", "picker", "wait", "session-1", "--timeout=-1s"}, want: "--timeout must be non-negative"},
+		{name: "zero list max", args: []string{"--account", "a@b.com", "photos", "picker", "list", "session-1", "--max", "0"}, want: "max must be > 0"},
+		{name: "large list max", args: []string{"--account", "a@b.com", "photos", "picker", "list", "session-1", "--max", "101"}, want: "max must be <= 100"},
+		{name: "empty media id", args: []string{"--account", "a@b.com", "photos", "picker", "download", "session-1", ""}, want: "empty mediaItemId"},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_ = captureStderr(t, func() {
+				err := Execute(tc.args)
+				if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("err = %v", err)
+				}
+			})
+		})
+	}
+}
+
+func TestPhotosPickerCreateDryRunSkipsAuth(t *testing.T) {
+	originalClient := newPhotosPickerClient
+	t.Cleanup(func() { newPhotosPickerClient = originalClient })
+	newPhotosPickerClient = func(context.Context, string) (*googleapi.PhotosPickerClient, error) {
+		t.Fatalf("dry-run should not create Picker client")
+		return nil, context.Canceled
+	}
+
+	output := captureStdout(t, func() {
+		cmd := &PhotosPickerCreateCmd{MaxItems: 4, Open: true}
+		if err := cmd.Run(newCalendarJSONContext(t), &RootFlags{DryRun: true}); ExitCode(err) != 0 {
+			t.Fatalf("dry-run: %v", err)
+		}
+	})
+	if !strings.Contains(output, `"op": "photos.picker.sessions.create"`) ||
+		!strings.Contains(output, `"max_items": 4`) {
+		t.Fatalf("output = %s", output)
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -92,7 +92,7 @@ type CLI struct {
 	Analytics     AnalyticsCmd          `cmd:"" aliases:"ga" help:"Google Analytics"`
 	SearchConsole SearchConsoleCmd      `cmd:"" name:"searchconsole" aliases:"gsc,search-console,webmasters" help:"Google Search Console"`
 	YouTube       YouTubeCmd            `cmd:"" name:"youtube" aliases:"yt" help:"YouTube Data API (search, activities, videos, playlists, comments, channels)"`
-	Photos        PhotosCmd             `cmd:"" name:"photos" aliases:"photo" help:"Google Photos Library API (app-created media)"`
+	Photos        PhotosCmd             `cmd:"" name:"photos" aliases:"photo" help:"Google Photos Library and Picker APIs"`
 	Config        ConfigCmd             `cmd:"" help:"Manage configuration"`
 	ExitCodes     AgentExitCodesCmd     `cmd:"" name:"exit-codes" aliases:"exitcodes" help:"Print stable exit codes (alias for 'agent exit-codes')"`
 	Agent         AgentCmd              `cmd:"" help:"Agent-friendly helpers"`

--- a/internal/googleapi/photos_picker.go
+++ b/internal/googleapi/photos_picker.go
@@ -1,0 +1,339 @@
+package googleapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/googleauth"
+)
+
+const defaultPhotosPickerBaseURL = "https://photospicker.googleapis.com/v1"
+
+var (
+	errEmptyPhotosPickerSessionID   = errors.New("empty Photos Picker session id")
+	errEmptyPhotosPickerMediaItemID = errors.New("empty Photos Picker media item id")
+	errPhotosPickerMediaItemMissing = errors.New("media item not found in Photos Picker session")
+	errPhotosPickerRepeatedPage     = errors.New("repeated page token from Photos Picker")
+	errPhotosPickerMediaFileMissing = errors.New("media item has no media file")
+	errPhotosPickerBaseURLMissing   = errors.New("media item has no base URL")
+	errPhotosPickerVideoNotReady    = errors.New("video is not ready")
+	errPhotosPickerDownloadFailed   = errors.New("media download failed")
+)
+
+type PhotosPickerClient struct {
+	baseURL string
+	client  *http.Client
+}
+
+type PhotosPickerClientOption func(*PhotosPickerClient)
+
+func WithPhotosPickerBaseURL(baseURL string) PhotosPickerClientOption {
+	return func(c *PhotosPickerClient) {
+		if strings.TrimSpace(baseURL) != "" {
+			c.baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+		}
+	}
+}
+
+func NewPhotosPickerClient(client *http.Client, opts ...PhotosPickerClientOption) *PhotosPickerClient {
+	if client == nil {
+		client = http.DefaultClient
+	}
+
+	c := &PhotosPickerClient{
+		baseURL: defaultPhotosPickerBaseURL,
+		client:  client,
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	return c
+}
+
+func NewPhotosPickerClientForAccount(ctx context.Context, email string, opts ...PhotosPickerClientOption) (*PhotosPickerClient, error) {
+	client, err := NewHTTPClient(ctx, googleauth.ServicePhotosPicker, email)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewPhotosPickerClient(client, opts...), nil
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerSession struct {
+	ID            string                     `json:"id,omitempty"`
+	PickerURI     string                     `json:"pickerUri,omitempty"`
+	PollingConfig *PhotosPickerPollingConfig `json:"pollingConfig,omitempty"`
+	ExpireTime    string                     `json:"expireTime,omitempty"`
+	PickingConfig *PhotosPickerPickingConfig `json:"pickingConfig,omitempty"`
+	MediaItemsSet bool                       `json:"mediaItemsSet,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerPollingConfig struct {
+	PollInterval string `json:"pollInterval,omitempty"`
+	TimeoutIn    string `json:"timeoutIn,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerPickingConfig struct {
+	MaxItemCount int64 `json:"maxItemCount,string,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerMediaItemsResponse struct {
+	MediaItems    []*PhotosPickerMediaItem `json:"mediaItems,omitempty"`
+	NextPageToken string                   `json:"nextPageToken,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerMediaItem struct {
+	ID         string                 `json:"id,omitempty"`
+	CreateTime string                 `json:"createTime,omitempty"`
+	Type       string                 `json:"type,omitempty"`
+	MediaFile  *PhotosPickerMediaFile `json:"mediaFile,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerMediaFile struct {
+	BaseURL           string                         `json:"baseUrl,omitempty"`
+	MimeType          string                         `json:"mimeType,omitempty"`
+	Filename          string                         `json:"filename,omitempty"`
+	MediaFileMetadata *PhotosPickerMediaFileMetadata `json:"mediaFileMetadata,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerMediaFileMetadata struct {
+	Width         int64                      `json:"width,omitempty"`
+	Height        int64                      `json:"height,omitempty"`
+	CameraMake    string                     `json:"cameraMake,omitempty"`
+	CameraModel   string                     `json:"cameraModel,omitempty"`
+	PhotoMetadata *PhotosPickerPhotoMetadata `json:"photoMetadata,omitempty"`
+	VideoMetadata *PhotosPickerVideoMetadata `json:"videoMetadata,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerPhotoMetadata struct {
+	FocalLength     float64 `json:"focalLength,omitempty"`
+	ApertureFNumber float64 `json:"apertureFNumber,omitempty"`
+	ISOEquivalent   int64   `json:"isoEquivalent,omitempty"`
+	ExposureTime    string  `json:"exposureTime,omitempty"`
+}
+
+//nolint:tagliatelle // Google Photos Picker API uses lowerCamelCase JSON fields.
+type PhotosPickerVideoMetadata struct {
+	FPS              float64 `json:"fps,omitempty"`
+	ProcessingStatus string  `json:"processingStatus,omitempty"`
+}
+
+func (c *PhotosPickerClient) CreateSession(ctx context.Context, maxItemCount int64) (*PhotosPickerSession, error) {
+	body := &PhotosPickerSession{}
+	if maxItemCount > 0 {
+		body.PickingConfig = &PhotosPickerPickingConfig{MaxItemCount: maxItemCount}
+	}
+
+	var out PhotosPickerSession
+	if err := c.doJSON(ctx, http.MethodPost, c.baseURL+"/sessions", body, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *PhotosPickerClient) GetSession(ctx context.Context, sessionID string) (*PhotosPickerSession, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, errEmptyPhotosPickerSessionID
+	}
+
+	var out PhotosPickerSession
+	if err := c.doJSON(ctx, http.MethodGet, c.baseURL+"/sessions/"+url.PathEscape(sessionID), nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *PhotosPickerClient) DeleteSession(ctx context.Context, sessionID string) error {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return errEmptyPhotosPickerSessionID
+	}
+
+	return c.doJSON(ctx, http.MethodDelete, c.baseURL+"/sessions/"+url.PathEscape(sessionID), nil, nil)
+}
+
+func (c *PhotosPickerClient) ListMediaItems(
+	ctx context.Context,
+	sessionID string,
+	pageSize int64,
+	pageToken string,
+) (*PhotosPickerMediaItemsResponse, error) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return nil, errEmptyPhotosPickerSessionID
+	}
+
+	u, err := url.Parse(c.baseURL + "/mediaItems")
+	if err != nil {
+		return nil, fmt.Errorf("build Photos Picker media list URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("sessionId", sessionID)
+
+	if pageSize > 0 {
+		q.Set("pageSize", fmt.Sprint(pageSize))
+	}
+
+	if strings.TrimSpace(pageToken) != "" {
+		q.Set("pageToken", strings.TrimSpace(pageToken))
+	}
+	u.RawQuery = q.Encode()
+
+	var out PhotosPickerMediaItemsResponse
+	if err := c.doJSON(ctx, http.MethodGet, u.String(), nil, &out); err != nil {
+		return nil, err
+	}
+
+	return &out, nil
+}
+
+func (c *PhotosPickerClient) FindMediaItem(
+	ctx context.Context,
+	sessionID string,
+	mediaItemID string,
+) (*PhotosPickerMediaItem, error) {
+	mediaItemID = strings.TrimSpace(mediaItemID)
+	if mediaItemID == "" {
+		return nil, errEmptyPhotosPickerMediaItemID
+	}
+
+	pageToken := ""
+	seenTokens := map[string]struct{}{}
+
+	for {
+		resp, err := c.ListMediaItems(ctx, sessionID, 100, pageToken)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range resp.MediaItems {
+			if item != nil && item.ID == mediaItemID {
+				return item, nil
+			}
+		}
+
+		next := strings.TrimSpace(resp.NextPageToken)
+		if next == "" {
+			return nil, fmt.Errorf("%w: %s", errPhotosPickerMediaItemMissing, mediaItemID)
+		}
+
+		if _, exists := seenTokens[next]; exists {
+			return nil, errPhotosPickerRepeatedPage
+		}
+		seenTokens[next] = struct{}{}
+		pageToken = next
+	}
+}
+
+func (c *PhotosPickerClient) DownloadMedia(ctx context.Context, item *PhotosPickerMediaItem) (*http.Response, error) {
+	if item == nil || item.MediaFile == nil {
+		return nil, errPhotosPickerMediaFileMissing
+	}
+
+	baseURL := strings.TrimSpace(item.MediaFile.BaseURL)
+	if baseURL == "" {
+		return nil, errPhotosPickerBaseURLMissing
+	}
+
+	suffix := "=d"
+
+	if strings.EqualFold(strings.TrimSpace(item.Type), "VIDEO") {
+		if metadata := item.MediaFile.MediaFileMetadata; metadata != nil && metadata.VideoMetadata != nil {
+			status := strings.ToUpper(strings.TrimSpace(metadata.VideoMetadata.ProcessingStatus))
+			if status != "" && status != "READY" {
+				return nil, fmt.Errorf("%w: %s", errPhotosPickerVideoNotReady, status)
+			}
+		}
+		suffix = "=dv"
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+suffix, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build Photos Picker download request: %w", err)
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download Photos Picker media item: %w", err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp, nil
+	}
+
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+
+	return nil, fmt.Errorf(
+		"%w: HTTP %d: %s",
+		errPhotosPickerDownloadFailed,
+		resp.StatusCode,
+		strings.TrimSpace(string(body)),
+	)
+}
+
+func (c *PhotosPickerClient) doJSON(ctx context.Context, method string, endpoint string, body any, out any) error {
+	var reader io.Reader
+
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("encode Photos Picker API request: %w", err)
+		}
+		reader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return fmt.Errorf("build Photos Picker API request: %w", err)
+	}
+
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("send Photos Picker API request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return fmt.Errorf("read Photos Picker API response: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return photosAPIError(resp.StatusCode, respBody)
+	}
+
+	if out == nil || len(bytes.TrimSpace(respBody)) == 0 {
+		return nil
+	}
+
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return fmt.Errorf("decode Photos Picker API response: %w", err)
+	}
+
+	return nil
+}

--- a/internal/googleapi/photos_picker_test.go
+++ b/internal/googleapi/photos_picker_test.go
@@ -1,0 +1,187 @@
+package googleapi
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestPhotosPickerSessionLifecycle(t *testing.T) {
+	var createCalls atomic.Int32
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/sessions":
+			createCalls.Add(1)
+
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+
+			config := body["pickingConfig"].(map[string]any)
+			if config["maxItemCount"] != "12" {
+				t.Fatalf("create body = %#v", body)
+			}
+			_, _ = io.WriteString(w, `{
+				"id":"session-1",
+				"pickerUri":"https://photos.google.com/picker/session-1",
+				"pollingConfig":{"pollInterval":"1s","timeoutIn":"60s"},
+				"pickingConfig":{"maxItemCount":"12"}
+			}`)
+		case r.Method == http.MethodGet && r.URL.Path == "/sessions/session-1":
+			_, _ = io.WriteString(w, `{"id":"session-1","mediaItemsSet":true}`)
+		case r.Method == http.MethodDelete && r.URL.Path == "/sessions/session-1":
+			_, _ = io.WriteString(w, `{}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := NewPhotosPickerClient(srv.Client(), WithPhotosPickerBaseURL(srv.URL))
+
+	session, err := client.CreateSession(context.Background(), 12)
+	if err != nil {
+		t.Fatalf("CreateSession: %v", err)
+	}
+
+	if session.ID != "session-1" || session.PickingConfig == nil || session.PickingConfig.MaxItemCount != 12 {
+		t.Fatalf("session = %#v", session)
+	}
+
+	got, err := client.GetSession(context.Background(), session.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+
+	if !got.MediaItemsSet {
+		t.Fatalf("session not ready: %#v", got)
+	}
+
+	if err := client.DeleteSession(context.Background(), session.ID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	if createCalls.Load() != 1 {
+		t.Fatalf("create calls = %d", createCalls.Load())
+	}
+}
+
+func TestPhotosPickerFindMediaItemPaginates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/mediaItems" {
+			http.NotFound(w, r)
+			return
+		}
+
+		if r.URL.Query().Get("sessionId") != "session-1" || r.URL.Query().Get("pageSize") != "100" {
+			t.Fatalf("query = %s", r.URL.RawQuery)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		if r.URL.Query().Get("pageToken") == "" {
+			_, _ = io.WriteString(w, `{"mediaItems":[{"id":"other"}],"nextPageToken":"page-2"}`)
+			return
+		}
+		_, _ = io.WriteString(w, `{
+			"mediaItems":[{
+				"id":"wanted",
+				"type":"PHOTO",
+				"mediaFile":{"filename":"photo.jpg","baseUrl":"https://example.test/photo"}
+			}]
+		}`)
+	}))
+	defer srv.Close()
+
+	client := NewPhotosPickerClient(srv.Client(), WithPhotosPickerBaseURL(srv.URL))
+
+	item, err := client.FindMediaItem(context.Background(), "session-1", "wanted")
+	if err != nil {
+		t.Fatalf("FindMediaItem: %v", err)
+	}
+
+	if item.ID != "wanted" || item.MediaFile == nil || item.MediaFile.Filename != "photo.jpg" {
+		t.Fatalf("item = %#v", item)
+	}
+}
+
+func TestPhotosPickerDownloadMedia(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/photo=d" {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = io.WriteString(w, "photo-bytes")
+	}))
+	defer srv.Close()
+
+	client := NewPhotosPickerClient(srv.Client())
+
+	resp, err := client.DownloadMedia(context.Background(), &PhotosPickerMediaItem{
+		ID:   "photo-1",
+		Type: "PHOTO",
+		MediaFile: &PhotosPickerMediaFile{
+			BaseURL: srv.URL + "/photo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("DownloadMedia: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	if string(body) != "photo-bytes" {
+		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestPhotosPickerDownloadRejectsUnreadyVideo(t *testing.T) {
+	client := NewPhotosPickerClient(nil)
+
+	resp, err := client.DownloadMedia(context.Background(), &PhotosPickerMediaItem{
+		ID:   "video-1",
+		Type: "VIDEO",
+		MediaFile: &PhotosPickerMediaFile{
+			BaseURL: "https://example.test/video",
+			MediaFileMetadata: &PhotosPickerMediaFileMetadata{
+				VideoMetadata: &PhotosPickerVideoMetadata{ProcessingStatus: "PROCESSING"},
+			},
+		},
+	})
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if err == nil || !strings.Contains(err.Error(), "not ready") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestPhotosPickerAPIError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusFailedDependency)
+		_, _ = io.WriteString(w, `{"error":{"code":424,"status":"FAILED_PRECONDITION","message":"finish picking first"}}`)
+	}))
+	defer srv.Close()
+
+	client := NewPhotosPickerClient(srv.Client(), WithPhotosPickerBaseURL(srv.URL))
+
+	_, err := client.ListMediaItems(context.Background(), "session-1", 50, "")
+	if err == nil || !strings.Contains(err.Error(), "FAILED_PRECONDITION") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -35,6 +35,7 @@ const (
 	ServiceAdmin         Service = "admin"
 	ServiceYouTube       Service = "youtube"
 	ServicePhotos        Service = "photos"
+	ServicePhotosPicker  Service = "photospicker"
 )
 
 const (
@@ -104,6 +105,7 @@ var serviceOrder = []Service{
 	ServiceAdmin,
 	ServiceYouTube,
 	ServicePhotos,
+	ServicePhotosPicker,
 }
 
 var serviceInfoByService = map[Service]serviceInfo{
@@ -301,6 +303,12 @@ var serviceInfoByService = map[Service]serviceInfo{
 		user:   true,
 		apis:   []string{"Photos Library API"},
 		note:   "Read-only app-created media only after Google Photos Library API scope changes",
+	},
+	ServicePhotosPicker: {
+		scopes: []string{"https://www.googleapis.com/auth/photospicker.mediaitems.readonly"},
+		user:   false,
+		apis:   []string{"Photos Picker API"},
+		note:   "Consumer OAuth; explicit opt-in with --services photospicker; selected media only",
 	},
 }
 
@@ -662,6 +670,8 @@ func scopesForServiceWithOptions(service Service, opts ScopeOptions) ([]string, 
 	case ServiceYouTube:
 		return Scopes(service)
 	case ServicePhotos:
+		return Scopes(service)
+	case ServicePhotosPicker:
 		return Scopes(service)
 	default:
 		return nil, errUnknownService

--- a/internal/googleauth/service_test.go
+++ b/internal/googleauth/service_test.go
@@ -31,6 +31,7 @@ func TestParseService(t *testing.T) {
 		{"keep", ServiceKeep},
 		{"youtube", ServiceYouTube},
 		{"photos", ServicePhotos},
+		{"photospicker", ServicePhotosPicker},
 	}
 	for _, tt := range tests {
 		got, err := ParseService(tt.in)
@@ -73,7 +74,7 @@ func TestExtractCodeAndState_Errors(t *testing.T) {
 
 func TestAllServices(t *testing.T) {
 	svcs := AllServices()
-	if len(svcs) != 25 {
+	if len(svcs) != 26 {
 		t.Fatalf("unexpected: %v", svcs)
 	}
 	seen := make(map[Service]bool)
@@ -82,7 +83,7 @@ func TestAllServices(t *testing.T) {
 		seen[s] = true
 	}
 
-	for _, want := range []Service{ServiceGmail, ServiceCalendar, ServiceChat, ServiceClassroom, ServiceDrive, ServiceDriveActivity, ServiceDriveLabels, ServiceDocs, ServiceSlides, ServiceContacts, ServiceTasks, ServicePeople, ServiceSheets, ServiceForms, ServiceSites, ServiceMeet, ServiceAppScript, ServiceAnalytics, ServiceSearchConsole, ServiceAds, ServiceGroups, ServiceKeep, ServiceAdmin, ServiceYouTube, ServicePhotos} {
+	for _, want := range []Service{ServiceGmail, ServiceCalendar, ServiceChat, ServiceClassroom, ServiceDrive, ServiceDriveActivity, ServiceDriveLabels, ServiceDocs, ServiceSlides, ServiceContacts, ServiceTasks, ServicePeople, ServiceSheets, ServiceForms, ServiceSites, ServiceMeet, ServiceAppScript, ServiceAnalytics, ServiceSearchConsole, ServiceAds, ServiceGroups, ServiceKeep, ServiceAdmin, ServiceYouTube, ServicePhotos, ServicePhotosPicker} {
 		if !seen[want] {
 			t.Fatalf("missing %q", want)
 		}

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -22,6 +22,7 @@ const sections = [
   ["Start", ["index.md", "install.md", "quickstart.md", "auth-clients.md", "workspace-admin.md", "safety-profiles.md"]],
   ["Gmail", ["gmail-workflows.md", "gmail-autoreply.md", "watch.md", "email-tracking.md", "email-tracking-worker.md"]],
   ["Drive & Files", ["drive-audits.md", "raw-api.md", "raw-audit.md"]],
+  ["Photos", ["photos-picker.md"]],
   ["Docs, Sheets, Slides", ["docs-editing.md", "sedmat.md", "sheets-batch-update.md", "sheets-tables.md", "sheets-formatting.md", "slides-markdown.md", "slides-template-replacement.md"]],
   ["Contacts", ["contacts-dedupe.md", "contacts-json-update.md"]],
   ["Backup", ["backup.md"]],

--- a/scripts/check-docs-coverage.mjs
+++ b/scripts/check-docs-coverage.mjs
@@ -22,6 +22,7 @@ const requiredFeatureDocs = [
   "drive-audits.md",
   "contacts-dedupe.md",
   "contacts-json-update.md",
+  "photos-picker.md",
   "docs-editing.md",
   "sheets-batch-update.md",
   "sheets-tables.md",


### PR DESCRIPTION
Closes #671.

## Summary

- add an explicit-opt-in `photospicker` OAuth service without expanding the default Photos Library authorization set
- add Photos Picker session create/get/wait/list/delete commands and authenticated selected-media downloads
- add pagination-loop protection, API-timed polling, safe output-file handling, unit coverage, and generated/user docs

## Verification

- Codex autoreview: clean, no actionable findings
- `make ci`
- `go test ./internal/googleauth ./internal/googleapi ./internal/cmd -run 'Test(ParseService|AllServices|UserServices|PhotosPicker)' -count=1`
- binary dry-run: Picker session create and delete
- binary service discovery: `photospicker` and its read-only scope present
- real noninteractive create attempt with `gog+clawdbot@gmail.com`: reached service-specific auth routing and exited cleanly because that account does not yet have the explicit `photospicker` grant

## Notes

The Picker scope remains excluded from `user` and `all-user`. A live Google-hosted picking session requires:

```bash
gog auth add gog+clawdbot@gmail.com --services photospicker
```
