### PR TITLE
fix(docs): preserve nested lists in table cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - CLI: remove the separate `gog agent` and `exit-codes` helpers; expose stable exit codes and effective automation safety state through `gog schema --json`, and summarize the contract in root help. (#677)
 - CLI: add Git-style `gog help <command>`, make explicit output flags override environment defaults, validate color and JSON-only transforms before command execution, report early usage errors on stderr, and reject contradictory schema plain output.
 - Docs: prevent multi-paragraph Markdown range replacements from inheriting the matched paragraph's heading or list style. (#756) — thanks @sebsnyk.
+- Docs: preserve nested Markdown list levels as native bullets inside imported and updated table cells. (#749) — thanks @sebsnyk.
 
 ## 0.24.0 - 2026-06-11
 

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -212,7 +212,9 @@ gog docs cell-update <docId> --table-index 1 --row 2 --col 3 \
 
 Coordinates are 1-based. `--tab` targets a specific tab, and `--append` inserts
 at the end of the cell instead of replacing its current content. Markdown list
-content creates native Google Docs bullets or numbering inside the cell.
+content creates native Google Docs bullets or numbering inside the cell,
+including nested levels. Markdown table imports preserve the same nested list
+structure inside cells.
 
 Set or reset native table column widths after inserting or importing tables:
 

--- a/internal/cmd/docs_cell_update.go
+++ b/internal/cmd/docs_cell_update.go
@@ -182,15 +182,13 @@ func updateDocsCellContent(ctx context.Context, svc *docs.Service, doc *docs.Doc
 				baseIndex++
 				prefix = "\n"
 			}
-			formatReqs, textToInsert, tables := MarkdownToDocsRequests(ParseMarkdown(content), baseIndex, tabID)
-			if len(tables) > 0 {
-				return usage("markdown tables are not supported inside table cells")
+			formatReqs, textToInsert, _, formatErr := buildMarkdownCellContent(content, baseIndex, tabID)
+			if formatErr != nil {
+				return formatErr
 			}
-			textToInsert = strings.TrimSuffix(textToInsert, "\n")
 			if textToInsert == "" {
 				return usage("markdown content produced no editable cell text")
 			}
-			formatReqs = clampDocsCellFormatRequests(formatReqs, baseIndex+utf16Len(textToInsert))
 			requests = append(requests, &docs.Request{
 				InsertText: &docs.InsertTextRequest{
 					Location: &docs.Location{Index: startIdx, TabId: tabID},
@@ -218,6 +216,29 @@ func updateDocsCellContent(ctx context.Context, svc *docs.Service, doc *docs.Doc
 		return fmt.Errorf("cell update: %w", err)
 	}
 	return nil
+}
+
+func buildMarkdownCellContent(content string, baseIndex int64, tabID string) ([]*docs.Request, string, int64, error) {
+	elements := ParseMarkdown(content)
+	formatReqs, text, tables := MarkdownToDocsRequests(elements, baseIndex, tabID)
+	if len(tables) > 0 {
+		return nil, "", 0, usage("markdown tables are not supported inside table cells")
+	}
+	text = strings.TrimSuffix(text, "\n")
+	if text == "" {
+		return nil, "", 0, nil
+	}
+	formatReqs = clampDocsCellFormatRequests(formatReqs, baseIndex+utf16Len(text))
+
+	// CreateParagraphBullets consumes one leading tab per nesting level.
+	// Report final document growth so later native-table offsets stay exact.
+	insertedLen := utf16Len(text)
+	for _, element := range elements {
+		if (element.Type == MDListItem || element.Type == MDNumberedList) && element.Level > 0 {
+			insertedLen -= int64(element.Level)
+		}
+	}
+	return formatReqs, text, insertedLen, nil
 }
 
 func markdownCellAppendNeedsBoundary(elements []MarkdownElement) bool {

--- a/internal/cmd/docs_cell_update_test.go
+++ b/internal/cmd/docs_cell_update_test.go
@@ -150,6 +150,46 @@ func TestDocsCellUpdate_ReplacesWithNativeMarkdownList(t *testing.T) {
 	}
 }
 
+func TestDocsCellUpdate_ReplacesWithNestedNativeMarkdownList(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(cellUpdateTestDoc())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+	newDocsService = func(context.Context, string) (*docs.Service, error) { return docSvc, nil }
+
+	cmd := &DocsCellUpdateCmd{}
+	content := "- a\n  - a1\n  - a2\n- b"
+	if err := runKong(t, cmd, []string{"doc1", "--row", "1", "--col", "2", "--content=" + content}, newDocsCmdContext(t), &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("docs cell-update nested list: %v", err)
+	}
+	if len(got.Requests) != 3 {
+		t.Fatalf("expected delete+insert+bullets, got %d requests", len(got.Requests))
+	}
+	ins := got.Requests[1].InsertText
+	if ins == nil || ins.Location.Index != 10 || ins.Text != "a\n\ta1\n\ta2\nb" {
+		t.Fatalf("unexpected nested-list insert: %#v", ins)
+	}
+	bullets := got.Requests[2].CreateParagraphBullets
+	if bullets == nil || bullets.Range.StartIndex != 10 || bullets.Range.EndIndex != 21 || bullets.BulletPreset != bulletPresetDisc {
+		t.Fatalf("unexpected nested bullet request: %#v", bullets)
+	}
+}
+
 func TestDocsCellUpdate_ReplacesPlainCellWithInlineCodeStyle(t *testing.T) {
 	origDocs := newDocsService
 	t.Cleanup(func() { newDocsService = origDocs })

--- a/internal/cmd/docs_table_inserter.go
+++ b/internal/cmd/docs_table_inserter.go
@@ -103,7 +103,10 @@ func (ti *TableInserter) InsertNativeTable(ctx context.Context, tableIndex int64
 			if cellIdx == 0 {
 				continue
 			}
-			requests, insertedLen := buildTableCellRequests(cellContent, cellIdx, rowIdx == 0, tabID)
+			requests, insertedLen, buildErr := buildTableCellRequests(cellContent, cellIdx, rowIdx == 0, tabID)
+			if buildErr != nil {
+				return tableEndIndex, buildErr
+			}
 			if len(requests) == 0 {
 				continue
 			}
@@ -134,25 +137,25 @@ func (ti *TableInserter) InsertNativeTable(ctx context.Context, tableIndex int64
 }
 
 // buildTableCellRequests constructs the batch requests required to populate a
-// single table cell, expanding inline markdown (**bold**, *italic*, `code`,
-// [links]) into UpdateTextStyle requests on top of the inserted text. Header
-// cells additionally receive a whole-cell bold style. Returns the requests and
-// the UTF-16 length of the text that will be inserted so callers can keep
-// running cell indices in sync. If the cell content strips to an empty string
-// (e.g. content was only markers), returns (nil, 0).
-func buildTableCellRequests(cellContent string, cellIdx int64, isHeaderRow bool, tabID string) ([]*docs.Request, int64) {
-	styles, stripped := ParseInlineFormatting(cellContent)
-	if stripped == "" {
-		return nil, 0
+// single table cell, including block Markdown such as native nested lists.
+// Header cells additionally receive a whole-cell bold style. insertedLen is
+// the final UTF-16 growth after CreateParagraphBullets consumes nesting tabs.
+func buildTableCellRequests(cellContent string, cellIdx int64, isHeaderRow bool, tabID string) ([]*docs.Request, int64, error) {
+	formatRequests, text, insertedLen, err := buildMarkdownCellContent(cellContent, cellIdx, tabID)
+	if err != nil {
+		return nil, 0, err
+	}
+	if text == "" {
+		return nil, 0, nil
 	}
 
-	insertedLen := utf16Len(stripped)
 	requests := []*docs.Request{{
 		InsertText: &docs.InsertTextRequest{
 			Location: &docs.Location{Index: cellIdx, TabId: tabID},
-			Text:     stripped,
+			Text:     text,
 		},
 	}}
+	requests = append(requests, formatRequests...)
 
 	if isHeaderRow {
 		requests = append(requests, &docs.Request{
@@ -168,13 +171,7 @@ func buildTableCellRequests(cellContent string, cellIdx int64, isHeaderRow bool,
 		})
 	}
 
-	for _, style := range styles {
-		if req := buildTextStyleRequest(style, cellIdx, tabID); req != nil {
-			requests = append(requests, req)
-		}
-	}
-
-	return requests, insertedLen
+	return requests, insertedLen, nil
 }
 
 // getTableCellIndices extracts the start index for each cell in the table that

--- a/internal/cmd/docs_table_inserter_inline_test.go
+++ b/internal/cmd/docs_table_inserter_inline_test.go
@@ -12,7 +12,10 @@ import (
 // pass used by paragraphs/headings.
 
 func TestBuildTableCellRequests_AppliesInlineBold(t *testing.T) {
-	reqs, inserted := buildTableCellRequests("**Alice**", 100, false, "")
+	reqs, inserted, err := buildTableCellRequests("**Alice**", 100, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if inserted != utf16Len("Alice") {
 		t.Fatalf("expected inserted len = utf16Len(\"Alice\") = %d, got %d", utf16Len("Alice"), inserted)
@@ -53,7 +56,10 @@ func TestBuildTableCellRequests_AppliesInlineItalicAndCode(t *testing.T) {
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			reqs, inserted := buildTableCellRequests(tt.cell, 50, false, "")
+			reqs, inserted, err := buildTableCellRequests(tt.cell, 50, false, "")
+			if err != nil {
+				t.Fatal(err)
+			}
 			if inserted != utf16Len(tt.wantText) {
 				t.Fatalf("inserted = %d, want %d", inserted, utf16Len(tt.wantText))
 			}
@@ -86,7 +92,10 @@ func TestBuildTableCellRequests_TableBreaksPreserveInlineStyleRanges(t *testing.
 		t.Fatalf("parseTableRow() = %#v, want one cell", rows)
 	}
 
-	reqs, inserted := buildTableCellRequests(rows[0], 100, false, "")
+	reqs, inserted, err := buildTableCellRequests(rows[0], 100, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if inserted != utf16Len("Alice\nBob and <br>") {
 		t.Fatalf("inserted = %d, want %d", inserted, utf16Len("Alice\nBob and <br>"))
 	}
@@ -113,7 +122,10 @@ func TestBuildTableCellRequests_TableBreaksPreserveInlineStyleRanges(t *testing.
 }
 
 func TestBuildTableCellRequests_HeaderRowAppliesBoldOverWholeCell(t *testing.T) {
-	reqs, inserted := buildTableCellRequests("Field", 10, true, "")
+	reqs, inserted, err := buildTableCellRequests("Field", 10, true, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if inserted != utf16Len("Field") {
 		t.Fatalf("inserted = %d, want %d", inserted, utf16Len("Field"))
@@ -131,7 +143,10 @@ func TestBuildTableCellRequests_HeaderRowAppliesBoldOverWholeCell(t *testing.T) 
 }
 
 func TestBuildTableCellRequests_IncludesTabID(t *testing.T) {
-	reqs, inserted := buildTableCellRequests("**Field**", 10, true, "t.second")
+	reqs, inserted, err := buildTableCellRequests("**Field**", 10, true, "t.second")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if inserted != utf16Len("Field") {
 		t.Fatalf("inserted = %d, want %d", inserted, utf16Len("Field"))
 	}
@@ -152,7 +167,10 @@ func TestBuildTableCellRequests_IncludesTabID(t *testing.T) {
 }
 
 func TestBuildTableCellRequests_PlainTextNoStyleRequest(t *testing.T) {
-	reqs, inserted := buildTableCellRequests("plain text", 1, false, "")
+	reqs, inserted, err := buildTableCellRequests("plain text", 1, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if inserted != utf16Len("plain text") {
 		t.Fatalf("inserted = %d, want %d", inserted, utf16Len("plain text"))
 	}
@@ -166,9 +184,40 @@ func TestBuildTableCellRequests_PlainTextNoStyleRequest(t *testing.T) {
 
 func TestBuildTableCellRequests_EmptyAfterStrippingReturnsNothing(t *testing.T) {
 	// A cell whose entire content is markers (e.g. "**") would strip to "".
-	reqs, inserted := buildTableCellRequests("", 1, false, "")
+	reqs, inserted, err := buildTableCellRequests("", 1, false, "")
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(reqs) != 0 || inserted != 0 {
 		t.Fatalf("expected (nil, 0) for empty cell, got reqs=%#v inserted=%d", reqs, inserted)
+	}
+}
+
+func TestBuildTableCellRequests_PreservesNestedMarkdownLists(t *testing.T) {
+	rows := parseTableRow("| nested | - a<br>  - a1<br>  - a2<br>- b |")
+	if len(rows) != 2 {
+		t.Fatalf("parseTableRow() = %#v, want two cells", rows)
+	}
+
+	reqs, inserted, err := buildTableCellRequests(rows[1], 100, false, "t.second")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inserted != utf16Len("a\na1\na2\nb") {
+		t.Fatalf("inserted = %d, want final nested-list length %d", inserted, utf16Len("a\na1\na2\nb"))
+	}
+	if got := reqs[0].InsertText; got == nil || got.Text != "a\n\ta1\n\ta2\nb" {
+		t.Fatalf("InsertText = %#v, want nested list text", got)
+	}
+	if len(reqs) != 2 {
+		t.Fatalf("requests = %d, want insert+bullets: %#v", len(reqs), reqs)
+	}
+	bullets := reqs[1].CreateParagraphBullets
+	if bullets == nil || bullets.BulletPreset != bulletPresetDisc {
+		t.Fatalf("missing native bullets: %#v", reqs[1])
+	}
+	if bullets.Range == nil || bullets.Range.StartIndex != 100 || bullets.Range.EndIndex != 111 || bullets.Range.TabId != "t.second" {
+		t.Fatalf("bullet range = %#v, want [100,111] in t.second", bullets.Range)
 	}
 }
 


### PR DESCRIPTION
## Summary

- route imported native-table cells through the block Markdown formatter instead of the inline-only parser
- preserve nested unordered/ordered list levels with native `CreateParagraphBullets` requests
- account for nesting tabs consumed by Docs so subsequent native-table offsets remain exact
- share the same conversion path with `docs cell-update` and document nested-list behavior

Closes #749.

## Verification

- focused table-cell, cell-update, and Markdown formatter tests
- `make ci` (629 generated command pages, 23 feature pages)
- structured autoreview: clean, no accepted/actionable findings
- live Google Docs E2E with `clawdbot@gmail.com`:
  - imported a Markdown table containing `a / a1 / a2 / b`; HTML readback showed `a1` and `a2` as native level-1 list items
  - updated a plain cell with `x / x1 / x2 / y`; HTML readback showed `x1` and `x2` as native level-1 list items
  - verified all eight labels and trashed the disposable document

## Risk

Low/medium. The table importer now supports block Markdown inside cells. Existing inline/header regressions remain covered; final table growth uses post-bullet UTF-16 length.
