### PR TITLE
feat(batch): add persisted Docs request batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Photos: add an explicit-opt-in Google Photos Picker workflow for creating selection sessions, waiting for completion, listing chosen media, and downloading selected files. (#754)
+- Docs: add persisted, revision-locked request batches for composing supported mutations locally and submitting them atomically, with explicit split and partial-recovery modes. (#755)
 
 ## 0.24.0 - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ gog contacts dedupe --match email,phone,name --dry-run
 ### Docs
 
 Docs: [Google Docs editing](docs/docs-editing.md),
+[atomic Docs request batches](docs/docs-batch.md),
 [sed-style document edits](docs/sedmat.md),
 [`gog docs`](docs/commands/gog-docs.md).
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -69,6 +69,13 @@ Generated from `gog schema --json`.
     - [`gog backup push [flags]`](commands/gog-backup-push.md) - Export services into encrypted backup shards
     - [`gog backup status [flags]`](commands/gog-backup-status.md) - Inspect backup manifest without decrypting shards
     - [`gog backup verify [flags]`](commands/gog-backup-verify.md) - Decrypt and verify all backup shards
+  - [`gog batch <command> [flags]`](commands/gog-batch.md) - Build and submit persisted Google Docs request batches
+    - [`gog batch abort (rm,delete) <batchId>`](commands/gog-batch-abort.md) - Delete a request batch without submitting
+    - [`gog batch begin --doc=STRING [flags]`](commands/gog-batch-begin.md) - Begin a persisted request batch
+    - [`gog batch end (submit) <batchId> [flags]`](commands/gog-batch-end.md) - Submit and remove a request batch
+    - [`gog batch list (ls)`](commands/gog-batch-list.md) - List persisted request batches
+    - [`gog batch prune [flags]`](commands/gog-batch-prune.md) - Delete stale request batches
+    - [`gog batch show <batchId>`](commands/gog-batch-show.md) - Show a persisted request batch
   - [`gog calendar (cal) <command> [flags]`](commands/gog-calendar.md) - Google Calendar
     - [`gog calendar (cal) acl (permissions,perms) <calendarId> [flags]`](commands/gog-calendar-acl.md) - List calendar ACL
     - [`gog calendar (cal) alias <command>`](commands/gog-calendar-alias.md) - Manage calendar aliases

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -12,6 +12,7 @@ Generated pages: 625.
 - [gog appscript](gog-appscript.md) - Google Apps Script
 - [gog auth](gog-auth.md) - Auth and credentials
 - [gog backup](gog-backup.md) - Encrypted Google account backups
+- [gog batch](gog-batch.md) - Build and submit persisted Google Docs request batches
 - [gog calendar](gog-calendar.md) - Google Calendar
 - [gog chat](gog-chat.md) - Google Chat
 - [gog classroom](gog-classroom.md) - Google Classroom
@@ -121,6 +122,13 @@ Generated pages: 625.
     - [gog backup push](gog-backup-push.md) - Export services into encrypted backup shards
     - [gog backup status](gog-backup-status.md) - Inspect backup manifest without decrypting shards
     - [gog backup verify](gog-backup-verify.md) - Decrypt and verify all backup shards
+  - [gog batch](gog-batch.md) - Build and submit persisted Google Docs request batches
+    - [gog batch abort](gog-batch-abort.md) - Delete a request batch without submitting
+    - [gog batch begin](gog-batch-begin.md) - Begin a persisted request batch
+    - [gog batch end](gog-batch-end.md) - Submit and remove a request batch
+    - [gog batch list](gog-batch-list.md) - List persisted request batches
+    - [gog batch prune](gog-batch-prune.md) - Delete stale request batches
+    - [gog batch show](gog-batch-show.md) - Show a persisted request batch
   - [gog calendar](gog-calendar.md) - Google Calendar
     - [gog calendar acl](gog-calendar-acl.md) - List calendar ACL
     - [gog calendar alias](gog-calendar-alias.md) - Manage calendar aliases

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 625.
+Generated pages: 632.
 
 ## Top-level Commands
 

--- a/docs/commands/gog-batch-abort.md
+++ b/docs/commands/gog-batch-abort.md
@@ -1,18 +1,18 @@
-# `gog docs cell-style`
+# `gog batch abort`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Delete a request batch without submitting
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch abort (rm,delete) <batchId>
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 
 ## Flags
 
@@ -20,12 +20,7 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -35,23 +30,16 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 - [Command index](README.md)

--- a/docs/commands/gog-batch-begin.md
+++ b/docs/commands/gog-batch-begin.md
@@ -1,18 +1,18 @@
-# `gog docs cell-style`
+# `gog batch begin`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Begin a persisted request batch
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch begin --doc=STRING [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 
 ## Flags
 
@@ -20,14 +20,10 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `--doc` | `string` |  | Google Doc ID |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
@@ -35,23 +31,18 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--name` | `string` |  | Optional batch label |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
+| `--service` | `string` | docs | Google API service |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 - [Command index](README.md)

--- a/docs/commands/gog-batch-end.md
+++ b/docs/commands/gog-batch-end.md
@@ -1,18 +1,18 @@
-# `gog docs cell-style`
+# `gog batch end`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Submit and remove a request batch
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch end (submit) <batchId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 
 ## Flags
 
@@ -20,13 +20,10 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
+| `--auto-split` | `bool` |  | Submit batches over 500 requests as ordered chunks (non-atomic) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--continue-on-error` | `bool` |  | After an atomic validation failure, submit requests individually and retain failures |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -35,23 +32,16 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 - [Command index](README.md)

--- a/docs/commands/gog-batch-list.md
+++ b/docs/commands/gog-batch-list.md
@@ -1,18 +1,18 @@
-# `gog docs cell-style`
+# `gog batch list`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+List persisted request batches
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch list (ls)
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 
 ## Flags
 
@@ -20,12 +20,7 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -35,23 +30,16 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 - [Command index](README.md)

--- a/docs/commands/gog-batch-prune.md
+++ b/docs/commands/gog-batch-prune.md
@@ -1,18 +1,18 @@
-# `gog docs cell-style`
+# `gog batch prune`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Delete stale request batches
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch prune [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 
 ## Flags
 
@@ -20,12 +20,7 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -35,23 +30,17 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--older-than` | `time.Duration` | 72h | Delete batches not updated within this duration |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 - [Command index](README.md)

--- a/docs/commands/gog-batch-show.md
+++ b/docs/commands/gog-batch-show.md
@@ -1,18 +1,18 @@
-# `gog docs cell-style`
+# `gog batch show`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Show a persisted request batch
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch show <batchId>
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 
 ## Flags
 
@@ -20,12 +20,7 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -35,23 +30,16 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog batch](gog-batch.md)
 - [Command index](README.md)

--- a/docs/commands/gog-batch.md
+++ b/docs/commands/gog-batch.md
@@ -1,18 +1,27 @@
-# `gog docs cell-style`
+# `gog batch`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Build and submit persisted Google Docs request batches
 
 ## Usage
 
 ```bash
-gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
+gog batch <command> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog](gog.md)
+
+## Subcommands
+
+- [gog batch abort](gog-batch-abort.md) - Delete a request batch without submitting
+- [gog batch begin](gog-batch-begin.md) - Begin a persisted request batch
+- [gog batch end](gog-batch-end.md) - Submit and remove a request batch
+- [gog batch list](gog-batch-list.md) - List persisted request batches
+- [gog batch prune](gog-batch-prune.md) - Delete stale request batches
+- [gog batch show](gog-batch-show.md) - Show a persisted request batch
 
 ## Flags
 
@@ -20,12 +29,7 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
-| `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
-| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
-| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
-| `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -35,23 +39,16 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
-| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
-| `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
-| `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
-| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog](gog.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-delete.md
+++ b/docs/commands/gog-docs-delete.md
@@ -21,6 +21,7 @@ gog docs (doc) delete <docId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at` | `string` |  | Anchor by literal text and delete that matched range |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-docs-format.md
+++ b/docs/commands/gog-docs-format.md
@@ -21,6 +21,7 @@ gog docs (doc) format <docId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--alignment` | `string` |  | Paragraph alignment: left, center, right, justify, start, end, justified |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |

--- a/docs/commands/gog-docs-insert-date-chip.md
+++ b/docs/commands/gog-docs-insert-date-chip.md
@@ -21,6 +21,7 @@ gog docs (doc) insert-date-chip --date=STRING <docId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--date` | `string` |  | Date to insert as YYYY-MM-DD |

--- a/docs/commands/gog-docs-insert-file-chip.md
+++ b/docs/commands/gog-docs-insert-file-chip.md
@@ -21,6 +21,7 @@ gog docs (doc) insert-file-chip (insert-rich-link) --file-id=STRING <docId> [fla
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-docs-insert-page-break.md
+++ b/docs/commands/gog-docs-insert-page-break.md
@@ -22,6 +22,7 @@ gog docs (doc) insert-page-break (page-break,pb) <docId> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at` | `string` |  | Anchor by literal text and insert at the start of the matched range |
 | `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-docs-insert-person.md
+++ b/docs/commands/gog-docs-insert-person.md
@@ -22,6 +22,7 @@ gog docs (doc) insert-person --email=STRING <docId> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at` | `string` |  | Anchor by literal text, delete the match, and insert the person chip there |
 | `--at-end` | `bool` |  | Insert at end-of-doc/tab (mutually exclusive with --index) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-docs-insert.md
+++ b/docs/commands/gog-docs-insert.md
@@ -21,6 +21,7 @@ gog docs (doc) insert <docId> [<content>] [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at` | `string` |  | Anchor by literal text and insert at the start of the matched range |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-docs-table-column-width.md
+++ b/docs/commands/gog-docs-table-column-width.md
@@ -20,6 +20,7 @@ gog docs (doc) table-column-width (table-width,column-width) <docId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--col` | `int` |  | 1-based column number. Omit with --evenly-distributed to reset all columns. |
 | `--color` | `string` | auto | Color output: auto\|always\|never |

--- a/docs/commands/gog-docs-update.md
+++ b/docs/commands/gog-docs-update.md
@@ -21,6 +21,7 @@ gog docs (doc) update <docId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--at` | `string` |  | Anchor by literal text and replace that matched range |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-docs-write.md
+++ b/docs/commands/gog-docs-write.md
@@ -22,6 +22,7 @@ gog docs (doc) write <docId> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
 | `--alignment` | `string` |  | Paragraph alignment: left, center, right, justify, start, end, justified |
 | `--append` | `bool` |  | Append instead of replacing the document body |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
 | `--check-orphans` | `bool` |  | Block markdown replacement when open comment quotes would disappear |

--- a/docs/commands/gog.md
+++ b/docs/commands/gog.md
@@ -22,6 +22,7 @@ gog <command> [flags]
 - [gog appscript](gog-appscript.md) - Google Apps Script
 - [gog auth](gog-auth.md) - Auth and credentials
 - [gog backup](gog-backup.md) - Encrypted Google account backups
+- [gog batch](gog-batch.md) - Build and submit persisted Google Docs request batches
 - [gog calendar](gog-calendar.md) - Google Calendar
 - [gog chat](gog-chat.md) - Google Chat
 - [gog classroom](gog-classroom.md) - Google Classroom

--- a/docs/docs-batch.md
+++ b/docs/docs-batch.md
@@ -1,0 +1,63 @@
+---
+title: Google Docs request batches
+description: "Build revision-locked Google Docs edits locally, inspect the exact API payload, and submit them atomically."
+---
+
+# Google Docs request batches
+
+`gog batch` persists Google Docs API requests locally, then submits them with one revision-locked `documents.batchUpdate` call. The default `batch end` path is atomic: either every request is accepted or none is applied.
+
+## Basic flow
+
+```bash
+BATCH_ID="$(gog --account you@example.com batch begin --service docs --doc <docId> --name "weekly update")"
+
+gog --account you@example.com docs insert <docId> "Status: ready" --index 1 --batch "$BATCH_ID"
+gog --account you@example.com docs format <docId> --match "Status: ready" --bold --batch "$BATCH_ID"
+
+gog batch show "$BATCH_ID" --json
+gog --dry-run batch end "$BATCH_ID" --json
+gog batch end "$BATCH_ID"
+```
+
+`batch begin` prints only the UUID in text and plain modes, making command substitution stable. The batch records the selected account, OAuth client, target document, and first observed document revision. Later appends fail if any of those values differ.
+
+## Supported mutations
+
+The `--batch` flag is available on directly composable Docs mutations:
+
+- `docs write` for plain text; replacement must be the first queued operation
+- `docs update` for plain text
+- `docs insert` and `docs delete`
+- `docs format`
+- `docs cell-style` and `docs table-column-width`
+- `docs insert-person`, `docs insert-file-chip`, and `docs insert-date-chip`
+- `docs insert-page-break`
+
+Markdown writes and updates, page-layout changes, image insertion, table construction, and other multi-phase operations are intentionally excluded. They perform reads or side effects between writes and cannot honestly share one atomic Docs API request.
+
+Ranges, anchors, tabs, and end-of-document positions are resolved against the live document when each command is queued. Earlier queued requests are not replayed locally during later position resolution. Prefer explicit stable indices, or queue position-sensitive operations from the end of the document toward the beginning.
+
+## Submit and recovery modes
+
+```bash
+# Default: one atomic call, maximum 500 requests.
+gog batch end "$BATCH_ID"
+
+# Non-atomic: ordered chunks of at most 500 requests.
+gog batch end "$BATCH_ID" --auto-split
+
+# Recovery after an atomic HTTP 400 validation failure.
+# Successful requests are removed; failed requests remain in the batch.
+gog batch end "$BATCH_ID" --continue-on-error
+```
+
+`--auto-split` and `--continue-on-error` are explicit non-atomic modes and cannot be combined. Failed default submissions leave the complete batch intact. Split submissions persist remaining requests after every successful chunk.
+
+Use `batch abort <batchId>` to discard a batch and `batch prune --older-than 72h` to remove stale batches.
+
+## Local state
+
+Batch files live under the state directory described in [Paths and State](paths.md), in the `batches/` subdirectory. Directories use mode `0700`; batch files and the lock file use mode `0600`.
+
+Requests can contain document text, links, email addresses, and other content. Treat the state directory as sensitive. `batch show` exposes both request metadata and the exact wire payload.

--- a/docs/docs-batch.md
+++ b/docs/docs-batch.md
@@ -20,7 +20,7 @@ gog --dry-run batch end "$BATCH_ID" --json
 gog batch end "$BATCH_ID"
 ```
 
-`batch begin` prints only the UUID in text and plain modes, making command substitution stable. The batch records the selected account, OAuth client, target document, and first observed document revision. Later appends fail if any of those values differ.
+`batch begin` prints only the UUID in text and plain modes, making command substitution stable. It records the selected account, OAuth client, and target document without reading the document or pinning a revision. The first queued mutation records the document revision because that is when request positions are first resolved. Later appends fail if the identity or revision differs.
 
 ## Supported mutations
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Managing Workspace.** [Workspace Admin](workspace-admin.md) covers user creation, cleanup, organizational units, and group administration.
 - **Backing up an account.** [Backup](backup.md) before pointing `gog backup push` at a busy mailbox.
 - **Selecting private Photos media.** [Photos Picker](photos-picker.md) keeps access limited to items the user explicitly chooses.
+- **Grouping Docs edits atomically.** [Google Docs request batches](docs-batch.md) covers persisted, revision-locked request queues and explicit recovery modes.
 - **Looking up a flag.** The [Command Index](commands/) has a generated page for every subcommand.
 
 ## Project

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
+	github.com/google/uuid v1.6.0
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gsterjov/go-libsecret v0.0.0-20161001094733-a6f4afe4910c // indirect

--- a/internal/cmd/batch.go
+++ b/internal/cmd/batch.go
@@ -1,0 +1,408 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type BatchCmd struct {
+	Begin BatchBeginCmd `cmd:"" help:"Begin a persisted request batch"`
+	List  BatchListCmd  `cmd:"" aliases:"ls" help:"List persisted request batches"`
+	Show  BatchShowCmd  `cmd:"" help:"Show a persisted request batch"`
+	End   BatchEndCmd   `cmd:"" aliases:"submit" help:"Submit and remove a request batch"`
+	Abort BatchAbortCmd `cmd:"" aliases:"rm,delete" help:"Delete a request batch without submitting"`
+	Prune BatchPruneCmd `cmd:"" help:"Delete stale request batches"`
+}
+
+type BatchBeginCmd struct {
+	Service string `name:"service" help:"Google API service" enum:"docs" default:"docs"`
+	DocID   string `name:"doc" required:"" help:"Google Doc ID"`
+	Name    string `name:"name" help:"Optional batch label"`
+}
+
+func (c *BatchBeginCmd) Run(ctx context.Context, flags *RootFlags) error {
+	documentID := strings.TrimSpace(c.DocID)
+	if documentID == "" {
+		return usage("empty --doc")
+	}
+	if err := dryRunExit(ctx, flags, "batch.begin", map[string]any{
+		"service": c.Service,
+		"doc_id":  documentID,
+		"name":    strings.TrimSpace(c.Name),
+	}); err != nil {
+		return err
+	}
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	client, err := resolveClientForEmail(account, flags)
+	if err != nil {
+		return err
+	}
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+	state, err := store.create(docsBatchState{
+		Name:       strings.TrimSpace(c.Name),
+		Service:    c.Service,
+		DocumentID: documentID,
+		Account:    account,
+		Client:     client,
+	})
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, state)
+	}
+	ui.FromContext(ctx).Out().Println(state.BatchID)
+
+	return nil
+}
+
+type BatchListCmd struct{}
+
+func (c *BatchListCmd) Run(ctx context.Context) error {
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+	batches, err := store.list()
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"batches": batches})
+	}
+
+	out := ui.FromContext(ctx).Out()
+	for _, batch := range batches {
+		out.Linef("%s\t%s\t%s\t%d\t%s", batch.BatchID, batch.Service, batch.DocumentID, batch.Requests, batch.UpdatedAt.Format(time.RFC3339))
+	}
+
+	return nil
+}
+
+type BatchShowCmd struct {
+	BatchID string `arg:"" name:"batchId" help:"Batch ID"`
+}
+
+func (c *BatchShowCmd) Run(ctx context.Context) error {
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+	state, err := store.get(strings.TrimSpace(c.BatchID))
+	if err != nil {
+		return err
+	}
+	payload := map[string]any{
+		"batch":   state,
+		"payload": docsBatchWirePayload(state, state.Requests),
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, payload)
+	}
+
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		return err
+	}
+	ui.FromContext(ctx).Out().Println(string(data))
+
+	return nil
+}
+
+type BatchAbortCmd struct {
+	BatchID string `arg:"" name:"batchId" help:"Batch ID"`
+}
+
+func (c *BatchAbortCmd) Run(ctx context.Context, flags *RootFlags) error {
+	batchID := strings.TrimSpace(c.BatchID)
+	if err := validateDocsBatchID(batchID); err != nil {
+		return err
+	}
+	if err := dryRunExit(ctx, flags, "batch.abort", map[string]any{"batch_id": batchID}); err != nil {
+		return err
+	}
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+	state, err := store.delete(batchID)
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"aborted":  true,
+			"batch_id": state.BatchID,
+			"requests": len(state.Requests),
+		})
+	}
+	ui.FromContext(ctx).Out().Linef("aborted\t%s\t%d", state.BatchID, len(state.Requests))
+
+	return nil
+}
+
+type BatchPruneCmd struct {
+	OlderThan time.Duration `name:"older-than" help:"Delete batches not updated within this duration" default:"72h"`
+}
+
+func (c *BatchPruneCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if c.OlderThan <= 0 {
+		return usage("--older-than must be greater than zero")
+	}
+	if err := dryRunExit(ctx, flags, "batch.prune", map[string]any{"older_than": c.OlderThan.String()}); err != nil {
+		return err
+	}
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+	removed, err := store.prune(c.OlderThan)
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"pruned":  len(removed),
+			"batches": removed,
+		})
+	}
+	ui.FromContext(ctx).Out().Linef("pruned\t%d", len(removed))
+
+	return nil
+}
+
+type BatchEndCmd struct {
+	BatchID         string `arg:"" name:"batchId" help:"Batch ID"`
+	ContinueOnError bool   `name:"continue-on-error" help:"After an atomic validation failure, submit requests individually and retain failures"`
+	AutoSplit       bool   `name:"auto-split" help:"Submit batches over 500 requests as ordered chunks (non-atomic)"`
+}
+
+type docsBatchEndResult struct {
+	BatchID  string `json:"batch_id"`
+	Requests int    `json:"requests"`
+	Chunks   int    `json:"chunks"`
+	Failed   int    `json:"failed"`
+	Atomic   bool   `json:"atomic"`
+	DryRun   bool   `json:"dry_run,omitempty"`
+	Payload  any    `json:"payload,omitempty"`
+}
+
+func (c *BatchEndCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if c.ContinueOnError && c.AutoSplit {
+		return usage("--continue-on-error and --auto-split are mutually exclusive")
+	}
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+
+	var result docsBatchEndResult
+	err = store.withLockedState(strings.TrimSpace(c.BatchID), func(state *docsBatchState) error {
+		if len(state.Requests) == 0 {
+			return errors.New("batch has no requests")
+		}
+		result.BatchID = state.BatchID
+		result.Requests = len(state.Requests)
+		result.Atomic = !c.AutoSplit
+		if flags != nil && flags.DryRun {
+			result.DryRun = true
+			result.Payload = docsBatchWirePayload(state, state.Requests)
+			return nil
+		}
+		if len(state.Requests) > docsBatchUpdateRequestCap && !c.AutoSplit {
+			return usagef("batch has %d requests; Docs allows at most %d per atomic update (use --auto-split for non-atomic submission)", len(state.Requests), docsBatchUpdateRequestCap)
+		}
+		if c.AutoSplit {
+			return c.submitSplit(ctx, store, state, &result)
+		}
+
+		_, submitErr := submitDocsBatch(ctx, state, state.Requests)
+		if submitErr == nil {
+			result.Chunks = 1
+			state.Requests = nil
+			return store.persistOrDeleteUnlocked(state)
+		}
+		if !c.ContinueOnError || !isDocsBatchBadRequest(submitErr) {
+			return submitErr
+		}
+
+		return c.submitIndividually(ctx, store, state, &result)
+	})
+	if err != nil {
+		return err
+	}
+
+	return writeDocsBatchEndResult(ctx, result)
+}
+
+func (c *BatchEndCmd) submitSplit(ctx context.Context, store *docsBatchStore, state *docsBatchState, result *docsBatchEndResult) error {
+	result.Atomic = false
+	for len(state.Requests) > 0 {
+		count := min(len(state.Requests), docsBatchUpdateRequestCap)
+		response, err := submitDocsBatch(ctx, state, state.Requests[:count])
+		if err != nil {
+			return err
+		}
+		result.Chunks++
+		state.Requests = state.Requests[count:]
+		if len(state.Requests) > 0 {
+			revision := docsBatchResponseRevision(response)
+			if revision == "" {
+				return errors.New("docs response omitted the revision required to continue split submission")
+			}
+			state.RequiredRevisionID = revision
+		}
+		if err := store.persistOrDeleteUnlocked(state); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *BatchEndCmd) submitIndividually(ctx context.Context, store *docsBatchStore, state *docsBatchState, result *docsBatchEndResult) error {
+	result.Atomic = false
+	failed := make([]docsBatchRequestEntry, 0)
+	for index, entry := range state.Requests {
+		response, err := submitDocsBatch(ctx, state, []docsBatchRequestEntry{entry})
+		if err != nil {
+			failed = append(failed, entry)
+			ui.FromContext(ctx).Err().Linef("batch request %d failed: %v", index+1, err)
+			continue
+		}
+		result.Chunks++
+		revision := docsBatchResponseRevision(response)
+		if index < len(state.Requests)-1 && revision == "" {
+			return errors.New("docs response omitted the revision required to continue individual submission")
+		}
+		if revision != "" {
+			state.RequiredRevisionID = revision
+		}
+	}
+	state.Requests = failed
+	result.Failed = len(failed)
+
+	return store.persistOrDeleteUnlocked(state)
+}
+
+func writeDocsBatchEndResult(ctx context.Context, result docsBatchEndResult) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, result)
+	}
+	out := ui.FromContext(ctx).Out()
+	out.Linef("batch_id\t%s", result.BatchID)
+	out.Linef("requests\t%d", result.Requests)
+	out.Linef("chunks\t%d", result.Chunks)
+	out.Linef("failed\t%d", result.Failed)
+	out.Linef("atomic\t%t", result.Atomic)
+	if result.DryRun {
+		data, err := json.Marshal(result.Payload)
+		if err != nil {
+			return fmt.Errorf("encode dry-run payload: %w", err)
+		}
+		out.Linef("dry_run\ttrue")
+		out.Linef("payload_json\t%s", data)
+	}
+
+	return nil
+}
+
+func validateDocsBatchTarget(flags *RootFlags, batchID, documentID string) error {
+	batchID = strings.TrimSpace(batchID)
+	if batchID == "" {
+		return nil
+	}
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	client, err := resolveClientForEmail(account, flags)
+	if err != nil {
+		return err
+	}
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return err
+	}
+	state, err := store.get(batchID)
+	if err != nil {
+		return err
+	}
+
+	return validateDocsBatchIdentity(state, strings.TrimSpace(documentID), account, client)
+}
+
+func captureDocsBatchRevision(ctx context.Context, svc *docs.Service, batchID, documentID string) (string, error) {
+	if strings.TrimSpace(batchID) == "" {
+		return "", nil
+	}
+	document, err := svc.Documents.Get(documentID).
+		Fields("revisionId").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return "", err
+	}
+	if document == nil || strings.TrimSpace(document.RevisionId) == "" {
+		return "", errors.New("docs response omitted document revision")
+	}
+
+	return document.RevisionId, nil
+}
+
+func queueDocsBatchRequests(ctx context.Context, flags *RootFlags, batchID, documentID, command, revisionID string, requests []*docs.Request, requireEmpty bool) (bool, error) {
+	batchID = strings.TrimSpace(batchID)
+	if batchID == "" {
+		return false, nil
+	}
+	if len(requests) == 0 {
+		return true, errors.New("no Docs requests to append")
+	}
+	account, err := requireAccount(flags)
+	if err != nil {
+		return true, err
+	}
+	client, err := resolveClientForEmail(account, flags)
+	if err != nil {
+		return true, err
+	}
+	store, err := newDocsBatchStore()
+	if err != nil {
+		return true, err
+	}
+	total, err := store.appendRequests(batchID, command, documentID, account, client, revisionID, requests, requireEmpty)
+	if err != nil {
+		return true, err
+	}
+	if outfmt.IsJSON(ctx) {
+		err = outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+			"batch_id": batchID,
+			"queued":   len(requests),
+			"requests": total,
+		})
+	} else {
+		out := ui.FromContext(ctx).Out()
+		out.Linef("batch_id\t%s", batchID)
+		out.Linef("queued\t%d", len(requests))
+		out.Linef("requests\t%d", total)
+	}
+
+	return true, err
+}

