### PR TITLE
feat(drive): add secure changes push receiver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Gmail: add explicit `gmail archive --thread` semantics so IDs from thread search can archive every message in each thread. (#752) — thanks @sebsnyk.
 - Drive/Docs: add persisted polling for Drive changes and Docs comments, with bounded runs, filters, retry-safe cursors, and sequential JSON hooks. (#690, #751)
 - Drive: expose shortcut targets in JSON and human-readable folder reports without changing stable `--plain` columns, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`. (#763)
+- Drive: add a secure push-notification receiver with persisted cursors, authenticated callbacks, sequential hooks, and optional channel auto-renewal. (#689, #764)
 
 ## 0.24.0 - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ gog drive changes start-token
 gog drive changes list --token <token> --json
 gog drive changes poll --state-file ~/.local/state/gog/drive-changes.json --json
 gog drive changes serve --state-file ~/.local/state/gog/drive-serve.json \
-  --channel-token "$CHANNEL_TOKEN" --auto-renew \
+  --channel-token-file ~/.config/gog/drive-channel-token --auto-renew \
   --webhook-url https://example.com/drive-changes
 gog drive revisions list <fileId> --all --json
 gog drive revisions get <fileId> <revisionId> --json

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ gog drive get <fileId> --fields 'id,name,mimeType,size,owners,emailAddress' --js
 gog drive changes start-token
 gog drive changes list --token <token> --json
 gog drive changes poll --state-file ~/.local/state/gog/drive-changes.json --json
+gog drive changes serve --state-file ~/.local/state/gog/drive-serve.json \
+  --channel-token "$CHANNEL_TOKEN" --auto-renew \
+  --webhook-url https://example.com/drive-changes
 gog drive revisions list <fileId> --all --json
 gog drive revisions get <fileId> <revisionId> --json
 gog drive activity query --file <fileId> --actions edit,share --from 2026-01-01T00:00:00Z --json

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -303,6 +303,7 @@ Generated from `gog schema --json`.
     - [`gog drive (drv) changes <command>`](commands/gog-drive-changes.md) - Track Drive changes for sync and automation
       - [`gog drive (drv) changes list (ls) --token=STRING [flags]`](commands/gog-drive-changes-list.md) - List Drive changes since a page token
       - [`gog drive (drv) changes poll --state-file=STRING [flags]`](commands/gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
+      - [`gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]`](commands/gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
       - [`gog drive (drv) changes start-token (token) [flags]`](commands/gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [`gog drive (drv) changes stop <channelId> <resourceId>`](commands/gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [`gog drive (drv) changes watch --token=STRING --webhook-url=STRING [flags]`](commands/gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -303,7 +303,7 @@ Generated from `gog schema --json`.
     - [`gog drive (drv) changes <command>`](commands/gog-drive-changes.md) - Track Drive changes for sync and automation
       - [`gog drive (drv) changes list (ls) --token=STRING [flags]`](commands/gog-drive-changes-list.md) - List Drive changes since a page token
       - [`gog drive (drv) changes poll --state-file=STRING [flags]`](commands/gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-      - [`gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]`](commands/gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
+      - [`gog drive (drv) changes serve --state-file=STRING [flags]`](commands/gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
       - [`gog drive (drv) changes start-token (token) [flags]`](commands/gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [`gog drive (drv) changes stop <channelId> <resourceId>`](commands/gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [`gog drive (drv) changes watch --token=STRING --webhook-url=STRING [flags]`](commands/gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 633.
+Generated pages: 634.
 
 ## Top-level Commands
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -354,6 +354,7 @@ Generated pages: 633.
     - [gog drive changes](gog-drive-changes.md) - Track Drive changes for sync and automation
       - [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
       - [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
+      - [gog drive changes serve](gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
       - [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
       - [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
       - [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel

--- a/docs/commands/gog-drive-changes-serve.md
+++ b/docs/commands/gog-drive-changes-serve.md
@@ -43,6 +43,7 @@ gog drive (drv) changes serve --state-file=STRING [flags]
 | `--listen` | `string` | 127.0.0.1:8443 | Listen address |
 | `--max`<br>`--limit` | `int64` | 100 | Max changes per API page |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--notification-timeout` | `time.Duration` | 5m | Maximum time for one callback, including Drive reads and the hook |
 | `--on-change` | `string` |  | Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin |
 | `--path` | `string` | /drive-changes | Notification handler path |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |

--- a/docs/commands/gog-drive-changes-serve.md
+++ b/docs/commands/gog-drive-changes-serve.md
@@ -1,27 +1,18 @@
-# `gog drive changes`
+# `gog drive changes serve`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Track Drive changes for sync and automation
+Receive Drive change notifications and run a local hook
 
 ## Usage
 
 ```bash
-gog drive (drv) changes <command>
+gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]
 ```
 
 ## Parent
 
-- [gog drive](gog-drive.md)
-
-## Subcommands
-
-- [gog drive changes list](gog-drive-changes-list.md) - List Drive changes since a page token
-- [gog drive changes poll](gog-drive-changes-poll.md) - Poll Drive changes with a persisted page token
-- [gog drive changes serve](gog-drive-changes-serve.md) - Receive Drive change notifications and run a local hook
-- [gog drive changes start-token](gog-drive-changes-start-token.md) - Get a Drive changes start page token
-- [gog drive changes stop](gog-drive-changes-stop.md) - Stop a Drive changes webhook channel
-- [gog drive changes watch](gog-drive-changes-watch.md) - Watch Drive changes with a webhook channel
+- [gog drive changes](gog-drive-changes.md)
 
 ## Flags
 
@@ -29,26 +20,42 @@ gog drive (drv) changes <command>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email for API commands (gmail/calendar/chat/classroom/drive/drivelabels/docs/slides/contacts/tasks/people/sheets/forms/sites/appscript/analytics/searchconsole/youtube/photos) |
+| `--auto-renew` | `bool` |  | Create and renew the Drive notification channel |
+| `--cert` | `string` |  | TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy) |
+| `--channel-token` | `string` |  | Expected X-Goog-Channel-Token value |
+| `--channel-ttl` | `time.Duration` | 24h | Requested channel lifetime |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `--drive`<br>`--drive-id` | `string` |  | Shared drive ID for a shared-drive change log |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--filter-file` | `string` |  | Only invoke the hook for changes to this file ID |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--include-removed` | `bool` | true | Include removed changes |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--key` | `string` |  | TLS private key path; pair with --cert |
+| `--listen` | `string` | 127.0.0.1:8443 | Listen address |
+| `--max`<br>`--limit` | `int64` | 100 | Max changes per API page |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--on-change` | `string` |  | Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin |
+| `--path` | `string` | /drive-changes | Notification handler path |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--renew-before` | `time.Duration` | 10m | Renew this long before channel expiration |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--state-file` | `string` |  | JSON file that stores the current Drive page token and channel state |
+| `--token` | `string` |  | Initial Drive page token when creating a new state file |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--webhook-url` | `string` |  | Public HTTPS callback URL used by --auto-renew |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog drive](gog-drive.md)
+- [gog drive changes](gog-drive-changes.md)
 - [Command index](README.md)

--- a/docs/commands/gog-drive-changes-serve.md
+++ b/docs/commands/gog-drive-changes-serve.md
@@ -7,7 +7,7 @@ Receive Drive change notifications and run a local hook
 ## Usage
 
 ```bash
-gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]
+gog drive (drv) changes serve --state-file=STRING [flags]
 ```
 
 ## Parent
@@ -23,6 +23,7 @@ gog drive (drv) changes serve --channel-token=STRING --state-file=STRING [flags]
 | `--auto-renew` | `bool` |  | Create and renew the Drive notification channel |
 | `--cert` | `string` |  | TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy) |
 | `--channel-token` | `string` |  | Expected X-Goog-Channel-Token value |
+| `--channel-token-file` | `string` |  | Read the expected channel token from a file |
 | `--channel-ttl` | `time.Duration` | 24h | Requested channel lifetime |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -163,9 +163,9 @@ token, including when reusing state previously written by auto-renew mode.
 `poll` and `serve` require separate state files; each state file records its
 own command kind and rejects cross-use. Legacy state files without a kind remain
 readable and gain one on the next write. Message-number deduplication is scoped
-to both channel and resource ID. A `sync` notification resets that pair's
-sequence for a newly registered channel, though channel IDs should still be
-unique as required by the Drive API.
+to both channel and resource ID. Channel IDs must be unique for every
+registration as required by the Drive API; reusing an ID for the same resource
+can inherit its prior sequence watermark and suppress notifications.
 
 Command page:
 

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -109,8 +109,9 @@ provide both `--cert` and `--key`.
 The channel token is required and compared before notification headers are
 parsed or any Drive API request or hook runs. Prefer `--channel-token-file` or
 `GOG_DRIVE_CHANNEL_TOKEN` so a long-running secret is not exposed in the process
-argument list. Use a random value; do not reuse OAuth credentials or other
-sensitive data.
+argument list. An explicit token file takes precedence over the ambient
+environment variable. Use a random value; do not reuse OAuth credentials or
+other sensitive data.
 
 To let `gog` create and renew the channel after the listener is bound:
 
@@ -158,10 +159,12 @@ Receiver behavior:
 The state file stores a SHA-256 digest of the channel token, not the token
 itself. Auto-renewed receivers also bind notifications to the persisted current
 or previous channel and resource IDs; manual receivers rely only on the channel
-token, including when reusing state previously written by auto-renew mode. Do
-not run `poll` and `serve` concurrently against the same state file.
-Message-number deduplication is scoped to both channel and resource ID, so a
-manually reused channel ID does not inherit the prior channel's sequence.
+token, including when reusing state previously written by auto-renew mode.
+`poll` and `serve` require separate state files; each state file records its
+own command kind and rejects cross-use. Legacy state files without a kind remain
+readable and gain one on the next write. Message-number deduplication is scoped
+to both channel and resource ID, so a manually reused channel ID does not
+inherit the prior channel's sequence.
 
 Command page:
 

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -144,6 +144,8 @@ Receiver behavior:
   without running the hook
 - change notifications are serialized so concurrent deliveries cannot race the
   page token
+- queued and in-flight callbacks are bounded by `--notification-timeout`
+  (default `5m`)
 - request disconnects do not cancel an in-flight Drive read or hook; command
   shutdown still cancels them
 - hooks remain sequential, but an in-flight hook does not block channel renewal
@@ -158,6 +160,8 @@ itself. Auto-renewed receivers also bind notifications to the persisted current
 or previous channel and resource IDs; manual receivers rely only on the channel
 token, including when reusing state previously written by auto-renew mode. Do
 not run `poll` and `serve` concurrently against the same state file.
+Message-number deduplication is scoped to both channel and resource ID, so a
+manually reused channel ID does not inherit the prior channel's sequence.
 
 Command page:
 

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -97,7 +97,7 @@ hook shape as polling:
 gog drive changes serve \
   --listen 127.0.0.1:8443 \
   --state-file ~/.local/state/gog/drive-serve.json \
-  --channel-token "$CHANNEL_TOKEN" \
+  --channel-token-file ~/.config/gog/drive-channel-token \
   --on-change './handle-drive-batch'
 ```
 
@@ -107,8 +107,10 @@ HTTPS callback with a valid certificate. To terminate TLS in `gog` instead,
 provide both `--cert` and `--key`.
 
 The channel token is required and compared before notification headers are
-parsed or any Drive API request or hook runs. Use a random value; do not put
-OAuth credentials or other sensitive data in it.
+parsed or any Drive API request or hook runs. Prefer `--channel-token-file` or
+`GOG_DRIVE_CHANNEL_TOKEN` so a long-running secret is not exposed in the process
+argument list. Use a random value; do not reuse OAuth credentials or other
+sensitive data.
 
 To let `gog` create and renew the channel after the listener is bound:
 
@@ -116,7 +118,7 @@ To let `gog` create and renew the channel after the listener is bound:
 gog drive changes serve \
   --listen 127.0.0.1:8443 \
   --state-file ~/.local/state/gog/drive-serve.json \
-  --channel-token "$CHANNEL_TOKEN" \
+  --channel-token-file ~/.config/gog/drive-channel-token \
   --auto-renew \
   --webhook-url https://example.com/drive-changes \
   --channel-ttl 24h \
@@ -142,6 +144,8 @@ Receiver behavior:
   without running the hook
 - change notifications are serialized so concurrent deliveries cannot race the
   page token
+- request disconnects do not cancel an in-flight Drive read or hook; command
+  shutdown still cancels them
 - Drive/API, hook, or state-write failure returns `500`; Google retries these
   statuses with backoff
 - the page token and message number advance only after the hook succeeds

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -146,6 +146,7 @@ Receiver behavior:
   page token
 - request disconnects do not cancel an in-flight Drive read or hook; command
   shutdown still cancels them
+- hooks remain sequential, but an in-flight hook does not block channel renewal
 - Drive/API, hook, or state-write failure returns `500`; Google retries these
   statuses with backoff
 - the page token and message number advance only after the hook succeeds

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -141,10 +141,10 @@ Receiver behavior:
 - only `POST` requests to the configured path are accepted
 - mismatched or missing `X-Goog-Channel-Token` returns `401`
 - malformed required `X-Goog-*` headers return `400`
-- `sync`, duplicate, and unknown resource-state notifications are acknowledged
-  without running the hook
-- change notifications are serialized so concurrent deliveries cannot race the
-  page token
+- `sync` and duplicate notifications are acknowledged without running the hook
+- every authenticated non-`sync` resource state is treated as a signal to read
+  the changes feed; notifications are serialized so concurrent deliveries
+  cannot race the page token
 - queued and in-flight callbacks are bounded by `--notification-timeout`
   (default `5m`)
 - request disconnects do not cancel an in-flight Drive read or hook; command
@@ -163,8 +163,9 @@ token, including when reusing state previously written by auto-renew mode.
 `poll` and `serve` require separate state files; each state file records its
 own command kind and rejects cross-use. Legacy state files without a kind remain
 readable and gain one on the next write. Message-number deduplication is scoped
-to both channel and resource ID, so a manually reused channel ID does not
-inherit the prior channel's sequence.
+to both channel and resource ID. A `sync` notification resets that pair's
+sequence for a newly registered channel, though channel IDs should still be
+unique as required by the Drive API.
 
 Command page:
 

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -86,3 +86,73 @@ Command pages:
 
 - [`gog drive changes poll`](commands/gog-drive-changes-poll.md)
 - [`gog docs comments poll`](commands/gog-docs-comments-poll.md)
+
+## Drive push receiver
+
+`gog drive changes serve` receives Drive push notifications, lists the actual
+changes from the persisted page token, and optionally runs the same JSON-stdin
+hook shape as polling:
+
+```bash
+gog drive changes serve \
+  --listen 127.0.0.1:8443 \
+  --state-file ~/.local/state/gog/drive-serve.json \
+  --channel-token "$CHANNEL_TOKEN" \
+  --on-change './handle-drive-batch'
+```
+
+The default listener is loopback-only. Expose it through an HTTPS reverse proxy
+or tunnel whose public route ends at `/drive-changes`. Google requires a public
+HTTPS callback with a valid certificate. To terminate TLS in `gog` instead,
+provide both `--cert` and `--key`.
+
+The channel token is required and compared before notification headers are
+parsed or any Drive API request or hook runs. Use a random value; do not put
+OAuth credentials or other sensitive data in it.
+
+To let `gog` create and renew the channel after the listener is bound:
+
+```bash
+gog drive changes serve \
+  --listen 127.0.0.1:8443 \
+  --state-file ~/.local/state/gog/drive-serve.json \
+  --channel-token "$CHANNEL_TOKEN" \
+  --auto-renew \
+  --webhook-url https://example.com/drive-changes \
+  --channel-ttl 24h \
+  --renew-before 10m \
+  --on-change './handle-drive-batch'
+```
+
+Auto-renew creates a unique replacement channel before expiration, persists the
+new channel, then stops the previous channel. If cleanup fails, the state keeps
+the previous channel metadata and retries before creating another replacement.
+The maximum `--channel-ttl` is seven days, matching the Drive Changes API.
+
+Without `--auto-renew`, register the channel separately with `drive changes
+watch`. For a new receiver state file, pass the same initial page token to
+`serve --token` that was used by `watch --token`.
+
+Receiver behavior:
+
+- only `POST` requests to the configured path are accepted
+- mismatched or missing `X-Goog-Channel-Token` returns `401`
+- malformed required `X-Goog-*` headers return `400`
+- `sync`, duplicate, and unknown resource-state notifications are acknowledged
+  without running the hook
+- change notifications are serialized so concurrent deliveries cannot race the
+  page token
+- Drive/API, hook, or state-write failure returns `500`; Google retries these
+  statuses with backoff
+- the page token and message number advance only after the hook succeeds
+- `--filter-file` suppresses hooks for unrelated changes while still advancing
+  state
+
+The state file stores a SHA-256 digest of the channel token, not the token
+itself. Auto-renewed receivers also bind notifications to the persisted current
+or previous channel and resource IDs; manual receivers rely on the channel
+token. Do not run `poll` and `serve` concurrently against the same state file.
+
+Command page:
+
+- [`gog drive changes serve`](commands/gog-drive-changes-serve.md)

--- a/docs/polling.md
+++ b/docs/polling.md
@@ -155,8 +155,9 @@ Receiver behavior:
 
 The state file stores a SHA-256 digest of the channel token, not the token
 itself. Auto-renewed receivers also bind notifications to the persisted current
-or previous channel and resource IDs; manual receivers rely on the channel
-token. Do not run `poll` and `serve` concurrently against the same state file.
+or previous channel and resource IDs; manual receivers rely only on the channel
+token, including when reusing state previously written by auto-renew mode. Do
+not run `poll` and `serve` concurrently against the same state file.
 
 Command page:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -232,7 +232,7 @@ Flag aliases:
 - `gog drive changes start-token [--drive DRIVE_ID]`
 - `gog drive changes list --token TOKEN [--max N] [--all] [--drive DRIVE_ID]`
 - `gog drive changes poll --state-file PATH [--interval DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--drive DRIVE_ID]`
