### PR TITLE
feat(drive): add shortcut support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Docs: preserve nested Markdown list levels as native bullets inside imported and updated table cells. (#749) — thanks @sebsnyk.
 - Gmail: add explicit `gmail archive --thread` semantics so IDs from thread search can archive every message in each thread. (#752) — thanks @sebsnyk.
 - Drive/Docs: add persisted polling for Drive changes and Docs comments, with bounded runs, filters, retry-safe cursors, and sequential JSON hooks. (#690, #751)
+- Drive: expose shortcut targets in metadata and folder reports, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`.
 
 ## 0.24.0 - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Docs: preserve nested Markdown list levels as native bullets inside imported and updated table cells. (#749) — thanks @sebsnyk.
 - Gmail: add explicit `gmail archive --thread` semantics so IDs from thread search can archive every message in each thread. (#752) — thanks @sebsnyk.
 - Drive/Docs: add persisted polling for Drive changes and Docs comments, with bounded runs, filters, retry-safe cursors, and sequential JSON hooks. (#690, #751)
-- Drive: expose shortcut targets in metadata and folder reports, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`.
+- Drive: expose shortcut targets in metadata and folder reports, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`. (#763)
 
 ## 0.24.0 - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Docs: preserve nested Markdown list levels as native bullets inside imported and updated table cells. (#749) — thanks @sebsnyk.
 - Gmail: add explicit `gmail archive --thread` semantics so IDs from thread search can archive every message in each thread. (#752) — thanks @sebsnyk.
 - Drive/Docs: add persisted polling for Drive changes and Docs comments, with bounded runs, filters, retry-safe cursors, and sequential JSON hooks. (#690, #751)
-- Drive: expose shortcut targets in metadata and folder reports, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`. (#763)
+- Drive: expose shortcut targets in JSON and human-readable folder reports without changing stable `--plain` columns, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`. (#763)
 
 ## 0.24.0 - 2026-06-11
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -340,6 +340,8 @@ Generated from `gog schema --json`.
       - [`gog drive (drv) revisions (revision) list (ls) <fileId> [flags]`](commands/gog-drive-revisions-list.md) - List revisions for a file
     - [`gog drive (drv) search <query> ... [flags]`](commands/gog-drive-search.md) - Full-text search across Drive
     - [`gog drive (drv) share <fileId> [flags]`](commands/gog-drive-share.md) - Share a file or folder
+    - [`gog drive (drv) shortcut (shortcuts) <command>`](commands/gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
+      - [`gog drive (drv) shortcut (shortcuts) create (add,new) <targetId> [flags]`](commands/gog-drive-shortcut-create.md) - Create a shortcut to a Drive file or folder
     - [`gog drive (drv) tree [flags]`](commands/gog-drive-tree.md) - Print a read-only folder tree
     - [`gog drive (drv) unshare <fileId> <permissionId>`](commands/gog-drive-unshare.md) - Remove a permission from a file
     - [`gog drive (drv) upload <localPath> [flags]`](commands/gog-drive-upload.md) - Upload a file

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 631.
+Generated pages: 633.
 
 ## Top-level Commands
 
@@ -391,6 +391,8 @@ Generated pages: 631.
       - [gog drive revisions list](gog-drive-revisions-list.md) - List revisions for a file
     - [gog drive search](gog-drive-search.md) - Full-text search across Drive
     - [gog drive share](gog-drive-share.md) - Share a file or folder
+    - [gog drive shortcut](gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
+      - [gog drive shortcut create](gog-drive-shortcut-create.md) - Create a shortcut to a Drive file or folder
     - [gog drive tree](gog-drive-tree.md) - Print a read-only folder tree
     - [gog drive unshare](gog-drive-unshare.md) - Remove a permission from a file
     - [gog drive upload](gog-drive-upload.md) - Upload a file

--- a/docs/commands/gog-drive-shortcut-create.md
+++ b/docs/commands/gog-drive-shortcut-create.md
@@ -1,48 +1,18 @@
-# `gog drive`
+# `gog drive shortcut create`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Drive
+Create a shortcut to a Drive file or folder
 
 ## Usage
 
 ```bash
-gog drive (drv) <command> [flags]
+gog drive (drv) shortcut (shortcuts) create (add,new) <targetId> [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog drive activity](gog-drive-activity.md) - Query Drive Activity audit events
-- [gog drive audit](gog-drive-audit.md) - Audit Drive sharing without mutation
-- [gog drive bulk](gog-drive-bulk.md) - Bulk Drive permission operations
-- [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
-- [gog drive comments](gog-drive-comments.md) - Manage comments on files
-- [gog drive copy](gog-drive-copy.md) - Copy a file
-- [gog drive delete](gog-drive-delete.md) - Move a file to trash (use --permanent to delete forever)
-- [gog drive download](gog-drive-download.md) - Download a file (exports Google Docs formats)
-- [gog drive drives](gog-drive-drives.md) - List shared drives (Team Drives)
-- [gog drive du](gog-drive-du.md) - Summarize Drive folder sizes
-- [gog drive get](gog-drive-get.md) - Get file metadata
-- [gog drive inventory](gog-drive-inventory.md) - Export a read-only Drive inventory
-- [gog drive labels](gog-drive-labels.md) - Read and modify Drive labels
-- [gog drive ls](gog-drive-ls.md) - List files in a folder (default: root)
-- [gog drive mkdir](gog-drive-mkdir.md) - Create a folder
-- [gog drive move](gog-drive-move.md) - Move a file to a different folder
-- [gog drive permissions](gog-drive-permissions.md) - List permissions on a file
-- [gog drive raw](gog-drive-raw.md) - Dump raw Google Drive API response as JSON (Files.Get; lossless; for scripting and LLM consumption)
-- [gog drive rename](gog-drive-rename.md) - Rename a file or folder
-- [gog drive revisions](gog-drive-revisions.md) - List and inspect file revisions
-- [gog drive search](gog-drive-search.md) - Full-text search across Drive
-- [gog drive share](gog-drive-share.md) - Share a file or folder
-- [gog drive shortcut](gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
-- [gog drive tree](gog-drive-tree.md) - Print a read-only folder tree
-- [gog drive unshare](gog-drive-unshare.md) - Remove a permission from a file
-- [gog drive upload](gog-drive-upload.md) - Upload a file
-- [gog drive url](gog-drive-url.md) - Print web URLs for files
+- [gog drive shortcut](gog-drive-shortcut.md)
 
 ## Flags
 
@@ -61,7 +31,9 @@ gog drive (drv) <command> [flags]
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--name` | `string` |  | Shortcut name (default: target name) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--parent` | `string` |  | Destination folder ID (required) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
@@ -71,5 +43,5 @@ gog drive (drv) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog drive shortcut](gog-drive-shortcut.md)
 - [Command index](README.md)

--- a/docs/commands/gog-drive-shortcut.md
+++ b/docs/commands/gog-drive-shortcut.md
@@ -1,48 +1,22 @@
-# `gog drive`
+# `gog drive shortcut`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Drive
+Manage shortcuts to Drive files and folders
 
 ## Usage
 
 ```bash
-gog drive (drv) <command> [flags]
+gog drive (drv) shortcut (shortcuts) <command>
 ```
 
 ## Parent
 
-- [gog](gog.md)
+- [gog drive](gog-drive.md)
 
 ## Subcommands
 
-- [gog drive activity](gog-drive-activity.md) - Query Drive Activity audit events
-- [gog drive audit](gog-drive-audit.md) - Audit Drive sharing without mutation
-- [gog drive bulk](gog-drive-bulk.md) - Bulk Drive permission operations
-- [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
-- [gog drive comments](gog-drive-comments.md) - Manage comments on files
-- [gog drive copy](gog-drive-copy.md) - Copy a file
-- [gog drive delete](gog-drive-delete.md) - Move a file to trash (use --permanent to delete forever)
-- [gog drive download](gog-drive-download.md) - Download a file (exports Google Docs formats)
-- [gog drive drives](gog-drive-drives.md) - List shared drives (Team Drives)
-- [gog drive du](gog-drive-du.md) - Summarize Drive folder sizes
-- [gog drive get](gog-drive-get.md) - Get file metadata
-- [gog drive inventory](gog-drive-inventory.md) - Export a read-only Drive inventory
-- [gog drive labels](gog-drive-labels.md) - Read and modify Drive labels
-- [gog drive ls](gog-drive-ls.md) - List files in a folder (default: root)
-- [gog drive mkdir](gog-drive-mkdir.md) - Create a folder
-- [gog drive move](gog-drive-move.md) - Move a file to a different folder
-- [gog drive permissions](gog-drive-permissions.md) - List permissions on a file
-- [gog drive raw](gog-drive-raw.md) - Dump raw Google Drive API response as JSON (Files.Get; lossless; for scripting and LLM consumption)
-- [gog drive rename](gog-drive-rename.md) - Rename a file or folder
-- [gog drive revisions](gog-drive-revisions.md) - List and inspect file revisions
-- [gog drive search](gog-drive-search.md) - Full-text search across Drive
-- [gog drive share](gog-drive-share.md) - Share a file or folder
-- [gog drive shortcut](gog-drive-shortcut.md) - Manage shortcuts to Drive files and folders
-- [gog drive tree](gog-drive-tree.md) - Print a read-only folder tree
-- [gog drive unshare](gog-drive-unshare.md) - Remove a permission from a file
-- [gog drive upload](gog-drive-upload.md) - Upload a file
-- [gog drive url](gog-drive-url.md) - Print web URLs for files
+- [gog drive shortcut create](gog-drive-shortcut-create.md) - Create a shortcut to a Drive file or folder
 
 ## Flags
 
@@ -71,5 +45,5 @@ gog drive (drv) <command> [flags]
 
 ## See Also
 
-- [gog](gog.md)
+- [gog drive](gog-drive.md)
 - [Command index](README.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -102,6 +102,7 @@ gog calendar create --summary "Review" \
 gog drive ls --max 20
 gog drive tree --parent <folderId> --depth 2
 gog drive du   --parent <folderId> --max 20 --json
+gog drive shortcut create <fileId> --parent <folderId>
 
 # Docs / Sheets / Slides
 gog docs cat <docId> --tab "Notes"

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -223,6 +223,7 @@ Flag aliases:
 - `gog drive delete <fileId> [--permanent]`
 - `gog drive move <fileId> --parent ID`
 - `gog drive rename <fileId> <newName>`
+- `gog drive shortcut create <targetId> --parent ID [--name N]`
 - `gog drive share <fileId> --to anyone|user|domain [--email addr] [--domain example.com] [--role reader|writer|commenter] [--discoverable]`
 - `gog drive permissions <fileId> [--max N] [--page TOKEN]`
 - `gog drive unshare <fileId> <permissionId>`
@@ -243,6 +244,21 @@ Flag aliases:
 - `gog drive labels file list <fileId> [--max N] [--page TOKEN]`
 - `gog drive labels file apply <fileId> <labelId> [--text FIELD=VALUE] [--selection FIELD=CHOICE[,CHOICE]] [--integer FIELD=N] [--date FIELD=YYYY-MM-DD] [--user FIELD=email] [--unset FIELD] [--fields-json JSON]`
 - `gog drive labels file remove <fileId> <labelId>`
+
+Drive hierarchy semantics:
+
+- Files and folders are identified by stable opaque IDs, not paths.
+- New files have one parent folder. The API still returns `parents` as an array
+  so legacy My Drive records with multiple parents can be read; `drive move`
+  removes every old parent and installs exactly the requested parent.
+- An item visible from another folder is represented by a separate shortcut
+  file with its own ID, name, parent, and permissions. Shortcut metadata exposes
+  `shortcutDetails.targetId`, `targetMimeType`, and `targetResourceKey`.
+- Mutations apply to the exact ID passed. Commands do not silently dereference
+  shortcut IDs to their targets.
+- `drive tree`, `drive inventory`, and `drive du` treat shortcuts as leaves,
+  including shortcuts whose targets are folders.
+
 - `gog slides thumbnail <presentationId> <slideId> [--size small|medium|large] [--format png|jpeg] [--out PATH]`
 - `gog calendar calendars`
 - `gog calendar create-calendar <summary> [--description D] [--timezone TZ] [--location L]`

--- a/internal/cmd/backup_drive_content.go
+++ b/internal/cmd/backup_drive_content.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	driveMimeGoogleFolder   = "application/vnd.google-apps.folder"
-	driveMimeGoogleShortcut = "application/vnd.google-apps.shortcut"
+	driveMimeGoogleFolder = "application/vnd.google-apps.folder"
 )
 
 type driveBackupContent struct {
@@ -104,7 +103,7 @@ func driveBackupContentPlans(file *drive.File, includeBinary bool) []driveBackup
 		return nil
 	}
 	switch file.MimeType {
-	case driveMimeGoogleFolder, driveMimeGoogleShortcut:
+	case driveMimeGoogleFolder, driveMimeShortcut:
 		return nil
 	case driveMimeGoogleDoc:
 		return []driveBackupContentPlan{

--- a/internal/cmd/drive.go
+++ b/internal/cmd/drive.go
@@ -35,6 +35,7 @@ const (
 	driveMimeGoogleSlides  = "application/vnd.google-apps.presentation"
 	driveMimeGoogleDrawing = "application/vnd.google-apps.drawing"
 	driveMimeGoogleSite    = "application/vnd.google-apps.site"
+	driveMimeShortcut      = "application/vnd.google-apps.shortcut"
 	driveQueryNotTrashed   = "trashed = false"
 	mimePDF                = "application/pdf"
 	mimeCSV                = "text/csv"
@@ -71,6 +72,7 @@ type DriveCmd struct {
 	Delete      DriveDeleteCmd      `cmd:"" name:"delete" help:"Move a file to trash (use --permanent to delete forever)" aliases:"rm,del"`
 	Move        DriveMoveCmd        `cmd:"" name:"move" help:"Move a file to a different folder"`
 	Rename      DriveRenameCmd      `cmd:"" name:"rename" help:"Rename a file or folder"`
+	Shortcut    DriveShortcutCmd    `cmd:"" name:"shortcut" aliases:"shortcuts" help:"Manage shortcuts to Drive files and folders"`
 	Share       DriveShareCmd       `cmd:"" name:"share" help:"Share a file or folder"`
 	Unshare     DriveUnshareCmd     `cmd:"" name:"unshare" help:"Remove a permission from a file"`
 	Permissions DrivePermissionsCmd `cmd:"" name:"permissions" help:"List permissions on a file"`
@@ -150,10 +152,14 @@ func (c *DriveGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u.Out().Linef("size\t%s", formatDriveSize(f.Size))
 	u.Out().Linef("created\t%s", f.CreatedTime)
 	u.Out().Linef("modified\t%s", f.ModifiedTime)
+	if len(f.Parents) > 0 {
+		u.Out().Linef("parents\t%s", strings.Join(f.Parents, ","))
+	}
 	if f.Description != "" {
 		u.Out().Linef("description\t%s", f.Description)
 	}
 	u.Out().Linef("starred\t%t", f.Starred)
+	writeDriveShortcutDetails(u, f.ShortcutDetails)
 	if f.WebViewLink != "" {
 		u.Out().Linef("link\t%s", f.WebViewLink)
 	}
@@ -490,8 +496,41 @@ func driveType(mimeType string) string {
 		return "drawing"
 	case driveMimeGoogleSite:
 		return "site"
+	case driveMimeShortcut:
+		return "shortcut"
 	}
 	return strFile
+}
+
+func driveShortcutTargetID(f *drive.File) string {
+	if f == nil {
+		return "-"
+	}
+	return driveShortcutDetailsTargetID(f.ShortcutDetails)
+}
+
+func driveShortcutDetailsTargetID(details *drive.FileShortcutDetails) string {
+	if details == nil {
+		return "-"
+	}
+	targetID := strings.TrimSpace(details.TargetId)
+	if targetID == "" {
+		return "-"
+	}
+	return targetID
+}
+
+func writeDriveShortcutDetails(u *ui.UI, details *drive.FileShortcutDetails) {
+	if details == nil {
+		return
+	}
+	u.Out().Linef("target_id\t%s", details.TargetId)
+	if details.TargetMimeType != "" {
+		u.Out().Linef("target_type\t%s", details.TargetMimeType)
+	}
+	if details.TargetResourceKey != "" {
+		u.Out().Linef("target_resource_key\t%s", details.TargetResourceKey)
+	}
 }
 
 func formatDateTime(iso string) string {

--- a/internal/cmd/drive_driveid_field_test.go
+++ b/internal/cmd/drive_driveid_field_test.go
@@ -12,6 +12,9 @@ func TestDriveFileListFieldsIncludesDriveID(t *testing.T) {
 	if !strings.Contains(driveFileListFields, "hasThumbnail") || !strings.Contains(driveFileListFields, "thumbnailLink") {
 		t.Fatalf("driveFileListFields must include thumbnail fields; got %q", driveFileListFields)
 	}
+	if !strings.Contains(driveFileListFields, "shortcutDetails(targetId,targetMimeType,targetResourceKey)") {
+		t.Fatalf("driveFileListFields must include shortcut details; got %q", driveFileListFields)
+	}
 }
 
 func TestDriveFileGetFieldsIncludesDriveID(t *testing.T) {
@@ -20,5 +23,8 @@ func TestDriveFileGetFieldsIncludesDriveID(t *testing.T) {
 	}
 	if !strings.Contains(driveFileGetFields, "hasThumbnail") || !strings.Contains(driveFileGetFields, "thumbnailLink") {
 		t.Fatalf("driveFileGetFields must include thumbnail fields; got %q", driveFileGetFields)
+	}
+	if !strings.Contains(driveFileGetFields, "shortcutDetails(targetId,targetMimeType,targetResourceKey)") {
+		t.Fatalf("driveFileGetFields must include shortcut details; got %q", driveFileGetFields)
 	}
 }

--- a/internal/cmd/drive_fields.go
+++ b/internal/cmd/drive_fields.go
@@ -1,6 +1,6 @@
 package cmd
 
 const (
-	driveFileListFields = "nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink, owners(emailAddress), driveId, hasThumbnail, thumbnailLink)"
-	driveFileGetFields  = "id, name, mimeType, size, modifiedTime, createdTime, parents, webViewLink, description, starred, driveId, hasThumbnail, thumbnailLink"
+	driveFileListFields = "nextPageToken, files(id, name, mimeType, size, modifiedTime, parents, webViewLink, owners(emailAddress), driveId, hasThumbnail, thumbnailLink, shortcutDetails(targetId,targetMimeType,targetResourceKey))"
+	driveFileGetFields  = "id, name, mimeType, size, modifiedTime, createdTime, parents, webViewLink, description, starred, driveId, hasThumbnail, thumbnailLink, shortcutDetails(targetId,targetMimeType,targetResourceKey)"
 )

--- a/internal/cmd/drive_listing.go
+++ b/internal/cmd/drive_listing.go
@@ -131,19 +131,36 @@ func writeDriveFileList(ctx context.Context, resp *drive.FileList, emptyMessage 
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER\tTARGET_ID")
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER")
+	} else {
+		fmt.Fprintln(w, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER\tTARGET_ID")
+	}
 	for _, f := range resp.Files {
-		fmt.Fprintf(
-			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			f.Id,
-			f.Name,
-			driveType(f.MimeType),
-			formatDriveSize(f.Size),
-			formatDateTime(f.ModifiedTime),
-			driveOwnerEmail(f.Owners),
-			driveShortcutTargetID(f),
-		)
+		if outfmt.IsPlain(ctx) {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\t%s\n",
+				f.Id,
+				f.Name,
+				driveType(f.MimeType),
+				formatDriveSize(f.Size),
+				formatDateTime(f.ModifiedTime),
+				driveOwnerEmail(f.Owners),
+			)
+		} else {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				f.Id,
+				f.Name,
+				driveType(f.MimeType),
+				formatDriveSize(f.Size),
+				formatDateTime(f.ModifiedTime),
+				driveOwnerEmail(f.Owners),
+				driveShortcutTargetID(f),
+			)
+		}
 	}
 	printNextPageHint(u, resp.NextPageToken)
 	return nil

--- a/internal/cmd/drive_listing.go
+++ b/internal/cmd/drive_listing.go
@@ -131,17 +131,18 @@ func writeDriveFileList(ctx context.Context, resp *drive.FileList, emptyMessage 
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER")
+	fmt.Fprintln(w, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER\tTARGET_ID")
 	for _, f := range resp.Files {
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			f.Id,
 			f.Name,
 			driveType(f.MimeType),
 			formatDriveSize(f.Size),
 			formatDateTime(f.ModifiedTime),
 			driveOwnerEmail(f.Owners),
+			driveShortcutTargetID(f),
 		)
 	}
 	printNextPageHint(u, resp.NextPageToken)

--- a/internal/cmd/drive_ls_cmd_test.go
+++ b/internal/cmd/drive_ls_cmd_test.go
@@ -50,6 +50,16 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 						"size":         "0",
 						"modifiedTime": "2025-12-11T00:00:00Z",
 					},
+					{
+						"id":           "s1",
+						"name":         "Folder shortcut",
+						"mimeType":     driveMimeShortcut,
+						"modifiedTime": "2025-12-10T00:00:00Z",
+						"shortcutDetails": map[string]any{
+							"targetId":       "d1",
+							"targetMimeType": driveMimeFolder,
+						},
+					},
 				},
 				"nextPageToken": "npt",
 			})
@@ -98,6 +108,9 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 	if !strings.Contains(textOut, "d1") || !strings.Contains(textOut, "Folder") || !strings.Contains(textOut, "folder") {
 		t.Fatalf("missing folder row: %q", textOut)
 	}
+	if !strings.Contains(textOut, "s1") || !strings.Contains(textOut, "shortcut") || !strings.Contains(textOut, "d1") {
+		t.Fatalf("missing shortcut row: %q", textOut)
+	}
 	if !strings.Contains(errBuf.String(), "--page npt") {
 		t.Fatalf("missing next page hint: %q", errBuf.String())
 	}
@@ -128,11 +141,14 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 	if unmarshalErr := json.Unmarshal([]byte(jsonOut), &parsed); unmarshalErr != nil {
 		t.Fatalf("json parse: %v\nout=%q", unmarshalErr, jsonOut)
 	}
-	if parsed.NextPageToken != "npt" || len(parsed.Files) != 2 {
+	if parsed.NextPageToken != "npt" || len(parsed.Files) != 3 {
 		t.Fatalf("unexpected json: %#v", parsed)
 	}
 	if !parsed.Files[0].HasThumbnail || parsed.Files[0].ThumbnailLink != "https://thumb.example/f1" {
 		t.Fatalf("expected thumbnail fields in json, got %#v", parsed.Files[0])
+	}
+	if got := driveShortcutTargetID(parsed.Files[2]); got != "d1" {
+		t.Fatalf("shortcut target = %q, want d1", got)
 	}
 
 	// Plain mode: stable TSV (tabs preserved).
@@ -150,7 +166,7 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 			t.Fatalf("execute: %v", execErr)
 		}
 	})
-	if !strings.Contains(plainOut, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER") {
+	if !strings.Contains(plainOut, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER\tTARGET_ID") {
 		t.Fatalf("expected TSV header, got: %q", plainOut)
 	}
 }

--- a/internal/cmd/drive_ls_cmd_test.go
+++ b/internal/cmd/drive_ls_cmd_test.go
@@ -166,8 +166,11 @@ func TestDriveLsCmd_TextAndJSON(t *testing.T) {
 			t.Fatalf("execute: %v", execErr)
 		}
 	})
-	if !strings.Contains(plainOut, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER\tTARGET_ID") {
+	if !strings.Contains(plainOut, "ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER\n") {
 		t.Fatalf("expected TSV header, got: %q", plainOut)
+	}
+	if strings.Contains(plainOut, "TARGET_ID") {
+		t.Fatalf("plain output schema changed unexpectedly: %q", plainOut)
 	}
 }
 

--- a/internal/cmd/drive_more_test.go
+++ b/internal/cmd/drive_more_test.go
@@ -9,6 +9,9 @@ func TestDriveType(t *testing.T) {
 	if got := driveType("application/pdf"); got != "file" {
 		t.Fatalf("unexpected: %q", got)
 	}
+	if got := driveType(driveMimeShortcut); got != "shortcut" {
+		t.Fatalf("unexpected shortcut type: %q", got)
+	}
 }
 
 func TestFormatDateTime(t *testing.T) {

--- a/internal/cmd/drive_reporting.go
+++ b/internal/cmd/drive_reporting.go
@@ -68,18 +68,34 @@ func (c *DriveTreeCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tID\tTARGET_ID")
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tID")
+	} else {
+		fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tID\tTARGET_ID")
+	}
 	for _, it := range items {
-		fmt.Fprintf(
-			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\n",
-			sanitizeTab(it.Path),
-			driveType(it.MimeType),
-			formatDriveSize(it.Size),
-			formatDateTime(it.ModifiedTime),
-			it.ID,
-			driveShortcutDetailsTargetID(it.ShortcutDetails),
-		)
+		if outfmt.IsPlain(ctx) {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\n",
+				sanitizeTab(it.Path),
+				driveType(it.MimeType),
+				formatDriveSize(it.Size),
+				formatDateTime(it.ModifiedTime),
+				it.ID,
+			)
+		} else {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\t%s\n",
+				sanitizeTab(it.Path),
+				driveType(it.MimeType),
+				formatDriveSize(it.Size),
+				formatDateTime(it.ModifiedTime),
+				it.ID,
+				driveShortcutDetailsTargetID(it.ShortcutDetails),
+			)
+		}
 	}
 	if truncated {
 		u.Err().Println("Results truncated; increase --max to see more.")
@@ -143,23 +159,40 @@ func (c *DriveInventoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tOWNER\tID\tTARGET_ID")
+	if outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tOWNER\tID")
+	} else {
+		fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tOWNER\tID\tTARGET_ID")
+	}
 	for _, it := range items {
 		owner := "-"
 		if len(it.Owners) > 0 {
 			owner = it.Owners[0]
 		}
-		fmt.Fprintf(
-			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			sanitizeTab(it.Path),
-			driveType(it.MimeType),
-			formatDriveSize(it.Size),
-			formatDateTime(it.ModifiedTime),
-			owner,
-			it.ID,
-			driveShortcutDetailsTargetID(it.ShortcutDetails),
-		)
+		if outfmt.IsPlain(ctx) {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\t%s\n",
+				sanitizeTab(it.Path),
+				driveType(it.MimeType),
+				formatDriveSize(it.Size),
+				formatDateTime(it.ModifiedTime),
+				owner,
+				it.ID,
+			)
+		} else {
+			fmt.Fprintf(
+				w,
+				"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				sanitizeTab(it.Path),
+				driveType(it.MimeType),
+				formatDriveSize(it.Size),
+				formatDateTime(it.ModifiedTime),
+				owner,
+				it.ID,
+				driveShortcutDetailsTargetID(it.ShortcutDetails),
+			)
+		}
 	}
 	if truncated {
 		u.Err().Println("Results truncated; increase --max to see more.")

--- a/internal/cmd/drive_reporting.go
+++ b/internal/cmd/drive_reporting.go
@@ -68,16 +68,17 @@ func (c *DriveTreeCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tID")
+	fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tID\tTARGET_ID")
 	for _, it := range items {
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\n",
 			sanitizeTab(it.Path),
 			driveType(it.MimeType),
 			formatDriveSize(it.Size),
 			formatDateTime(it.ModifiedTime),
 			it.ID,
+			driveShortcutDetailsTargetID(it.ShortcutDetails),
 		)
 	}
 	if truncated {
@@ -142,7 +143,7 @@ func (c *DriveInventoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	w, flush := tableWriter(ctx)
 	defer flush()
-	fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tOWNER\tID")
+	fmt.Fprintln(w, "PATH\tTYPE\tSIZE\tMODIFIED\tOWNER\tID\tTARGET_ID")
 	for _, it := range items {
 		owner := "-"
 		if len(it.Owners) > 0 {
@@ -150,13 +151,14 @@ func (c *DriveInventoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 		fmt.Fprintf(
 			w,
-			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			"%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			sanitizeTab(it.Path),
 			driveType(it.MimeType),
 			formatDriveSize(it.Size),
 			formatDateTime(it.ModifiedTime),
 			owner,
 			it.ID,
+			driveShortcutDetailsTargetID(it.ShortcutDetails),
 		)
 	}
 	if truncated {
@@ -236,17 +238,18 @@ func (c *DriveDuCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 type driveTreeItem struct {
-	ID           string   `json:"id"`
-	Name         string   `json:"name"`
-	Path         string   `json:"path"`
-	ParentID     string   `json:"parentId,omitempty"`
-	MimeType     string   `json:"mimeType"`
-	Size         int64    `json:"size,omitempty"`
-	ModifiedTime string   `json:"modifiedTime,omitempty"`
-	WebViewLink  string   `json:"webViewLink,omitempty"`
-	Owners       []string `json:"owners,omitempty"`
-	MD5          string   `json:"md5,omitempty"`
-	Depth        int      `json:"depth"`
+	ID              string                     `json:"id"`
+	Name            string                     `json:"name"`
+	Path            string                     `json:"path"`
+	ParentID        string                     `json:"parentId,omitempty"`
+	MimeType        string                     `json:"mimeType"`
+	Size            int64                      `json:"size,omitempty"`
+	ModifiedTime    string                     `json:"modifiedTime,omitempty"`
+	WebViewLink     string                     `json:"webViewLink,omitempty"`
+	Owners          []string                   `json:"owners,omitempty"`
+	MD5             string                     `json:"md5,omitempty"`
+	ShortcutDetails *drive.FileShortcutDetails `json:"shortcutDetails,omitempty"`
+	Depth           int                        `json:"depth"`
 }
 
 func (d driveTreeItem) IsFolder() bool {
@@ -280,8 +283,8 @@ type driveFolderQueueItem struct {
 }
 
 const (
-	driveTreeFields      = "id,name,mimeType,size,modifiedTime"
-	driveInventoryFields = "id,name,mimeType,size,modifiedTime,owners(emailAddress,displayName)"
+	driveTreeFields      = "id,name,mimeType,size,modifiedTime,shortcutDetails(targetId,targetMimeType,targetResourceKey)"
+	driveInventoryFields = "id,name,mimeType,size,modifiedTime,owners(emailAddress,displayName),shortcutDetails(targetId,targetMimeType,targetResourceKey)"
 )
 
 func listDriveTree(ctx context.Context, svc *drive.Service, opts driveTreeOptions) ([]driveTreeItem, bool, error) {
@@ -312,19 +315,22 @@ func listDriveTree(ctx context.Context, svc *drive.Service, opts driveTreeOption
 			}
 			depth := folder.Depth + 1
 			item := driveTreeItem{
-				ID:           child.Id,
-				Name:         child.Name,
-				Path:         joinDrivePath(folder.Path, child.Name),
-				ParentID:     folder.ID,
-				MimeType:     child.MimeType,
-				Size:         child.Size,
-				ModifiedTime: child.ModifiedTime,
-				WebViewLink:  child.WebViewLink,
-				Owners:       driveOwners(child),
-				MD5:          child.Md5Checksum,
-				Depth:        depth,
+				ID:              child.Id,
+				Name:            child.Name,
+				Path:            joinDrivePath(folder.Path, child.Name),
+				ParentID:        folder.ID,
+				MimeType:        child.MimeType,
+				Size:            child.Size,
+				ModifiedTime:    child.ModifiedTime,
+				WebViewLink:     child.WebViewLink,
+				Owners:          driveOwners(child),
+				MD5:             child.Md5Checksum,
+				ShortcutDetails: child.ShortcutDetails,
+				Depth:           depth,
 			}
 
+			// Shortcuts are leaves even when their target is a folder. Following
+			// targets would duplicate paths and can introduce traversal cycles.
 			if item.IsFolder() {
 				if opts.IncludeFolder {
 					out = append(out, item)

--- a/internal/cmd/drive_reporting_test.go
+++ b/internal/cmd/drive_reporting_test.go
@@ -95,6 +95,16 @@ func TestExecuteDriveTreeJSON(t *testing.T) {
 						"size":         "12",
 						"modifiedTime": "2026-01-02T00:00:00Z",
 					},
+					{
+						"id":           "shortcut1",
+						"name":         "Reports elsewhere",
+						"mimeType":     driveMimeShortcut,
+						"modifiedTime": "2026-01-02T00:00:00Z",
+						"shortcutDetails": map[string]any{
+							"targetId":       "folder-target",
+							"targetMimeType": driveMimeFolder,
+						},
+					},
 				},
 			})
 		case strings.Contains(q, "'folder1' in parents"):
@@ -130,10 +140,13 @@ func TestExecuteDriveTreeJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
 		t.Fatalf("json parse: %v\nout=%q", err, out)
 	}
-	if len(parsed.Items) != 3 {
-		t.Fatalf("items len = %d, want 3: %#v", len(parsed.Items), parsed.Items)
+	if len(parsed.Items) != 4 {
+		t.Fatalf("items len = %d, want 4: %#v", len(parsed.Items), parsed.Items)
 	}
-	if parsed.Items[2].Path != "Reports/child.txt" {
-		t.Fatalf("nested path = %q, want Reports/child.txt", parsed.Items[2].Path)
+	if parsed.Items[2].Path != "Reports elsewhere" || driveShortcutDetailsTargetID(parsed.Items[2].ShortcutDetails) != "folder-target" {
+		t.Fatalf("shortcut item = %#v", parsed.Items[2])
+	}
+	if parsed.Items[3].Path != "Reports/child.txt" {
+		t.Fatalf("nested path = %q, want Reports/child.txt", parsed.Items[3].Path)
 	}
 }

--- a/internal/cmd/drive_reporting_test.go
+++ b/internal/cmd/drive_reporting_test.go
@@ -149,4 +149,37 @@ func TestExecuteDriveTreeJSON(t *testing.T) {
 	if parsed.Items[3].Path != "Reports/child.txt" {
 		t.Fatalf("nested path = %q, want Reports/child.txt", parsed.Items[3].Path)
 	}
+
+	for _, tc := range []struct {
+		name       string
+		args       []string
+		wantHeader string
+	}{
+		{
+			name:       "tree",
+			args:       []string{"--plain", "--account", "a@example.com", "drive", "tree", "--parent", "root", "--depth", "2"},
+			wantHeader: "PATH\tTYPE\tSIZE\tMODIFIED\tID\n",
+		},
+		{
+			name:       "inventory",
+			args:       []string{"--plain", "--account", "a@example.com", "drive", "inventory", "--parent", "root", "--depth", "2"},
+			wantHeader: "PATH\tTYPE\tSIZE\tMODIFIED\tOWNER\tID\n",
+		},
+	} {
+		t.Run(tc.name+" plain schema", func(t *testing.T) {
+			plainOut := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute(tc.args); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if !strings.HasPrefix(plainOut, tc.wantHeader) {
+				t.Fatalf("plain output header = %q, want prefix %q", plainOut, tc.wantHeader)
+			}
+			if strings.Contains(plainOut, "TARGET_ID") {
+				t.Fatalf("plain output schema changed unexpectedly: %q", plainOut)
+			}
+		})
+	}
 }

--- a/internal/cmd/drive_shortcuts.go
+++ b/internal/cmd/drive_shortcuts.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DriveShortcutCmd struct {
+	Create DriveShortcutCreateCmd `cmd:"" name:"create" aliases:"add,new" help:"Create a shortcut to a Drive file or folder"`
+}
+
+type DriveShortcutCreateCmd struct {
+	TargetID string `arg:"" name:"targetId" help:"Target file or folder ID"`
+	Parent   string `name:"parent" help:"Destination folder ID (required)"`
+	Name     string `name:"name" help:"Shortcut name (default: target name)"`
+}
+
+func (c *DriveShortcutCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
+	u := ui.FromContext(ctx)
+	targetID := strings.TrimSpace(c.TargetID)
+	if targetID == "" {
+		return usage("empty targetId")
+	}
+	parent := strings.TrimSpace(c.Parent)
+	if parent == "" {
+		return usage("missing --parent")
+	}
+	name := strings.TrimSpace(c.Name)
+
+	if err := dryRunExit(ctx, flags, "drive.shortcut.create", map[string]any{
+		"targetId": targetID,
+		"parent":   parent,
+		"name":     name,
+	}); err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := newDriveService(ctx, account)
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		target, getErr := svc.Files.Get(targetID).
+			SupportsAllDrives(true).
+			Fields("id,name").
+			Context(ctx).
+			Do()
+		if getErr != nil {
+			return getErr
+		}
+		name = target.Name
+		if strings.TrimSpace(name) == "" {
+			return usage("target file has no name; specify --name")
+		}
+	}
+
+	created, err := svc.Files.Create(&drive.File{
+		Name:     name,
+		MimeType: driveMimeShortcut,
+		Parents:  []string{parent},
+		ShortcutDetails: &drive.FileShortcutDetails{
+			TargetId: targetID,
+		},
+	}).
+		SupportsAllDrives(true).
+		Fields("id,name,mimeType,parents,webViewLink,shortcutDetails(targetId,targetMimeType,targetResourceKey)").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return err
+	}
+
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{"shortcut": created})
+	}
+
+	u.Out().Linef("id\t%s", created.Id)
+	u.Out().Linef("name\t%s", created.Name)
+	u.Out().Linef("target_id\t%s", driveShortcutTargetID(created))
+	if len(created.Parents) > 0 {
+		u.Out().Linef("parent\t%s", created.Parents[0])
+	}
+	if created.WebViewLink != "" {
+		u.Out().Linef("link\t%s", created.WebViewLink)
+	}
+	return nil
+}

--- a/internal/cmd/drive_shortcuts_test.go
+++ b/internal/cmd/drive_shortcuts_test.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/drive/v3"
+	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+func TestDriveShortcutCreateCmd_DefaultNameAndJSON(t *testing.T) {
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+
+	var createBody drive.File
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/files/target1"):
+			requireQuery(t, r, "supportsAllDrives", "true")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":   "target1",
+				"name": "Target Folder",
+			})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/files"):
+			requireQuery(t, r, "supportsAllDrives", "true")
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatalf("decode create body: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "shortcut1",
+				"name":     "Target Folder",
+				"mimeType": driveMimeShortcut,
+				"parents":  []string{"folder1"},
+				"shortcutDetails": map[string]any{
+					"targetId":       "target1",
+					"targetMimeType": driveMimeFolder,
+				},
+				"webViewLink": "https://drive.example/shortcut1",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	u, err := ui.New(ui.Options{Stdout: io.Discard, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := outfmt.WithMode(ui.WithUI(context.Background(), u), outfmt.Mode{JSON: true})
+	out := captureStdout(t, func() {
+		cmd := &DriveShortcutCreateCmd{}
+		if execErr := runKong(t, cmd, []string{"target1", "--parent", "folder1"}, ctx, &RootFlags{Account: "a@example.com"}); execErr != nil {
+			t.Fatalf("execute: %v", execErr)
+		}
+	})
+
+	if createBody.Name != "Target Folder" || createBody.MimeType != driveMimeShortcut {
+		t.Fatalf("unexpected create body: %#v", createBody)
+	}
+	if len(createBody.Parents) != 1 || createBody.Parents[0] != "folder1" {
+		t.Fatalf("unexpected parents: %#v", createBody.Parents)
+	}
+	if createBody.ShortcutDetails == nil || createBody.ShortcutDetails.TargetId != "target1" {
+		t.Fatalf("unexpected shortcut details: %#v", createBody.ShortcutDetails)
+	}
+
+	var parsed struct {
+		Shortcut *drive.File `json:"shortcut"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, out)
+	}
+	if parsed.Shortcut == nil || parsed.Shortcut.Id != "shortcut1" {
+		t.Fatalf("unexpected output: %#v", parsed.Shortcut)
+	}
+	if got := driveShortcutTargetID(parsed.Shortcut); got != "target1" {
+		t.Fatalf("target id = %q, want target1", got)
+	}
+}
+
+func TestDriveShortcutCreateCmd_ExplicitNameSkipsTargetLookup(t *testing.T) {
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, "/files") {
+			t.Fatalf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body drive.File
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode create body: %v", err)
+		}
+		if body.Name != "Alias" {
+			t.Fatalf("name = %q, want Alias", body.Name)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":   "shortcut1",
+			"name": body.Name,
+			"shortcutDetails": map[string]any{
+				"targetId": "target1",
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	var stdout bytes.Buffer
+	u, err := ui.New(ui.Options{Stdout: &stdout, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	cmd := &DriveShortcutCreateCmd{}
+	if execErr := runKong(t, cmd, []string{"target1", "--parent", "folder1", "--name", "Alias"}, ctx, &RootFlags{Account: "a@example.com"}); execErr != nil {
+		t.Fatalf("execute: %v", execErr)
+	}
+	if !strings.Contains(stdout.String(), "target_id\ttarget1") {
+		t.Fatalf("missing target output: %q", stdout.String())
+	}
+}
+
+func TestDriveShortcutCreateCmd_ValidationAndDryRun(t *testing.T) {
+	ctx := newCmdOutputContext(t, io.Discard, io.Discard)
+	flags := &RootFlags{Account: "a@example.com"}
+	for _, tc := range []struct {
+		name string
+		cmd  DriveShortcutCreateCmd
+		want string
+	}{
+		{name: "target", cmd: DriveShortcutCreateCmd{Parent: "folder1"}, want: "empty targetId"},
+		{name: "parent", cmd: DriveShortcutCreateCmd{TargetID: "target1"}, want: "missing --parent"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cmd.Run(ctx, flags)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	dryCtx := outfmt.WithMode(ctx, outfmt.Mode{JSON: true})
+	out := captureStdout(t, func() {
+		err := (&DriveShortcutCreateCmd{
+			TargetID: "target1",
+			Parent:   "folder1",
+		}).Run(dryCtx, &RootFlags{DryRun: true})
+		var exitErr *ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+			t.Fatalf("dry run exit = %v", err)
+		}
+	})
+	if !strings.Contains(out, "drive.shortcut.create") {
+		t.Fatalf("unexpected dry-run output: %q", out)
+	}
+}
+
+func TestDriveGetCmd_ShortcutDetails(t *testing.T) {
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || !strings.HasSuffix(r.URL.Path, "/files/shortcut1") {
+			http.NotFound(w, r)
+			return
+		}
+		if fields := r.URL.Query().Get("fields"); !strings.Contains(fields, "shortcutDetails") {
+			http.Error(w, "missing shortcutDetails field mask", http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"id":       "shortcut1",
+			"name":     "Alias",
+			"mimeType": driveMimeShortcut,
+			"parents":  []string{"folder1"},
+			"shortcutDetails": map[string]any{
+				"targetId":          "target1",
+				"targetMimeType":    driveMimeFolder,
+				"targetResourceKey": "resource-key",
+			},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	var stdout bytes.Buffer
+	u, err := ui.New(ui.Options{Stdout: &stdout, Stderr: io.Discard, Color: "never"})
+	if err != nil {
+		t.Fatalf("ui.New: %v", err)
+	}
+	ctx := ui.WithUI(context.Background(), u)
+	if err := (&DriveGetCmd{FileID: "shortcut1"}).Run(ctx, &RootFlags{Account: "a@example.com"}); err != nil {
+		t.Fatalf("get shortcut: %v", err)
+	}
+	text := stdout.String()
+	for _, want := range []string{
+		"type\t" + driveMimeShortcut,
+		"parents\tfolder1",
+		"target_id\ttarget1",
+		"target_type\t" + driveMimeFolder,
+		"target_resource_key\tresource-key",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in output: %q", want, text)
+		}
+	}
+}
+
+func TestDriveMoveCmd_ReplacesAllLegacyParents(t *testing.T) {
+	origNew := newDriveService
+	t.Cleanup(func() { newDriveService = origNew })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "file1",
+				"name":    "Legacy file",
+				"parents": []string{"old-a", "old-b"},
+			})
+		case http.MethodPatch:
+			requireQuery(t, r, "addParents", "new-parent")
+			requireQuery(t, r, "removeParents", "old-a,old-b")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "file1",
+				"name":    "Legacy file",
+				"parents": []string{"new-parent"},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	svc, err := drive.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewService: %v", err)
+	}
+	newDriveService = func(context.Context, string) (*drive.Service, error) { return svc, nil }
+
+	ctx := newCmdOutputContext(t, io.Discard, io.Discard)
+	if err := (&DriveMoveCmd{FileID: "file1", Parent: "new-parent"}).Run(ctx, &RootFlags{Account: "a@example.com"}); err != nil {
+		t.Fatalf("move legacy file: %v", err)
+	}
+}

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -157,6 +157,11 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			op:   "drive.move",
 		},
 		{
+			name: "drive shortcut create",
+			args: []string{"drive", "shortcut", "create", "file123", "--parent", "folder123"},
+			op:   "drive.shortcut.create",
+		},
+		{
 			name: "drive rename",
 			args: []string{"drive", "rename", "file123", "New"},
 			op:   "drive.rename",

--- a/scripts/live-tests/drive.sh
+++ b/scripts/live-tests/drive.sh
@@ -37,6 +37,29 @@ run_drive_tests() {
   run_required "drive" "drive move" gog drive move "$file_id" --parent "$folder_b_id" --json >/dev/null
   run_required "drive" "drive search" gog drive search "name contains 'gogcli-smoke'" --json --max 1 >/dev/null
 
+  local shortcut_json shortcut_id shortcut_get_json shortcut_target_id shortcut_list_json shortcut_tree_json
+  shortcut_json=$(gog drive shortcut create "$file_id" --parent "$folder_a_id" --name "gogcli-smoke-shortcut-$TS" --json)
+  shortcut_id=$(extract_id "$shortcut_json")
+  [ -n "$shortcut_id" ] || { echo "Failed to parse shortcut id" >&2; exit 1; }
+
+  shortcut_get_json=$(gog drive get "$shortcut_id" --json)
+  shortcut_target_id=$(extract_field "$shortcut_get_json" targetId)
+  [ "$shortcut_target_id" = "$file_id" ] || { echo "Shortcut target mismatch from drive get" >&2; exit 1; }
+
+  shortcut_list_json=$(gog drive ls --parent "$folder_a_id" --json --max 10)
+  shortcut_target_id=$(extract_field "$shortcut_list_json" targetId)
+  [ "$shortcut_target_id" = "$file_id" ] || { echo "Shortcut target missing from drive ls" >&2; exit 1; }
+
+  shortcut_tree_json=$(gog drive tree --parent "$folder_a_id" --json --depth 2)
+  shortcut_target_id=$(extract_field "$shortcut_tree_json" targetId)
+  [ "$shortcut_target_id" = "$file_id" ] || { echo "Shortcut target missing from drive tree" >&2; exit 1; }
+
+  run_required "drive" "drive rename shortcut" gog drive rename "$shortcut_id" "gogcli-smoke-shortcut-renamed-$TS" >/dev/null
+  local target_after_shortcut_rename target_name
+  target_after_shortcut_rename=$(gog drive get "$file_id" --json)
+  target_name=$(extract_field "$target_after_shortcut_rename" name)
+  [ "$target_name" = "gogcli-smoke-renamed-$TS.txt" ] || { echo "Renaming shortcut mutated target name" >&2; exit 1; }
+
   run_required "drive" "drive permissions" gog drive permissions "$file_id" --json >/dev/null
 
   local share_json perm_id perms_json
@@ -69,6 +92,7 @@ run_drive_tests() {
   download_path="$LIVE_TMP/drive-download-$TS.txt"
   run_required "drive" "drive download" gog drive download "$file_id" --out "$download_path" >/dev/null
 
+  run_required "drive" "drive delete shortcut" gog drive delete "$shortcut_id" --force >/dev/null
   run_required "drive" "drive delete copy" gog drive delete "$copy_id" --force >/dev/null
   run_required "drive" "drive delete file" gog drive delete "$file_id" --force >/dev/null
   run_required "drive" "drive delete folder A" gog drive delete "$folder_a_id" --force >/dev/null


### PR DESCRIPTION
## Summary

- add `gog drive shortcut create <targetId> --parent <folderId> [--name ...]`
- expose shortcut target metadata in default `get`, `ls`, `search`, `tree`, and `inventory` JSON
- classify shortcuts distinctly and keep folder shortcuts as non-traversed leaves
- preserve exact-ID mutation semantics and collapse legacy multi-parent files on move
- show `TARGET_ID` in human tables while preserving existing stable `--plain` TSV schemas

## Validation

- `make ci`
- focused Drive command tests
- structured autoreview: clean, no actionable findings
- live Drive E2E with account and IDs redacted:

```text
live_e2e account=[redacted]
shortcut_create type=application/vnd.google-apps.shortcut target_match=true parent_count=1
shortcut_get target_match=true target_type=text/plain
shortcut_ls found=true target_match=true
shortcut_tree found=true target_match=true
plain_ls_header=ID\tNAME\tTYPE\tSIZE\tMODIFIED\tOWNER
shortcut_rename target_name_unchanged=true
cleanup remaining=0
```

The live run created two temporary folders, uploaded and moved a target file, created/read/listed/traversed/renamed/deleted its shortcut, verified the target name was unchanged, deleted all objects, and confirmed no matching artifacts remained.