--- a/internal/cmd/docs_batch_store.go
+++ b/internal/cmd/docs_batch_store.go
@@ -177,8 +177,10 @@ func (s *docsBatchStore) appendRequests(batchID, command, documentID, account, c
 		if revisionID == "" {
 			return errors.New("document revision is empty")
 		}
+		// An empty batch has no revision boundary because no request positions have
+		// been resolved yet. The first queued operation establishes the baseline.
 		if state.RequiredRevisionID != "" && state.RequiredRevisionID != revisionID {
-			return fmt.Errorf("document revision changed since batch began (batch=%s current=%s)", state.RequiredRevisionID, revisionID)
+			return fmt.Errorf("document revision changed since the first request was queued (batch=%s current=%s)", state.RequiredRevisionID, revisionID)
 		}
 		if requireEmpty && len(state.Requests) > 0 {
 			return errors.New("this operation must be the first request in a batch")

--- a/internal/cmd/docs_batch_store.go
+++ b/internal/cmd/docs_batch_store.go
@@ -1,0 +1,442 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"google.golang.org/api/docs/v1"
+	gapi "google.golang.org/api/googleapi"
+
+	"github.com/steipete/gogcli/internal/authclient"
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/filelock"
+	"github.com/steipete/gogcli/internal/googleapi"
+	"github.com/steipete/gogcli/internal/googleauth"
+)
+
+const (
+	docsBatchService        = "docs"
+	docsBatchLockTimeout    = 5 * time.Second
+	docsBatchBaseURLDefault = "https://docs.googleapis.com/v1"
+)
+
+var (
+	docsBatchNow           = time.Now
+	docsBatchBaseURL       = docsBatchBaseURLDefault
+	newDocsBatchHTTPClient = func(ctx context.Context, account string) (*http.Client, error) {
+		return googleapi.NewHTTPClient(ctx, googleauth.ServiceDocs, account)
+	}
+)
+
+type docsBatchRequestEntry struct {
+	AppendedAt time.Time       `json:"appended_at"`
+	Command    string          `json:"command"`
+	Request    json.RawMessage `json:"request"`
+}
+
+type docsBatchState struct {
+	BatchID            string                  `json:"batch_id"`
+	Name               string                  `json:"name,omitempty"`
+	Service            string                  `json:"service"`
+	DocumentID         string                  `json:"doc_id"`
+	Account            string                  `json:"account"`
+	Client             string                  `json:"client"`
+	CreatedAt          time.Time               `json:"created_at"`
+	UpdatedAt          time.Time               `json:"updated_at"`
+	RequiredRevisionID string                  `json:"required_revision_id,omitempty"`
+	Requests           []docsBatchRequestEntry `json:"requests"`
+}
+
+type docsBatchSummary struct {
+	BatchID    string    `json:"batch_id"`
+	Name       string    `json:"name,omitempty"`
+	Service    string    `json:"service"`
+	DocumentID string    `json:"doc_id"`
+	Account    string    `json:"account"`
+	Client     string    `json:"client"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Requests   int       `json:"requests"`
+}
+
+type docsBatchWireBody struct {
+	Requests     []json.RawMessage  `json:"requests"`
+	WriteControl *docs.WriteControl `json:"writeControl,omitempty"`
+}
+
+type docsBatchStore struct {
+	dir  string
+	lock *filelock.Lock
+}
+
+func newDocsBatchStore() (*docsBatchStore, error) {
+	dir, err := config.EnsureBatchDir()
+	if err != nil {
+		return nil, err
+	}
+
+	return newDocsBatchStoreAt(dir), nil
+}
+
+func newDocsBatchStoreAt(dir string) *docsBatchStore {
+	return &docsBatchStore{
+		dir:  dir,
+		lock: filelock.Shared(filepath.Join(dir, ".lock"), docsBatchLockTimeout),
+	}
+}
+
+func (s *docsBatchStore) create(state docsBatchState) (*docsBatchState, error) {
+	var created *docsBatchState
+	err := s.lock.WithExclusive(func() error {
+		id, err := uuid.NewV7()
+		if err != nil {
+			return fmt.Errorf("create batch ID: %w", err)
+		}
+
+		now := docsBatchNow().UTC()
+		state.BatchID = id.String()
+		state.CreatedAt = now
+		state.UpdatedAt = now
+		state.Requests = []docsBatchRequestEntry{}
+		if err := s.writeUnlocked(&state); err != nil {
+			return err
+		}
+		created = &state
+
+		return nil
+	})
+
+	return created, err
+}
+
+func (s *docsBatchStore) list() ([]docsBatchSummary, error) {
+	var summaries []docsBatchSummary
+	err := s.lock.WithExclusive(func() error {
+		states, err := s.listStatesUnlocked()
+		if err != nil {
+			return err
+		}
+
+		summaries = make([]docsBatchSummary, 0, len(states))
+		for _, state := range states {
+			summaries = append(summaries, docsBatchSummary{
+				BatchID:    state.BatchID,
+				Name:       state.Name,
+				Service:    state.Service,
+				DocumentID: state.DocumentID,
+				Account:    state.Account,
+				Client:     state.Client,
+				CreatedAt:  state.CreatedAt,
+				UpdatedAt:  state.UpdatedAt,
+				Requests:   len(state.Requests),
+			})
+		}
+
+		return nil
+	})
+
+	return summaries, err
+}
+
+func (s *docsBatchStore) get(batchID string) (*docsBatchState, error) {
+	var state *docsBatchState
+	err := s.lock.WithExclusive(func() error {
+		loaded, err := s.readUnlocked(batchID)
+		if err != nil {
+			return err
+		}
+		state = loaded
+
+		return nil
+	})
+
+	return state, err
+}
+
+func (s *docsBatchStore) appendRequests(batchID, command, documentID, account, client, revisionID string, requests []*docs.Request, requireEmpty bool) (int, error) {
+	total := 0
+	err := s.lock.WithExclusive(func() error {
+		state, err := s.readUnlocked(batchID)
+		if err != nil {
+			return err
+		}
+		if err := validateDocsBatchIdentity(state, documentID, account, client); err != nil {
+			return err
+		}
+		if revisionID == "" {
+			return errors.New("document revision is empty")
+		}
+		if state.RequiredRevisionID != "" && state.RequiredRevisionID != revisionID {
+			return fmt.Errorf("document revision changed since batch began (batch=%s current=%s)", state.RequiredRevisionID, revisionID)
+		}
+		if requireEmpty && len(state.Requests) > 0 {
+			return errors.New("this operation must be the first request in a batch")
+		}
+
+		now := docsBatchNow().UTC()
+		for _, request := range requests {
+			raw, marshalErr := json.Marshal(request)
+			if marshalErr != nil {
+				return fmt.Errorf("marshal Docs request: %w", marshalErr)
+			}
+			state.Requests = append(state.Requests, docsBatchRequestEntry{
+				AppendedAt: now,
+				Command:    command,
+				Request:    raw,
+			})
+		}
+		state.RequiredRevisionID = revisionID
+		state.UpdatedAt = now
+		if err := s.writeUnlocked(state); err != nil {
+			return err
+		}
+		total = len(state.Requests)
+
+		return nil
+	})
+
+	return total, err
+}
+
+func (s *docsBatchStore) delete(batchID string) (*docsBatchState, error) {
+	var deleted *docsBatchState
+	err := s.lock.WithExclusive(func() error {
+		state, err := s.readUnlocked(batchID)
+		if err != nil {
+			return err
+		}
+		if err := os.Remove(s.path(state.BatchID)); err != nil {
+			return fmt.Errorf("remove batch: %w", err)
+		}
+		deleted = state
+
+		return nil
+	})
+
+	return deleted, err
+}
+
+func (s *docsBatchStore) prune(olderThan time.Duration) ([]docsBatchSummary, error) {
+	var removed []docsBatchSummary
+	err := s.lock.WithExclusive(func() error {
+		states, err := s.listStatesUnlocked()
+		if err != nil {
+			return err
+		}
+
+		cutoff := docsBatchNow().UTC().Add(-olderThan)
+		for _, state := range states {
+			if state.UpdatedAt.After(cutoff) {
+				continue
+			}
+			if err := os.Remove(s.path(state.BatchID)); err != nil {
+				return fmt.Errorf("remove batch %s: %w", state.BatchID, err)
+			}
+			removed = append(removed, docsBatchSummary{
+				BatchID:    state.BatchID,
+				Name:       state.Name,
+				Service:    state.Service,
+				DocumentID: state.DocumentID,
+				Account:    state.Account,
+				Client:     state.Client,
+				CreatedAt:  state.CreatedAt,
+				UpdatedAt:  state.UpdatedAt,
+				Requests:   len(state.Requests),
+			})
+		}
+
+		return nil
+	})
+
+	return removed, err
+}
+
+func (s *docsBatchStore) withLockedState(batchID string, fn func(*docsBatchState) error) error {
+	return s.lock.WithExclusive(func() error {
+		state, err := s.readUnlocked(batchID)
+		if err != nil {
+			return err
+		}
+
+		return fn(state)
+	})
+}
+
+func (s *docsBatchStore) persistOrDeleteUnlocked(state *docsBatchState) error {
+	if len(state.Requests) == 0 {
+		if err := os.Remove(s.path(state.BatchID)); err != nil {
+			return fmt.Errorf("remove completed batch: %w", err)
+		}
+		return nil
+	}
+
+	state.UpdatedAt = docsBatchNow().UTC()
+	return s.writeUnlocked(state)
+}
+
+func (s *docsBatchStore) listStatesUnlocked() ([]*docsBatchState, error) {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return nil, fmt.Errorf("read batch directory: %w", err)
+	}
+
+	states := make([]*docsBatchState, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		state, readErr := s.readPathUnlocked(filepath.Join(s.dir, entry.Name()))
+		if readErr != nil {
+			return nil, readErr
+		}
+		states = append(states, state)
+	}
+	sort.Slice(states, func(i, j int) bool {
+		return states[i].UpdatedAt.After(states[j].UpdatedAt)
+	})
+
+	return states, nil
+}
+
+func (s *docsBatchStore) readUnlocked(batchID string) (*docsBatchState, error) {
+	if err := validateDocsBatchID(batchID); err != nil {
+		return nil, err
+	}
+
+	return s.readPathUnlocked(s.path(batchID))
+}
+
+func (s *docsBatchStore) readPathUnlocked(path string) (*docsBatchState, error) {
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from the private batch directory and a validated UUID.
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("batch not found: %s", strings.TrimSuffix(filepath.Base(path), ".json"))
+		}
+		return nil, fmt.Errorf("read batch: %w", err)
+	}
+
+	var state docsBatchState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, fmt.Errorf("decode batch %s: %w", filepath.Base(path), err)
+	}
+	if err := validateDocsBatchID(state.BatchID); err != nil {
+		return nil, fmt.Errorf("invalid stored batch: %w", err)
+	}
+
+	return &state, nil
+}
+
+func (s *docsBatchStore) writeUnlocked(state *docsBatchState) error {
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode batch: %w", err)
+	}
+	data = append(data, '\n')
+	if err := config.WriteFileAtomic(s.path(state.BatchID), data, 0o600); err != nil {
+		return fmt.Errorf("write batch: %w", err)
+	}
+
+	return nil
+}
+
+func (s *docsBatchStore) path(batchID string) string {
+	return filepath.Join(s.dir, batchID+".json")
+}
+
+func validateDocsBatchID(batchID string) error {
+	batchID = strings.TrimSpace(batchID)
+	parsed, err := uuid.Parse(batchID)
+	if err != nil || parsed.String() != batchID {
+		return fmt.Errorf("invalid batch ID: %s", batchID)
+	}
+
+	return nil
+}
+
+func validateDocsBatchIdentity(state *docsBatchState, documentID, account, client string) error {
+	switch {
+	case state.Service != docsBatchService:
+		return fmt.Errorf("batch service is %s, not docs", state.Service)
+	case state.DocumentID != documentID:
+		return fmt.Errorf("batch targets doc %s, not %s", state.DocumentID, documentID)
+	case !strings.EqualFold(state.Account, account):
+		return fmt.Errorf("batch uses account %s, not %s", state.Account, account)
+	case state.Client != client:
+		return fmt.Errorf("batch uses OAuth client %s, not %s", state.Client, client)
+	default:
+		return nil
+	}
+}
+
+func docsBatchWirePayload(state *docsBatchState, entries []docsBatchRequestEntry) docsBatchWireBody {
+	requests := make([]json.RawMessage, 0, len(entries))
+	for _, entry := range entries {
+		requests = append(requests, entry.Request)
+	}
+	body := docsBatchWireBody{Requests: requests}
+	if state.RequiredRevisionID != "" {
+		body.WriteControl = &docs.WriteControl{RequiredRevisionId: state.RequiredRevisionID}
+	}
+
+	return body
+}
+
+func submitDocsBatch(ctx context.Context, state *docsBatchState, entries []docsBatchRequestEntry) (*docs.BatchUpdateDocumentResponse, error) {
+	ctx = authclient.WithClient(ctx, state.Client)
+	client, err := newDocsBatchHTTPClient(ctx, state.Account)
+	if err != nil {
+		return nil, err
+	}
+
+	payload, err := json.Marshal(docsBatchWirePayload(state, entries))
+	if err != nil {
+		return nil, fmt.Errorf("encode Docs batch: %w", err)
+	}
+	endpoint := docsBatchBaseURL + "/documents/" + url.PathEscape(state.DocumentID) + ":batchUpdate"
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+	if err != nil {
+		return nil, fmt.Errorf("create Docs batch request: %w", err)
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("submit Docs batch: %w", err)
+	}
+	defer response.Body.Close()
+
+	if err := gapi.CheckResponse(response); err != nil {
+		return nil, err
+	}
+
+	var result docs.BatchUpdateDocumentResponse
+	if err := json.NewDecoder(response.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode Docs batch response: %w", err)
+	}
+
+	return &result, nil
+}
+
+func docsBatchResponseRevision(result *docs.BatchUpdateDocumentResponse) string {
+	if result == nil || result.WriteControl == nil {
+		return ""
+	}
+
+	return strings.TrimSpace(result.WriteControl.RequiredRevisionId)
+}
+
+func isDocsBatchBadRequest(err error) bool {
+	var apiErr *gapi.Error
+	return errors.As(err, &apiErr) && apiErr.Code == http.StatusBadRequest
+}

--- a/internal/cmd/docs_batch_store_test.go
+++ b/internal/cmd/docs_batch_store_test.go
@@ -1,0 +1,459 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestDocsBatchStoreLifecyclePreservesRequestJSON(t *testing.T) {
+	dir := t.TempDir()
+	store := newDocsBatchStoreAt(dir)
+	state, err := store.create(docsBatchState{
+		Service:    docsBatchService,
+		DocumentID: "doc1",
+		Account:    "user@example.com",
+		Client:     "default",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	request := &docs.Request{UpdateTextStyle: &docs.UpdateTextStyleRequest{
+		Range:  &docs.Range{StartIndex: 1, EndIndex: 2},
+		Fields: "bold",
+		TextStyle: &docs.TextStyle{
+			Bold:            false,
+			ForceSendFields: []string{"Bold"},
+		},
+	}}
+	total, err := store.appendRequests(state.BatchID, "docs.format", "doc1", "user@example.com", "default", "rev1", []*docs.Request{request}, false)
+	if err != nil {
+		t.Fatalf("append: %v", err)
+	}
+	if total != 1 {
+		t.Fatalf("total = %d, want 1", total)
+	}
+
+	loaded, err := store.get(state.BatchID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if !compactJSONContains(t, loaded.Requests[0].Request, `"bold":false`) {
+		t.Fatalf("request JSON lost explicit false: %s", loaded.Requests[0].Request)
+	}
+	if loaded.RequiredRevisionID != "rev1" {
+		t.Fatalf("revision = %q, want rev1", loaded.RequiredRevisionID)
+	}
+
+	listed, err := store.list()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(listed) != 1 || listed[0].Requests != 1 {
+		t.Fatalf("list = %#v", listed)
+	}
+
+	deleted, err := store.delete(state.BatchID)
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if len(deleted.Requests) != 1 {
+		t.Fatalf("deleted requests = %d, want 1", len(deleted.Requests))
+	}
+}
+
+func TestDocsBatchStoreRejectsIdentityRevisionAndNonemptyReplace(t *testing.T) {
+	store := newDocsBatchStoreAt(t.TempDir())
+	state, err := store.create(docsBatchState{
+		Service:    docsBatchService,
+		DocumentID: "doc1",
+		Account:    "user@example.com",
+		Client:     "default",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	request := []*docs.Request{{InsertText: &docs.InsertTextRequest{
+		Location: &docs.Location{Index: 1},
+		Text:     "x",
+	}}}
+
+	if _, err := store.appendRequests(state.BatchID, "docs.insert", "other", "user@example.com", "default", "rev1", request, false); err == nil {
+		t.Fatal("expected document mismatch")
+	}
+	if _, err := store.appendRequests(state.BatchID, "docs.insert", "doc1", "user@example.com", "default", "rev1", request, false); err != nil {
+		t.Fatalf("first append: %v", err)
+	}
+	if _, err := store.appendRequests(state.BatchID, "docs.insert", "doc1", "user@example.com", "default", "rev2", request, false); err == nil {
+		t.Fatal("expected revision mismatch")
+	}
+	if _, err := store.appendRequests(state.BatchID, "docs.write", "doc1", "user@example.com", "default", "rev1", request, true); err == nil {
+		t.Fatal("expected nonempty batch rejection")
+	}
+}
+
+func TestBatchEndAtomicSubmitsExactPayloadAndDeletesState(t *testing.T) {
+	store, state := prepareDocsBatchEndTest(t, 1)
+
+	var received docsBatchWireBody
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/documents/doc1:batchUpdate" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		_, _ = fmt.Fprint(w, `{"documentId":"doc1","writeControl":{"requiredRevisionId":"rev2"}}`)
+	}))
+	defer server.Close()
+	restoreDocsBatchHTTPTest(t, server)
+
+	if err := (&BatchEndCmd{BatchID: state.BatchID}).Run(batchTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("end: %v", err)
+	}
+	if len(received.Requests) != 1 {
+		t.Fatalf("requests = %d, want 1", len(received.Requests))
+	}
+	if received.WriteControl == nil || received.WriteControl.RequiredRevisionId != "rev1" {
+		t.Fatalf("write control = %#v", received.WriteControl)
+	}
+	if _, err := store.get(state.BatchID); err == nil {
+		t.Fatal("completed batch still exists")
+	}
+}
+
+func TestBatchEndAutoSplitChainsRevision(t *testing.T) {
+	store, state := prepareDocsBatchEndTest(t, docsBatchUpdateRequestCap+1)
+
+	var requestCounts []int
+	var revisions []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body docsBatchWireBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		requestCounts = append(requestCounts, len(body.Requests))
+		revision := ""
+		if body.WriteControl != nil {
+			revision = body.WriteControl.RequiredRevisionId
+		}
+		revisions = append(revisions, revision)
+		next := "rev2"
+		if len(requestCounts) == 2 {
+			next = "rev3"
+		}
+		_, _ = fmt.Fprintf(w, `{"documentId":"doc1","writeControl":{"requiredRevisionId":%q}}`, next)
+	}))
+	defer server.Close()
+	restoreDocsBatchHTTPTest(t, server)
+
+	if err := (&BatchEndCmd{BatchID: state.BatchID, AutoSplit: true}).Run(batchTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("end split: %v", err)
+	}
+	if fmt.Sprint(requestCounts) != "[500 1]" {
+		t.Fatalf("request counts = %v", requestCounts)
+	}
+	if fmt.Sprint(revisions) != "[rev1 rev2]" {
+		t.Fatalf("revisions = %v", revisions)
+	}
+	if _, err := store.get(state.BatchID); err == nil {
+		t.Fatal("completed split batch still exists")
+	}
+}
+
+func TestBatchEndContinueOnErrorRetainsFailedRequests(t *testing.T) {
+	store, state := prepareDocsBatchEndTest(t, 2)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body docsBatchWireBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		if len(body.Requests) == 2 || bytes.Contains(body.Requests[0], []byte(`"text":"request-1"`)) {
+			w.WriteHeader(http.StatusBadRequest)
+			_, _ = fmt.Fprint(w, `{"error":{"code":400,"message":"invalid request","status":"INVALID_ARGUMENT"}}`)
+			return
+		}
+		_, _ = fmt.Fprint(w, `{"documentId":"doc1","writeControl":{"requiredRevisionId":"rev2"}}`)
+	}))
+	defer server.Close()
+	restoreDocsBatchHTTPTest(t, server)
+
+	if err := (&BatchEndCmd{BatchID: state.BatchID, ContinueOnError: true}).Run(batchTestContext(t), &RootFlags{}); err != nil {
+		t.Fatalf("end continue: %v", err)
+	}
+	loaded, err := store.get(state.BatchID)
+	if err != nil {
+		t.Fatalf("get retained state: %v", err)
+	}
+	if len(loaded.Requests) != 1 || !compactJSONContains(t, loaded.Requests[0].Request, `"text":"request-1"`) {
+		t.Fatalf("retained requests = %#v", loaded.Requests)
+	}
+	if loaded.RequiredRevisionID != "rev2" {
+		t.Fatalf("revision = %q, want rev2", loaded.RequiredRevisionID)
+	}
+}
+
+func TestBatchEndDryRunKeepsStateWithoutHTTP(t *testing.T) {
+	store, state := prepareDocsBatchEndTest(t, 1)
+	oldClient := newDocsBatchHTTPClient
+	newDocsBatchHTTPClient = func(context.Context, string) (*http.Client, error) {
+		t.Fatal("dry run created HTTP client")
+		return nil, errors.New("unexpected HTTP client request")
+	}
+	t.Cleanup(func() { newDocsBatchHTTPClient = oldClient })
+
+	if err := (&BatchEndCmd{BatchID: state.BatchID}).Run(batchTestContext(t), &RootFlags{DryRun: true}); err != nil {
+		t.Fatalf("dry-run end: %v", err)
+	}
+	if _, err := store.get(state.BatchID); err != nil {
+		t.Fatalf("dry run removed state: %v", err)
+	}
+}
+
+func TestBatchLocalMutatorsHonorDryRun(t *testing.T) {
+	restoreHome, err := config.SetHomeOverride(t.TempDir())
+	if err != nil {
+		t.Fatalf("set home: %v", err)
+	}
+	t.Cleanup(restoreHome)
+
+	ctx := batchTestContext(t)
+	dryRun := &RootFlags{DryRun: true}
+	beginErr := (&BatchBeginCmd{Service: docsBatchService, DocID: "doc1"}).Run(ctx, dryRun)
+	if !isSuccessfulDryRunExit(beginErr) {
+		t.Fatalf("begin dry run: %v", beginErr)
+	}
+
+	store, err := newDocsBatchStore()
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	batches, err := store.list()
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(batches) != 0 {
+		t.Fatalf("begin dry run created batches: %#v", batches)
+	}
+
+	state, err := store.create(docsBatchState{
+		Service:    docsBatchService,
+		DocumentID: "doc1",
+		Account:    "a@b.com",
+		Client:     "default",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	abortErr := (&BatchAbortCmd{BatchID: state.BatchID}).Run(ctx, dryRun)
+	if !isSuccessfulDryRunExit(abortErr) {
+		t.Fatalf("abort dry run: %v", abortErr)
+	}
+	if _, err := store.get(state.BatchID); err != nil {
+		t.Fatalf("abort dry run removed batch: %v", err)
+	}
+
+	pruneErr := (&BatchPruneCmd{OlderThan: time.Nanosecond}).Run(ctx, dryRun)
+	if !isSuccessfulDryRunExit(pruneErr) {
+		t.Fatalf("prune dry run: %v", pruneErr)
+	}
+	if _, err := store.get(state.BatchID); err != nil {
+		t.Fatalf("prune dry run removed batch: %v", err)
+	}
+}
+
+func TestDocsInsertPageBreakBatchQueuesWithoutSubmitting(t *testing.T) {
+	restoreHome, err := config.SetHomeOverride(t.TempDir())
+	if err != nil {
+		t.Fatalf("set home: %v", err)
+	}
+	t.Cleanup(restoreHome)
+
+	store, err := newDocsBatchStore()
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	state, err := store.create(docsBatchState{
+		Service:    docsBatchService,
+		DocumentID: "doc1",
+		Account:    "a@b.com",
+		Client:     "default",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+
+	originalDocs := newDocsService
+	t.Cleanup(func() { newDocsService = originalDocs })
+	postCalls := 0
+	docService, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = fmt.Fprint(w, `{"documentId":"doc1","revisionId":"rev1"}`)
+		case http.MethodPost:
+			postCalls++
+			http.Error(w, "unexpected submit", http.StatusInternalServerError)
+		}
+	}))
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docService, nil }
+
+	command := &DocsInsertPageBreakCmd{}
+	if runErr := runKong(t, command, []string{"doc1", "--index", "7", "--batch", state.BatchID}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); runErr != nil {
+		t.Fatalf("queue page break: %v", runErr)
+	}
+	if postCalls != 0 {
+		t.Fatalf("POST calls = %d, want 0", postCalls)
+	}
+	loaded, err := store.get(state.BatchID)
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(loaded.Requests) != 1 || !compactJSONContains(t, loaded.Requests[0].Request, `"insertPageBreak"`) {
+		t.Fatalf("queued requests = %#v", loaded.Requests)
+	}
+	if loaded.RequiredRevisionID != "rev1" {
+		t.Fatalf("revision = %q, want rev1", loaded.RequiredRevisionID)
+	}
+}
+
+func TestDocsWriteBatchRejectsMultiPhaseModes(t *testing.T) {
+	command := &DocsWriteCmd{}
+	err := runKong(t, command, []string{"doc1", "--text", "# title", "--markdown", "--replace", "--batch", "not-used"}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "--batch supports plain text") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func prepareDocsBatchEndTest(t *testing.T, requestCount int) (*docsBatchStore, *docsBatchState) {
+	t.Helper()
+	restoreHome, err := config.SetHomeOverride(t.TempDir())
+	if err != nil {
+		t.Fatalf("set home: %v", err)
+	}
+	t.Cleanup(restoreHome)
+
+	store, err := newDocsBatchStore()
+	if err != nil {
+		t.Fatalf("new store: %v", err)
+	}
+	state, err := store.create(docsBatchState{
+		Service:    docsBatchService,
+		DocumentID: "doc1",
+		Account:    "user@example.com",
+		Client:     "default",
+	})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	requests := make([]*docs.Request, 0, requestCount)
+	for index := range requestCount {
+		requests = append(requests, &docs.Request{InsertText: &docs.InsertTextRequest{
+			Location: &docs.Location{Index: int64(index + 1)},
+			Text:     fmt.Sprintf("request-%d", index),
+		}})
+	}
+	if _, err := store.appendRequests(state.BatchID, "docs.insert", "doc1", "user@example.com", "default", "rev1", requests, false); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	return store, state
+}
+
+func restoreDocsBatchHTTPTest(t *testing.T, server *httptest.Server) {
+	t.Helper()
+	oldBaseURL := docsBatchBaseURL
+	oldClient := newDocsBatchHTTPClient
+	docsBatchBaseURL = server.URL
+	newDocsBatchHTTPClient = func(context.Context, string) (*http.Client, error) {
+		return server.Client(), nil
+	}
+	t.Cleanup(func() {
+		docsBatchBaseURL = oldBaseURL
+		newDocsBatchHTTPClient = oldClient
+	})
+}
+
+func batchTestContext(t *testing.T) context.Context {
+	t.Helper()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	testUI, err := ui.New(ui.Options{Stdout: &stdout, Stderr: &stderr, Color: "never"})
+	if err != nil {
+		t.Fatalf("new UI: %v", err)
+	}
+
+	return outfmt.WithMode(ui.WithUI(context.Background(), testUI), outfmt.Mode{})
+}
+
+func TestDocsBatchPruneRemovesOnlyStaleState(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	store := newDocsBatchStoreAt(dir)
+	oldNow := docsBatchNow
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	docsBatchNow = func() time.Time { return now.Add(-4 * time.Hour) }
+	stale, err := store.create(docsBatchState{Service: docsBatchService, DocumentID: "old", Account: "a", Client: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	docsBatchNow = func() time.Time { return now }
+	current, err := store.create(docsBatchState{Service: docsBatchService, DocumentID: "new", Account: "a", Client: "default"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { docsBatchNow = oldNow })
+
+	removed, err := store.prune(3 * time.Hour)
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if len(removed) != 1 || removed[0].BatchID != stale.BatchID {
+		t.Fatalf("removed = %#v", removed)
+	}
+	if _, err := os.Stat(filepath.Join(dir, current.BatchID+".json")); err != nil {
+		t.Fatalf("current batch missing: %v", err)
+	}
+}
+
+func TestValidateDocsBatchIDRejectsTraversal(t *testing.T) {
+	for _, value := range []string{"../batch", "not-a-uuid", strings.ToUpper("018f47b5-7b5e-7cc0-9a78-4a5bb1886251")} {
+		if err := validateDocsBatchID(value); err == nil {
+			t.Fatalf("validateDocsBatchID(%q) succeeded", value)
+		}
+	}
+}
+
+func compactJSONContains(t *testing.T, data []byte, value string) bool {
+	t.Helper()
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, data); err != nil {
+		t.Fatalf("compact JSON: %v", err)
+	}
+
+	return strings.Contains(compact.String(), value)
+}
+
+func isSuccessfulDryRunExit(err error) bool {
+	var exitErr *ExitError
+	return errors.As(err, &exitErr) && exitErr.Code == 0
+}

--- a/internal/cmd/docs_cell_style.go
+++ b/internal/cmd/docs_cell_style.go
@@ -25,6 +25,7 @@ type DocsCellStyleCmd struct {
 	Italic          bool   `name:"italic" help:"Set cell text italic"`
 	Underline       bool   `name:"underline" help:"Set cell text underline"`
 	Tab             string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Batch           string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -64,7 +65,11 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"italic":          c.Italic,
 		"underline":       c.Underline,
 		"tab":             c.Tab,
+		"batch":           c.Batch,
 	}); err != nil {
+		return err
+	}
+	if err := validateDocsBatchTarget(flags, c.Batch, docID); err != nil {
 		return err
 	}
 
@@ -97,6 +102,9 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 	reqs, err := c.buildRequests(table.startIdx, cell, c.Tab)
 	if err != nil {
 		return err
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.cell-style", loaded.full.RevisionId, reqs, false); queued || queueErr != nil {
+		return queueErr
 	}
 	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 		WriteControl: &docs.WriteControl{RequiredRevisionId: loaded.full.RevisionId},

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -45,6 +45,7 @@ type DocsWriteCmd struct {
 	Layout       DocsLayoutFlags `embed:""`
 	Tab          string          `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 	TabID        string          `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+	Batch        string          `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 	Format       DocsFormatFlags `embed:""`
 }
 
@@ -73,6 +74,9 @@ func (c *DocsWriteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootF
 
 	if err := c.validateDocumentStyle(); err != nil {
 		return err
+	}
+	if c.Batch != "" && (c.Markdown || c.Pageless || c.Layout.any()) {
+		return usage("--batch supports plain text writes without --pageless or layout flags")
 	}
 
 	if c.Markdown {
@@ -129,6 +133,7 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, flags *RootFlags, doc
 		"markdown":    false,
 		"pageless":    c.Pageless,
 		"tab":         c.Tab,
+		"batch":       c.Batch,
 	}
 	for k, v := range c.Layout.dryRunPayload() {
 		dryRunPayload[k] = v
@@ -136,8 +141,15 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, flags *RootFlags, doc
 	if err := dryRunExit(ctx, flags, "docs.write", dryRunPayload); err != nil {
 		return err
 	}
+	if err := validateDocsBatchTarget(flags, c.Batch, docID); err != nil {
+		return err
+	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, c.Batch, docID)
 	if err != nil {
 		return err
 	}
@@ -155,6 +167,9 @@ func (c *DocsWriteCmd) writePlainText(ctx context.Context, flags *RootFlags, doc
 	reqs, err := c.buildPlainWriteRequests(endIndex, insertIndex, text)
 	if err != nil {
 		return err
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.write", batchRevision, reqs, !c.Append); queued || queueErr != nil {
+		return queueErr
 	}
 	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: reqs}).Context(ctx).Do()
 	if err != nil {
@@ -617,9 +632,10 @@ type DocsUpdateCmd struct {
 	Pageless     bool   `name:"pageless" help:"Set document to pageless mode"`
 	Tab          string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 	TabID        string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+	Batch        string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
-func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error { //nolint:gocyclo,cyclop // Existing command supports several placement and content modes.
 	u := ui.FromContext(ctx)
 	id := strings.TrimSpace(c.DocID)
 	if id == "" {
@@ -651,12 +667,21 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return tabErr
 	}
 	c.Tab = tab
-
+	if c.Batch != "" && (c.Markdown || c.Pageless) {
+		return usage("--batch supports plain text updates without --pageless")
+	}
 	if dryRunErr := dryRunExit(ctx, flags, "docs.update", c.dryRunPayload(id, len(text), replacing, replaceStart, replaceEnd, at)); dryRunErr != nil {
 		return dryRunErr
 	}
+	if batchErr := validateDocsBatchTarget(flags, c.Batch, id); batchErr != nil {
+		return batchErr
+	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, c.Batch, id)
 	if err != nil {
 		return err
 	}
@@ -766,6 +791,9 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		if anchor != nil {
 			batchReq.WriteControl = docsRequiredRevisionWriteControl(anchor.RevisionID)
 		}
+		if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, id, "docs.update", batchRevision, reqs, false); queued || queueErr != nil {
+			return queueErr
+		}
 		resp, err = svc.Documents.BatchUpdate(id, batchReq).Context(ctx).Do()
 		if err != nil {
 			if isDocsNotFound(err) {
@@ -857,6 +885,7 @@ func (c *DocsUpdateCmd) dryRunPayload(docID string, written int, replacing bool,
 		"markdown":    c.Markdown,
 		"pageless":    c.Pageless,
 		"tab":         c.Tab,
+		"batch":       c.Batch,
 	}
 	if replacing {
 		payload["replaceRange"] = map[string]int64{"start": replaceStart, "end": replaceEnd}
@@ -918,6 +947,7 @@ type DocsInsertCmd struct {
 	File       string `name:"file" short:"f" help:"Read content from file (use - for stdin)"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -949,11 +979,11 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return tabErr
 	}
 	c.Tab = tab
-
 	dryRunPayload := map[string]any{
 		"documentId": docID,
 		"inserted":   len(content),
 		"tab":        c.Tab,
+		"batch":      c.Batch,
 	}
 	switch {
 	case c.Index != nil:
@@ -967,8 +997,15 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	if dryRunErr := dryRunExit(ctx, flags, "docs.insert", dryRunPayload); dryRunErr != nil {
 		return dryRunErr
 	}
+	if batchErr := validateDocsBatchTarget(flags, c.Batch, docID); batchErr != nil {
+		return batchErr
+	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, c.Batch, docID)
 	if err != nil {
 		return err
 	}
@@ -1021,6 +1058,9 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	if anchor != nil {
 		batchReq.WriteControl = docsRequiredRevisionWriteControl(anchor.RevisionID)
 	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.insert", batchRevision, batchReq.Requests, false); queued || queueErr != nil {
+		return queueErr
+	}
 	result, err := svc.Documents.BatchUpdate(docID, batchReq).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("inserting text: %w", err)
@@ -1052,6 +1092,7 @@ type DocsDeleteCmd struct {
 	MatchCase  bool   `name:"match-case" help:"Use case-sensitive --at matching"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -1083,20 +1124,27 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return tabErr
 	}
 	c.Tab = tab
-
 	dryRunPayload := map[string]any{
 		"document_id": docID,
 		"start_index": docsDeleteDryRunStart(c.Start),
 		"end_index":   docsDeleteDryRunEnd(c.End),
 		"deleted":     docsDeleteDryRunDeleted(c.Start, c.End, at),
 		"tab":         c.Tab,
+		"batch":       c.Batch,
 	}
 	addDocsAtAnchorDryRunPayload(dryRunPayload, docsAtAnchorFlags{At: at, Occurrence: c.Occurrence, MatchCase: c.MatchCase})
 	if err := dryRunExit(ctx, flags, "docs.delete", dryRunPayload); err != nil {
 		return err
 	}
+	if err := validateDocsBatchTarget(flags, c.Batch, docID); err != nil {
+		return err
+	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, c.Batch, docID)
 	if err != nil {
 		return err
 	}
@@ -1137,6 +1185,9 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	}
 	if anchor != nil {
 		batchReq.WriteControl = docsRequiredRevisionWriteControl(anchor.RevisionID)
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.delete", batchRevision, batchReq.Requests, false); queued || queueErr != nil {
+		return queueErr
 	}
 	result, err := svc.Documents.BatchUpdate(docID, batchReq).Context(ctx).Do()
 	if err != nil {

--- a/internal/cmd/docs_format.go
+++ b/internal/cmd/docs_format.go
@@ -21,6 +21,7 @@ type DocsFormatCmd struct {
 	TabID     string          `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 	Link      string          `name:"link" help:"Set hyperlink target (http://, https://, mailto:, #bookmarkId, or #heading-slug)"`
 	NoLink    bool            `name:"no-link" help:"Clear hyperlink"`
+	Batch     string          `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 	Format    DocsFormatFlags `embed:""`
 }
 
@@ -78,7 +79,6 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return tabErr
 	}
 	c.Tab = tab
-
 	if _, err := format.buildRequests(1, 2, c.Tab); err != nil {
 		return err
 	}
@@ -89,6 +89,7 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"match_all":   c.MatchAll,
 		"match_case":  c.MatchCase,
 		"tab":         c.Tab,
+		"batch":       c.Batch,
 		"format": map[string]any{
 			"font_family":   c.Format.FontFamily,
 			"font_size":     c.Format.FontSize,
@@ -113,8 +114,15 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}); err != nil {
 		return err
 	}
+	if err := validateDocsBatchTarget(flags, c.Batch, id); err != nil {
+		return err
+	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, c.Batch, id)
 	if err != nil {
 		return err
 	}
@@ -139,6 +147,9 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 			return buildErr
 		}
 		reqs = append(reqs, formatReqs...)
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, id, "docs.format", batchRevision, reqs, false); queued || queueErr != nil {
+		return queueErr
 	}
 
 	resp, err := svc.Documents.BatchUpdate(id, &docs.BatchUpdateDocumentRequest{Requests: reqs}).Context(ctx).Do()

--- a/internal/cmd/docs_insert_page_break.go
+++ b/internal/cmd/docs_insert_page_break.go
@@ -27,6 +27,7 @@ type DocsInsertPageBreakCmd struct {
 	AtEnd      bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
+	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 func (c *DocsInsertPageBreakCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -54,12 +55,12 @@ func (c *DocsInsertPageBreakCmd) Run(ctx context.Context, kctx *kong.Context, fl
 		return tabErr
 	}
 	c.Tab = tab
-
 	resolveEnd := at == "" && (c.AtEnd || c.Index == nil)
 
 	dryRunPayload := map[string]any{
 		"documentId": docID,
 		"tab":        c.Tab,
+		"batch":      c.Batch,
 	}
 	switch {
 	case at != "":
@@ -73,8 +74,15 @@ func (c *DocsInsertPageBreakCmd) Run(ctx context.Context, kctx *kong.Context, fl
 	if dryRunErr := dryRunExit(ctx, flags, "docs.insert-page-break", dryRunPayload); dryRunErr != nil {
 		return dryRunErr
 	}
+	if err := validateDocsBatchTarget(flags, c.Batch, docID); err != nil {
+		return err
+	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, c.Batch, docID)
 	if err != nil {
 		return err
 	}
@@ -128,6 +136,9 @@ func (c *DocsInsertPageBreakCmd) Run(ctx context.Context, kctx *kong.Context, fl
 	}
 	if anchor != nil {
 		batchReq.WriteControl = docsRequiredRevisionWriteControl(anchor.RevisionID)
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.insert-page-break", batchRevision, batchReq.Requests, false); queued || queueErr != nil {
+		return queueErr
 	}
 	result, err := svc.Documents.BatchUpdate(docID, batchReq).Context(ctx).Do()
 	if err != nil {

--- a/internal/cmd/docs_smart_chips.go
+++ b/internal/cmd/docs_smart_chips.go
@@ -23,6 +23,7 @@ type DocsInsertPersonCmd struct {
 	MatchCase  bool   `name:"match-case" help:"Use case-sensitive --at matching"`
 	AtEnd      bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 type DocsInsertFileChipCmd struct {
@@ -31,6 +32,7 @@ type DocsInsertFileChipCmd struct {
 	Index  *int64 `name:"index" help:"Character index to insert at. Omit or use --at-end for end-of-doc."`
 	AtEnd  bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
 	Tab    string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Batch  string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 type DocsInsertDateChipCmd struct {
@@ -40,6 +42,7 @@ type DocsInsertDateChipCmd struct {
 	Index  *int64 `name:"index" help:"Character index to insert at. Omit or use --at-end for end-of-doc."`
 	AtEnd  bool   `name:"at-end" help:"Insert at end-of-doc/tab (mutually exclusive with --index)"`
 	Tab    string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Batch  string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 const docsDateChipFormatFull = "full"
@@ -54,6 +57,7 @@ type docsInsertLocationFlags struct {
 	replaceAt  bool
 	atEnd      bool
 	tab        string
+	batch      string
 }
 
 func (c *DocsInsertPersonCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -74,6 +78,7 @@ func (c *DocsInsertPersonCmd) Run(ctx context.Context, kctx *kong.Context, flags
 		replaceAt:  true,
 		atEnd:      c.AtEnd,
 		tab:        c.Tab,
+		batch:      c.Batch,
 	}, req, map[string]any{"email": email})
 }
 
@@ -87,9 +92,13 @@ func (c *DocsInsertFileChipCmd) Run(ctx context.Context, flags *RootFlags) error
 		index: c.Index,
 		atEnd: c.AtEnd,
 		tab:   c.Tab,
+		batch: c.Batch,
 	}
 	if dryRunErr := dryRunDocsSingleInsert(ctx, flags, "docs.insert-file-chip", loc, map[string]any{"fileId": fileID}); dryRunErr != nil {
 		return dryRunErr
+	}
+	if err := validateDocsBatchTarget(flags, c.Batch, c.DocID); err != nil {
+		return err
 	}
 
 	account, err := requireAccount(flags)
@@ -122,6 +131,7 @@ func (c *DocsInsertFileChipCmd) Run(ctx context.Context, flags *RootFlags) error
 		index: c.Index,
 		atEnd: c.AtEnd,
 		tab:   c.Tab,
+		batch: c.Batch,
 	}, req, map[string]any{"fileId": fileID, "title": file.Name})
 }
 
@@ -150,6 +160,7 @@ func (c *DocsInsertDateChipCmd) Run(ctx context.Context, flags *RootFlags) error
 		index: c.Index,
 		atEnd: c.AtEnd,
 		tab:   c.Tab,
+		batch: c.Batch,
 	}, req, map[string]any{"date": date, "format": c.Format})
 }
 
@@ -184,12 +195,18 @@ func runDocsSingleInsert(ctx context.Context, flags *RootFlags, action string, l
 	if loc.at != "" && (loc.atEnd || loc.index != nil) {
 		return usage("--at cannot be combined with --at-end or --index")
 	}
-
 	if err := dryRunDocsSingleInsert(ctx, flags, action, loc, payload); err != nil {
+		return err
+	}
+	if err := validateDocsBatchTarget(flags, loc.batch, docID); err != nil {
 		return err
 	}
 
 	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, loc.batch, docID)
 	if err != nil {
 		return err
 	}
@@ -208,6 +225,9 @@ func runDocsSingleInsert(ctx context.Context, flags *RootFlags, action string, l
 	batchReq := &docs.BatchUpdateDocumentRequest{Requests: reqs}
 	if matched != nil {
 		batchReq.WriteControl = docsRequiredRevisionWriteControl(matched.RevisionID)
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, loc.batch, docID, action, batchRevision, reqs, false); queued || queueErr != nil {
+		return queueErr
 	}
 	resp, err := svc.Documents.BatchUpdate(docID, batchReq).Context(ctx).Do()
 	if err != nil {
@@ -261,7 +281,7 @@ func dryRunDocsSingleInsert(ctx context.Context, flags *RootFlags, action string
 	if at != "" && (loc.atEnd || loc.index != nil) {
 		return usage("--at cannot be combined with --at-end or --index")
 	}
-	dryRunPayload := map[string]any{"documentId": docID, "tab": loc.tab}
+	dryRunPayload := map[string]any{"documentId": docID, "tab": loc.tab, "batch": loc.batch}
 	for k, v := range payload {
 		dryRunPayload[k] = v
 	}

--- a/internal/cmd/docs_table_column_width.go
+++ b/internal/cmd/docs_table_column_width.go
@@ -19,6 +19,7 @@ type DocsTableColumnWidthCmd struct {
 	Width             float64 `name:"width" help:"Fixed column width in points (minimum 5pt)"`
 	EvenlyDistributed bool    `name:"evenly-distributed" aliases:"even" help:"Reset selected column, or all columns when --col is omitted, to Docs-managed equal width"`
 	Tab               string  `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Batch             string  `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
 
 func (c *DocsTableColumnWidthCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -35,6 +36,7 @@ func (c *DocsTableColumnWidthCmd) Run(ctx context.Context, flags *RootFlags) err
 		"tableIndex":        c.TableIndex,
 		"evenlyDistributed": c.EvenlyDistributed,
 		"tab":               c.Tab,
+		"batch":             c.Batch,
 	}
 	if c.Col > 0 {
 		dryRunPayload["col"] = c.Col
@@ -46,6 +48,9 @@ func (c *DocsTableColumnWidthCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 	if dryRunErr := dryRunExit(ctx, flags, "docs.table-column-width", dryRunPayload); dryRunErr != nil {
 		return dryRunErr
+	}
+	if err := validateDocsBatchTarget(flags, c.Batch, docID); err != nil {
+		return err
 	}
 
 	svc, err := requireDocsService(ctx, flags)
@@ -65,6 +70,9 @@ func (c *DocsTableColumnWidthCmd) Run(ctx context.Context, flags *RootFlags) err
 	req, err := c.buildRequest(table.startIdx, docsTableColumnCount(table.table), c.Tab)
 	if err != nil {
 		return err
+	}
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.table-column-width", loaded.full.RevisionId, []*docs.Request{req}, false); queued || queueErr != nil {
+		return queueErr
 	}
 	resp, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
 		WriteControl: &docs.WriteControl{RequiredRevisionId: loaded.full.RevisionId},

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -68,6 +68,7 @@ type CLI struct {
 
 	Auth          AuthCmd               `cmd:"" help:"Auth and credentials"`
 	Backup        BackupCmd             `cmd:"" help:"Encrypted Google account backups"`
+	Batch         BatchCmd              `cmd:"" help:"Build and submit persisted Google Docs request batches"`
 	Groups        GroupsCmd             `cmd:"" aliases:"group" help:"Google Groups"`
 	Admin         AdminCmd              `cmd:"" help:"Google Workspace Admin (Directory API) - requires domain-wide delegation"`
 	Drive         DriveCmd              `cmd:"" aliases:"drv" help:"Google Drive"`

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -296,6 +296,28 @@ func EnsureStateDir() (string, error) {
 	return dir, nil
 }
 
+func BatchDir() (string, error) {
+	dir, err := StateDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, "batches"), nil
+}
+
+func EnsureBatchDir() (string, error) {
+	dir, err := BatchDir()
+	if err != nil {
+		return "", err
+	}
+
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("ensure batch dir: %w", err)
+	}
+
+	return dir, nil
+}
+
 // KeyringDir is where the keyring "file" backend stores encrypted entries.
 //
 // We keep this separate from the main config dir because the file backend creates

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,103 @@
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+var ErrTimeout = errors.New("file lock timeout")
+
+var (
+	sharedLocksMu sync.Mutex
+	sharedLocks   = make(map[string]*Lock)
+)
+
+type Lock struct {
+	path    string
+	timeout time.Duration
+	mu      sync.Mutex
+}
+
+func Shared(path string, timeout time.Duration) *Lock {
+	path = filepath.Clean(path)
+
+	sharedLocksMu.Lock()
+	defer sharedLocksMu.Unlock()
+
+	if existing := sharedLocks[path]; existing != nil {
+		return existing
+	}
+
+	lock := &Lock{path: path, timeout: timeout}
+	sharedLocks[path] = lock
+
+	return lock
+}
+
+func (l *Lock) WithExclusive(fn func() error) error {
+	if l == nil {
+		return fn()
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	file, err := os.OpenFile(l.path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return fmt.Errorf("open lock file: %w", err)
+	}
+	defer file.Close()
+
+	if err := l.acquire(file); err != nil {
+		return err
+	}
+
+	fnErr := fn()
+	unlockErr := unlockFile(file)
+
+	if fnErr != nil {
+		return fnErr
+	}
+
+	if unlockErr != nil {
+		return fmt.Errorf("unlock file: %w", unlockErr)
+	}
+
+	return nil
+}
+
+func (l *Lock) acquire(file *os.File) error {
+	timeout := l.timeout
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	deadline := time.Now().Add(timeout)
+
+	for {
+		err := lockFile(file)
+		if err == nil {
+			return nil
+		}
+
+		if !wouldBlock(err) {
+			return fmt.Errorf("lock file: %w", err)
+		}
+
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fmt.Errorf("%w after %v: %s", ErrTimeout, timeout, l.path)
+		}
+
+		sleep := 10 * time.Millisecond
+		if remaining < sleep {
+			sleep = remaining
+		}
+
+		time.Sleep(sleep)
+	}
+}

--- a/internal/filelock/filelock_test.go
+++ b/internal/filelock/filelock_test.go
@@ -1,0 +1,46 @@
+package filelock
+
+import (
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSharedExclusiveSerializesCallers(t *testing.T) {
+	lock := Shared(filepath.Join(t.TempDir(), "test.lock"), time.Second)
+	var active atomic.Int32
+	var maxActive atomic.Int32
+
+	run := func(done chan<- error) {
+		done <- lock.WithExclusive(func() error {
+			current := active.Add(1)
+			defer active.Add(-1)
+
+			for {
+				observedMax := maxActive.Load()
+				if current <= observedMax || maxActive.CompareAndSwap(observedMax, current) {
+					break
+				}
+			}
+
+			time.Sleep(20 * time.Millisecond)
+
+			return nil
+		})
+	}
+
+	done := make(chan error, 2)
+	go run(done)
+	go run(done)
+
+	for range 2 {
+		if err := <-done; err != nil {
+			t.Fatalf("lock: %v", err)
+		}
+	}
+
+	if maxActive.Load() != 1 {
+		t.Fatalf("max active = %d, want 1", maxActive.Load())
+	}
+}

--- a/internal/filelock/filelock_unix.go
+++ b/internal/filelock/filelock_unix.go
@@ -1,0 +1,35 @@
+//go:build !windows
+
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFile(file *os.File) error {
+	// File descriptors are OS-assigned small integers; unix.Flock requires int.
+	//nolint:gosec
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB); err != nil {
+		return fmt.Errorf("flock: %w", err)
+	}
+
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	// File descriptors are OS-assigned small integers; unix.Flock requires int.
+	//nolint:gosec
+	if err := unix.Flock(int(file.Fd()), unix.LOCK_UN); err != nil {
+		return fmt.Errorf("unlock flock: %w", err)
+	}
+
+	return nil
+}
+
+func wouldBlock(err error) bool {
+	return errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN)
+}

--- a/internal/filelock/filelock_windows.go
+++ b/internal/filelock/filelock_windows.go
@@ -1,0 +1,40 @@
+//go:build windows
+
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		&overlapped,
+	); err != nil {
+		return fmt.Errorf("lock file: %w", err)
+	}
+
+	return nil
+}
+
+func unlockFile(file *os.File) error {
+	var overlapped windows.Overlapped
+	if err := windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, &overlapped); err != nil {
+		return fmt.Errorf("unlock file: %w", err)
+	}
+
+	return nil
+}
+
+func wouldBlock(err error) bool {
+	return errors.Is(err, windows.ERROR_LOCK_VIOLATION)
+}

--- a/scripts/build-docs-site.mjs
+++ b/scripts/build-docs-site.mjs
@@ -23,7 +23,7 @@ const sections = [
   ["Gmail", ["gmail-workflows.md", "gmail-autoreply.md", "watch.md", "email-tracking.md", "email-tracking-worker.md"]],
   ["Drive & Files", ["drive-audits.md", "raw-api.md", "raw-audit.md"]],
   ["Photos", ["photos-picker.md"]],
-  ["Docs, Sheets, Slides", ["docs-editing.md", "sedmat.md", "sheets-batch-update.md", "sheets-tables.md", "sheets-formatting.md", "slides-markdown.md", "slides-template-replacement.md"]],
+  ["Docs, Sheets, Slides", ["docs-editing.md", "docs-batch.md", "sedmat.md", "sheets-batch-update.md", "sheets-tables.md", "sheets-formatting.md", "slides-markdown.md", "slides-template-replacement.md"]],
   ["Contacts", ["contacts-dedupe.md", "contacts-json-update.md"]],
   ["Backup", ["backup.md"]],
   ["Reference", ["dates.md", "spec.md", "RELEASING.md", "commands/README.md"]],

--- a/scripts/check-docs-coverage.mjs
+++ b/scripts/check-docs-coverage.mjs
@@ -24,6 +24,7 @@ const requiredFeatureDocs = [
   "contacts-json-update.md",
   "photos-picker.md",
   "docs-editing.md",
+  "docs-batch.md",
   "sheets-batch-update.md",
   "sheets-tables.md",
   "sheets-formatting.md",


### PR DESCRIPTION
## Summary

- add persisted UUIDv7 Google Docs request batches under the state directory, with cross-process locking and atomic file replacement
- add `batch begin/list/show/end/abort/prune`, exact wire-payload inspection, revision-locked atomic submission, `--auto-split`, and `--continue-on-error`
- add `--batch` to directly composable Docs mutations: plain write/update, insert/delete/format, cell style, table column width, smart chips, and page breaks
- document state sensitivity, append-time position resolution, request limits, and non-atomic recovery modes

Refs #698.

## Scope decisions

This PR is a Docs-only foundation. It intentionally refuses markdown/layout write modes and does not add batching to image insertion, table construction, find-replace, or other multi-phase commands whose intermediate reads or side effects cannot honestly share one atomic Docs API call.

Plain `docs write --replace` must be the first queued operation. An empty batch does not read the document or pin a revision; the first queued mutation establishes the revision boundary when its request positions are resolved. Later appends are bound to the batch's document, account, OAuth client, and that revision. Batches over 500 requests fail unless `--auto-split` is explicit.

## Verification

- `make ci`
- generated command reference and docs site coverage: 632 command pages, 23 feature pages
- focused store/submit tests: exact generated JSON preservation, identity/revision mismatch, atomic cleanup, 500-request split chaining, partial-failure retention, dry-run state preservation, prune, traversal rejection
- structured autoreview: clean after fixing local-state `--dry-run` handling and clarifying the intentional first-queued-request revision boundary
- binary state smoke: begin/list/show/dry-run abort/abort passed with an isolated `--home`
- live Google attempt with `gog+clawdbot@gmail.com`: reached auth routing and failed closed because Drive is not authorized and the file keyring password is unavailable non-interactively; no remote mutation occurred

## Risk

Medium. The default path is one revision-locked atomic Docs request. Explicit recovery modes are non-atomic and documented. Persisted request bodies may contain document content, so files and lock state use private permissions.