-- `gog drive changes serve --state-file PATH (--channel-token TOKEN|--channel-token-file PATH) [--listen ADDR] [--on-change COMMAND] [--filter-file FILE_ID] [--auto-renew --webhook-url HTTPS_URL]`
+- `gog drive changes serve --state-file PATH (--channel-token TOKEN|--channel-token-file PATH) [--listen ADDR] [--notification-timeout DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--auto-renew --webhook-url HTTPS_URL]`
 - `gog drive changes watch --token TOKEN --webhook-url URL [--channel-id ID] [--channel-token TOKEN]`
 - `gog drive changes stop <channelId> <resourceId>`
 - `gog drive activity query [--file FILE_ID|--folder FOLDER_ID] [--actions edit,share] [--from RFC3339] [--to RFC3339] [--filter FILTER]`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -232,6 +232,7 @@ Flag aliases:
 - `gog drive changes start-token [--drive DRIVE_ID]`
 - `gog drive changes list --token TOKEN [--max N] [--all] [--drive DRIVE_ID]`
 - `gog drive changes poll --state-file PATH [--interval DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--drive DRIVE_ID]`
+- `gog drive changes serve --state-file PATH --channel-token TOKEN [--listen ADDR] [--on-change COMMAND] [--filter-file FILE_ID] [--auto-renew --webhook-url HTTPS_URL]`
 - `gog drive changes watch --token TOKEN --webhook-url URL [--channel-id ID] [--channel-token TOKEN]`
 - `gog drive changes stop <channelId> <resourceId>`
 - `gog drive activity query [--file FILE_ID|--folder FOLDER_ID] [--actions edit,share] [--from RFC3339] [--to RFC3339] [--filter FILTER]`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -232,7 +232,7 @@ Flag aliases:
 - `gog drive changes start-token [--drive DRIVE_ID]`
 - `gog drive changes list --token TOKEN [--max N] [--all] [--drive DRIVE_ID]`
 - `gog drive changes poll --state-file PATH [--interval DURATION] [--on-change COMMAND] [--filter-file FILE_ID] [--drive DRIVE_ID]`
-- `gog drive changes serve --state-file PATH --channel-token TOKEN [--listen ADDR] [--on-change COMMAND] [--filter-file FILE_ID] [--auto-renew --webhook-url HTTPS_URL]`
+- `gog drive changes serve --state-file PATH (--channel-token TOKEN|--channel-token-file PATH) [--listen ADDR] [--on-change COMMAND] [--filter-file FILE_ID] [--auto-renew --webhook-url HTTPS_URL]`
 - `gog drive changes watch --token TOKEN --webhook-url URL [--channel-id ID] [--channel-token TOKEN]`
 - `gog drive changes stop <channelId> <resourceId>`
 - `gog drive activity query [--file FILE_ID|--folder FOLDER_ID] [--actions edit,share] [--from RFC3339] [--to RFC3339] [--filter FILTER]`

--- a/internal/cmd/drive_changes.go
+++ b/internal/cmd/drive_changes.go
@@ -15,12 +15,17 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
-const driveChangesFields = "nextPageToken,newStartPageToken,changes(kind,type,removed,time,fileId,driveId,file(id,name,mimeType,modifiedTime,trashed,webViewLink))"
+const (
+	driveChangesFields             = "nextPageToken,newStartPageToken,changes(kind,type,removed,time,fileId,driveId,file(id,name,mimeType,modifiedTime,trashed,webViewLink))"
+	driveChangesWebhookSchemeHTTPS = "https"
+	driveChangesServerSchemeHTTP   = "http"
+)
 
 type DriveChangesCmd struct {
 	StartToken DriveChangesStartTokenCmd `cmd:"" name:"start-token" aliases:"token" help:"Get a Drive changes start page token"`
 	List       DriveChangesListCmd       `cmd:"" name:"list" aliases:"ls" help:"List Drive changes since a page token"`
 	Poll       DriveChangesPollCmd       `cmd:"" name:"poll" help:"Poll Drive changes with a persisted page token"`
+	Serve      DriveChangesServeCmd      `cmd:"" name:"serve" help:"Receive Drive change notifications and run a local hook"`
 	Watch      DriveChangesWatchCmd      `cmd:"" name:"watch" help:"Watch Drive changes with a webhook channel"`
 	Stop       DriveChangesStopCmd       `cmd:"" name:"stop" help:"Stop a Drive changes webhook channel"`
 }
@@ -289,7 +294,7 @@ func (c *DriveChangesWatchCmd) Run(ctx context.Context, flags *RootFlags) error 
 
 func validateDriveChangesWebhookURL(rawURL string) error {
 	u, err := url.Parse(strings.TrimSpace(rawURL))
-	if err != nil || u.Scheme != "https" || u.Host == "" {
+	if err != nil || u.Scheme != driveChangesWebhookSchemeHTTPS || u.Host == "" {
 		return usage("--webhook-url must be an absolute HTTPS URL")
 	}
 	return nil

--- a/internal/cmd/drive_changes_poll.go
+++ b/internal/cmd/drive_changes_poll.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -9,6 +10,11 @@ import (
 	"google.golang.org/api/drive/v3"
 
 	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+const (
+	driveChangesPollStateKind  = "drive_changes_poll"
+	driveChangesServeStateKind = "drive_changes_serve"
 )
 
 type DriveChangesPollCmd struct {
@@ -24,6 +30,7 @@ type DriveChangesPollCmd struct {
 
 type driveChangesPollState struct {
 	Version   int    `json:"version"`
+	Kind      string `json:"kind,omitempty"`
 	PageToken string `json:"page_token"`
 	DriveID   string `json:"drive_id,omitempty"`
 	UpdatedAt string `json:"updated_at"`
@@ -97,6 +104,7 @@ func (c *DriveChangesPollCmd) run(ctx context.Context, flags *RootFlags, runtime
 		}
 		state = driveChangesPollState{
 			Version:   pollStateVersion,
+			Kind:      driveChangesPollStateKind,
 			PageToken: startPageToken,
 			DriveID:   driveID,
 			UpdatedAt: runtime.now().UTC().Format(time.RFC3339Nano),
@@ -138,6 +146,7 @@ func (c *DriveChangesPollCmd) run(ctx context.Context, flags *RootFlags, runtime
 
 		nextState := driveChangesPollState{
 			Version:   pollStateVersion,
+			Kind:      driveChangesPollStateKind,
 			PageToken: nextPageToken,
 			DriveID:   driveID,
 			UpdatedAt: runtime.now().UTC().Format(time.RFC3339Nano),
@@ -164,6 +173,14 @@ func readDriveChangesPollState(path string) (driveChangesPollState, bool, error)
 	}
 	if state.Version != pollStateVersion {
 		return driveChangesPollState{}, false, fmt.Errorf("unsupported Drive changes poll state version %d", state.Version)
+	}
+	switch state.Kind {
+	case "", driveChangesPollStateKind:
+		state.Kind = driveChangesPollStateKind
+	case driveChangesServeStateKind:
+		return driveChangesPollState{}, false, errors.New("state file belongs to drive changes serve; use a separate --state-file")
+	default:
+		return driveChangesPollState{}, false, fmt.Errorf("unsupported Drive changes poll state kind %q", state.Kind)
 	}
 	if strings.TrimSpace(state.PageToken) == "" {
 		return driveChangesPollState{}, false, fmt.Errorf("drive changes poll state has empty page_token")

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -101,6 +101,7 @@ func (r driveChangesServeRuntime) withDefaults() driveChangesServeRuntime {
 
 type driveChangesServer struct {
 	mu             sync.Mutex
+	notificationMu sync.Mutex
 	renewMu        sync.Mutex
 	runCtx         context.Context
 	pendingChannel string
@@ -536,6 +537,13 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 		}
 	}
 	delay := s.channelRenewalDelayLocked(now)
+	if delay <= 0 {
+		s.warnf(
+			"drive changes serve: channel expiration is inside the renewal window; retrying renewal in %s",
+			driveChangesRenewRetry,
+		)
+		delay = driveChangesRenewRetry
+	}
 	if s.state.PreviousChannel != nil && delay > driveChangesRenewRetry {
 		delay = driveChangesRenewRetry
 	}

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -23,6 +23,7 @@ import (
 const (
 	defaultDriveChangesChannelTTL          = 24 * time.Hour
 	defaultDriveChangesNotificationTimeout = 5 * time.Minute
+	defaultDriveChangesReadTimeout         = 10 * time.Second
 	maxDriveChangesChannelTTL              = 7 * 24 * time.Hour
 	driveChangesRenewRetry                 = time.Minute
 )
@@ -234,6 +235,7 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	}
 	httpServer := &http.Server{
 		Handler:           server,
+		ReadTimeout:       defaultDriveChangesReadTimeout,
 		ReadHeaderTimeout: 5 * time.Second,
 		IdleTimeout:       30 * time.Second,
 		MaxHeaderBytes:    64 << 10,

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -34,7 +34,7 @@ type DriveChangesServeCmd struct {
 	Path                string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
 	Cert                string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
 	Key                 string        `name:"key" help:"TLS private key path; pair with --cert"`
-	ChannelToken        string        `name:"channel-token" help:"Expected X-Goog-Channel-Token value" env:"GOG_DRIVE_CHANNEL_TOKEN"`
+	ChannelToken        string        `name:"channel-token" help:"Expected X-Goog-Channel-Token value"`
 	ChannelTokenFile    string        `name:"channel-token-file" type:"path" help:"Read the expected channel token from a file"`
 	StateFile           string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
 	Token               string        `name:"token" help:"Initial Drive page token when creating a new state file"`
@@ -61,6 +61,7 @@ type driveChangesServeChannelState struct {
 
 type driveChangesServeState struct {
 	Version            int                            `json:"version"`
+	Kind               string                         `json:"kind,omitempty"`
 	PageToken          string                         `json:"page_token"`
 	DriveID            string                         `json:"drive_id,omitempty"`
 	Channel            *driveChangesServeChannelState `json:"channel,omitempty"`
@@ -293,6 +294,9 @@ func (c *DriveChangesServeCmd) resolveChannelToken() (string, error) {
 		direct = strings.TrimSpace(string(raw))
 	}
 	if direct == "" {
+		direct = strings.TrimSpace(os.Getenv("GOG_DRIVE_CHANNEL_TOKEN"))
+	}
+	if direct == "" {
 		return "", usage("provide --channel-token, --channel-token-file, or GOG_DRIVE_CHANNEL_TOKEN")
 	}
 	return direct, nil
@@ -378,6 +382,7 @@ func initializeDriveChangesServeState(
 	}
 	state = driveChangesServeState{
 		Version:   pollStateVersion,
+		Kind:      driveChangesServeStateKind,
 		PageToken: initialToken,
 		DriveID:   driveID,
 		UpdatedAt: now.Format(time.RFC3339Nano),
@@ -396,6 +401,14 @@ func readDriveChangesServeState(path string) (driveChangesServeState, bool, erro
 	}
 	if state.Version != pollStateVersion {
 		return driveChangesServeState{}, false, fmt.Errorf("unsupported drive changes serve state version %d", state.Version)
+	}
+	switch state.Kind {
+	case "", driveChangesServeStateKind:
+		state.Kind = driveChangesServeStateKind
+	case driveChangesPollStateKind:
+		return driveChangesServeState{}, false, errors.New("state file belongs to drive changes poll; use a separate --state-file")
+	default:
+		return driveChangesServeState{}, false, fmt.Errorf("unsupported drive changes serve state kind %q", state.Kind)
 	}
 	state.PageToken = strings.TrimSpace(state.PageToken)
 	state.DriveID = strings.TrimSpace(state.DriveID)

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -105,7 +105,7 @@ type driveChangesServer struct {
 	mu             sync.Mutex
 	notificationMu sync.Mutex
 	renewMu        sync.Mutex
-	runCtx         context.Context
+	runDone        <-chan struct{}
 	pendingChannel string
 	statePath      string
 	state          driveChangesServeState
@@ -208,7 +208,7 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	}
 
 	server := &driveChangesServer{
-		runCtx:         ctx,
+		runDone:        ctx.Done(),
 		statePath:      statePath,
 		state:          state,
 		service:        svc,

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -21,31 +21,33 @@ import (
 )
 
 const (
-	defaultDriveChangesChannelTTL = 24 * time.Hour
-	maxDriveChangesChannelTTL     = 7 * 24 * time.Hour
-	driveChangesRenewRetry        = time.Minute
+	defaultDriveChangesChannelTTL          = 24 * time.Hour
+	defaultDriveChangesNotificationTimeout = 5 * time.Minute
+	maxDriveChangesChannelTTL              = 7 * 24 * time.Hour
+	driveChangesRenewRetry                 = time.Minute
 )
 
 var errDriveChangesPreviousCleanupPending = errors.New("previous Drive changes channel cleanup is pending")
 
 type DriveChangesServeCmd struct {
-	Listen           string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
-	Path             string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
-	Cert             string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
-	Key              string        `name:"key" help:"TLS private key path; pair with --cert"`
-	ChannelToken     string        `name:"channel-token" help:"Expected X-Goog-Channel-Token value" env:"GOG_DRIVE_CHANNEL_TOKEN"`
-	ChannelTokenFile string        `name:"channel-token-file" type:"path" help:"Read the expected channel token from a file"`
-	StateFile        string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
-	Token            string        `name:"token" help:"Initial Drive page token when creating a new state file"`
-	OnChange         string        `name:"on-change" help:"Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin"`
-	FilterFile       string        `name:"filter-file" help:"Only invoke the hook for changes to this file ID"`
-	DriveID          string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
-	Max              int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
-	IncludeRemoved   bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
-	AutoRenew        bool          `name:"auto-renew" help:"Create and renew the Drive notification channel"`
-	WebhookURL       string        `name:"webhook-url" help:"Public HTTPS callback URL used by --auto-renew"`
-	ChannelTTL       time.Duration `name:"channel-ttl" help:"Requested channel lifetime" default:"24h"`
-	RenewBefore      time.Duration `name:"renew-before" help:"Renew this long before channel expiration" default:"10m"`
+	Listen              string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
+	Path                string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
+	Cert                string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
+	Key                 string        `name:"key" help:"TLS private key path; pair with --cert"`
+	ChannelToken        string        `name:"channel-token" help:"Expected X-Goog-Channel-Token value" env:"GOG_DRIVE_CHANNEL_TOKEN"`
+	ChannelTokenFile    string        `name:"channel-token-file" type:"path" help:"Read the expected channel token from a file"`
+	StateFile           string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
+	Token               string        `name:"token" help:"Initial Drive page token when creating a new state file"`
+	OnChange            string        `name:"on-change" help:"Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin"`
+	FilterFile          string        `name:"filter-file" help:"Only invoke the hook for changes to this file ID"`
+	DriveID             string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
+	Max                 int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
+	IncludeRemoved      bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
+	AutoRenew           bool          `name:"auto-renew" help:"Create and renew the Drive notification channel"`
+	WebhookURL          string        `name:"webhook-url" help:"Public HTTPS callback URL used by --auto-renew"`
+	ChannelTTL          time.Duration `name:"channel-ttl" help:"Requested channel lifetime" default:"24h"`
+	RenewBefore         time.Duration `name:"renew-before" help:"Renew this long before channel expiration" default:"10m"`
+	NotificationTimeout time.Duration `name:"notification-timeout" help:"Maximum time for one callback, including Drive reads and the hook" default:"5m"`
 }
 
 type driveChangesServeChannelState struct {
@@ -102,27 +104,29 @@ func (r driveChangesServeRuntime) withDefaults() driveChangesServeRuntime {
 }
 
 type driveChangesServer struct {
-	mu             sync.Mutex
-	notificationMu sync.Mutex
-	renewMu        sync.Mutex
-	runDone        <-chan struct{}
-	pendingChannel string
-	statePath      string
-	state          driveChangesServeState
-	service        *drive.Service
-	path           string
-	channelToken   string
-	onChange       string
-	filterFile     string
-	max            int64
-	includeRemoved bool
-	autoRenew      bool
-	webhookURL     string
-	channelTTL     time.Duration
-	renewBefore    time.Duration
-	runtime        driveChangesServeRuntime
-	logf           func(string, ...any)
-	warnf          func(string, ...any)
+	mu                  sync.Mutex
+	notificationOnce    sync.Once
+	notificationGate    chan struct{}
+	renewMu             sync.Mutex
+	runDone             <-chan struct{}
+	pendingChannel      string
+	statePath           string
+	state               driveChangesServeState
+	service             *drive.Service
+	path                string
+	channelToken        string
+	onChange            string
+	filterFile          string
+	max                 int64
+	includeRemoved      bool
+	autoRenew           bool
+	webhookURL          string
+	channelTTL          time.Duration
+	renewBefore         time.Duration
+	notificationTimeout time.Duration
+	runtime             driveChangesServeRuntime
+	logf                func(string, ...any)
+	warnf               func(string, ...any)
 }
 
 func (c *DriveChangesServeCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -149,21 +153,21 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	driveID := strings.TrimSpace(c.DriveID)
 	filterFile := normalizeGoogleID(strings.TrimSpace(c.FilterFile))
 	if dryRunErr := dryRunExit(ctx, flags, "drive.changes.serve", map[string]any{
-		"listen":           strings.TrimSpace(c.Listen),
-		"path":             strings.TrimSpace(c.Path),
-		"tls":              strings.TrimSpace(c.Cert) != "",
-		"state_file":       statePath,
-		"initial_token":    strings.TrimSpace(c.Token) != "",
-		"drive_id":         driveID,
-		"filter_file":      filterFile,
-		"max":              c.Max,
-		"include_removed":  c.IncludeRemoved,
-		"hook_configured":  strings.TrimSpace(c.OnChange) != "",
-		"auto_renew":       c.AutoRenew,
-		"webhook_url":      strings.TrimSpace(c.WebhookURL),
-		"channel_ttl":      c.ChannelTTL.String(),
-		"renew_before":     c.RenewBefore.String(),
-		"token_configured": true,
+		"listen":               strings.TrimSpace(c.Listen),
+		"path":                 strings.TrimSpace(c.Path),
+		"tls":                  strings.TrimSpace(c.Cert) != "",
+		"state_file":           statePath,
+		"initial_token":        strings.TrimSpace(c.Token) != "",
+		"drive_id":             driveID,
+		"filter_file":          filterFile,
+		"max":                  c.Max,
+		"include_removed":      c.IncludeRemoved,
+		"hook_configured":      strings.TrimSpace(c.OnChange) != "",
+		"auto_renew":           c.AutoRenew,
+		"webhook_url":          strings.TrimSpace(c.WebhookURL),
+		"channel_ttl":          c.ChannelTTL.String(),
+		"renew_before":         c.RenewBefore.String(),
+		"notification_timeout": c.NotificationTimeout.String(),
 	}); dryRunErr != nil {
 		return dryRunErr
 	}
@@ -208,23 +212,24 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	}
 
 	server := &driveChangesServer{
-		runDone:        ctx.Done(),
-		statePath:      statePath,
-		state:          state,
-		service:        svc,
-		path:           strings.TrimSpace(c.Path),
-		channelToken:   channelToken,
-		onChange:       strings.TrimSpace(c.OnChange),
-		filterFile:     filterFile,
-		max:            c.Max,
-		includeRemoved: c.IncludeRemoved,
-		autoRenew:      c.AutoRenew,
-		webhookURL:     strings.TrimSpace(c.WebhookURL),
-		channelTTL:     c.ChannelTTL,
-		renewBefore:    c.RenewBefore,
-		runtime:        runtime,
-		logf:           u.Err().Linef,
-		warnf:          u.Err().Linef,
+		runDone:             ctx.Done(),
+		statePath:           statePath,
+		state:               state,
+		service:             svc,
+		path:                strings.TrimSpace(c.Path),
+		channelToken:        channelToken,
+		onChange:            strings.TrimSpace(c.OnChange),
+		filterFile:          filterFile,
+		max:                 c.Max,
+		includeRemoved:      c.IncludeRemoved,
+		autoRenew:           c.AutoRenew,
+		webhookURL:          strings.TrimSpace(c.WebhookURL),
+		channelTTL:          c.ChannelTTL,
+		renewBefore:         c.RenewBefore,
+		notificationTimeout: c.NotificationTimeout,
+		runtime:             runtime,
+		logf:                u.Err().Linef,
+		warnf:               u.Err().Linef,
 	}
 	httpServer := &http.Server{
 		Handler:           server,
@@ -320,6 +325,9 @@ func (c *DriveChangesServeCmd) validate(channelToken string) error {
 	}
 	if c.Max <= 0 {
 		return usage("--max must be greater than zero")
+	}
+	if c.NotificationTimeout <= 0 {
+		return usage("--notification-timeout must be greater than zero")
 	}
 	webhookURL := strings.TrimSpace(c.WebhookURL)
 	if c.AutoRenew {
@@ -523,7 +531,11 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 		TokenHash:   channelTokenHash(s.channelToken),
 	}
 	nextState.UpdatedAt = now.Format(time.RFC3339Nano)
-	trimDriveChangesMessageNumbers(&nextState, nextState.Channel.ID, channelIDFor(nextState.PreviousChannel))
+	trimDriveChangesMessageNumbers(
+		&nextState,
+		driveChangesMessageKeyForChannel(nextState.Channel),
+		driveChangesMessageKeyForChannel(nextState.PreviousChannel),
+	)
 	if err := writePollState(s.statePath, nextState); err != nil {
 		channelToStop := *nextState.Channel
 		s.mu.Unlock()
@@ -648,29 +660,29 @@ func (s *driveChangesServer) runRenewLoop(ctx context.Context, delay time.Durati
 	}
 }
 
-func channelIDFor(channel *driveChangesServeChannelState) string {
+func driveChangesMessageKeyForChannel(channel *driveChangesServeChannelState) string {
 	if channel == nil {
 		return ""
 	}
-	return channel.ID
+	return driveChangesMessageKey(channel.ID, channel.ResourceID)
 }
 
-func trimDriveChangesMessageNumbers(state *driveChangesServeState, keepChannelIDs ...string) {
+func trimDriveChangesMessageNumbers(state *driveChangesServeState, keepKeys ...string) {
 	if len(state.LastMessageNumbers) <= 32 {
 		return
 	}
-	keep := make(map[string]struct{}, len(keepChannelIDs))
-	for _, channelID := range keepChannelIDs {
-		if channelID != "" {
-			keep[channelID] = struct{}{}
+	keep := make(map[string]struct{}, len(keepKeys))
+	for _, key := range keepKeys {
+		if key != "" {
+			keep[key] = struct{}{}
 		}
 	}
-	for channelID := range state.LastMessageNumbers {
+	for key := range state.LastMessageNumbers {
 		if len(state.LastMessageNumbers) <= 32 {
 			break
 		}
-		if _, ok := keep[channelID]; !ok {
-			delete(state.LastMessageNumbers, channelID)
+		if _, ok := keep[key]; !ok {
+			delete(state.LastMessageNumbers, key)
 		}
 	}
 }

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -9,12 +9,14 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"google.golang.org/api/drive/v3"
 
+	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/ui"
 )
 
@@ -25,22 +27,23 @@ const (
 )
 
 type DriveChangesServeCmd struct {
-	Listen         string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
-	Path           string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
-	Cert           string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
-	Key            string        `name:"key" help:"TLS private key path; pair with --cert"`
-	ChannelToken   string        `name:"channel-token" required:"" help:"Expected X-Goog-Channel-Token value"`
-	StateFile      string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
-	Token          string        `name:"token" help:"Initial Drive page token when creating a new state file"`
-	OnChange       string        `name:"on-change" help:"Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin"`
-	FilterFile     string        `name:"filter-file" help:"Only invoke the hook for changes to this file ID"`
-	DriveID        string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
-	Max            int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
-	IncludeRemoved bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
-	AutoRenew      bool          `name:"auto-renew" help:"Create and renew the Drive notification channel"`
-	WebhookURL     string        `name:"webhook-url" help:"Public HTTPS callback URL used by --auto-renew"`
-	ChannelTTL     time.Duration `name:"channel-ttl" help:"Requested channel lifetime" default:"24h"`
-	RenewBefore    time.Duration `name:"renew-before" help:"Renew this long before channel expiration" default:"10m"`
+	Listen           string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
+	Path             string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
+	Cert             string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
+	Key              string        `name:"key" help:"TLS private key path; pair with --cert"`
+	ChannelToken     string        `name:"channel-token" help:"Expected X-Goog-Channel-Token value" env:"GOG_DRIVE_CHANNEL_TOKEN"`
+	ChannelTokenFile string        `name:"channel-token-file" type:"path" help:"Read the expected channel token from a file"`
+	StateFile        string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
+	Token            string        `name:"token" help:"Initial Drive page token when creating a new state file"`
+	OnChange         string        `name:"on-change" help:"Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin"`
+	FilterFile       string        `name:"filter-file" help:"Only invoke the hook for changes to this file ID"`
+	DriveID          string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
+	Max              int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
+	IncludeRemoved   bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
+	AutoRenew        bool          `name:"auto-renew" help:"Create and renew the Drive notification channel"`
+	WebhookURL       string        `name:"webhook-url" help:"Public HTTPS callback URL used by --auto-renew"`
+	ChannelTTL       time.Duration `name:"channel-ttl" help:"Requested channel lifetime" default:"24h"`
+	RenewBefore      time.Duration `name:"renew-before" help:"Renew this long before channel expiration" default:"10m"`
 }
 
 type driveChangesServeChannelState struct {
@@ -99,6 +102,7 @@ func (r driveChangesServeRuntime) withDefaults() driveChangesServeRuntime {
 type driveChangesServer struct {
 	mu             sync.Mutex
 	renewMu        sync.Mutex
+	runCtx         context.Context
 	pendingChannel string
 	statePath      string
 	state          driveChangesServeState
@@ -131,7 +135,11 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	if err != nil {
 		return err
 	}
-	if validationErr := c.validate(); validationErr != nil {
+	channelToken, err := c.resolveChannelToken()
+	if err != nil {
+		return err
+	}
+	if validationErr := c.validate(channelToken); validationErr != nil {
 		return validationErr
 	}
 
@@ -193,11 +201,12 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	}
 
 	server := &driveChangesServer{
+		runCtx:         ctx,
 		statePath:      statePath,
 		state:          state,
 		service:        svc,
 		path:           strings.TrimSpace(c.Path),
-		channelToken:   strings.TrimSpace(c.ChannelToken),
+		channelToken:   channelToken,
 		onChange:       strings.TrimSpace(c.OnChange),
 		filterFile:     filterFile,
 		max:            c.Max,
@@ -250,7 +259,30 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	}
 }
 
-func (c *DriveChangesServeCmd) validate() error {
+func (c *DriveChangesServeCmd) resolveChannelToken() (string, error) {
+	direct := strings.TrimSpace(c.ChannelToken)
+	tokenFile := strings.TrimSpace(c.ChannelTokenFile)
+	if direct != "" && tokenFile != "" {
+		return "", usage("provide only one of --channel-token or --channel-token-file")
+	}
+	if tokenFile != "" {
+		path, err := config.ExpandPath(tokenFile)
+		if err != nil {
+			return "", fmt.Errorf("expand --channel-token-file: %w", err)
+		}
+		raw, err := os.ReadFile(path) //nolint:gosec // explicit operator-provided secret file.
+		if err != nil {
+			return "", fmt.Errorf("read --channel-token-file: %w", err)
+		}
+		direct = strings.TrimSpace(string(raw))
+	}
+	if direct == "" {
+		return "", usage("provide --channel-token, --channel-token-file, or GOG_DRIVE_CHANNEL_TOKEN")
+	}
+	return direct, nil
+}
+
+func (c *DriveChangesServeCmd) validate(channelToken string) error {
 	if strings.TrimSpace(c.Listen) == "" {
 		return usage("missing --listen")
 	}
@@ -259,10 +291,6 @@ func (c *DriveChangesServeCmd) validate() error {
 	}
 	if (strings.TrimSpace(c.Cert) == "") != (strings.TrimSpace(c.Key) == "") {
 		return usage("--cert and --key must be provided together")
-	}
-	channelToken := strings.TrimSpace(c.ChannelToken)
-	if channelToken == "" {
-		return usage("missing --channel-token")
 	}
 	if len(channelToken) > 256 {
 		return usage("--channel-token must be at most 256 bytes")

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -167,7 +167,11 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 
 	var tlsConfig *tls.Config
 	if strings.TrimSpace(c.Cert) != "" {
-		certificate, certErr := tls.LoadX509KeyPair(c.Cert, c.Key)
+		certPath, keyPath, pathErr := expandDriveChangesTLSPaths(c.Cert, c.Key)
+		if pathErr != nil {
+			return pathErr
+		}
+		certificate, certErr := tls.LoadX509KeyPair(certPath, keyPath)
 		if certErr != nil {
 			return fmt.Errorf("load TLS certificate: %w", certErr)
 		}
@@ -280,6 +284,18 @@ func (c *DriveChangesServeCmd) resolveChannelToken() (string, error) {
 		return "", usage("provide --channel-token, --channel-token-file, or GOG_DRIVE_CHANNEL_TOKEN")
 	}
 	return direct, nil
+}
+
+func expandDriveChangesTLSPaths(cert string, key string) (string, string, error) {
+	certPath, err := config.ExpandPath(strings.TrimSpace(cert))
+	if err != nil {
+		return "", "", fmt.Errorf("expand --cert: %w", err)
+	}
+	keyPath, err := config.ExpandPath(strings.TrimSpace(key))
+	if err != nil {
+		return "", "", fmt.Errorf("expand --key: %w", err)
+	}
+	return certPath, keyPath, nil
 }
 
 func (c *DriveChangesServeCmd) validate(channelToken string) error {

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -441,16 +441,13 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 	s.renewMu.Lock()
 	defer s.renewMu.Unlock()
 
-	s.mu.Lock()
-
 	pendingStopFailed := false
-	if s.state.PreviousChannel != nil {
-		if err := s.stopPreviousChannelLocked(ctx); err != nil {
-			pendingStopFailed = true
-			s.warnf("drive changes serve: stop previous channel failed: %v", err)
-		}
+	if err := s.stopPreviousChannel(ctx); err != nil {
+		pendingStopFailed = true
+		s.warnf("drive changes serve: stop previous channel failed: %v", err)
 	}
 
+	s.mu.Lock()
 	now := s.runtime.now().UTC()
 	if s.currentChannelMatchesLocked() {
 		delay := s.channelRenewalDelayLocked(now)
@@ -506,7 +503,6 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if s.pendingChannel == channelID {
 		s.pendingChannel = ""
 	}
@@ -523,19 +519,19 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 	nextState.UpdatedAt = now.Format(time.RFC3339Nano)
 	trimDriveChangesMessageNumbers(&nextState, nextState.Channel.ID, channelIDFor(nextState.PreviousChannel))
 	if err := writePollState(s.statePath, nextState); err != nil {
-		_ = s.service.Channels.Stop(&drive.Channel{
-			Id:         nextState.Channel.ID,
-			ResourceId: nextState.Channel.ResourceID,
-		}).Context(ctx).Do()
+		channelToStop := *nextState.Channel
+		s.mu.Unlock()
+		_ = s.stopDriveChangesChannel(ctx, &channelToStop)
 		return 0, err
 	}
 	s.state = nextState
+	s.mu.Unlock()
 
-	if s.state.PreviousChannel != nil {
-		if err := s.stopPreviousChannelLocked(ctx); err != nil {
-			s.warnf("drive changes serve: stop previous channel failed: %v", err)
-		}
+	if err := s.stopPreviousChannel(ctx); err != nil {
+		s.warnf("drive changes serve: stop previous channel failed: %v", err)
 	}
+
+	s.mu.Lock()
 	delay := s.channelRenewalDelayLocked(now)
 	if delay <= 0 {
 		s.warnf(
@@ -547,6 +543,7 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 	if s.state.PreviousChannel != nil && delay > driveChangesRenewRetry {
 		delay = driveChangesRenewRetry
 	}
+	s.mu.Unlock()
 	return delay, nil
 }
 
@@ -578,18 +575,22 @@ func (s *driveChangesServer) channelRenewalDelayLocked(now time.Time) time.Durat
 	return delay
 }
 
-func (s *driveChangesServer) stopPreviousChannelLocked(ctx context.Context) error {
-	previous := s.state.PreviousChannel
+func (s *driveChangesServer) stopPreviousChannel(ctx context.Context) error {
+	s.mu.Lock()
+	previous := cloneDriveChangesServeChannel(s.state.PreviousChannel)
+	s.mu.Unlock()
 	if previous == nil {
 		return nil
 	}
-	if previous.ID != "" && previous.ResourceID != "" {
-		if err := s.service.Channels.Stop(&drive.Channel{
-			Id:         previous.ID,
-			ResourceId: previous.ResourceID,
-		}).Context(ctx).Do(); err != nil && !isNotFoundAPIError(err) {
-			return err
-		}
+	if err := s.stopDriveChangesChannel(ctx, previous); err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	current := s.state.PreviousChannel
+	if current == nil || current.ID != previous.ID || current.ResourceID != previous.ResourceID {
+		return nil
 	}
 	nextState := cloneDriveChangesServeState(s.state)
 	nextState.PreviousChannel = nil
@@ -599,6 +600,28 @@ func (s *driveChangesServer) stopPreviousChannelLocked(ctx context.Context) erro
 	}
 	s.state = nextState
 	return nil
+}
+
+func (s *driveChangesServer) stopDriveChangesChannel(ctx context.Context, channel *driveChangesServeChannelState) error {
+	if channel == nil || channel.ID == "" || channel.ResourceID == "" {
+		return nil
+	}
+	err := s.service.Channels.Stop(&drive.Channel{
+		Id:         channel.ID,
+		ResourceId: channel.ResourceID,
+	}).Context(ctx).Do()
+	if err != nil && !isNotFoundAPIError(err) {
+		return err
+	}
+	return nil
+}
+
+func cloneDriveChangesServeChannel(channel *driveChangesServeChannelState) *driveChangesServeChannelState {
+	if channel == nil {
+		return nil
+	}
+	cloned := *channel
+	return &cloned
 }
 
 func (s *driveChangesServer) runRenewLoop(ctx context.Context, delay time.Duration) {

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -26,6 +26,8 @@ const (
 	driveChangesRenewRetry        = time.Minute
 )
 
+var errDriveChangesPreviousCleanupPending = errors.New("previous Drive changes channel cleanup is pending")
+
 type DriveChangesServeCmd struct {
 	Listen           string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
 	Path             string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
@@ -244,8 +246,12 @@ func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtim
 	if c.AutoRenew {
 		nextRenewal, renewErr := server.ensureChannel(ctx)
 		if renewErr != nil {
-			_ = shutdownHTTPServer(ctx, httpServer)
-			return renewErr
+			if !errors.Is(renewErr, errDriveChangesPreviousCleanupPending) {
+				_ = shutdownHTTPServer(ctx, httpServer)
+				return renewErr
+			}
+			server.warnf("drive changes serve: channel cleanup pending; retrying renewal in %s", driveChangesRenewRetry)
+			nextRenewal = driveChangesRenewRetry
 		}
 		go server.runRenewLoop(ctx, nextRenewal)
 	}
@@ -461,7 +467,7 @@ func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, 
 	}
 	if s.state.PreviousChannel != nil {
 		s.mu.Unlock()
-		return 0, errors.New("cannot renew Drive changes channel while previous channel cleanup is pending")
+		return 0, errDriveChangesPreviousCleanupPending
 	}
 	pageToken := s.state.PageToken
 	driveID := s.state.DriveID

--- a/internal/cmd/drive_changes_serve.go
+++ b/internal/cmd/drive_changes_serve.go
@@ -1,0 +1,595 @@
+package cmd
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/tls"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+const (
+	defaultDriveChangesChannelTTL = 24 * time.Hour
+	maxDriveChangesChannelTTL     = 7 * 24 * time.Hour
+	driveChangesRenewRetry        = time.Minute
+)
+
+type DriveChangesServeCmd struct {
+	Listen         string        `name:"listen" help:"Listen address" default:"127.0.0.1:8443"`
+	Path           string        `name:"path" help:"Notification handler path" default:"/drive-changes"`
+	Cert           string        `name:"cert" help:"TLS certificate path; pair with --key (omit behind an HTTPS reverse proxy)"`
+	Key            string        `name:"key" help:"TLS private key path; pair with --cert"`
+	ChannelToken   string        `name:"channel-token" required:"" help:"Expected X-Goog-Channel-Token value"`
+	StateFile      string        `name:"state-file" required:"" help:"JSON file that stores the current Drive page token and channel state"`
+	Token          string        `name:"token" help:"Initial Drive page token when creating a new state file"`
+	OnChange       string        `name:"on-change" help:"Trusted local shell command run for each non-empty change batch; event JSON is provided on stdin"`
+	FilterFile     string        `name:"filter-file" help:"Only invoke the hook for changes to this file ID"`
+	DriveID        string        `name:"drive" aliases:"drive-id" help:"Shared drive ID for a shared-drive change log"`
+	Max            int64         `name:"max" aliases:"limit" help:"Max changes per API page" default:"100"`
+	IncludeRemoved bool          `name:"include-removed" help:"Include removed changes" default:"true" negatable:"_"`
+	AutoRenew      bool          `name:"auto-renew" help:"Create and renew the Drive notification channel"`
+	WebhookURL     string        `name:"webhook-url" help:"Public HTTPS callback URL used by --auto-renew"`
+	ChannelTTL     time.Duration `name:"channel-ttl" help:"Requested channel lifetime" default:"24h"`
+	RenewBefore    time.Duration `name:"renew-before" help:"Renew this long before channel expiration" default:"10m"`
+}
+
+type driveChangesServeChannelState struct {
+	ID          string `json:"id"`
+	ResourceID  string `json:"resource_id"`
+	ResourceURI string `json:"resource_uri,omitempty"`
+	Expiration  int64  `json:"expiration_ms"`
+	WebhookURL  string `json:"webhook_url,omitempty"`
+	TokenHash   string `json:"token_sha256,omitempty"`
+}
+
+type driveChangesServeState struct {
+	Version            int                            `json:"version"`
+	PageToken          string                         `json:"page_token"`
+	DriveID            string                         `json:"drive_id,omitempty"`
+	Channel            *driveChangesServeChannelState `json:"channel,omitempty"`
+	PreviousChannel    *driveChangesServeChannelState `json:"previous_channel,omitempty"`
+	LastMessageNumbers map[string]uint64              `json:"last_message_numbers,omitempty"`
+	UpdatedAt          string                         `json:"updated_at"`
+}
+
+type driveChangesServeRuntime struct {
+	now     func() time.Time
+	runHook func(context.Context, string, any) error
+	wait    func(context.Context, time.Duration) error
+	listen  func(context.Context, string, string) (net.Listener, error)
+}
+
+func defaultDriveChangesServeRuntime() driveChangesServeRuntime {
+	var listenConfig net.ListenConfig
+	return driveChangesServeRuntime{
+		now:     time.Now,
+		runHook: runJSONShellHook,
+		wait:    waitForPollInterval,
+		listen:  listenConfig.Listen,
+	}
+}
+
+func (r driveChangesServeRuntime) withDefaults() driveChangesServeRuntime {
+	defaults := defaultDriveChangesServeRuntime()
+	if r.now == nil {
+		r.now = defaults.now
+	}
+	if r.runHook == nil {
+		r.runHook = defaults.runHook
+	}
+	if r.wait == nil {
+		r.wait = defaults.wait
+	}
+	if r.listen == nil {
+		r.listen = defaults.listen
+	}
+	return r
+}
+
+type driveChangesServer struct {
+	mu             sync.Mutex
+	renewMu        sync.Mutex
+	pendingChannel string
+	statePath      string
+	state          driveChangesServeState
+	service        *drive.Service
+	path           string
+	channelToken   string
+	onChange       string
+	filterFile     string
+	max            int64
+	includeRemoved bool
+	autoRenew      bool
+	webhookURL     string
+	channelTTL     time.Duration
+	renewBefore    time.Duration
+	runtime        driveChangesServeRuntime
+	logf           func(string, ...any)
+	warnf          func(string, ...any)
+}
+
+func (c *DriveChangesServeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	serveCtx, stop := pollSignalContext(ctx)
+	defer stop()
+	return c.run(serveCtx, flags, defaultDriveChangesServeRuntime())
+}
+
+func (c *DriveChangesServeCmd) run(ctx context.Context, flags *RootFlags, runtime driveChangesServeRuntime) error {
+	runtime = runtime.withDefaults()
+	u := ui.FromContext(ctx)
+	statePath, err := expandPollStatePath(c.StateFile)
+	if err != nil {
+		return err
+	}
+	if validationErr := c.validate(); validationErr != nil {
+		return validationErr
+	}
+
+	driveID := strings.TrimSpace(c.DriveID)
+	filterFile := normalizeGoogleID(strings.TrimSpace(c.FilterFile))
+	if dryRunErr := dryRunExit(ctx, flags, "drive.changes.serve", map[string]any{
+		"listen":           strings.TrimSpace(c.Listen),
+		"path":             strings.TrimSpace(c.Path),
+		"tls":              strings.TrimSpace(c.Cert) != "",
+		"state_file":       statePath,
+		"initial_token":    strings.TrimSpace(c.Token) != "",
+		"drive_id":         driveID,
+		"filter_file":      filterFile,
+		"max":              c.Max,
+		"include_removed":  c.IncludeRemoved,
+		"hook_configured":  strings.TrimSpace(c.OnChange) != "",
+		"auto_renew":       c.AutoRenew,
+		"webhook_url":      strings.TrimSpace(c.WebhookURL),
+		"channel_ttl":      c.ChannelTTL.String(),
+		"renew_before":     c.RenewBefore.String(),
+		"token_configured": true,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	var tlsConfig *tls.Config
+	if strings.TrimSpace(c.Cert) != "" {
+		certificate, certErr := tls.LoadX509KeyPair(c.Cert, c.Key)
+		if certErr != nil {
+			return fmt.Errorf("load TLS certificate: %w", certErr)
+		}
+		tlsConfig = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{certificate},
+		}
+	}
+
+	_, svc, err := requireDriveService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	state, err := initializeDriveChangesServeState(
+		ctx,
+		svc,
+		statePath,
+		strings.TrimSpace(c.Token),
+		driveID,
+		runtime.now().UTC(),
+	)
+	if err != nil {
+		return err
+	}
+	listener, err := runtime.listen(ctx, "tcp", strings.TrimSpace(c.Listen))
+	if err != nil {
+		return fmt.Errorf("listen on %s: %w", c.Listen, err)
+	}
+	if tlsConfig != nil {
+		listener = tls.NewListener(listener, tlsConfig)
+	}
+
+	server := &driveChangesServer{
+		statePath:      statePath,
+		state:          state,
+		service:        svc,
+		path:           strings.TrimSpace(c.Path),
+		channelToken:   strings.TrimSpace(c.ChannelToken),
+		onChange:       strings.TrimSpace(c.OnChange),
+		filterFile:     filterFile,
+		max:            c.Max,
+		includeRemoved: c.IncludeRemoved,
+		autoRenew:      c.AutoRenew,
+		webhookURL:     strings.TrimSpace(c.WebhookURL),
+		channelTTL:     c.ChannelTTL,
+		renewBefore:    c.RenewBefore,
+		runtime:        runtime,
+		logf:           u.Err().Linef,
+		warnf:          u.Err().Linef,
+	}
+	httpServer := &http.Server{
+		Handler:           server,
+		ReadHeaderTimeout: 5 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		MaxHeaderBytes:    64 << 10,
+	}
+	serveErrors := make(chan error, 1)
+	go func() {
+		serveErrors <- httpServer.Serve(listener)
+	}()
+
+	scheme := driveChangesServerSchemeHTTP
+	if tlsConfig != nil {
+		scheme = driveChangesWebhookSchemeHTTPS
+	}
+	u.Err().Linef("drive changes serve: listening on %s://%s%s", scheme, listener.Addr(), server.path)
+
+	if c.AutoRenew {
+		nextRenewal, renewErr := server.ensureChannel(ctx)
+		if renewErr != nil {
+			_ = shutdownHTTPServer(ctx, httpServer)
+			return renewErr
+		}
+		go server.runRenewLoop(ctx, nextRenewal)
+	}
+
+	select {
+	case serveErr := <-serveErrors:
+		if errors.Is(serveErr, http.ErrServerClosed) {
+			return nil
+		}
+		return serveErr
+	case <-ctx.Done():
+		if shutdownErr := shutdownHTTPServer(ctx, httpServer); shutdownErr != nil {
+			return shutdownErr
+		}
+		return ctx.Err()
+	}
+}
+
+func (c *DriveChangesServeCmd) validate() error {
+	if strings.TrimSpace(c.Listen) == "" {
+		return usage("missing --listen")
+	}
+	if path := strings.TrimSpace(c.Path); path == "" || !strings.HasPrefix(path, "/") {
+		return usage("--path must start with '/'")
+	}
+	if (strings.TrimSpace(c.Cert) == "") != (strings.TrimSpace(c.Key) == "") {
+		return usage("--cert and --key must be provided together")
+	}
+	channelToken := strings.TrimSpace(c.ChannelToken)
+	if channelToken == "" {
+		return usage("missing --channel-token")
+	}
+	if len(channelToken) > 256 {
+		return usage("--channel-token must be at most 256 bytes")
+	}
+	if c.Max <= 0 {
+		return usage("--max must be greater than zero")
+	}
+	webhookURL := strings.TrimSpace(c.WebhookURL)
+	if c.AutoRenew {
+		if webhookURL == "" {
+			return usage("--webhook-url is required with --auto-renew")
+		}
+		if err := validateDriveChangesWebhookURL(webhookURL); err != nil {
+			return err
+		}
+		if c.ChannelTTL <= 0 || c.ChannelTTL > maxDriveChangesChannelTTL {
+			return usage("--channel-ttl must be greater than zero and at most 168h")
+		}
+		if c.RenewBefore <= 0 || c.RenewBefore >= c.ChannelTTL {
+			return usage("--renew-before must be greater than zero and less than --channel-ttl")
+		}
+	} else if webhookURL != "" {
+		return usage("--webhook-url requires --auto-renew")
+	}
+	return nil
+}
+
+func initializeDriveChangesServeState(
+	ctx context.Context,
+	svc *drive.Service,
+	path string,
+	initialToken string,
+	driveID string,
+	now time.Time,
+) (driveChangesServeState, error) {
+	state, exists, err := readDriveChangesServeState(path)
+	if err != nil {
+		return driveChangesServeState{}, err
+	}
+	if exists {
+		if initialToken != "" && initialToken != state.PageToken {
+			return driveChangesServeState{}, usage("--token does not match the persisted page token")
+		}
+		if driveID != "" && driveID != state.DriveID {
+			return driveChangesServeState{}, usagef("serve state drive_id %q does not match --drive %q", state.DriveID, driveID)
+		}
+		return state, nil
+	}
+	if initialToken == "" {
+		initialToken, err = getDriveChangesStartToken(ctx, svc, driveID)
+		if err != nil {
+			return driveChangesServeState{}, err
+		}
+	}
+	state = driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: initialToken,
+		DriveID:   driveID,
+		UpdatedAt: now.Format(time.RFC3339Nano),
+	}
+	if err := writePollState(path, state); err != nil {
+		return driveChangesServeState{}, err
+	}
+	return state, nil
+}
+
+func readDriveChangesServeState(path string) (driveChangesServeState, bool, error) {
+	var state driveChangesServeState
+	exists, err := readPollState(path, &state)
+	if err != nil || !exists {
+		return state, exists, err
+	}
+	if state.Version != pollStateVersion {
+		return driveChangesServeState{}, false, fmt.Errorf("unsupported drive changes serve state version %d", state.Version)
+	}
+	state.PageToken = strings.TrimSpace(state.PageToken)
+	state.DriveID = strings.TrimSpace(state.DriveID)
+	if state.PageToken == "" {
+		return driveChangesServeState{}, false, fmt.Errorf("drive changes serve state has empty page_token")
+	}
+	normalizeDriveChangesServeChannel(state.Channel)
+	normalizeDriveChangesServeChannel(state.PreviousChannel)
+	return state, true, nil
+}
+
+func normalizeDriveChangesServeChannel(channel *driveChangesServeChannelState) {
+	if channel == nil {
+		return
+	}
+	channel.ID = strings.TrimSpace(channel.ID)
+	channel.ResourceID = strings.TrimSpace(channel.ResourceID)
+	channel.ResourceURI = strings.TrimSpace(channel.ResourceURI)
+	channel.WebhookURL = strings.TrimSpace(channel.WebhookURL)
+	channel.TokenHash = strings.TrimSpace(channel.TokenHash)
+}
+
+func cloneDriveChangesServeState(state driveChangesServeState) driveChangesServeState {
+	cloned := state
+	if state.Channel != nil {
+		channel := *state.Channel
+		cloned.Channel = &channel
+	}
+	if state.PreviousChannel != nil {
+		channel := *state.PreviousChannel
+		cloned.PreviousChannel = &channel
+	}
+	if state.LastMessageNumbers != nil {
+		cloned.LastMessageNumbers = make(map[string]uint64, len(state.LastMessageNumbers))
+		for channelID, messageNumber := range state.LastMessageNumbers {
+			cloned.LastMessageNumbers[channelID] = messageNumber
+		}
+	}
+	return cloned
+}
+
+func channelTokenHash(token string) string {
+	sum := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(sum[:])
+}
+
+func shutdownHTTPServer(ctx context.Context, server *http.Server) error {
+	shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+	defer cancel()
+	if err := server.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("shut down Drive changes server: %w", err)
+	}
+	return nil
+}
+
+func (s *driveChangesServer) ensureChannel(ctx context.Context) (time.Duration, error) {
+	s.renewMu.Lock()
+	defer s.renewMu.Unlock()
+
+	s.mu.Lock()
+
+	pendingStopFailed := false
+	if s.state.PreviousChannel != nil {
+		if err := s.stopPreviousChannelLocked(ctx); err != nil {
+			pendingStopFailed = true
+			s.warnf("drive changes serve: stop previous channel failed: %v", err)
+		}
+	}
+
+	now := s.runtime.now().UTC()
+	if s.currentChannelMatchesLocked() {
+		delay := s.channelRenewalDelayLocked(now)
+		if delay > 0 {
+			if pendingStopFailed && delay > driveChangesRenewRetry {
+				delay = driveChangesRenewRetry
+			}
+			s.mu.Unlock()
+			return delay, nil
+		}
+	}
+	if s.state.PreviousChannel != nil {
+		s.mu.Unlock()
+		return 0, errors.New("cannot renew Drive changes channel while previous channel cleanup is pending")
+	}
+	pageToken := s.state.PageToken
+	driveID := s.state.DriveID
+	s.mu.Unlock()
+
+	channelID, err := randomChannelID()
+	if err != nil {
+		return 0, err
+	}
+	s.mu.Lock()
+	s.pendingChannel = channelID
+	s.mu.Unlock()
+	requestedExpiration := now.Add(s.channelTTL).UnixMilli()
+	channel := &drive.Channel{
+		Id:         channelID,
+		Type:       "web_hook",
+		Address:    s.webhookURL,
+		Token:      s.channelToken,
+		Expiration: requestedExpiration,
+	}
+	call := s.service.Changes.Watch(pageToken, channel).
+		SupportsAllDrives(true).
+		Context(ctx)
+	if driveID != "" {
+		call = call.DriveId(driveID)
+	}
+	response, err := call.Do()
+	if err != nil {
+		s.clearPendingChannel(channelID)
+		return 0, err
+	}
+	if response == nil || strings.TrimSpace(response.Id) == "" || strings.TrimSpace(response.ResourceId) == "" {
+		s.clearPendingChannel(channelID)
+		return 0, errors.New("drive changes watch response missing channel identifiers")
+	}
+	expiration := response.Expiration
+	if expiration <= 0 {
+		expiration = requestedExpiration
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pendingChannel == channelID {
+		s.pendingChannel = ""
+	}
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.PreviousChannel = nextState.Channel
+	nextState.Channel = &driveChangesServeChannelState{
+		ID:          strings.TrimSpace(response.Id),
+		ResourceID:  strings.TrimSpace(response.ResourceId),
+		ResourceURI: strings.TrimSpace(response.ResourceUri),
+		Expiration:  expiration,
+		WebhookURL:  s.webhookURL,
+		TokenHash:   channelTokenHash(s.channelToken),
+	}
+	nextState.UpdatedAt = now.Format(time.RFC3339Nano)
+	trimDriveChangesMessageNumbers(&nextState, nextState.Channel.ID, channelIDFor(nextState.PreviousChannel))
+	if err := writePollState(s.statePath, nextState); err != nil {
+		_ = s.service.Channels.Stop(&drive.Channel{
+			Id:         nextState.Channel.ID,
+			ResourceId: nextState.Channel.ResourceID,
+		}).Context(ctx).Do()
+		return 0, err
+	}
+	s.state = nextState
+
+	if s.state.PreviousChannel != nil {
+		if err := s.stopPreviousChannelLocked(ctx); err != nil {
+			s.warnf("drive changes serve: stop previous channel failed: %v", err)
+		}
+	}
+	delay := s.channelRenewalDelayLocked(now)
+	if s.state.PreviousChannel != nil && delay > driveChangesRenewRetry {
+		delay = driveChangesRenewRetry
+	}
+	return delay, nil
+}
+
+func (s *driveChangesServer) clearPendingChannel(channelID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pendingChannel == channelID {
+		s.pendingChannel = ""
+	}
+}
+
+func (s *driveChangesServer) currentChannelMatchesLocked() bool {
+	channel := s.state.Channel
+	return channel != nil &&
+		channel.ID != "" &&
+		channel.ResourceID != "" &&
+		channel.WebhookURL == s.webhookURL &&
+		channel.TokenHash == channelTokenHash(s.channelToken)
+}
+
+func (s *driveChangesServer) channelRenewalDelayLocked(now time.Time) time.Duration {
+	if s.state.Channel == nil || s.state.Channel.Expiration <= 0 {
+		return 0
+	}
+	delay := time.UnixMilli(s.state.Channel.Expiration).Sub(now) - s.renewBefore
+	if delay < time.Second {
+		return 0
+	}
+	return delay
+}
+
+func (s *driveChangesServer) stopPreviousChannelLocked(ctx context.Context) error {
+	previous := s.state.PreviousChannel
+	if previous == nil {
+		return nil
+	}
+	if previous.ID != "" && previous.ResourceID != "" {
+		if err := s.service.Channels.Stop(&drive.Channel{
+			Id:         previous.ID,
+			ResourceId: previous.ResourceID,
+		}).Context(ctx).Do(); err != nil && !isNotFoundAPIError(err) {
+			return err
+		}
+	}
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.PreviousChannel = nil
+	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
+	if err := writePollState(s.statePath, nextState); err != nil {
+		return err
+	}
+	s.state = nextState
+	return nil
+}
+
+func (s *driveChangesServer) runRenewLoop(ctx context.Context, delay time.Duration) {
+	for {
+		if delay < time.Second {
+			delay = time.Second
+		}
+		if err := s.runtime.wait(ctx, delay); err != nil {
+			return
+		}
+		nextDelay, err := s.ensureChannel(ctx)
+		if err != nil {
+			s.warnf("drive changes serve: channel renewal failed: %v", err)
+			delay = driveChangesRenewRetry
+			continue
+		}
+		delay = nextDelay
+	}
+}
+
+func channelIDFor(channel *driveChangesServeChannelState) string {
+	if channel == nil {
+		return ""
+	}
+	return channel.ID
+}
+
+func trimDriveChangesMessageNumbers(state *driveChangesServeState, keepChannelIDs ...string) {
+	if len(state.LastMessageNumbers) <= 32 {
+		return
+	}
+	keep := make(map[string]struct{}, len(keepChannelIDs))
+	for _, channelID := range keepChannelIDs {
+		if channelID != "" {
+			keep[channelID] = struct{}{}
+		}
+	}
+	for channelID := range state.LastMessageNumbers {
+		if len(state.LastMessageNumbers) <= 32 {
+			break
+		}
+		if _, ok := keep[channelID]; !ok {
+			delete(state.LastMessageNumbers, channelID)
+		}
+	}
+}

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -47,6 +47,25 @@ func TestDriveChangesServeRejectsWrongTokenBeforeAPI(t *testing.T) {
 	}
 }
 
+func TestParseDriveChangesNotificationRejectsOversizedOptionalHeaders(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		header string
+		value  string
+	}{
+		{name: "changed", header: "X-Goog-Changed", value: strings.Repeat("x", 1025)},
+		{name: "expiration", header: "X-Goog-Channel-Expiration", value: strings.Repeat("x", 257)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 2)
+			request.Header.Set(tc.header, tc.value)
+			if _, err := parseDriveChangesNotification(request); err == nil || !strings.Contains(err.Error(), "too long") {
+				t.Fatalf("error = %v", err)
+			}
+		})
+	}
+}
+
 func TestDriveChangesServeRejectsUntrackedChannel(t *testing.T) {
 	state := driveChangesServeState{
 		Version:   pollStateVersion,
@@ -405,6 +424,58 @@ func TestDriveChangesServeHookDoesNotBlockStateMutex(t *testing.T) {
 	close(releaseHook)
 	if code := <-done; code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204", code)
+	}
+}
+
+func TestDriveChangesServeChannelStopDoesNotBlockStateMutex(t *testing.T) {
+	stopStarted := make(chan struct{})
+	releaseStop := make(chan struct{})
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/channels/stop" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		close(stopStarted)
+		<-releaseStop
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		PreviousChannel: &driveChangesServeChannelState{
+			ID:         "channel-old",
+			ResourceID: "resource-old",
+		},
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+
+	done := make(chan error, 1)
+	go func() {
+		done <- server.stopPreviousChannel(context.Background())
+	}()
+	<-stopStarted
+
+	stateLockAcquired := make(chan struct{})
+	go func() {
+		server.mu.Lock()
+		server.mu.Unlock()
+		close(stateLockAcquired)
+	}()
+	select {
+	case <-stateLockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("state mutex remained blocked during channel stop")
+	}
+
+	close(releaseStop)
+	if err := <-done; err != nil {
+		t.Fatalf("stop previous channel: %v", err)
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -140,7 +140,7 @@ func TestDriveChangesServeAcceptsPreviousAndPendingChannels(t *testing.T) {
 	}
 }
 
-func TestDriveChangesServeManualModeAcceptsNewChannelWithPersistedBindings(t *testing.T) {
+func TestDriveChangesServeSyncDoesNotLowerMessageNumber(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	state := driveChangesServeState{
 		Version:   pollStateVersion,
@@ -168,8 +168,8 @@ func TestDriveChangesServeManualModeAcceptsNewChannelWithPersistedBindings(t *te
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if got := persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")]; got != 1 {
-		t.Fatalf("message number = %d, want reset to 1", got)
+	if got := persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")]; got != 99 {
+		t.Fatalf("message number = %d, want 99", got)
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -574,6 +574,21 @@ func TestDriveChangesServeResolvesChannelTokenFile(t *testing.T) {
 	}
 }
 
+func TestExpandDriveChangesTLSPaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	certPath, keyPath, err := expandDriveChangesTLSPaths("~/tls/cert.pem", "~/tls/key.pem")
+	if err != nil {
+		t.Fatalf("expand TLS paths: %v", err)
+	}
+	if certPath != filepath.Join(home, "tls", "cert.pem") {
+		t.Fatalf("cert path = %q", certPath)
+	}
+	if keyPath != filepath.Join(home, "tls", "key.pem") {
+		t.Fatalf("key path = %q", keyPath)
+	}
+}
+
 func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
 	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -289,7 +289,6 @@ func TestDriveChangesServeProcessingSurvivesRequestCancellation(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 	server := newDriveChangesTestReceiver(t, svc, state)
-	server.runCtx = context.Background()
 	server.statePath = statePath
 	server.onChange = "./handle-change"
 	server.runtime.runHook = func(ctx context.Context, _ string, _ any) error {
@@ -314,6 +313,24 @@ func TestDriveChangesServeProcessingSurvivesRequestCancellation(t *testing.T) {
 	}
 	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 8 {
 		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeProcessingStopsOnCommandCancellation(t *testing.T) {
+	runDone := make(chan struct{})
+	server := newDriveChangesTestReceiver(t, nil, driveChangesServeState{})
+	server.runDone = runDone
+	ctx, cancel := server.notificationContext(context.Background())
+	defer cancel()
+
+	close(runDone)
+	select {
+	case <-ctx.Done():
+		if !errors.Is(ctx.Err(), context.Canceled) {
+			t.Fatalf("context error = %v", ctx.Err())
+		}
+	case <-time.After(time.Second):
+		t.Fatal("processing context did not stop with command context")
 	}
 }
 
@@ -437,6 +454,7 @@ func TestDriveChangesServeHookDoesNotBlockStateMutex(t *testing.T) {
 	stateLockAcquired := make(chan struct{})
 	go func() {
 		server.mu.Lock()
+		_ = server.state.PageToken
 		server.mu.Unlock()
 		close(stateLockAcquired)
 	}()
@@ -489,6 +507,7 @@ func TestDriveChangesServeChannelStopDoesNotBlockStateMutex(t *testing.T) {
 	stateLockAcquired := make(chan struct{})
 	go func() {
 		server.mu.Lock()
+		_ = server.state.PageToken
 		server.mu.Unlock()
 		close(stateLockAcquired)
 	}()

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -146,8 +146,11 @@ func TestDriveChangesServeManualModeAcceptsNewChannelWithPersistedBindings(t *te
 		Version:   pollStateVersion,
 		PageToken: pollTestStartToken,
 		Channel: &driveChangesServeChannelState{
-			ID:         "old-channel",
+			ID:         "channel-1",
 			ResourceID: "old-resource",
+		},
+		LastMessageNumbers: map[string]uint64{
+			driveChangesMessageKey("channel-1", "old-resource"): 99,
 		},
 	}
 	if err := writePollState(statePath, state); err != nil {
@@ -199,8 +202,9 @@ func TestDriveChangesServeAcknowledgesSyncUnknownAndDuplicates(t *testing.T) {
 	if persisted.PageToken != pollTestStartToken {
 		t.Fatalf("page token = %q", persisted.PageToken)
 	}
-	if persisted.LastMessageNumbers["channel-1"] != 2 {
-		t.Fatalf("message number = %d, want 2", persisted.LastMessageNumbers["channel-1"])
+	messageKey := driveChangesMessageKey("channel-1", "resource-1")
+	if persisted.LastMessageNumbers[messageKey] != 2 {
+		t.Fatalf("message number = %d, want 2", persisted.LastMessageNumbers[messageKey])
 	}
 }
 
@@ -266,7 +270,8 @@ func TestDriveChangesServeProcessesNotificationOverHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 7 {
+	if persisted.PageToken != "next-token" ||
+		persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")] != 7 {
 		t.Fatalf("unexpected state: %#v", persisted)
 	}
 }
@@ -311,7 +316,8 @@ func TestDriveChangesServeProcessingSurvivesRequestCancellation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 8 {
+	if persisted.PageToken != "next-token" ||
+		persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")] != 8 {
 		t.Fatalf("unexpected state: %#v", persisted)
 	}
 }
@@ -331,6 +337,20 @@ func TestDriveChangesServeProcessingStopsOnCommandCancellation(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("processing context did not stop with command context")
+	}
+}
+
+func TestDriveChangesServeNotificationGateHonorsTimeout(t *testing.T) {
+	server := newDriveChangesTestReceiver(t, nil, driveChangesServeState{})
+	if err := server.acquireNotification(context.Background()); err != nil {
+		t.Fatalf("acquire first notification: %v", err)
+	}
+	defer server.releaseNotification()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := server.acquireNotification(ctx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("queued notification error = %v, want deadline exceeded", err)
 	}
 }
 
@@ -373,7 +393,8 @@ func TestDriveChangesServeFilterSkipsHookButAdvancesState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 3 {
+	if persisted.PageToken != "next-token" ||
+		persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")] != 3 {
 		t.Fatalf("unexpected state: %#v", persisted)
 	}
 }
@@ -410,7 +431,8 @@ func TestDriveChangesServeHookFailureRetainsStateForRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if persisted.PageToken != pollTestStartToken || persisted.LastMessageNumbers["channel-1"] != 0 {
+	if persisted.PageToken != pollTestStartToken ||
+		persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")] != 0 {
 		t.Fatalf("unexpected state: %#v", persisted)
 	}
 }
@@ -584,7 +606,8 @@ func TestDriveChangesServeSerializesConcurrentNotifications(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read state: %v", err)
 	}
-	if persisted.PageToken != "next-2" || persisted.LastMessageNumbers["channel-1"] != 3 {
+	if persisted.PageToken != "next-2" ||
+		persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")] != 3 {
 		t.Fatalf("unexpected state: %#v", persisted)
 	}
 }
@@ -738,16 +761,17 @@ func TestDriveChangesServeRunRetriesPendingCleanupAtStartup(t *testing.T) {
 	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
 	retryScheduled := make(chan struct{})
 	cmd := DriveChangesServeCmd{
-		Listen:         "127.0.0.1:0",
-		Path:           driveChangesTestStatePath,
-		ChannelToken:   driveChangesTestChannelToken,
-		StateFile:      statePath,
-		Max:            100,
-		IncludeRemoved: true,
-		AutoRenew:      true,
-		WebhookURL:     "https://example.com/drive-changes",
-		ChannelTTL:     defaultDriveChangesChannelTTL,
-		RenewBefore:    10 * time.Minute,
+		Listen:              "127.0.0.1:0",
+		Path:                driveChangesTestStatePath,
+		ChannelToken:        driveChangesTestChannelToken,
+		StateFile:           statePath,
+		Max:                 100,
+		IncludeRemoved:      true,
+		AutoRenew:           true,
+		WebhookURL:          "https://example.com/drive-changes",
+		ChannelTTL:          defaultDriveChangesChannelTTL,
+		RenewBefore:         10 * time.Minute,
+		NotificationTimeout: defaultDriveChangesNotificationTimeout,
 	}
 	runtime := defaultDriveChangesServeRuntime()
 	runtime.wait = func(ctx context.Context, delay time.Duration) error {
@@ -771,14 +795,15 @@ func TestDriveChangesServeRunRetriesPendingCleanupAtStartup(t *testing.T) {
 
 func TestDriveChangesServeValidation(t *testing.T) {
 	valid := DriveChangesServeCmd{
-		Listen:         "127.0.0.1:8443",
-		Path:           driveChangesTestStatePath,
-		ChannelToken:   driveChangesTestChannelToken,
-		StateFile:      "state.json",
-		Max:            100,
-		IncludeRemoved: true,
-		ChannelTTL:     defaultDriveChangesChannelTTL,
-		RenewBefore:    10 * time.Minute,
+		Listen:              "127.0.0.1:8443",
+		Path:                driveChangesTestStatePath,
+		ChannelToken:        driveChangesTestChannelToken,
+		StateFile:           "state.json",
+		Max:                 100,
+		IncludeRemoved:      true,
+		ChannelTTL:          defaultDriveChangesChannelTTL,
+		RenewBefore:         10 * time.Minute,
+		NotificationTimeout: defaultDriveChangesNotificationTimeout,
 	}
 	cases := []struct {
 		name   string
@@ -870,16 +895,17 @@ func TestDriveChangesServeRejectsInvalidTLSKeyPair(t *testing.T) {
 		t.Fatalf("write private key: %v", err)
 	}
 	cmd := DriveChangesServeCmd{
-		Listen:         "127.0.0.1:0",
-		Path:           driveChangesTestStatePath,
-		Cert:           certPath,
-		Key:            keyPath,
-		ChannelToken:   driveChangesTestChannelToken,
-		StateFile:      filepath.Join(dir, "state.json"),
-		Max:            100,
-		IncludeRemoved: true,
-		ChannelTTL:     defaultDriveChangesChannelTTL,
-		RenewBefore:    10 * time.Minute,
+		Listen:              "127.0.0.1:0",
+		Path:                driveChangesTestStatePath,
+		Cert:                certPath,
+		Key:                 keyPath,
+		ChannelToken:        driveChangesTestChannelToken,
+		StateFile:           filepath.Join(dir, "state.json"),
+		Max:                 100,
+		IncludeRemoved:      true,
+		ChannelTTL:          defaultDriveChangesChannelTTL,
+		RenewBefore:         10 * time.Minute,
+		NotificationTimeout: defaultDriveChangesNotificationTimeout,
 	}
 	err := cmd.run(
 		newCmdOutputContext(t, io.Discard, io.Discard),
@@ -901,15 +927,16 @@ func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
 	listening := make(chan struct{})
 	cmd := DriveChangesServeCmd{
-		Listen:         "127.0.0.1:0",
-		Path:           driveChangesTestStatePath,
-		ChannelToken:   driveChangesTestChannelToken,
-		StateFile:      filepath.Join(t.TempDir(), "state.json"),
-		Token:          pollTestStartToken,
-		Max:            100,
-		IncludeRemoved: true,
-		ChannelTTL:     defaultDriveChangesChannelTTL,
-		RenewBefore:    10 * time.Minute,
+		Listen:              "127.0.0.1:0",
+		Path:                driveChangesTestStatePath,
+		ChannelToken:        driveChangesTestChannelToken,
+		StateFile:           filepath.Join(t.TempDir(), "state.json"),
+		Token:               pollTestStartToken,
+		Max:                 100,
+		IncludeRemoved:      true,
+		ChannelTTL:          defaultDriveChangesChannelTTL,
+		RenewBefore:         10 * time.Minute,
+		NotificationTimeout: defaultDriveChangesNotificationTimeout,
 	}
 	runtime := defaultDriveChangesServeRuntime()
 	runtime.listen = func(ctx context.Context, network string, address string) (net.Listener, error) {
@@ -934,17 +961,18 @@ func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
 func newDriveChangesTestReceiver(t *testing.T, svc *drive.Service, state driveChangesServeState) *driveChangesServer {
 	t.Helper()
 	return &driveChangesServer{
-		state:          state,
-		service:        svc,
-		path:           driveChangesTestStatePath,
-		channelToken:   driveChangesTestChannelToken,
-		max:            100,
-		includeRemoved: true,
-		channelTTL:     defaultDriveChangesChannelTTL,
-		renewBefore:    10 * time.Minute,
-		runtime:        defaultDriveChangesServeRuntime(),
-		logf:           func(string, ...any) {},
-		warnf:          func(string, ...any) {},
+		state:               state,
+		service:             svc,
+		path:                driveChangesTestStatePath,
+		channelToken:        driveChangesTestChannelToken,
+		max:                 100,
+		includeRemoved:      true,
+		channelTTL:          defaultDriveChangesChannelTTL,
+		renewBefore:         10 * time.Minute,
+		notificationTimeout: defaultDriveChangesNotificationTimeout,
+		runtime:             defaultDriveChangesServeRuntime(),
+		logf:                func(string, ...any) {},
+		warnf:               func(string, ...any) {},
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -859,6 +859,38 @@ func TestExpandDriveChangesTLSPaths(t *testing.T) {
 	}
 }
 
+func TestDriveChangesServeRejectsInvalidTLSKeyPair(t *testing.T) {
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, []byte("not a certificate"), 0o600); err != nil {
+		t.Fatalf("write certificate: %v", err)
+	}
+	if err := os.WriteFile(keyPath, []byte("not a private key"), 0o600); err != nil {
+		t.Fatalf("write private key: %v", err)
+	}
+	cmd := DriveChangesServeCmd{
+		Listen:         "127.0.0.1:0",
+		Path:           driveChangesTestStatePath,
+		Cert:           certPath,
+		Key:            keyPath,
+		ChannelToken:   driveChangesTestChannelToken,
+		StateFile:      filepath.Join(dir, "state.json"),
+		Max:            100,
+		IncludeRemoved: true,
+		ChannelTTL:     defaultDriveChangesChannelTTL,
+		RenewBefore:    10 * time.Minute,
+	}
+	err := cmd.run(
+		newCmdOutputContext(t, io.Discard, io.Discard),
+		&RootFlags{Account: "a@example.com"},
+		defaultDriveChangesServeRuntime(),
+	)
+	if err == nil || !strings.Contains(err.Error(), "load TLS certificate") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
 func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
 	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.NotFound(w, nil)

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -354,6 +354,60 @@ func TestDriveChangesServeHookFailureRetainsStateForRetry(t *testing.T) {
 	}
 }
 
+func TestDriveChangesServeHookDoesNotBlockStateMutex(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes":           []map[string]any{{"fileId": "file-1"}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.onChange = "./handle-change"
+	hookStarted := make(chan struct{})
+	releaseHook := make(chan struct{})
+	server.runtime.runHook = func(context.Context, string, any) error {
+		close(hookStarted)
+		<-releaseHook
+		return nil
+	}
+
+	done := make(chan int, 1)
+	go func() {
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 5))
+		done <- response.Code
+	}()
+	<-hookStarted
+
+	stateLockAcquired := make(chan struct{})
+	go func() {
+		server.mu.Lock()
+		server.mu.Unlock()
+		close(stateLockAcquired)
+	}()
+	select {
+	case <-stateLockAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("state mutex remained blocked while hook was running")
+	}
+
+	close(releaseHook)
+	if code := <-done; code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", code)
+	}
+}
+
 func TestDriveChangesServeSerializesConcurrentNotifications(t *testing.T) {
 	firstAPIStarted := make(chan struct{})
 	releaseFirstAPI := make(chan struct{})
@@ -496,6 +550,51 @@ func TestDriveChangesServeRenewsAndStopsPreviousChannel(t *testing.T) {
 	}
 	if persisted.Channel.TokenHash == driveChangesTestChannelToken || persisted.Channel.TokenHash == "" {
 		t.Fatalf("channel token was not hashed")
+	}
+}
+
+func TestDriveChangesServeBacksOffWhenGrantedExpirationIsInsideRenewalWindow(t *testing.T) {
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/changes/watch":
+			var watched drive.Channel
+			if err := json.NewDecoder(r.Body).Decode(&watched); err != nil {
+				t.Fatalf("decode watch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":         watched.Id,
+				"resourceId": "resource-new",
+				"expiration": strconv.FormatInt(now.Add(5*time.Minute).UnixMilli(), 10),
+			})
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.autoRenew = true
+	server.webhookURL = "https://example.com/hook"
+	server.channelTTL = defaultDriveChangesChannelTTL
+	server.renewBefore = 10 * time.Minute
+	server.runtime.now = func() time.Time { return now }
+
+	delay, err := server.ensureChannel(context.Background())
+	if err != nil {
+		t.Fatalf("ensureChannel: %v", err)
+	}
+	if delay != driveChangesRenewRetry {
+		t.Fatalf("delay = %v, want %v", delay, driveChangesRenewRetry)
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -854,6 +854,7 @@ func TestDriveChangesServeResolvesChannelTokenFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte(" file-secret \n"), 0o600); err != nil {
 		t.Fatalf("write token file: %v", err)
 	}
+	t.Setenv("GOG_DRIVE_CHANNEL_TOKEN", "ambient-secret")
 	cmd := DriveChangesServeCmd{ChannelTokenFile: path}
 	token, err := cmd.resolveChannelToken()
 	if err != nil {
@@ -866,6 +867,33 @@ func TestDriveChangesServeResolvesChannelTokenFile(t *testing.T) {
 	cmd.ChannelToken = "direct-secret"
 	if _, err := cmd.resolveChannelToken(); err == nil || !strings.Contains(err.Error(), "only one") {
 		t.Fatalf("combined source error = %v", err)
+	}
+}
+
+func TestDriveChangesStateKindsRejectCrossUse(t *testing.T) {
+	dir := t.TempDir()
+	servePath := filepath.Join(dir, "serve.json")
+	if err := writePollState(servePath, driveChangesServeState{
+		Version:   pollStateVersion,
+		Kind:      driveChangesServeStateKind,
+		PageToken: pollTestStartToken,
+	}); err != nil {
+		t.Fatalf("write serve state: %v", err)
+	}
+	if _, _, err := readDriveChangesPollState(servePath); err == nil || !strings.Contains(err.Error(), "belongs to drive changes serve") {
+		t.Fatalf("poll reader error = %v", err)
+	}
+
+	pollPath := filepath.Join(dir, "poll.json")
+	if err := writePollState(pollPath, driveChangesPollState{
+		Version:   pollStateVersion,
+		Kind:      driveChangesPollStateKind,
+		PageToken: pollTestStartToken,
+	}); err != nil {
+		t.Fatalf("write poll state: %v", err)
+	}
+	if _, _, err := readDriveChangesServeState(pollPath); err == nil || !strings.Contains(err.Error(), "belongs to drive changes poll") {
+		t.Fatalf("serve reader error = %v", err)
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -788,7 +788,6 @@ func TestDriveChangesServeRunRetriesPendingCleanupAtStartup(t *testing.T) {
 		http.Error(w, "temporary failure", http.StatusInternalServerError)
 	}))
 	defer closeDrive()
-	stubDriveServiceForTest(t, svc)
 
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	if err := writePollState(statePath, driveChangesServeState{
@@ -802,7 +801,8 @@ func TestDriveChangesServeRunRetriesPendingCleanupAtStartup(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 
-	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
+	ctx := withDriveTestService(newCmdOutputContext(t, io.Discard, io.Discard), svc)
+	ctx, cancel := context.WithCancel(ctx)
 	retryScheduled := make(chan struct{})
 	cmd := DriveChangesServeCmd{
 		Listen:              "127.0.0.1:0",
@@ -996,9 +996,9 @@ func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
 		http.NotFound(w, nil)
 	}))
 	defer closeDrive()
-	stubDriveServiceForTest(t, svc)
 
-	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
+	ctx := withDriveTestService(newCmdOutputContext(t, io.Discard, io.Discard), svc)
+	ctx, cancel := context.WithCancel(ctx)
 	listening := make(chan struct{})
 	cmd := DriveChangesServeCmd{
 		Listen:              "127.0.0.1:0",

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -945,6 +945,7 @@ func TestDriveChangesStateKindsRejectCrossUse(t *testing.T) {
 func TestExpandDriveChangesTLSPaths(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
 	certPath, keyPath, err := expandDriveChangesTLSPaths("~/tls/cert.pem", "~/tls/key.pem")
 	if err != nil {
 		t.Fatalf("expand TLS paths: %v", err)

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -76,6 +76,7 @@ func TestDriveChangesServeRejectsUntrackedChannel(t *testing.T) {
 		},
 	}
 	server := newDriveChangesTestReceiver(t, nil, state)
+	server.autoRenew = true
 	var hookCalls atomic.Int32
 	server.onChange = "./handle-change"
 	server.runtime.runHook = func(context.Context, string, any) error {
@@ -116,6 +117,7 @@ func TestDriveChangesServeAcceptsPreviousAndPendingChannels(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 	server := newDriveChangesTestReceiver(t, nil, state)
+	server.autoRenew = true
 	server.statePath = statePath
 
 	previous := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "sync", 1)
@@ -135,6 +137,29 @@ func TestDriveChangesServeAcceptsPreviousAndPendingChannels(t *testing.T) {
 	server.ServeHTTP(response, pending)
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("pending channel status = %d, want 204", response.Code)
+	}
+}
+
+func TestDriveChangesServeManualModeAcceptsNewChannelWithPersistedBindings(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "old-channel",
+			ResourceID: "old-resource",
+		},
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	server.statePath = statePath
+
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "sync", 1))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.Code)
 	}
 }
 
@@ -666,6 +691,62 @@ func TestDriveChangesServeBacksOffWhenGrantedExpirationIsInsideRenewalWindow(t *
 	}
 	if delay != driveChangesRenewRetry {
 		t.Fatalf("delay = %v, want %v", delay, driveChangesRenewRetry)
+	}
+}
+
+func TestDriveChangesServeRunRetriesPendingCleanupAtStartup(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/channels/stop" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		http.Error(w, "temporary failure", http.StatusInternalServerError)
+	}))
+	defer closeDrive()
+	stubDriveServiceForTest(t, svc)
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	if err := writePollState(statePath, driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		PreviousChannel: &driveChangesServeChannelState{
+			ID:         "channel-old",
+			ResourceID: "resource-old",
+		},
+	}); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
+	retryScheduled := make(chan struct{})
+	cmd := DriveChangesServeCmd{
+		Listen:         "127.0.0.1:0",
+		Path:           driveChangesTestStatePath,
+		ChannelToken:   driveChangesTestChannelToken,
+		StateFile:      statePath,
+		Max:            100,
+		IncludeRemoved: true,
+		AutoRenew:      true,
+		WebhookURL:     "https://example.com/drive-changes",
+		ChannelTTL:     defaultDriveChangesChannelTTL,
+		RenewBefore:    10 * time.Minute,
+	}
+	runtime := defaultDriveChangesServeRuntime()
+	runtime.wait = func(ctx context.Context, delay time.Duration) error {
+		if delay != driveChangesRenewRetry {
+			t.Errorf("retry delay = %v, want %v", delay, driveChangesRenewRetry)
+		}
+		close(retryScheduled)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.run(ctx, &RootFlags{Account: "a@example.com"}, runtime)
+	}()
+	<-retryScheduled
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error = %v, want context canceled", err)
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -1,0 +1,574 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+)
+
+const (
+	driveChangesTestChannelToken = "channel-secret"
+	driveChangesTestStatePath    = "/drive-changes"
+)
+
+func TestDriveChangesServeRejectsWrongTokenBeforeAPI(t *testing.T) {
+	server := newDriveChangesTestReceiver(t, nil, driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	})
+	var hookCalls atomic.Int32
+	server.runtime.runHook = func(context.Context, string, any) error {
+		hookCalls.Add(1)
+		return nil
+	}
+
+	request := newDriveChangesNotificationRequest(t, "wrong", "change", 2)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", response.Code)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("hook calls = %d, want 0", hookCalls.Load())
+	}
+}
+
+func TestDriveChangesServeRejectsUntrackedChannel(t *testing.T) {
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "expected-channel",
+			ResourceID: "expected-resource",
+		},
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	var hookCalls atomic.Int32
+	server.onChange = "./handle-change"
+	server.runtime.runHook = func(context.Context, string, any) error {
+		hookCalls.Add(1)
+		return nil
+	}
+
+	request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 2)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", response.Code)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("hook calls = %d, want 0", hookCalls.Load())
+	}
+	if server.state.PageToken != pollTestStartToken || len(server.state.LastMessageNumbers) != 0 {
+		t.Fatalf("state changed: %#v", server.state)
+	}
+}
+
+func TestDriveChangesServeAcceptsPreviousAndPendingChannels(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "current-channel",
+			ResourceID: "current-resource",
+		},
+		PreviousChannel: &driveChangesServeChannelState{
+			ID:         "channel-1",
+			ResourceID: "resource-1",
+		},
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	server.statePath = statePath
+
+	previous := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "sync", 1)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, previous)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("previous channel status = %d, want 204", response.Code)
+	}
+
+	server.mu.Lock()
+	server.pendingChannel = "pending-channel"
+	server.mu.Unlock()
+	pending := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "sync", 1)
+	pending.Header.Set("X-Goog-Channel-ID", "pending-channel")
+	pending.Header.Set("X-Goog-Resource-ID", "pending-resource")
+	response = httptest.NewRecorder()
+	server.ServeHTTP(response, pending)
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("pending channel status = %d, want 204", response.Code)
+	}
+}
+
+func TestDriveChangesServeAcknowledgesSyncUnknownAndDuplicates(t *testing.T) {
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		UpdatedAt: "2026-06-11T10:00:00Z",
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, nil, state)
+	server.statePath = statePath
+
+	for _, tc := range []struct {
+		resourceState string
+		messageNumber uint64
+	}{
+		{resourceState: "sync", messageNumber: 1},
+		{resourceState: "future-state", messageNumber: 2},
+		{resourceState: "future-state", messageNumber: 2},
+	} {
+		request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, tc.resourceState, tc.messageNumber)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, request)
+		if response.Code != http.StatusNoContent {
+			t.Fatalf("%s status = %d, want 204", tc.resourceState, response.Code)
+		}
+	}
+
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != pollTestStartToken {
+		t.Fatalf("page token = %q", persisted.PageToken)
+	}
+	if persisted.LastMessageNumbers["channel-1"] != 2 {
+		t.Fatalf("message number = %d, want 2", persisted.LastMessageNumbers["channel-1"])
+	}
+}
+
+func TestDriveChangesServeProcessesNotificationOverHTTP(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/changes" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		requireQuery(t, r, "pageToken", pollTestStartToken)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes": []map[string]any{{
+				"fileId": "file-1",
+				"type":   "file",
+				"file":   map[string]any{"name": "Doc"},
+			}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		UpdatedAt: "2026-06-11T10:00:00Z",
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.onChange = "./handle-change"
+	var event driveChangesServeEvent
+	server.runtime.runHook = func(_ context.Context, command string, payload any) error {
+		if command != "./handle-change" {
+			t.Fatalf("command = %q", command)
+		}
+		event = payload.(driveChangesServeEvent)
+		return nil
+	}
+
+	httpServer := httptest.NewServer(server)
+	defer httpServer.Close()
+	request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 7)
+	request.URL.Scheme = "http"
+	request.URL.Host = strings.TrimPrefix(httpServer.URL, "http://")
+	request.RequestURI = ""
+	response, err := httpServer.Client().Do(request)
+	if err != nil {
+		t.Fatalf("notification request: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.StatusCode)
+	}
+	if event.MessageNumber != 7 || event.PageToken != pollTestStartToken || event.NextPageToken != "next-token" {
+		t.Fatalf("unexpected event: %#v", event)
+	}
+	if len(event.Changes) != 1 || event.Changes[0].FileId != "file-1" {
+		t.Fatalf("unexpected changes: %#v", event.Changes)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 7 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeFilterSkipsHookButAdvancesState(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes":           []map[string]any{{"fileId": "other"}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.filterFile = "wanted"
+	server.onChange = "./handle-change"
+	var hookCalls atomic.Int32
+	server.runtime.runHook = func(context.Context, string, any) error {
+		hookCalls.Add(1)
+		return nil
+	}
+
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 3))
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.Code)
+	}
+	if hookCalls.Load() != 0 {
+		t.Fatalf("hook calls = %d, want 0", hookCalls.Load())
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 3 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeHookFailureRetainsStateForRetry(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes":           []map[string]any{{"fileId": "file-1"}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.onChange = "./handle-change"
+	hookErr := errors.New("hook failed")
+	server.runtime.runHook = func(context.Context, string, any) error { return hookErr }
+
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 4))
+	if response.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", response.Code)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != pollTestStartToken || persisted.LastMessageNumbers["channel-1"] != 0 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeSerializesConcurrentNotifications(t *testing.T) {
+	firstAPIStarted := make(chan struct{})
+	releaseFirstAPI := make(chan struct{})
+	var apiCalls atomic.Int32
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call := apiCalls.Add(1)
+		if call == 1 {
+			close(firstAPIStarted)
+			<-releaseFirstAPI
+			requireQuery(t, r, "pageToken", pollTestStartToken)
+			_ = json.NewEncoder(w).Encode(map[string]any{"newStartPageToken": "next-1"})
+			return
+		}
+		requireQuery(t, r, "pageToken", "next-1")
+		_ = json.NewEncoder(w).Encode(map[string]any{"newStartPageToken": "next-2"})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+
+	firstDone := make(chan struct{})
+	go func() {
+		defer close(firstDone)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 2))
+		if response.Code != http.StatusNoContent {
+			t.Errorf("first status = %d", response.Code)
+		}
+	}()
+	<-firstAPIStarted
+
+	secondDone := make(chan struct{})
+	go func() {
+		defer close(secondDone)
+		response := httptest.NewRecorder()
+		server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 3))
+		if response.Code != http.StatusNoContent {
+			t.Errorf("second status = %d", response.Code)
+		}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	if apiCalls.Load() != 1 {
+		t.Fatalf("API calls before releasing first = %d, want 1", apiCalls.Load())
+	}
+	close(releaseFirstAPI)
+	<-firstDone
+	<-secondDone
+
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-2" || persisted.LastMessageNumbers["channel-1"] != 3 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeRenewsAndStopsPreviousChannel(t *testing.T) {
+	now := time.Date(2026, 6, 11, 10, 0, 0, 0, time.UTC)
+	var watched drive.Channel
+	var stopped drive.Channel
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/changes/watch":
+			requireQuery(t, r, "pageToken", pollTestStartToken)
+			if err := json.NewDecoder(r.Body).Decode(&watched); err != nil {
+				t.Fatalf("decode watch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          watched.Id,
+				"resourceId":  "resource-new",
+				"resourceUri": "https://www.googleapis.com/drive/v3/changes",
+				"expiration":  strconv.FormatInt(now.Add(defaultDriveChangesChannelTTL).UnixMilli(), 10),
+			})
+		case "/channels/stop":
+			if err := json.NewDecoder(r.Body).Decode(&stopped); err != nil {
+				t.Fatalf("decode stop: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+		Channel: &driveChangesServeChannelState{
+			ID:         "channel-old",
+			ResourceID: "resource-old",
+			Expiration: now.Add(time.Minute).UnixMilli(),
+			WebhookURL: "https://old.example/hook",
+			TokenHash:  channelTokenHash(driveChangesTestChannelToken),
+		},
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.statePath = statePath
+	server.autoRenew = true
+	server.webhookURL = "https://example.com/hook"
+	server.channelTTL = defaultDriveChangesChannelTTL
+	server.renewBefore = 10 * time.Minute
+	server.runtime.now = func() time.Time { return now }
+
+	delay, err := server.ensureChannel(context.Background())
+	if err != nil {
+		t.Fatalf("ensureChannel: %v", err)
+	}
+	if delay != defaultDriveChangesChannelTTL-10*time.Minute {
+		t.Fatalf("delay = %v", delay)
+	}
+	if watched.Address != server.webhookURL || watched.Token != driveChangesTestChannelToken {
+		t.Fatalf("unexpected watch request: %#v", watched)
+	}
+	if watched.Expiration != now.Add(defaultDriveChangesChannelTTL).UnixMilli() {
+		t.Fatalf("expiration = %d", watched.Expiration)
+	}
+	if stopped.Id != "channel-old" || stopped.ResourceId != "resource-old" {
+		t.Fatalf("unexpected stopped channel: %#v", stopped)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.Channel == nil || persisted.Channel.ResourceID != "resource-new" || persisted.PreviousChannel != nil {
+		t.Fatalf("unexpected channel state: %#v", persisted)
+	}
+	if persisted.Channel.TokenHash == driveChangesTestChannelToken || persisted.Channel.TokenHash == "" {
+		t.Fatalf("channel token was not hashed")
+	}
+}
+
+func TestDriveChangesServeValidation(t *testing.T) {
+	valid := DriveChangesServeCmd{
+		Listen:         "127.0.0.1:8443",
+		Path:           driveChangesTestStatePath,
+		ChannelToken:   driveChangesTestChannelToken,
+		StateFile:      "state.json",
+		Max:            100,
+		IncludeRemoved: true,
+		ChannelTTL:     defaultDriveChangesChannelTTL,
+		RenewBefore:    10 * time.Minute,
+	}
+	cases := []struct {
+		name   string
+		mutate func(*DriveChangesServeCmd)
+		want   string
+	}{
+		{name: "missing token", mutate: func(c *DriveChangesServeCmd) { c.ChannelToken = "" }, want: "channel-token"},
+		{name: "cert without key", mutate: func(c *DriveChangesServeCmd) { c.Cert = "cert.pem" }, want: "--cert and --key"},
+		{name: "bad path", mutate: func(c *DriveChangesServeCmd) { c.Path = "hook" }, want: "--path"},
+		{name: "renew without url", mutate: func(c *DriveChangesServeCmd) { c.AutoRenew = true }, want: "--webhook-url"},
+		{name: "url without renew", mutate: func(c *DriveChangesServeCmd) { c.WebhookURL = "https://example.com" }, want: "requires --auto-renew"},
+		{
+			name: "ttl too long",
+			mutate: func(c *DriveChangesServeCmd) {
+				c.AutoRenew = true
+				c.WebhookURL = "https://example.com/hook"
+				c.ChannelTTL = maxDriveChangesChannelTTL + time.Second
+			},
+			want: "--channel-ttl",
+		},
+		{
+			name: "renew after expiration",
+			mutate: func(c *DriveChangesServeCmd) {
+				c.AutoRenew = true
+				c.WebhookURL = "https://example.com/hook"
+				c.RenewBefore = c.ChannelTTL
+			},
+			want: "--renew-before",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := valid
+			tc.mutate(&cmd)
+			err := cmd.validate()
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDriveChangesServeRunShutsDownOnContextCancel(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	defer closeDrive()
+	stubDriveServiceForTest(t, svc)
+
+	ctx, cancel := context.WithCancel(newCmdOutputContext(t, io.Discard, io.Discard))
+	listening := make(chan struct{})
+	cmd := DriveChangesServeCmd{
+		Listen:         "127.0.0.1:0",
+		Path:           driveChangesTestStatePath,
+		ChannelToken:   driveChangesTestChannelToken,
+		StateFile:      filepath.Join(t.TempDir(), "state.json"),
+		Token:          pollTestStartToken,
+		Max:            100,
+		IncludeRemoved: true,
+		ChannelTTL:     defaultDriveChangesChannelTTL,
+		RenewBefore:    10 * time.Minute,
+	}
+	runtime := defaultDriveChangesServeRuntime()
+	runtime.listen = func(ctx context.Context, network string, address string) (net.Listener, error) {
+		var listenConfig net.ListenConfig
+		listener, err := listenConfig.Listen(ctx, network, address)
+		if err == nil {
+			close(listening)
+		}
+		return listener, err
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.run(ctx, &RootFlags{Account: "a@example.com"}, runtime)
+	}()
+	<-listening
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("run error = %v, want context canceled", err)
+	}
+}
+
+func newDriveChangesTestReceiver(t *testing.T, svc *drive.Service, state driveChangesServeState) *driveChangesServer {
+	t.Helper()
+	return &driveChangesServer{
+		state:          state,
+		service:        svc,
+		path:           driveChangesTestStatePath,
+		channelToken:   driveChangesTestChannelToken,
+		max:            100,
+		includeRemoved: true,
+		channelTTL:     defaultDriveChangesChannelTTL,
+		renewBefore:    10 * time.Minute,
+		runtime:        defaultDriveChangesServeRuntime(),
+		logf:           func(string, ...any) {},
+		warnf:          func(string, ...any) {},
+	}
+}
+
+func newDriveChangesNotificationRequest(t *testing.T, token string, resourceState string, messageNumber uint64) *http.Request {
+	t.Helper()
+	request := httptest.NewRequestWithContext(context.Background(), http.MethodPost, driveChangesTestStatePath, nil)
+	request.Header.Set("X-Goog-Channel-ID", "channel-1")
+	request.Header.Set("X-Goog-Channel-Token", token)
+	request.Header.Set("X-Goog-Resource-ID", "resource-1")
+	request.Header.Set("X-Goog-Resource-State", resourceState)
+	request.Header.Set("X-Goog-Resource-URI", "https://www.googleapis.com/drive/v3/changes")
+	request.Header.Set("X-Goog-Message-Number", strconv.FormatUint(messageNumber, 10))
+	return request
+}

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -222,6 +223,52 @@ func TestDriveChangesServeProcessesNotificationOverHTTP(t *testing.T) {
 		t.Fatalf("read state: %v", err)
 	}
 	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 7 {
+		t.Fatalf("unexpected state: %#v", persisted)
+	}
+}
+
+func TestDriveChangesServeProcessingSurvivesRequestCancellation(t *testing.T) {
+	svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"newStartPageToken": "next-token",
+			"changes":           []map[string]any{{"fileId": "file-1"}},
+		})
+	}))
+	defer closeDrive()
+
+	statePath := filepath.Join(t.TempDir(), "state.json")
+	state := driveChangesServeState{
+		Version:   pollStateVersion,
+		PageToken: pollTestStartToken,
+	}
+	if err := writePollState(statePath, state); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	server := newDriveChangesTestReceiver(t, svc, state)
+	server.runCtx = context.Background()
+	server.statePath = statePath
+	server.onChange = "./handle-change"
+	server.runtime.runHook = func(ctx context.Context, _ string, _ any) error {
+		if err := ctx.Err(); err != nil {
+			t.Fatalf("hook context canceled with request: %v", err)
+		}
+		return nil
+	}
+
+	requestCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, "change", 8).WithContext(requestCtx)
+	response := httptest.NewRecorder()
+	server.ServeHTTP(response, request)
+
+	if response.Code != http.StatusNoContent {
+		t.Fatalf("status = %d, want 204", response.Code)
+	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if persisted.PageToken != "next-token" || persisted.LastMessageNumbers["channel-1"] != 8 {
 		t.Fatalf("unexpected state: %#v", persisted)
 	}
 }
@@ -496,11 +543,34 @@ func TestDriveChangesServeValidation(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cmd := valid
 			tc.mutate(&cmd)
-			err := cmd.validate()
+			token, err := cmd.resolveChannelToken()
+			if err == nil {
+				err = cmd.validate(token)
+			}
 			if err == nil || !strings.Contains(err.Error(), tc.want) {
 				t.Fatalf("error = %v, want %q", err, tc.want)
 			}
 		})
+	}
+}
+
+func TestDriveChangesServeResolvesChannelTokenFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "channel-token")
+	if err := os.WriteFile(path, []byte(" file-secret \n"), 0o600); err != nil {
+		t.Fatalf("write token file: %v", err)
+	}
+	cmd := DriveChangesServeCmd{ChannelTokenFile: path}
+	token, err := cmd.resolveChannelToken()
+	if err != nil {
+		t.Fatalf("resolve channel token: %v", err)
+	}
+	if token != "file-secret" {
+		t.Fatalf("token = %q", token)
+	}
+
+	cmd.ChannelToken = "direct-secret"
+	if _, err := cmd.resolveChannelToken(); err == nil || !strings.Contains(err.Error(), "only one") {
+		t.Fatalf("combined source error = %v", err)
 	}
 }
 

--- a/internal/cmd/drive_changes_serve_test.go
+++ b/internal/cmd/drive_changes_serve_test.go
@@ -147,10 +147,10 @@ func TestDriveChangesServeManualModeAcceptsNewChannelWithPersistedBindings(t *te
 		PageToken: pollTestStartToken,
 		Channel: &driveChangesServeChannelState{
 			ID:         "channel-1",
-			ResourceID: "old-resource",
+			ResourceID: "resource-1",
 		},
 		LastMessageNumbers: map[string]uint64{
-			driveChangesMessageKey("channel-1", "old-resource"): 99,
+			driveChangesMessageKey("channel-1", "resource-1"): 99,
 		},
 	}
 	if err := writePollState(statePath, state); err != nil {
@@ -164,9 +164,16 @@ func TestDriveChangesServeManualModeAcceptsNewChannelWithPersistedBindings(t *te
 	if response.Code != http.StatusNoContent {
 		t.Fatalf("status = %d, want 204", response.Code)
 	}
+	persisted, _, err := readDriveChangesServeState(statePath)
+	if err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if got := persisted.LastMessageNumbers[driveChangesMessageKey("channel-1", "resource-1")]; got != 1 {
+		t.Fatalf("message number = %d, want reset to 1", got)
+	}
 }
 
-func TestDriveChangesServeAcknowledgesSyncUnknownAndDuplicates(t *testing.T) {
+func TestDriveChangesServeAcknowledgesSyncAndDuplicates(t *testing.T) {
 	statePath := filepath.Join(t.TempDir(), "state.json")
 	state := driveChangesServeState{
 		Version:   pollStateVersion,
@@ -184,8 +191,7 @@ func TestDriveChangesServeAcknowledgesSyncUnknownAndDuplicates(t *testing.T) {
 		messageNumber uint64
 	}{
 		{resourceState: "sync", messageNumber: 1},
-		{resourceState: "future-state", messageNumber: 2},
-		{resourceState: "future-state", messageNumber: 2},
+		{resourceState: "sync", messageNumber: 1},
 	} {
 		request := newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, tc.resourceState, tc.messageNumber)
 		response := httptest.NewRecorder()
@@ -203,8 +209,46 @@ func TestDriveChangesServeAcknowledgesSyncUnknownAndDuplicates(t *testing.T) {
 		t.Fatalf("page token = %q", persisted.PageToken)
 	}
 	messageKey := driveChangesMessageKey("channel-1", "resource-1")
-	if persisted.LastMessageNumbers[messageKey] != 2 {
-		t.Fatalf("message number = %d, want 2", persisted.LastMessageNumbers[messageKey])
+	if persisted.LastMessageNumbers[messageKey] != 1 {
+		t.Fatalf("message number = %d, want 1", persisted.LastMessageNumbers[messageKey])
+	}
+}
+
+func TestDriveChangesServeProcessesEveryNonSyncResourceState(t *testing.T) {
+	for _, resourceState := range []string{"add", "remove", "update", "trash", "untrash", "change", "future-state"} {
+		t.Run(resourceState, func(t *testing.T) {
+			svc, closeDrive := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"newStartPageToken": "next-token",
+					"changes":           []map[string]any{{"fileId": "file-1"}},
+				})
+			}))
+			defer closeDrive()
+
+			statePath := filepath.Join(t.TempDir(), "state.json")
+			state := driveChangesServeState{
+				Version:   pollStateVersion,
+				PageToken: pollTestStartToken,
+			}
+			if err := writePollState(statePath, state); err != nil {
+				t.Fatalf("write state: %v", err)
+			}
+			server := newDriveChangesTestReceiver(t, svc, state)
+			server.statePath = statePath
+
+			response := httptest.NewRecorder()
+			server.ServeHTTP(response, newDriveChangesNotificationRequest(t, driveChangesTestChannelToken, resourceState, 2))
+			if response.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", response.Code)
+			}
+			persisted, _, err := readDriveChangesServeState(statePath)
+			if err != nil {
+				t.Fatalf("read state: %v", err)
+			}
+			if persisted.PageToken != "next-token" {
+				t.Fatalf("page token = %q, want next-token", persisted.PageToken)
+			}
+		})
 	}
 }
 
@@ -794,6 +838,7 @@ func TestDriveChangesServeRunRetriesPendingCleanupAtStartup(t *testing.T) {
 }
 
 func TestDriveChangesServeValidation(t *testing.T) {
+	t.Setenv("GOG_DRIVE_CHANNEL_TOKEN", "")
 	valid := DriveChangesServeCmd{
 		Listen:              "127.0.0.1:8443",
 		Path:                driveChangesTestStatePath,

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -63,7 +63,7 @@ func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	if err := s.handleNotification(r.Context(), notification); err != nil {
+	if err := s.handleNotification(s.notificationContext(), notification); err != nil {
 		if errors.Is(err, errDriveChangesUntrackedNotification) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -77,6 +77,13 @@ func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *driveChangesServer) notificationContext() context.Context {
+	if s.runCtx != nil {
+		return s.runCtx
+	}
+	return context.Background()
 }
 
 func driveChangesChannelTokenMatches(got string, expected string) bool {

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -194,21 +194,6 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 		return errDriveChangesUntrackedNotification
 	}
 	messageKey := driveChangesMessageKey(notification.ChannelID, notification.ResourceID)
-	if notification.ResourceState == "sync" {
-		if last := s.state.LastMessageNumbers[messageKey]; last > notification.MessageNumber {
-			s.logf(
-				"drive changes serve: resetting reused channel=%s message=%d",
-				notification.ChannelID,
-				notification.MessageNumber,
-			)
-		}
-		err := s.acknowledgeNotificationLocked(notification)
-		s.mu.Unlock()
-		if err != nil {
-			return err
-		}
-		return errDriveChangesIgnoredNotification
-	}
 	if last := s.state.LastMessageNumbers[messageKey]; last >= notification.MessageNumber {
 		s.logf(
 			"drive changes serve: ignoring duplicate channel=%s message=%d",
@@ -217,6 +202,14 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 		)
 		s.mu.Unlock()
 		return errDriveChangesDuplicateNotification
+	}
+	if notification.ResourceState == "sync" {
+		err := s.acknowledgeNotificationLocked(notification)
+		s.mu.Unlock()
+		if err != nil {
+			return err
+		}
+		return errDriveChangesIgnoredNotification
 	}
 
 	pageToken := s.state.PageToken

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -232,6 +232,9 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 }
 
 func (s *driveChangesServer) notificationChannelAllowedLocked(notification driveChangesNotification) bool {
+	if !s.autoRenew {
+		return true
+	}
 	tracked := false
 	for _, channel := range []*driveChangesServeChannelState{s.state.Channel, s.state.PreviousChannel} {
 		if channel == nil {

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -1,0 +1,242 @@
+package cmd
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/api/drive/v3"
+)
+
+var (
+	errDriveChangesDuplicateNotification = errors.New("duplicate drive changes notification")
+	errDriveChangesIgnoredNotification   = errors.New("ignored drive changes notification")
+	errDriveChangesUntrackedNotification = errors.New("untracked drive changes notification channel")
+)
+
+type driveChangesNotification struct {
+	ChannelID         string
+	ResourceID        string
+	ResourceState     string
+	ResourceURI       string
+	Changed           string
+	ChannelExpiration string
+	MessageNumber     uint64
+}
+
+type driveChangesServeEvent struct {
+	Kind              string          `json:"kind"`
+	ChannelID         string          `json:"channelId"`
+	ResourceID        string          `json:"resourceId"`
+	ResourceState     string          `json:"resourceState"`
+	ResourceURI       string          `json:"resourceUri"`
+	Changed           string          `json:"changed,omitempty"`
+	ChannelExpiration string          `json:"channelExpiration,omitempty"`
+	MessageNumber     uint64          `json:"messageNumber"`
+	DriveID           string          `json:"driveId,omitempty"`
+	PageToken         string          `json:"pageToken"`
+	NextPageToken     string          `json:"nextPageToken"`
+	Changes           []*drive.Change `json:"changes"`
+}
+
+func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != s.path {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		return
+	}
+	if !driveChangesChannelTokenMatches(r.Header.Get("X-Goog-Channel-Token"), s.channelToken) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+	notification, err := parseDriveChangesNotification(r)
+	if err != nil {
+		s.warnf("drive changes serve: invalid notification: %v", err)
+		w.WriteHeader(http.StatusBadRequest)
+		return
+	}
+	if err := s.handleNotification(r.Context(), notification); err != nil {
+		if errors.Is(err, errDriveChangesUntrackedNotification) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if errors.Is(err, errDriveChangesDuplicateNotification) || errors.Is(err, errDriveChangesIgnoredNotification) {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		s.warnf("drive changes serve: notification failed: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func driveChangesChannelTokenMatches(got string, expected string) bool {
+	got = strings.TrimSpace(got)
+	expected = strings.TrimSpace(expected)
+	return subtle.ConstantTimeCompare([]byte(got), []byte(expected)) == 1
+}
+
+func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, error) {
+	channelID := strings.TrimSpace(r.Header.Get("X-Goog-Channel-ID"))
+	resourceID := strings.TrimSpace(r.Header.Get("X-Goog-Resource-ID"))
+	resourceState := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Goog-Resource-State")))
+	resourceURI := strings.TrimSpace(r.Header.Get("X-Goog-Resource-URI"))
+	messageNumberRaw := strings.TrimSpace(r.Header.Get("X-Goog-Message-Number"))
+	switch {
+	case channelID == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Channel-ID")
+	case len(channelID) > 128:
+		return driveChangesNotification{}, errors.New("x-goog-channel-id is too long")
+	case resourceID == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Resource-ID")
+	case len(resourceID) > 512:
+		return driveChangesNotification{}, errors.New("x-goog-resource-id is too long")
+	case resourceState == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Resource-State")
+	case len(resourceState) > 64:
+		return driveChangesNotification{}, errors.New("x-goog-resource-state is too long")
+	case resourceURI == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Resource-URI")
+	case len(resourceURI) > 4096:
+		return driveChangesNotification{}, errors.New("x-goog-resource-uri is too long")
+	case messageNumberRaw == "":
+		return driveChangesNotification{}, errors.New("missing X-Goog-Message-Number")
+	}
+	messageNumber, err := strconv.ParseUint(messageNumberRaw, 10, 64)
+	if err != nil || messageNumber == 0 {
+		return driveChangesNotification{}, errors.New("invalid X-Goog-Message-Number")
+	}
+	return driveChangesNotification{
+		ChannelID:         channelID,
+		ResourceID:        resourceID,
+		ResourceState:     resourceState,
+		ResourceURI:       resourceURI,
+		Changed:           strings.TrimSpace(r.Header.Get("X-Goog-Changed")),
+		ChannelExpiration: strings.TrimSpace(r.Header.Get("X-Goog-Channel-Expiration")),
+		MessageNumber:     messageNumber,
+	}, nil
+}
+
+func (s *driveChangesServer) handleNotification(ctx context.Context, notification driveChangesNotification) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if !s.notificationChannelAllowedLocked(notification) {
+		s.warnf(
+			"drive changes serve: rejecting untracked channel=%s resource=%s",
+			notification.ChannelID,
+			notification.ResourceID,
+		)
+		return errDriveChangesUntrackedNotification
+	}
+	if last := s.state.LastMessageNumbers[notification.ChannelID]; last >= notification.MessageNumber {
+		s.logf(
+			"drive changes serve: ignoring duplicate channel=%s message=%d",
+			notification.ChannelID,
+			notification.MessageNumber,
+		)
+		return errDriveChangesDuplicateNotification
+	}
+	switch notification.ResourceState {
+	case "sync":
+		if err := s.acknowledgeNotificationLocked(notification); err != nil {
+			return err
+		}
+		return errDriveChangesIgnoredNotification
+	case "change", "changed":
+	default:
+		if err := s.acknowledgeNotificationLocked(notification); err != nil {
+			return err
+		}
+		s.logf("drive changes serve: ignoring resource state %q", notification.ResourceState)
+		return errDriveChangesIgnoredNotification
+	}
+
+	changes, nextPageToken, err := loadDriveChanges(ctx, s.service, s.state.PageToken, driveChangesLoadOptions{
+		max:            s.max,
+		includeRemoved: s.includeRemoved,
+		driveID:        s.state.DriveID,
+		all:            true,
+	})
+	if err != nil {
+		return err
+	}
+	filtered := filterDriveChangesByFile(changes, s.filterFile)
+	if len(filtered) > 0 && s.onChange != "" {
+		event := driveChangesServeEvent{
+			Kind:              "drive_changes_notification",
+			ChannelID:         notification.ChannelID,
+			ResourceID:        notification.ResourceID,
+			ResourceState:     notification.ResourceState,
+			ResourceURI:       notification.ResourceURI,
+			Changed:           notification.Changed,
+			ChannelExpiration: notification.ChannelExpiration,
+			MessageNumber:     notification.MessageNumber,
+			DriveID:           s.state.DriveID,
+			PageToken:         s.state.PageToken,
+			NextPageToken:     nextPageToken,
+			Changes:           filtered,
+		}
+		if err := s.runtime.runHook(ctx, s.onChange, event); err != nil {
+			return err
+		}
+	}
+
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.PageToken = nextPageToken
+	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
+	setDriveChangesMessageNumber(&nextState, notification.ChannelID, notification.MessageNumber)
+	if err := writePollState(s.statePath, nextState); err != nil {
+		return err
+	}
+	s.state = nextState
+	return nil
+}
+
+func (s *driveChangesServer) notificationChannelAllowedLocked(notification driveChangesNotification) bool {
+	tracked := false
+	for _, channel := range []*driveChangesServeChannelState{s.state.Channel, s.state.PreviousChannel} {
+		if channel == nil {
+			continue
+		}
+		tracked = true
+		if channel.ID == notification.ChannelID && channel.ResourceID == notification.ResourceID {
+			return true
+		}
+	}
+	if s.pendingChannel != "" {
+		tracked = true
+		if s.pendingChannel == notification.ChannelID {
+			return true
+		}
+	}
+	return !tracked
+}
+
+func (s *driveChangesServer) acknowledgeNotificationLocked(notification driveChangesNotification) error {
+	nextState := cloneDriveChangesServeState(s.state)
+	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
+	setDriveChangesMessageNumber(&nextState, notification.ChannelID, notification.MessageNumber)
+	if err := writePollState(s.statePath, nextState); err != nil {
+		return err
+	}
+	s.state = nextState
+	return nil
+}
+
+func setDriveChangesMessageNumber(state *driveChangesServeState, channelID string, messageNumber uint64) {
+	if state.LastMessageNumbers == nil {
+		state.LastMessageNumbers = make(map[string]uint64)
+	}
+	state.LastMessageNumbers[channelID] = messageNumber
+	trimDriveChangesMessageNumbers(state, channelIDFor(state.Channel), channelIDFor(state.PreviousChannel), channelID)
+}

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -134,15 +134,17 @@ func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, e
 }
 
 func (s *driveChangesServer) handleNotification(ctx context.Context, notification driveChangesNotification) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.notificationMu.Lock()
+	defer s.notificationMu.Unlock()
 
+	s.mu.Lock()
 	if !s.notificationChannelAllowedLocked(notification) {
 		s.warnf(
 			"drive changes serve: rejecting untracked channel=%s resource=%s",
 			notification.ChannelID,
 			notification.ResourceID,
 		)
+		s.mu.Unlock()
 		return errDriveChangesUntrackedNotification
 	}
 	if last := s.state.LastMessageNumbers[notification.ChannelID]; last >= notification.MessageNumber {
@@ -151,27 +153,36 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 			notification.ChannelID,
 			notification.MessageNumber,
 		)
+		s.mu.Unlock()
 		return errDriveChangesDuplicateNotification
 	}
 	switch notification.ResourceState {
 	case "sync":
-		if err := s.acknowledgeNotificationLocked(notification); err != nil {
+		err := s.acknowledgeNotificationLocked(notification)
+		s.mu.Unlock()
+		if err != nil {
 			return err
 		}
 		return errDriveChangesIgnoredNotification
 	case "change", "changed":
 	default:
-		if err := s.acknowledgeNotificationLocked(notification); err != nil {
+		err := s.acknowledgeNotificationLocked(notification)
+		s.mu.Unlock()
+		if err != nil {
 			return err
 		}
 		s.logf("drive changes serve: ignoring resource state %q", notification.ResourceState)
 		return errDriveChangesIgnoredNotification
 	}
 
-	changes, nextPageToken, err := loadDriveChanges(ctx, s.service, s.state.PageToken, driveChangesLoadOptions{
+	pageToken := s.state.PageToken
+	driveID := s.state.DriveID
+	s.mu.Unlock()
+
+	changes, nextPageToken, err := loadDriveChanges(ctx, s.service, pageToken, driveChangesLoadOptions{
 		max:            s.max,
 		includeRemoved: s.includeRemoved,
-		driveID:        s.state.DriveID,
+		driveID:        driveID,
 		all:            true,
 	})
 	if err != nil {
@@ -188,8 +199,8 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 			Changed:           notification.Changed,
 			ChannelExpiration: notification.ChannelExpiration,
 			MessageNumber:     notification.MessageNumber,
-			DriveID:           s.state.DriveID,
-			PageToken:         s.state.PageToken,
+			DriveID:           driveID,
+			PageToken:         pageToken,
 			NextPageToken:     nextPageToken,
 			Changes:           filtered,
 		}
@@ -198,6 +209,11 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 		}
 	}
 
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state.PageToken != pageToken {
+		return errors.New("drive changes serve state advanced during notification processing")
+	}
 	nextState := cloneDriveChangesServeState(s.state)
 	nextState.PageToken = nextPageToken
 	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -98,6 +98,8 @@ func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, e
 	resourceState := strings.ToLower(strings.TrimSpace(r.Header.Get("X-Goog-Resource-State")))
 	resourceURI := strings.TrimSpace(r.Header.Get("X-Goog-Resource-URI"))
 	messageNumberRaw := strings.TrimSpace(r.Header.Get("X-Goog-Message-Number"))
+	changed := strings.TrimSpace(r.Header.Get("X-Goog-Changed"))
+	channelExpiration := strings.TrimSpace(r.Header.Get("X-Goog-Channel-Expiration"))
 	switch {
 	case channelID == "":
 		return driveChangesNotification{}, errors.New("missing X-Goog-Channel-ID")
@@ -117,6 +119,10 @@ func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, e
 		return driveChangesNotification{}, errors.New("x-goog-resource-uri is too long")
 	case messageNumberRaw == "":
 		return driveChangesNotification{}, errors.New("missing X-Goog-Message-Number")
+	case len(changed) > 1024:
+		return driveChangesNotification{}, errors.New("x-goog-changed is too long")
+	case len(channelExpiration) > 256:
+		return driveChangesNotification{}, errors.New("x-goog-channel-expiration is too long")
 	}
 	messageNumber, err := strconv.ParseUint(messageNumberRaw, 10, 64)
 	if err != nil || messageNumber == 0 {
@@ -127,8 +133,8 @@ func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, e
 		ResourceID:        resourceID,
 		ResourceState:     resourceState,
 		ResourceURI:       resourceURI,
-		Changed:           strings.TrimSpace(r.Header.Get("X-Goog-Changed")),
-		ChannelExpiration: strings.TrimSpace(r.Header.Get("X-Goog-Channel-Expiration")),
+		Changed:           changed,
+		ChannelExpiration: channelExpiration,
 		MessageNumber:     messageNumber,
 	}, nil
 }

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"crypto/subtle"
+	"encoding/base64"
 	"errors"
 	"net/http"
 	"strconv"
@@ -82,7 +83,11 @@ func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *driveChangesServer) notificationContext(requestCtx context.Context) (context.Context, context.CancelFunc) {
-	ctx, cancel := context.WithCancel(context.WithoutCancel(requestCtx))
+	timeout := s.notificationTimeout
+	if timeout <= 0 {
+		timeout = defaultDriveChangesNotificationTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.WithoutCancel(requestCtx), timeout)
 	if s.runDone == nil {
 		return ctx, cancel
 	}
@@ -101,6 +106,22 @@ func (s *driveChangesServer) notificationContext(requestCtx context.Context) (co
 		}
 		cancel()
 	}
+}
+
+func (s *driveChangesServer) acquireNotification(ctx context.Context) error {
+	s.notificationOnce.Do(func() {
+		s.notificationGate = make(chan struct{}, 1)
+	})
+	select {
+	case s.notificationGate <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *driveChangesServer) releaseNotification() {
+	<-s.notificationGate
 }
 
 func driveChangesChannelTokenMatches(got string, expected string) bool {
@@ -157,8 +178,10 @@ func parseDriveChangesNotification(r *http.Request) (driveChangesNotification, e
 }
 
 func (s *driveChangesServer) handleNotification(ctx context.Context, notification driveChangesNotification) error {
-	s.notificationMu.Lock()
-	defer s.notificationMu.Unlock()
+	if err := s.acquireNotification(ctx); err != nil {
+		return err
+	}
+	defer s.releaseNotification()
 
 	s.mu.Lock()
 	if !s.notificationChannelAllowedLocked(notification) {
@@ -170,7 +193,8 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 		s.mu.Unlock()
 		return errDriveChangesUntrackedNotification
 	}
-	if last := s.state.LastMessageNumbers[notification.ChannelID]; last >= notification.MessageNumber {
+	messageKey := driveChangesMessageKey(notification.ChannelID, notification.ResourceID)
+	if last := s.state.LastMessageNumbers[messageKey]; last >= notification.MessageNumber {
 		s.logf(
 			"drive changes serve: ignoring duplicate channel=%s message=%d",
 			notification.ChannelID,
@@ -240,7 +264,7 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 	nextState := cloneDriveChangesServeState(s.state)
 	nextState.PageToken = nextPageToken
 	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
-	setDriveChangesMessageNumber(&nextState, notification.ChannelID, notification.MessageNumber)
+	setDriveChangesMessageNumber(&nextState, notification, notification.MessageNumber)
 	if err := writePollState(s.statePath, nextState); err != nil {
 		return err
 	}
@@ -274,7 +298,7 @@ func (s *driveChangesServer) notificationChannelAllowedLocked(notification drive
 func (s *driveChangesServer) acknowledgeNotificationLocked(notification driveChangesNotification) error {
 	nextState := cloneDriveChangesServeState(s.state)
 	nextState.UpdatedAt = s.runtime.now().UTC().Format(time.RFC3339Nano)
-	setDriveChangesMessageNumber(&nextState, notification.ChannelID, notification.MessageNumber)
+	setDriveChangesMessageNumber(&nextState, notification, notification.MessageNumber)
 	if err := writePollState(s.statePath, nextState); err != nil {
 		return err
 	}
@@ -282,10 +306,21 @@ func (s *driveChangesServer) acknowledgeNotificationLocked(notification driveCha
 	return nil
 }
 
-func setDriveChangesMessageNumber(state *driveChangesServeState, channelID string, messageNumber uint64) {
+func setDriveChangesMessageNumber(state *driveChangesServeState, notification driveChangesNotification, messageNumber uint64) {
 	if state.LastMessageNumbers == nil {
 		state.LastMessageNumbers = make(map[string]uint64)
 	}
-	state.LastMessageNumbers[channelID] = messageNumber
-	trimDriveChangesMessageNumbers(state, channelIDFor(state.Channel), channelIDFor(state.PreviousChannel), channelID)
+	messageKey := driveChangesMessageKey(notification.ChannelID, notification.ResourceID)
+	state.LastMessageNumbers[messageKey] = messageNumber
+	trimDriveChangesMessageNumbers(
+		state,
+		driveChangesMessageKeyForChannel(state.Channel),
+		driveChangesMessageKeyForChannel(state.PreviousChannel),
+		messageKey,
+	)
+}
+
+func driveChangesMessageKey(channelID string, resourceID string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(channelID)) + "." +
+		base64.RawURLEncoding.EncodeToString([]byte(resourceID))
 }

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -194,6 +194,21 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 		return errDriveChangesUntrackedNotification
 	}
 	messageKey := driveChangesMessageKey(notification.ChannelID, notification.ResourceID)
+	if notification.ResourceState == "sync" {
+		if last := s.state.LastMessageNumbers[messageKey]; last > notification.MessageNumber {
+			s.logf(
+				"drive changes serve: resetting reused channel=%s message=%d",
+				notification.ChannelID,
+				notification.MessageNumber,
+			)
+		}
+		err := s.acknowledgeNotificationLocked(notification)
+		s.mu.Unlock()
+		if err != nil {
+			return err
+		}
+		return errDriveChangesIgnoredNotification
+	}
 	if last := s.state.LastMessageNumbers[messageKey]; last >= notification.MessageNumber {
 		s.logf(
 			"drive changes serve: ignoring duplicate channel=%s message=%d",
@@ -202,24 +217,6 @@ func (s *driveChangesServer) handleNotification(ctx context.Context, notificatio
 		)
 		s.mu.Unlock()
 		return errDriveChangesDuplicateNotification
-	}
-	switch notification.ResourceState {
-	case "sync":
-		err := s.acknowledgeNotificationLocked(notification)
-		s.mu.Unlock()
-		if err != nil {
-			return err
-		}
-		return errDriveChangesIgnoredNotification
-	case "change", "changed":
-	default:
-		err := s.acknowledgeNotificationLocked(notification)
-		s.mu.Unlock()
-		if err != nil {
-			return err
-		}
-		s.logf("drive changes serve: ignoring resource state %q", notification.ResourceState)
-		return errDriveChangesIgnoredNotification
 	}
 
 	pageToken := s.state.PageToken

--- a/internal/cmd/drive_changes_server.go
+++ b/internal/cmd/drive_changes_server.go
@@ -63,7 +63,9 @@ func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	if err := s.handleNotification(s.notificationContext(), notification); err != nil {
+	notificationCtx, cancel := s.notificationContext(r.Context())
+	defer cancel()
+	if err := s.handleNotification(notificationCtx, notification); err != nil {
 		if errors.Is(err, errDriveChangesUntrackedNotification) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -79,11 +81,26 @@ func (s *driveChangesServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (s *driveChangesServer) notificationContext() context.Context {
-	if s.runCtx != nil {
-		return s.runCtx
+func (s *driveChangesServer) notificationContext(requestCtx context.Context) (context.Context, context.CancelFunc) {
+	ctx, cancel := context.WithCancel(context.WithoutCancel(requestCtx))
+	if s.runDone == nil {
+		return ctx, cancel
 	}
-	return context.Background()
+	finished := make(chan struct{}, 1)
+	go func() {
+		select {
+		case <-s.runDone:
+			cancel()
+		case <-finished:
+		}
+	}()
+	return ctx, func() {
+		select {
+		case finished <- struct{}{}:
+		default:
+		}
+		cancel()
+	}
 }
 
 func driveChangesChannelTokenMatches(got string, expected string) bool {

--- a/internal/cmd/poll_helpers.go
+++ b/internal/cmd/poll_helpers.go
@@ -29,7 +29,7 @@ type pollRuntime struct {
 func defaultPollRuntime() pollRuntime {
 	return pollRuntime{
 		now:     time.Now,
-		runHook: runPollHook,
+		runHook: runJSONShellHook,
 		wait:    waitForPollInterval,
 	}
 }
@@ -63,7 +63,7 @@ func waitForPollInterval(ctx context.Context, interval time.Duration) error {
 	}
 }
 
-func runPollHook(ctx context.Context, command string, payload any) error {
+func runJSONShellHook(ctx context.Context, command string, payload any) error {
 	command = strings.TrimSpace(command)
 	if command == "" {
 		return nil
@@ -87,7 +87,7 @@ func runPollHook(ctx context.Context, command string, payload any) error {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
-		return fmt.Errorf("poll hook failed: %w", err)
+		return fmt.Errorf("shell hook failed: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes #689. Replaces closed stacked PR #753 after #751 landed.

## Summary

- add `gog drive changes serve` with loopback-default HTTP or direct TLS
- authenticate callbacks before parsing headers, Drive reads, or hooks
- process every authenticated non-sync Drive resource state through the changes feed
- serialize callback processing and persist cursor/message progress only after hook success
- support file-backed channel tokens, filters, bounded hooks, and optional channel auto-renewal
- keep poll and receiver state files explicitly separated while accepting legacy state

## Reliability and security

- state stores only the channel-token SHA-256 digest
- auto-renew binds callbacks to current, previous, or pending channel identity
- API, hook, and state failures return 500 without advancing the cursor
- notification work survives request disconnects but stops on command shutdown
- callback processing and request reads have explicit time bounds
- channel cleanup and renewal avoid holding the shared state mutex across network or hook work

## Proof

- autoreview panel: Codex and Claude clean, zero actionable findings
- focused receiver tests under the race detector
- full `make ci`
- live Google Drive callback E2E with `clawdbot@gmail.com`
- real auto-renewed watch channel and initial sync notification
- real Docs creation observed through the callback hook
- persisted page token advanced from 7055 to 7059
- hook payload contained the created Google Doc ID
- wrong public callback token returned HTTP 401
- channel stopped and disposable Doc moved to trash
