### PR TITLE
test(live): verify recent releases and fix Docs regressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Fixed
 
-- Docs: recognize valid one-column Markdown tables instead of rendering their pipe syntax as literal paragraphs.
+- Docs: recognize valid one-column Markdown tables, while preserving separator-shaped rows after the delimiter as table data.
 - Docs: scope default-tab named-range replace and delete requests correctly in multi-tab documents.
 
 ## 0.24.0 - 2026-06-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 - Drive: expose shortcut targets in JSON and human-readable folder reports without changing stable `--plain` columns, classify shortcuts distinctly, keep tree scans from following folder targets, and add `drive shortcut create`. (#763)
 - Drive: add a secure push-notification receiver with persisted cursors, authenticated callbacks, sequential hooks, and optional channel auto-renewal. (#689, #764)
 
+### Fixed
+
+- Docs: recognize valid one-column Markdown tables instead of rendering their pipe syntax as literal paragraphs.
+- Docs: scope default-tab named-range replace and delete requests correctly in multi-tab documents.
+
 ## 0.24.0 - 2026-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Docs: [Google Docs editing](docs/docs-editing.md),
 ```bash
 gog docs write <docId> --append --markdown --text '## Status'
 gog docs format <docId> --match Status --bold --font-size 18
+gog docs format <docId> --match "Project site" --link https://example.com
+gog docs find-range <docId> "Release status" --json
 gog docs insert-page-break <docId> --at-end
 gog docs insert-table <docId> --rows 3 --cols 2 --at-end
 gog docs named-range create <docId> --name Status --at "Ready"
@@ -323,6 +325,8 @@ gog sheets table append <spreadsheetId> Tasks 'Ship README|done'
 gog sheets table clear <spreadsheetId> Tasks
 gog sheets validation set <spreadsheetId> 'Sheet1!B2:B100' \
   --type ONE_OF_LIST --value Open --value Done
+gog sheets links set <spreadsheetId> 'Sheet1!C2' https://example.com "Project"
+gog sheets delete-dimension <spreadsheetId> 'Sheet1!3:3' --dimension ROWS --force
 gog sheets conditional-format add <spreadsheetId> 'Sheet1!A2:A100' \
   --type text-contains \
   --expr blocked \
@@ -339,6 +343,7 @@ Docs: [Slides from Markdown](docs/slides-markdown.md),
 
 ```bash
 gog slides create-from-markdown "Weekly update" --content-file slides.md
+gog slides insert-image <presentationId> <slideId> chart.png --x 24 --y 24 --width 240
 gog slides insert-text <presentationId> <objectId> "New text"
 gog forms update <formId> --quiz=true
 gog forms add-question <formId> --title "What is 2+2?" --type radio -o 1 -o 4 --correct 4 --points 1

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -73,6 +73,49 @@ Command page:
 
 - [`gog docs format`](commands/gog-docs-format.md)
 
+## Ranges, Links, And Anchors
+
+Resolve literal text to Docs API UTF-16 indexes before composing a lower-level
+edit:
+
+```bash
+gog docs find-range <docId> "Release status" --json
+gog docs find-range <docId> "Owner" --all --tab "Plan" --plain
+```
+
+Emoji and other non-BMP characters occupy two UTF-16 code units. The returned
+indexes are ready for Docs API ranges; do not recalculate them from byte or
+rune offsets.
+
+Set or clear a hyperlink on matched text:
+
+```bash
+gog docs format <docId> --match "Project site" --link https://example.com
+gog docs format <docId> --match "Project site" --no-link
+```
+
+`--link` accepts HTTP(S), `mailto:`, bookmark IDs, and same-document heading
+slugs. `--link` and `--no-link` are mutually exclusive.
+
+The direct mutators can resolve the same literal anchors:
+
+```bash
+gog docs insert <docId> "Prefix: " --at "Release status"
+gog docs update <docId> --at "Draft" --text "Ready"
+gog docs delete <docId> --at "Remove me"
+gog docs insert-person <docId> --email owner@example.com --at "@owner"
+gog docs insert-page-break <docId> --at "Appendix"
+```
+
+Use `--occurrence N` when an anchor is ambiguous and `--match-case` when case
+must be exact. `docs comments locate` applies the same matching rules to a
+comment's quoted text and reports its tab plus UTF-16 range.
+
+Command pages:
+
+- [`gog docs find-range`](commands/gog-docs-find-range.md)
+- [`gog docs comments locate`](commands/gog-docs-comments-locate.md)
+
 ## Discover Content
 
 List document elements before using index- or object-ID-based edit commands:
@@ -114,8 +157,10 @@ gog docs named-range replace <docId> ReleaseStatus --text "Released"
 gog docs named-range delete <docId> ReleaseStatus
 ```
 
-Commands are tab-aware. Use `--occurrence` when `--at` matches more than once,
-and `--match-case` when case matters.
+Commands are tab-aware. Without `--tab`, they target the default tab and scope
+named-range mutations correctly even when the document has additional tabs.
+Use `--occurrence` when `--at` matches more than once, and `--match-case` when
+case matters.
 
 Command page:
 
@@ -199,7 +244,8 @@ gog docs insert-table <docId> --rows 2 --cols 2 --index 1 \
 to append at the end of the document (or the selected `--tab`), or `--index N`
 to insert at a specific document index. Prefer this primitive when you want a
 guaranteed native table rather than relying on the Markdown writer's table
-rendering (see `gog docs write --markdown`).
+rendering (see `gog docs write --markdown`). Markdown rendering accepts
+one-column tables as well as wider tables.
 
 Update one existing table cell without round-tripping the surrounding document:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,6 +56,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Backing up an account.** [Backup](backup.md) before pointing `gog backup push` at a busy mailbox.
 - **Selecting private Photos media.** [Photos Picker](photos-picker.md) keeps access limited to items the user explicitly chooses.
 - **Grouping Docs edits atomically.** [Google Docs request batches](docs-batch.md) covers persisted, revision-locked request queues and explicit recovery modes.
+- **Verifying real API behavior.** [Live testing](live-testing.md) covers the dedicated-account smoke suite, cleanup, retries, and optional infrastructure.
 - **Looking up a flag.** The [Command Index](commands/) has a generated page for every subcommand.
 
 ## Project

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -1,0 +1,68 @@
+---
+title: Live testing
+description: "Run broad Google API smoke tests against a dedicated account, including recent feature workflows and cleanup."
+---
+
+# Live Testing
+
+The repository's live suite exercises real Google APIs and cleans up disposable
+resources. Use a dedicated test account:
+
+```bash
+make build
+scripts/live-test.sh --account clawdbot@gmail.com
+```
+
+The account name must look like a test, bot, sandbox, QA, staging, or development
+account unless `--allow-nontest` is supplied. `GOG_KEYRING_PASSWORD` must already
+be available when the file keyring is active.
+
+## Coverage
+
+The default suite covers core output and schema behavior plus live Gmail,
+Calendar, Drive, Docs, Sheets, Slides, Tasks, Contacts, People, and other
+available services. Recent-feature coverage includes:
+
+- Docs UTF-16 ranges, links, named ranges, comments locate/poll, orphan guards,
+  literal anchors, tab-scoped Markdown/export, one-column and nested-list
+  tables, persisted batches, direct table operations, URL images, and content
+  enumerators.
+- Sheets rich-text links, validation, structured tables, and table-aware
+  dimension deletion.
+- Slides local-image insertion with API read-back.
+- Calendar attachment replacement and clearing.
+- Drive shortcuts, revisions, and persisted changes polling.
+- Gmail thread-aware drafts, attachment metadata preservation/clearing, and
+  explicit thread archive semantics.
+- CLI schema exit codes, Git-style help, output-mode precedence, and early
+  validation errors.
+
+Commands that return stable retryable exit code `8` are retried up to three
+times by default. Set `GOG_LIVE_RETRIES` to change the attempt count. Created
+Drive files, Docs batches, Calendar events, Gmail drafts/threads, and Photos
+Picker sessions are also registered for best-effort cleanup if a later check
+fails.
+
+## Optional Coverage
+
+Some APIs need account- or project-specific setup:
+
+```bash
+GOG_LIVE_CHAT_SPACE=spaces/... scripts/live-test.sh --account workspace@example.com
+GOG_LIVE_GMAIL_WATCH_TOPIC=projects/.../topics/... scripts/live-test.sh --account bot@example.com
+GOG_LIVE_CLASSROOM_COURSE=<courseId> scripts/live-test.sh --account bot@example.com
+```
+
+Photos Picker is tested when the account has the explicit `photospicker`
+service:
+
+```bash
+gog auth add you@gmail.com --services photospicker
+```
+
+Google Chat attachments and Keep require Workspace accounts. Gmail watch pull
+requires a configured Pub/Sub subscription. The suite reports these as skipped
+instead of treating unavailable infrastructure as a product failure.
+
+Use `--fast` to skip Docs, Sheets, and Slides, `--skip` for selected modules,
+and `--strict` when optional service failures should fail the run.

--- a/docs/sheets-formatting.md
+++ b/docs/sheets-formatting.md
@@ -51,6 +51,29 @@ cells. When a target fully selects a table-managed dropdown column, pass
 column to text. Validation-only copy/paste preserves table-managed dropdown
 definitions when copying from a table column into ordinary cells.
 
+## Cell Links
+
+Write a single whole-cell link, multiple independently linked text runs, or a
+batch of cells:
+
+```bash
+gog sheets links set "$spreadsheet_id" 'Sheet1!A1' \
+  https://example.com "Project"
+gog sheets links set "$spreadsheet_id" 'Sheet1!B1' \
+  --runs-json '[{"text":"Docs","uri":"https://docs.example.com"},{"text":" / "},{"text":"Issues","uri":"https://issues.example.com"}]'
+gog sheets links set "$spreadsheet_id" \
+  --cells-json '[{"cell":"Sheet1!C1","url":"mailto:owner@example.com","text":"Owner"}]'
+```
+
+Read links back from a range:
+
+```bash
+gog sheets links get "$spreadsheet_id" 'Sheet1!A1:C1' --json
+```
+
+The read command emits one result per URL, so a rich-text cell can appear more
+than once with the same A1 address.
+
 ## Conditional Formats
 
 Add a rule to a sheet-qualified range:
@@ -126,6 +149,8 @@ gog sheets banding clear "$spreadsheet_id" --sheet Sheet1 --all --force
 - [`gog sheets validation get`](commands/gog-sheets-validation-get.md)
 - [`gog sheets validation set`](commands/gog-sheets-validation-set.md)
 - [`gog sheets validation clear`](commands/gog-sheets-validation-clear.md)
+- [`gog sheets links get`](commands/gog-sheets-links-get.md)
+- [`gog sheets links set`](commands/gog-sheets-links-set.md)
 - [`gog sheets conditional-format`](commands/gog-sheets-conditional-format.md)
 - [`gog sheets conditional-format add`](commands/gog-sheets-conditional-format-add.md)
 - [`gog sheets conditional-format list`](commands/gog-sheets-conditional-format-list.md)

--- a/internal/cmd/docs_cell_update_test.go
+++ b/internal/cmd/docs_cell_update_test.go
@@ -349,6 +349,20 @@ func TestDocsCellUpdate_RejectsMarkdownWithoutEditableText(t *testing.T) {
 	}
 }
 
+func TestBuildMarkdownCellContent_PreservesHorizontalRuleSemantics(t *testing.T) {
+	_, text, inserted, err := buildMarkdownCellContent("---", 1, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Repeat("-", 40)
+	if text != want {
+		t.Fatalf("text = %q, want %q", text, want)
+	}
+	if inserted != utf16Len(want) {
+		t.Fatalf("inserted = %d, want %d", inserted, utf16Len(want))
+	}
+}
+
 func cellUpdateTestDoc() *docs.Document {
 	return &docs.Document{
 		DocumentId: "doc1",

--- a/internal/cmd/docs_markdown.go
+++ b/internal/cmd/docs_markdown.go
@@ -340,7 +340,7 @@ func isTableSeparator(line string) bool {
 		}
 		sawDashSegment = true
 	}
-	return sawDashSegment && len(segments) > 1
+	return sawDashSegment
 }
 
 // parseMarkdownTable parses a markdown table into rows of cells

--- a/internal/cmd/docs_markdown.go
+++ b/internal/cmd/docs_markdown.go
@@ -347,7 +347,7 @@ func isTableSeparator(line string) bool {
 func parseMarkdownTable(lines []string) [][]string {
 	var rows [][]string
 
-	for _, line := range lines {
+	for lineIndex, line := range lines {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			break
@@ -355,8 +355,9 @@ func parseMarkdownTable(lines []string) [][]string {
 		if !strings.HasPrefix(line, "|") {
 			break
 		}
-		// Skip separator line
-		if isTableSeparator(line) {
+		// The parser only calls this after recognizing the second line as the
+		// table delimiter. Separator-shaped rows later in the table are data.
+		if lineIndex == 1 && isTableSeparator(line) {
 			continue
 		}
 

--- a/internal/cmd/docs_markdown_test.go
+++ b/internal/cmd/docs_markdown_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestParseMarkdown(t *testing.T) {
 	tests := []struct {
@@ -567,6 +570,7 @@ func TestIsTableSeparator_EmptyPipeRowRejected(t *testing.T) {
 		{"empty cells", "|     |     |", false},
 		{"empty cells tight", "||", false},
 		{"empty cells three cols", "|   |   |   |", false},
+		{"one column", "|---|", true},
 		{"normal separator", "|---|---|", true},
 		{"spaced separator", "| --- | --- |", true},
 		{"left align", "|:---|---|", true},
@@ -579,6 +583,18 @@ func TestIsTableSeparator_EmptyPipeRowRejected(t *testing.T) {
 				t.Errorf("isTableSeparator(%q) = %v, want %v", tt.line, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestParseMarkdown_OneColumnTable(t *testing.T) {
+	input := "| Status |\n| --- |\n| Ready |"
+	got := ParseMarkdown(input)
+	if len(got) != 1 || got[0].Type != MDTable {
+		t.Fatalf("ParseMarkdown() = %#v, want one table", got)
+	}
+	want := [][]string{{"Status"}, {"Ready"}}
+	if !reflect.DeepEqual(got[0].TableCells, want) {
+		t.Fatalf("table rows = %#v, want %#v", got[0].TableCells, want)
 	}
 }
 

--- a/internal/cmd/docs_markdown_test.go
+++ b/internal/cmd/docs_markdown_test.go
@@ -598,6 +598,30 @@ func TestParseMarkdown_OneColumnTable(t *testing.T) {
 	}
 }
 
+func TestParseMarkdown_OneColumnDashOnlyDataRow(t *testing.T) {
+	input := "| Status |\n| --- |\n| --- |"
+	got := ParseMarkdown(input)
+	if len(got) != 1 || got[0].Type != MDTable {
+		t.Fatalf("ParseMarkdown() = %#v, want one table", got)
+	}
+	want := [][]string{{"Status"}, {"---"}}
+	if !reflect.DeepEqual(got[0].TableCells, want) {
+		t.Fatalf("table rows = %#v, want %#v", got[0].TableCells, want)
+	}
+}
+
+func TestParseMarkdown_MultiColumnDashOnlyDataRow(t *testing.T) {
+	input := "| Left | Right |\n| --- | --- |\n| --- | :---: |"
+	got := ParseMarkdown(input)
+	if len(got) != 1 || got[0].Type != MDTable {
+		t.Fatalf("ParseMarkdown() = %#v, want one table", got)
+	}
+	want := [][]string{{"Left", "Right"}, {"---", ":---:"}}
+	if !reflect.DeepEqual(got[0].TableCells, want) {
+		t.Fatalf("table rows = %#v, want %#v", got[0].TableCells, want)
+	}
+}
+
 func TestParseMarkdown_EmptyHeaderTableDropsBlankHeaderAndKeepsDataRows(t *testing.T) {
 	// Regression for #609: an empty-header table previously had its last data
 	// row re-parsed as a literal pipe paragraph (because the empty pipe row

--- a/internal/cmd/docs_named_ranges.go
+++ b/internal/cmd/docs_named_ranges.go
@@ -359,7 +359,11 @@ func (c *DocsNamedRangesReplaceCmd) Run(ctx context.Context, kctx *kong.Context,
 	if err != nil {
 		return fmt.Errorf("replace named range: %w", err)
 	}
-	updated, err := loadDocsTargetDocument(ctx, svc, docID, tab)
+	updatedTab := tab
+	if tab == "" && loaded.tabID != "" {
+		updatedTab = loaded.tabID
+	}
+	updated, err := loadDocsTargetDocument(ctx, svc, docID, updatedTab)
 	if err != nil {
 		return fmt.Errorf("read replaced named range: %w", err)
 	}
@@ -421,7 +425,67 @@ func loadAndResolveDocsNamedRange(ctx context.Context, svc *docs.Service, docID,
 			Err:  fmt.Errorf("named range not found: %q", in),
 		}
 	}
+	if loaded.tabID == "" {
+		scopedLoaded, scopedItem, scoped, scopeErr := scopeDocsNamedRangeToOwningTab(ctx, svc, docID, item)
+		if scopeErr != nil {
+			return nil, docsNamedRangeItem{}, scopeErr
+		}
+		if scoped {
+			return scopedLoaded, scopedItem, nil
+		}
+	}
 	return loaded, item, nil
+}
+
+func scopeDocsNamedRangeToOwningTab(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	item docsNamedRangeItem,
+) (*docsLoadedTarget, docsNamedRangeItem, bool, error) {
+	doc, err := svc.Documents.Get(docID).IncludeTabsContent(true).Context(ctx).Do()
+	if err != nil {
+		return nil, docsNamedRangeItem{}, false, err
+	}
+	if doc == nil || len(doc.Tabs) == 0 {
+		return nil, docsNamedRangeItem{}, false, nil
+	}
+
+	var matchedLoaded *docsLoadedTarget
+	var matchedItem docsNamedRangeItem
+	for _, tab := range flattenTabs(doc.Tabs) {
+		if tab == nil || tab.TabProperties == nil || tab.DocumentTab == nil {
+			continue
+		}
+		tabID := strings.TrimSpace(tab.TabProperties.TabId)
+		if tabID == "" {
+			continue
+		}
+		loaded := &docsLoadedTarget{full: doc, tabID: tabID}
+		items, itemsErr := docsNamedRangeItemsForLoaded(loaded)
+		if itemsErr != nil {
+			return nil, docsNamedRangeItem{}, false, itemsErr
+		}
+		candidate, found, resolveErr := resolveDocsNamedRange(item.NamedRangeID, items)
+		if resolveErr != nil {
+			return nil, docsNamedRangeItem{}, false, resolveErr
+		}
+		if !found {
+			continue
+		}
+		if matchedLoaded != nil {
+			return nil, docsNamedRangeItem{}, false, fmt.Errorf(
+				"named range ID %q exists in multiple tabs; pass --tab",
+				item.NamedRangeID,
+			)
+		}
+		matchedLoaded = loaded
+		matchedItem = candidate
+	}
+	if matchedLoaded == nil {
+		return nil, docsNamedRangeItem{}, false, nil
+	}
+	return matchedLoaded, matchedItem, true, nil
 }
 
 func docsNamedRangeItemsForLoaded(loaded *docsLoadedTarget) ([]docsNamedRangeItem, error) {

--- a/internal/cmd/docs_named_ranges_test.go
+++ b/internal/cmd/docs_named_ranges_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -252,6 +253,67 @@ func TestDocsNamedRangesDeleteAndReplaceByExactID(t *testing.T) {
 	}
 	if !bytes.Contains(rec.rawBatches[2], []byte(`"text":""`)) {
 		t.Fatalf("empty text omitted from wire body: %s", rec.rawBatches[2])
+	}
+}
+
+func TestDocsNamedRangesReplaceDefaultTabScopesMultiTabRequest(t *testing.T) {
+	origDocs := newDocsService
+	t.Cleanup(func() { newDocsService = origDocs })
+
+	mainRange := &docs.NamedRange{
+		Name:         "stable",
+		NamedRangeId: "nr-stable",
+		Ranges:       []*docs.Range{{StartIndex: 1, EndIndex: 7}},
+	}
+	doc := docsFindRangeDoc(docsFindRangeParagraph(1, "stable\n"))
+	doc.DocumentId = "doc1"
+	doc.RevisionId = "rev-tabs"
+	doc.NamedRanges = map[string]docs.NamedRanges{
+		"stable": {Name: "stable", NamedRanges: []*docs.NamedRange{mainRange}},
+	}
+	doc.Tabs = []*docs.Tab{
+		{
+			TabProperties: &docs.TabProperties{TabId: "t.main", Title: "Tab 1"},
+			DocumentTab: &docs.DocumentTab{
+				Body: docsFindRangeDoc(docsFindRangeParagraph(1, "stable\n")).Body,
+				NamedRanges: map[string]docs.NamedRanges{
+					"stable": {Name: "stable", NamedRanges: []*docs.NamedRange{mainRange}},
+				},
+			},
+		},
+		{
+			TabProperties: &docs.TabProperties{TabId: "t.other", Title: "Other"},
+			DocumentTab:   &docs.DocumentTab{Body: docsFindRangeDoc(docsFindRangeParagraph(1, "other\n")).Body},
+		},
+	}
+	rec := &docsNamedRangeRecorder{}
+	setupDocsNamedRangeTestService(t, doc, rec)
+
+	var err error
+	captureStdout(t, func() {
+		err = runKong(t, &DocsNamedRangesReplaceCmd{}, []string{
+			"doc1", "stable", "--text", "replacement",
+		}, newDocsJSONContext(t), &RootFlags{Account: "a@b.com"})
+	})
+	if err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	got := rec.batches[0].Requests[0].ReplaceNamedRangeContent
+	if got == nil || got.TabsCriteria == nil || !reflect.DeepEqual(got.TabsCriteria.TabIds, []string{"t.main"}) {
+		t.Fatalf("replace request tabs = %#v, want t.main", got)
+	}
+
+	captureStdout(t, func() {
+		err = runKong(t, &DocsNamedRangesDeleteCmd{}, []string{
+			"doc1", "stable",
+		}, newDocsJSONContext(t), &RootFlags{Account: "a@b.com"})
+	})
+	if err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	deleted := rec.batches[1].Requests[0].DeleteNamedRange
+	if deleted == nil || deleted.TabsCriteria == nil || !reflect.DeepEqual(deleted.TabsCriteria.TabIds, []string{"t.main"}) {
+		t.Fatalf("delete request tabs = %#v, want t.main", deleted)
 	}
 }
 

--- a/internal/cmd/docs_table_inserter.go
+++ b/internal/cmd/docs_table_inserter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"google.golang.org/api/docs/v1"
 )
@@ -141,9 +142,19 @@ func (ti *TableInserter) InsertNativeTable(ctx context.Context, tableIndex int64
 // Header cells additionally receive a whole-cell bold style. insertedLen is
 // the final UTF-16 growth after CreateParagraphBullets consumes nesting tabs.
 func buildTableCellRequests(cellContent string, cellIdx int64, isHeaderRow bool, tabID string) ([]*docs.Request, int64, error) {
-	formatRequests, text, insertedLen, err := buildMarkdownCellContent(cellContent, cellIdx, tabID)
-	if err != nil {
-		return nil, 0, err
+	trimmed := strings.TrimSpace(cellContent)
+	var formatRequests []*docs.Request
+	var text string
+	var insertedLen int64
+	if isTableSeparator("|" + trimmed + "|") {
+		text = trimmed
+		insertedLen = utf16Len(trimmed)
+	} else {
+		var err error
+		formatRequests, text, insertedLen, err = buildMarkdownCellContent(cellContent, cellIdx, tabID)
+		if err != nil {
+			return nil, 0, err
+		}
 	}
 	if text == "" {
 		return nil, 0, nil

--- a/internal/cmd/docs_table_inserter_inline_test.go
+++ b/internal/cmd/docs_table_inserter_inline_test.go
@@ -182,6 +182,26 @@ func TestBuildTableCellRequests_PlainTextNoStyleRequest(t *testing.T) {
 	}
 }
 
+func TestBuildTableCellRequests_PreservesSeparatorShapedData(t *testing.T) {
+	for _, content := range []string{"---", ":---", "---:", ":---:"} {
+		t.Run(content, func(t *testing.T) {
+			reqs, inserted, err := buildTableCellRequests(content, 1, false, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if inserted != utf16Len(content) {
+				t.Fatalf("inserted = %d, want %d", inserted, utf16Len(content))
+			}
+			if len(reqs) != 1 {
+				t.Fatalf("expected just InsertText, got %d: %#v", len(reqs), reqs)
+			}
+			if got := reqs[0].InsertText; got == nil || got.Text != content {
+				t.Fatalf("InsertText.Text = %q, want %q", textOf(reqs[0]), content)
+			}
+		})
+	}
+}
+
 func TestBuildTableCellRequests_EmptyAfterStrippingReturnsNothing(t *testing.T) {
 	// A cell whose entire content is markers (e.g. "**") would strip to "".
 	reqs, inserted, err := buildTableCellRequests("", 1, false, "")

--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -26,15 +26,17 @@ Options:
   -h, --help          Show this help
 
 Skip keys (base):
-  time, version, completion, auth, auth-alias, config, enable-commands,
+  time, version, completion, schema, help, output-precedence, auth, auth-alias, config, enable-commands,
   gmail, gmail-settings, gmail-delegates, gmail-batch-delete, gmail-history, gmail-url, gmail-labels,
   gmail-send-safety, gmail-forward,
-  gmail-attachments, gmail-track, gmail-watch, drive, docs, sheets, slides,
+  gmail-attachments, gmail-track, gmail-watch, chat, drive, docs, sheets, slides,
+  photos-picker,
   calendar, calendar-enterprise, calendar-respond, calendar-team, calendar-users,
   tasks, contacts, people, groups, keep, classroom
 
 Env:
   GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com
+  GOG_LIVE_CHAT_SPACE=spaces/...
   GOG_LIVE_GROUP_EMAIL=<group@domain>
   GOG_LIVE_CLASSROOM_COURSE=<courseId>
   GOG_LIVE_CLASSROOM_CREATE=1
@@ -48,6 +50,7 @@ Env:
   GOG_LIVE_CLIENT=work
   GOG_LIVE_GMAIL_WATCH_TOPIC=projects/.../topics/...
   GOG_LIVE_CALENDAR_RECURRENCE=1
+  GOG_LIVE_RETRIES=3
   GOG_KEEP_SERVICE_ACCOUNT=/path/to/service-account.json
   GOG_KEEP_IMPERSONATE=user@workspace-domain
 USAGE
@@ -144,7 +147,6 @@ echo "Using account: $ACCOUNT"
 EMAIL_TEST="${GOG_LIVE_EMAIL_TEST:-steipete+gogtest@gmail.com}"
 TS=$(date +%Y%m%d%H%M%S)
 LIVE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/gog-live-$TS-XXXX")
-trap 'rm -rf "$LIVE_TMP"' EXIT
 
 source "$ROOT_DIR/scripts/live-tests/common.sh"
 source "$ROOT_DIR/scripts/live-tests/core.sh"
@@ -153,6 +155,7 @@ source "$ROOT_DIR/scripts/live-tests/drive.sh"
 source "$ROOT_DIR/scripts/live-tests/docs.sh"
 source "$ROOT_DIR/scripts/live-tests/sheets.sh"
 source "$ROOT_DIR/scripts/live-tests/slides.sh"
+source "$ROOT_DIR/scripts/live-tests/photos.sh"
 source "$ROOT_DIR/scripts/live-tests/calendar.sh"
 source "$ROOT_DIR/scripts/live-tests/tasks.sh"
 source "$ROOT_DIR/scripts/live-tests/contacts.sh"
@@ -160,6 +163,8 @@ source "$ROOT_DIR/scripts/live-tests/people.sh"
 source "$ROOT_DIR/scripts/live-tests/workspace.sh"
 source "$ROOT_DIR/scripts/live-tests/classroom.sh"
 source "$ROOT_DIR/scripts/live-tests/meet.sh"
+
+trap 'cleanup_live_resources || true; rm -rf "$LIVE_TMP"' EXIT
 
 ensure_test_account
 
@@ -182,6 +187,7 @@ run_drive_tests
 run_docs_tests
 run_sheets_tests
 run_slides_tests
+run_photos_picker_tests
 run_calendar_tests
 run_tasks_tests
 run_contacts_tests

--- a/scripts/live-tests/calendar.sh
+++ b/scripts/live-tests/calendar.sh
@@ -26,10 +26,29 @@ PY
   ev_json=$(gog calendar create primary --summary "gogcli-smoke-$TS" --from "$START" --to "$END" --location "Test" --send-updates none --json)
   ev_id=$(extract_id "$ev_json")
   [ -n "$ev_id" ] || { echo "Failed to parse calendar event id" >&2; exit 1; }
+  register_calendar_cleanup primary "$ev_id"
 
   run_required "calendar" "calendar event get" gog calendar event primary "$ev_id" --json >/dev/null
   run_required "calendar" "calendar propose-time" gog calendar propose-time primary "$ev_id" --json >/dev/null
   run_required "calendar" "calendar update" gog calendar update primary "$ev_id" --summary "gogcli-smoke-updated-$TS" --json >/dev/null
+
+  local attachment_doc_json attachment_doc_id attachment_url attachment_event_json
+  attachment_doc_json=$(gog docs create "gogcli-calendar-attachment-$TS" --json)
+  attachment_doc_id=$(extract_id "$attachment_doc_json")
+  [ -n "$attachment_doc_id" ] || { echo "Failed to parse calendar attachment doc id" >&2; exit 1; }
+  register_drive_cleanup "$attachment_doc_id"
+  attachment_url="https://drive.google.com/file/d/$attachment_doc_id/view"
+  run_required "calendar" "calendar update attachment" gog calendar update primary "$ev_id" \
+    --attachment "$attachment_url" --json >/dev/null
+  attachment_event_json=$(gog calendar event primary "$ev_id" --json)
+  "$PY" -c 'import json,sys
+want=sys.argv[1]
+obj=json.load(sys.stdin)
+attachments=obj.get("event", {}).get("attachments", [])
+assert any(a.get("fileUrl") == want for a in attachments)' "$attachment_url" <<<"$attachment_event_json"
+  run_required "calendar" "calendar clear attachments" gog calendar update primary "$ev_id" \
+    --attachment= --json >/dev/null
+
   run_required "calendar" "calendar events list" gog calendar events primary --from "$START" --to "$END" --json --max 5 >/dev/null
   run_required "calendar" "calendar search" gog calendar search "gogcli-smoke" --from "$START" --to "$END" --json --max 5 >/dev/null
   run_required "calendar" "calendar freebusy" gog calendar freebusy primary --from "$START" --to "$END" --json >/dev/null

--- a/scripts/live-tests/common.sh
+++ b/scripts/live-tests/common.sh
@@ -7,6 +7,13 @@ if ! command -v "$PY" >/dev/null 2>&1; then
   PY="python"
 fi
 
+LIVE_DRIVE_CLEANUP_IDS=()
+LIVE_BATCH_CLEANUP_IDS=()
+LIVE_CALENDAR_CLEANUP_EVENTS=()
+LIVE_GMAIL_CLEANUP_DRAFTS=()
+LIVE_GMAIL_CLEANUP_THREADS=()
+LIVE_PHOTOS_PICKER_CLEANUP_IDS=()
+
 skip() {
   local key="$1"
   [ -n "${SKIP:-}" ] || return 1
@@ -203,7 +210,74 @@ print(find(obj))' <<<"$1"
 }
 
 gog() {
-  "$BIN" --account "$ACCOUNT" "$@"
+  local attempt max_attempts rc
+  max_attempts="${GOG_LIVE_RETRIES:-3}"
+  case "$max_attempts" in
+    ''|*[!0-9]*|0)
+      max_attempts=3
+      ;;
+  esac
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if "$BIN" --account "$ACCOUNT" "$@"; then
+      return 0
+    else
+      rc=$?
+    fi
+    if [ "$rc" -ne 8 ] || [ "$attempt" -eq "$max_attempts" ]; then
+      return "$rc"
+    fi
+    echo "retryable gog failure; retry $attempt/$max_attempts: $*" >&2
+    sleep "$attempt"
+  done
+}
+
+register_drive_cleanup() {
+  [ -n "${1:-}" ] && LIVE_DRIVE_CLEANUP_IDS+=("$1")
+}
+
+register_batch_cleanup() {
+  [ -n "${1:-}" ] && LIVE_BATCH_CLEANUP_IDS+=("$1")
+}
+
+register_calendar_cleanup() {
+  [ -n "${1:-}" ] && [ -n "${2:-}" ] && LIVE_CALENDAR_CLEANUP_EVENTS+=("$1"$'\t'"$2")
+}
+
+register_gmail_draft_cleanup() {
+  [ -n "${1:-}" ] && LIVE_GMAIL_CLEANUP_DRAFTS+=("$1")
+}
+
+register_gmail_thread_cleanup() {
+  [ -n "${1:-}" ] && LIVE_GMAIL_CLEANUP_THREADS+=("$1")
+}
+
+register_photos_picker_cleanup() {
+  [ -n "${1:-}" ] && LIVE_PHOTOS_PICKER_CLEANUP_IDS+=("$1")
+}
+
+cleanup_live_resources() {
+  local entry calendar_id event_id id
+
+  for id in "${LIVE_GMAIL_CLEANUP_DRAFTS[@]}"; do
+    gog gmail drafts delete "$id" --force >/dev/null 2>&1 || true
+  done
+  for id in "${LIVE_BATCH_CLEANUP_IDS[@]}"; do
+    "$BIN" batch abort "$id" >/dev/null 2>&1 || true
+  done
+  for entry in "${LIVE_CALENDAR_CLEANUP_EVENTS[@]}"; do
+    IFS=$'\t' read -r calendar_id event_id <<<"$entry"
+    gog calendar delete "$calendar_id" "$event_id" --force >/dev/null 2>&1 || true
+  done
+  for id in "${LIVE_GMAIL_CLEANUP_THREADS[@]}"; do
+    gog gmail thread modify "$id" --add TRASH --json >/dev/null 2>&1 || true
+  done
+  for id in "${LIVE_PHOTOS_PICKER_CLEANUP_IDS[@]}"; do
+    gog photos picker delete "$id" --force --json >/dev/null 2>&1 || true
+  done
+  for id in "${LIVE_DRIVE_CLEANUP_IDS[@]}"; do
+    gog drive delete "$id" --force >/dev/null 2>&1 || true
+  done
 }
 
 is_test_account() {

--- a/scripts/live-tests/core.sh
+++ b/scripts/live-tests/core.sh
@@ -6,6 +6,44 @@ run_core_tests() {
   run_required "time" "time now" "$BIN" time now --json >/dev/null
   run_required "version" "version" "$BIN" version --json >/dev/null
   run_required "completion" "completion bash" "$BIN" completion bash >/dev/null
+  if ! skip "schema"; then
+    local schema_json
+    echo "==> schema automation contract"
+    schema_json=$("$BIN" schema --json)
+    "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+codes=obj.get("automation",{}).get("exit_codes",{})
+assert codes.get("usage") == 2
+assert codes.get("retryable") == 8
+assert codes.get("orphaned") == 11' <<<"$schema_json"
+  else
+    echo "==> schema automation contract (skipped)"
+  fi
+  run_required "help" "git-style command help" "$BIN" help docs format >/dev/null
+
+  if ! skip "output-precedence"; then
+    local plain_output json_output
+    echo "==> plain overrides JSON environment"
+    plain_output=$(GOG_JSON=1 "$BIN" --plain time now)
+    "$PY" -c 'import sys
+text=sys.stdin.read()
+assert text.startswith("timezone\t")' <<<"$plain_output"
+    echo "==> JSON overrides plain environment"
+    json_output=$(GOG_PLAIN=1 "$BIN" --json time now)
+    "$PY" -c 'import json,sys; assert isinstance(json.load(sys.stdin), dict)' <<<"$json_output"
+  else
+    echo "==> output precedence (skipped)"
+  fi
+
+  local invalid_stdout invalid_stderr
+  invalid_stdout="$LIVE_TMP/invalid-color.stdout"
+  invalid_stderr="$LIVE_TMP/invalid-color.stderr"
+  if "$BIN" --color invalid time now >"$invalid_stdout" 2>"$invalid_stderr"; then
+    echo "Expected invalid color to fail, but it succeeded" >&2
+    exit 1
+  fi
+  [ ! -s "$invalid_stdout" ] || { echo "Invalid color wrote to stdout" >&2; exit 1; }
+  grep -q "invalid" "$invalid_stderr"
 
   if ! skip "auth-alias"; then
     local alias_name

--- a/scripts/live-tests/docs.sh
+++ b/scripts/live-tests/docs.sh
@@ -8,10 +8,156 @@ run_docs_tests() {
     return 0
   fi
 
-  local doc_json doc_id copy_json copy_id export_path
+  local doc_json doc_id copy_json copy_id export_path markdown_path replacement_path tab_markdown_path tab_export_path
   doc_json=$(gog docs create "gogcli-smoke-doc-$TS" --json)
   doc_id=$(extract_id "$doc_json")
   [ -n "$doc_id" ] || { echo "Failed to parse doc id" >&2; exit 1; }
+  register_drive_cleanup "$doc_id"
+
+  markdown_path="$LIVE_TMP/docs-recent-$TS.md"
+  replacement_path="$LIVE_TMP/docs-replacement-$TS.md"
+  tab_markdown_path="$LIVE_TMP/docs-tab-recent-$TS.md"
+  tab_export_path="$LIVE_TMP/docs-tab-export-$TS.txt"
+  printf '# Heading {#heading}\n\nAnchorTarget and LinkTarget.\n\nEmoji 😀 range.\n\nOrphanTarget remains quoted.\n\nInsertHere UpdateHere DeleteHere PersonHere BreakHere\n\nBatchAnchor.\n\n~~Strike~~ and `code`.\n\n- Parent\n  - Child\n' >"$markdown_path"
+  printf '# Replacement\n\nNo quoted content remains.\n' >"$replacement_path"
+  printf '# Recent Tab {#recent-tab}\n\n```go\nfmt.Println("ok")\n```\n\n| Solo |\n| --- |\n| value |\n\n| Kind | Steps |\n| --- | --- |\n| nested | - parent<br>  - child |\n' >"$tab_markdown_path"
+
+  run_required "docs" "docs markdown write" gog docs write "$doc_id" \
+    --file "$markdown_path" --replace --markdown --json >/dev/null
+
+  local range_json
+  range_json=$(gog docs find-range "$doc_id" "😀" --json)
+  "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+def walk(value):
+    if isinstance(value, dict):
+        if value.get("endIndex", 0) - value.get("startIndex", 0) == 2:
+            return True
+        return any(walk(v) for v in value.values())
+    if isinstance(value, list):
+        return any(walk(v) for v in value)
+    return False
+assert walk(obj)' <<<"$range_json"
+
+  run_required "docs" "docs format link and code" gog docs format "$doc_id" \
+    --match LinkTarget --link https://example.com --code --json >/dev/null
+  local raw_json
+  raw_json=$(gog docs raw "$doc_id" --json)
+  "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+def walk(value):
+    if isinstance(value, dict):
+        if value.get("link", {}).get("url") == "https://example.com":
+            return True
+        return any(walk(v) for v in value.values())
+    if isinstance(value, list):
+        return any(walk(v) for v in value)
+    return False
+assert walk(obj)' <<<"$raw_json"
+  run_required "docs" "docs format clear link" gog docs format "$doc_id" \
+    --match LinkTarget --no-link --json >/dev/null
+
+  run_required "docs" "docs add recent tab" gog docs add-tab "$doc_id" \
+    --title Recent --json >/dev/null
+  run_required "docs" "docs markdown write recent tab" gog docs write "$doc_id" \
+    --file "$tab_markdown_path" --replace --markdown --tab Recent --json >/dev/null
+  local tab_raw_json
+  tab_raw_json=$(gog docs raw "$doc_id" --tab Recent --json)
+  "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+def walk(value):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from walk(child)
+objects=list(walk(obj))
+assert sum("tableRows" in item for item in objects) == 2
+assert any(item.get("bullet", {}).get("nestingLevel") == 1 for item in objects)
+assert any(item.get("textStyle", {}).get("weightedFontFamily", {}).get("fontFamily") == "Roboto Mono" for item in objects)
+assert not any("{#recent-tab}" in value for item in objects for value in item.values() if isinstance(value, str))' <<<"$tab_raw_json"
+  run_required "docs" "docs export recent tab" gog docs export "$doc_id" \
+    --tab Recent --format txt --out "$tab_export_path" >/dev/null
+  [ -s "$tab_export_path" ] || { echo "Docs tab export was empty" >&2; exit 1; }
+
+  run_required "docs" "docs named range create" gog docs named-range create "$doc_id" \
+    --name smoke_anchor --at AnchorTarget --json >/dev/null
+  run_required "docs" "docs named range list" gog docs named-range list "$doc_id" \
+    --name smoke_anchor --json >/dev/null
+  run_required "docs" "docs named range replace" gog docs named-range replace "$doc_id" \
+    smoke_anchor --text AnchorReplaced --json >/dev/null
+
+  local since comment_json comment_id comments_state
+  since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+  comment_json=$(gog docs comments add "$doc_id" "gogcli locate $TS" --quoted OrphanTarget --json)
+  comment_id=$(extract_id "$comment_json")
+  [ -n "$comment_id" ] || { echo "Failed to parse Docs comment id" >&2; exit 1; }
+  run_required "docs" "docs comments since" gog docs comments list "$doc_id" \
+    --since "$since" --json >/dev/null
+  run_required "docs" "docs comments locate" gog docs comments locate "$doc_id" \
+    "$comment_id" --json >/dev/null
+  comments_state="$LIVE_TMP/docs-comments-$TS.json"
+  run_required "docs" "docs comments poll" gog docs comments poll "$doc_id" \
+    --state-file "$comments_state" --max-iterations 1 --interval 1ms --json >/dev/null
+  [ -s "$comments_state" ] || { echo "Docs comments poll did not persist state" >&2; exit 1; }
+
+  local orphan_rc
+  if gog docs write "$doc_id" --file "$replacement_path" --replace --markdown \
+    --check-orphans --json >/dev/null 2>"$LIVE_TMP/docs-orphan-$TS.err"; then
+    echo "Expected orphan guard to block replacement, but it succeeded" >&2
+    exit 1
+  else
+    orphan_rc=$?
+  fi
+  [ "$orphan_rc" -eq 11 ] || { echo "Unexpected orphan guard exit: $orphan_rc" >&2; exit 1; }
+
+  run_required "docs" "docs insert at anchor" gog docs insert "$doc_id" "Inserted-" \
+    --at InsertHere --json >/dev/null
+  run_required "docs" "docs update at anchor" gog docs update "$doc_id" \
+    --at UpdateHere --text Updated --json >/dev/null
+  run_required "docs" "docs delete at anchor" gog docs delete "$doc_id" \
+    --at DeleteHere --json >/dev/null
+  run_required "docs" "docs person chip at anchor" gog docs insert-person "$doc_id" \
+    --email "$ACCOUNT" --at PersonHere --json >/dev/null
+  run_required "docs" "docs page break at anchor" gog docs insert-page-break "$doc_id" \
+    --at BreakHere --json >/dev/null
+
+  local batch_id batch_json
+  batch_id=$("$BIN" --account "$ACCOUNT" batch begin --service docs --doc "$doc_id" --name "live-$TS")
+  [ -n "$batch_id" ] || { echo "Failed to create Docs batch" >&2; exit 1; }
+  register_batch_cleanup "$batch_id"
+  run_required "docs" "docs batch insert" gog docs insert "$doc_id" "BatchedText " \
+    --at BatchAnchor --batch "$batch_id" --json >/dev/null
+  run_required "docs" "docs batch format" gog docs format "$doc_id" \
+    --match AnchorReplaced --bold --batch "$batch_id" --json >/dev/null
+  batch_json=$("$BIN" batch show "$batch_id" --json)
+  "$PY" -c 'import json,sys; assert len(json.load(sys.stdin)["batch"]["requests"]) >= 2' <<<"$batch_json"
+  run_required "docs" "docs batch dry-run" "$BIN" --dry-run batch end "$batch_id" --json >/dev/null
+  run_required "docs" "docs batch submit" "$BIN" batch end "$batch_id" --json >/dev/null
+
+  run_required "docs" "docs insert table" gog docs insert-table "$doc_id" \
+    --rows 2 --cols 2 --at-end --values-json '[["A","B"],["C","D"]]' --json >/dev/null
+  run_required "docs" "docs table row insert" gog docs table-row insert "$doc_id" \
+    --table 1 --at end --values-json '["E","F"]' --json >/dev/null
+  run_required "docs" "docs table column insert" gog docs table-column insert "$doc_id" \
+    --table 1 --at end --json >/dev/null
+  run_required "docs" "docs table merge" gog docs table-merge "$doc_id" \
+    --table 1 --range 1,1:1,2 --json >/dev/null
+  run_required "docs" "docs table unmerge" gog docs table-unmerge "$doc_id" \
+    --table 1 --cell 1,1 --json >/dev/null
+
+  run_required "docs" "docs URL image insert" gog docs insert-image "$doc_id" \
+    --url https://www.gstatic.com/images/branding/product/2x/docs_48dp.png \
+    --at end --width 48 --json >/dev/null
+  local images_json
+  images_json=$(gog docs images list "$doc_id" --json)
+  "$PY" -c 'import json,sys; assert len(json.load(sys.stdin).get("images", [])) >= 1' <<<"$images_json"
+  run_required "docs" "docs tables list" gog docs tables list "$doc_id" --json >/dev/null
+  run_required "docs" "docs headings list" gog docs headings list "$doc_id" --json >/dev/null
+  run_required "docs" "docs paragraphs list" gog docs paragraphs list "$doc_id" --json >/dev/null
+  run_required "docs" "docs raw all tabs" gog docs raw "$doc_id" --all-tabs --json >/dev/null
 
   run_required "docs" "docs info" gog docs info "$doc_id" --json >/dev/null
   run_required "docs" "docs cat" gog docs cat "$doc_id" >/dev/null
@@ -22,7 +168,12 @@ run_docs_tests() {
   copy_json=$(gog docs copy "$doc_id" "gogcli-smoke-doc-copy-$TS" --json)
   copy_id=$(extract_id "$copy_json")
   [ -n "$copy_id" ] || { echo "Failed to parse doc copy id" >&2; exit 1; }
+  register_drive_cleanup "$copy_id"
 
+  run_required "docs" "docs comments delete" gog docs comments delete "$doc_id" \
+    "$comment_id" --force >/dev/null
+  run_required "docs" "docs named range delete" gog docs named-range delete "$doc_id" \
+    smoke_anchor --force --json >/dev/null
   run_required "docs" "drive delete doc copy" gog drive delete "$copy_id" --force >/dev/null
   run_required "docs" "drive delete doc" gog drive delete "$doc_id" --force >/dev/null
 }

--- a/scripts/live-tests/docs.sh
+++ b/scripts/live-tests/docs.sh
@@ -20,7 +20,7 @@ run_docs_tests() {
   tab_export_path="$LIVE_TMP/docs-tab-export-$TS.txt"
   printf '# Heading {#heading}\n\nAnchorTarget and LinkTarget.\n\nEmoji 😀 range.\n\nOrphanTarget remains quoted.\n\nInsertHere UpdateHere DeleteHere PersonHere BreakHere\n\nBatchAnchor.\n\n~~Strike~~ and `code`.\n\n- Parent\n  - Child\n' >"$markdown_path"
   printf '# Replacement\n\nNo quoted content remains.\n' >"$replacement_path"
-  printf '# Recent Tab {#recent-tab}\n\n```go\nfmt.Println("ok")\n```\n\n| Solo |\n| --- |\n| value |\n\n| Kind | Steps |\n| --- | --- |\n| nested | - parent<br>  - child |\n' >"$tab_markdown_path"
+  printf '# Recent Tab {#recent-tab}\n\n```go\nfmt.Println("ok")\n```\n\n| Solo |\n| --- |\n| value |\n| --- |\n\n| Kind | Steps |\n| --- | --- |\n| nested | - parent<br>  - child |\n' >"$tab_markdown_path"
 
   run_required "docs" "docs markdown write" gog docs write "$doc_id" \
     --file "$markdown_path" --replace --markdown --json >/dev/null
@@ -75,6 +75,7 @@ def walk(value):
             yield from walk(child)
 objects=list(walk(obj))
 assert sum("tableRows" in item for item in objects) == 2
+assert any(item.get("textRun", {}).get("content", "").strip() == "---" for item in objects)
 assert any(item.get("bullet", {}).get("nestingLevel") == 1 for item in objects)
 assert any(item.get("textStyle", {}).get("weightedFontFamily", {}).get("fontFamily") == "Roboto Mono" for item in objects)
 assert not any("{#recent-tab}" in value for item in objects for value in item.values() if isinstance(value, str))' <<<"$tab_raw_json"

--- a/scripts/live-tests/drive.sh
+++ b/scripts/live-tests/drive.sh
@@ -15,9 +15,11 @@ run_drive_tests() {
   folder_a_json=$(gog drive mkdir "gogcli-smoke-a-$TS" --json)
   folder_a_id=$(extract_id "$folder_a_json")
   [ -n "$folder_a_id" ] || { echo "Failed to parse folder A id" >&2; exit 1; }
+  register_drive_cleanup "$folder_a_id"
   folder_b_json=$(gog drive mkdir "gogcli-smoke-b-$TS" --json)
   folder_b_id=$(extract_id "$folder_b_json")
   [ -n "$folder_b_id" ] || { echo "Failed to parse folder B id" >&2; exit 1; }
+  register_drive_cleanup "$folder_b_id"
 
   local upload_path upload_json file_id
   upload_path="$LIVE_TMP/drive-upload-$TS.txt"
@@ -25,6 +27,7 @@ run_drive_tests() {
   upload_json=$(gog drive upload "$upload_path" --parent "$folder_a_id" --name "gogcli-smoke-$TS.txt" --json)
   file_id=$(extract_id "$upload_json")
   [ -n "$file_id" ] || { echo "Failed to parse uploaded file id" >&2; exit 1; }
+  register_drive_cleanup "$file_id"
 
   run_required "drive" "drive get file" gog drive get "$file_id" --json >/dev/null
   run_required "drive" "drive rename" gog drive rename "$file_id" "gogcli-smoke-renamed-$TS.txt" >/dev/null
@@ -33,6 +36,7 @@ run_drive_tests() {
   copy_json=$(gog drive copy "$file_id" "gogcli-smoke-copy-$TS.txt" --json)
   copy_id=$(extract_id "$copy_json")
   [ -n "$copy_id" ] || { echo "Failed to parse copy id" >&2; exit 1; }
+  register_drive_cleanup "$copy_id"
 
   run_required "drive" "drive move" gog drive move "$file_id" --parent "$folder_b_id" --json >/dev/null
   run_required "drive" "drive search" gog drive search "name contains 'gogcli-smoke'" --json --max 1 >/dev/null
@@ -41,6 +45,7 @@ run_drive_tests() {
   shortcut_json=$(gog drive shortcut create "$file_id" --parent "$folder_a_id" --name "gogcli-smoke-shortcut-$TS" --json)
   shortcut_id=$(extract_id "$shortcut_json")
   [ -n "$shortcut_id" ] || { echo "Failed to parse shortcut id" >&2; exit 1; }
+  register_drive_cleanup "$shortcut_id"
 
   shortcut_get_json=$(gog drive get "$shortcut_id" --json)
   shortcut_target_id=$(extract_field "$shortcut_get_json" targetId)
@@ -78,12 +83,29 @@ run_drive_tests() {
 
   run_required "drive" "drive url" gog drive url "$file_id" --json >/dev/null
 
-  local comment_json comment_id
+  printf "drive replacement %s\n" "$TS" >"$upload_path"
+  run_required "drive" "drive upload replace" gog drive upload "$upload_path" --replace "$file_id" --json >/dev/null
+  local revisions_json revision_id
+  revisions_json=$(gog drive revisions list "$file_id" --all --json)
+  revision_id=$(extract_id "$revisions_json")
+  [ -n "$revision_id" ] || { echo "Failed to parse revision id" >&2; exit 1; }
+  run_required "drive" "drive revisions get" gog drive revisions get "$file_id" "$revision_id" --json >/dev/null
+
+  local changes_state
+  changes_state="$LIVE_TMP/drive-changes-$TS.json"
+  run_required "drive" "drive changes poll" gog drive changes poll \
+    --state-file "$changes_state" --max-iterations 1 --interval 1ms --json >/dev/null
+  [ -s "$changes_state" ] || { echo "Drive changes poll did not persist state" >&2; exit 1; }
+
+  local comment_since comment_json comment_id
+  comment_since=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   comment_json=$(gog drive comments create "$file_id" "gogcli comment $TS" --json)
   comment_id=$(extract_id "$comment_json")
   [ -n "$comment_id" ] || { echo "Failed to parse comment id" >&2; exit 1; }
   run_required "drive" "drive comments get" gog drive comments get "$file_id" "$comment_id" --json >/dev/null
   run_required "drive" "drive comments list" gog drive comments list "$file_id" --json >/dev/null
+  run_required "drive" "drive comments since" gog drive comments list "$file_id" \
+    --since "$comment_since" --json >/dev/null
   run_required "drive" "drive comments update" gog drive comments update "$file_id" "$comment_id" "gogcli comment updated $TS" --json >/dev/null
   run_required "drive" "drive comments reply" gog drive comments reply "$file_id" "$comment_id" "gogcli reply $TS" --json >/dev/null
   run_required "drive" "drive comments delete" gog drive comments delete "$file_id" "$comment_id" --force >/dev/null

--- a/scripts/live-tests/gmail.sh
+++ b/scripts/live-tests/gmail.sh
@@ -130,6 +130,52 @@ run_gmail_tests() {
     run_required "gmail" "gmail drafts delete" gog --force gmail drafts delete "$delete_draft_id" --json >/dev/null
   fi
 
+  local thread_seed_json recent_thread_id recent_attach_path recent_draft_json recent_draft_id recent_update_json recent_clear_json recent_thread_json
+  recent_attach_path="$LIVE_TMP/gmail-recent-attach-$TS.txt"
+  printf "recent attachment %s\n" "$TS" >"$recent_attach_path"
+  thread_seed_json=$(gog gmail send --to "$ACCOUNT" --subject "gogcli recent thread $TS" --body "thread seed $TS" --json)
+  recent_thread_id=$(extract_field "$thread_seed_json" threadId)
+  [ -n "$recent_thread_id" ] || { echo "Failed to parse recent Gmail thread id" >&2; exit 1; }
+  register_gmail_thread_cleanup "$recent_thread_id"
+  recent_draft_json=$(gog gmail drafts create --to "$ACCOUNT" \
+    --subject "Re: gogcli recent thread $TS" --body "draft reply" \
+    --thread-id "$recent_thread_id" --attach "$recent_attach_path" --json)
+  recent_draft_id=$(extract_field "$recent_draft_json" draftId)
+  [ -n "$recent_draft_id" ] || { echo "Failed to parse threaded draft id" >&2; exit 1; }
+  register_gmail_draft_cleanup "$recent_draft_id"
+  "$PY" -c 'import json,sys
+expected=sys.argv[1]
+attachments=json.load(sys.stdin).get("attachments", [])
+assert any(a.get("filename") == expected and a.get("size", 0) > 0 for a in attachments)' \
+    "gmail-recent-attach-$TS.txt" <<<"$recent_draft_json"
+
+  recent_update_json=$(gog gmail drafts update "$recent_draft_id" \
+    --subject "Re: gogcli recent thread $TS" --body "updated reply" \
+    --thread-id "$recent_thread_id" --json)
+  "$PY" -c 'import json,sys
+attachments=json.load(sys.stdin).get("attachments", [])
+assert attachments and attachments[0].get("size", 0) > 0' <<<"$recent_update_json"
+  recent_clear_json=$(gog gmail drafts update "$recent_draft_id" \
+    --subject "Re: gogcli recent thread $TS" --body "cleared reply" \
+    --thread-id "$recent_thread_id" --clear-attachments --json)
+  "$PY" -c 'import json,sys; assert not json.load(sys.stdin).get("attachments")' <<<"$recent_clear_json"
+  run_required "gmail" "gmail threaded draft delete" gog gmail drafts delete \
+    "$recent_draft_id" --force >/dev/null
+  run_required "gmail" "gmail archive thread" gog gmail archive \
+    --thread "$recent_thread_id" --json >/dev/null
+  recent_thread_json=$(gog gmail thread get "$recent_thread_id" --json)
+  "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+def walk(value):
+    if isinstance(value, dict):
+        if "labelIds" in value and "INBOX" in (value.get("labelIds") or []):
+            return False
+        return all(walk(v) for v in value.values())
+    if isinstance(value, list):
+        return all(walk(v) for v in value)
+    return True
+assert walk(obj)' <<<"$recent_thread_json"
+
   local body_file send_json send_msg_id send_thread_id
   body_file="$LIVE_TMP/gmail-body-$TS.txt"
   printf "hello from gogcli %s\n" "$TS" >"$body_file"

--- a/scripts/live-tests/photos.sh
+++ b/scripts/live-tests/photos.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+run_photos_picker_tests() {
+  if skip "photos-picker"; then
+    echo "==> photos picker (skipped)"
+    return 0
+  fi
+
+  local auth_json
+  auth_json=$("$BIN" auth list --json)
+  if ! "$PY" -c 'import json,sys
+account=sys.argv[1].lower()
+for item in json.load(sys.stdin).get("accounts", []):
+    if item.get("email", "").lower() == account:
+        raise SystemExit(0 if "photospicker" in (item.get("services") or []) else 1)
+raise SystemExit(1)' "$ACCOUNT" <<<"$auth_json"; then
+    echo "==> photos picker (skipped; reauthorize with --services photospicker)"
+    return 0
+  fi
+
+  local session_json session_id
+  session_json=$(gog photos picker create --max-items 1 --json)
+  session_id=$(extract_id "$session_json")
+  [ -n "$session_id" ] || { echo "Failed to parse Photos Picker session id" >&2; exit 1; }
+  register_photos_picker_cleanup "$session_id"
+  run_required "photos-picker" "photos picker get" gog photos picker get "$session_id" --json >/dev/null
+  run_required "photos-picker" "photos picker delete" gog photos picker delete \
+    "$session_id" --force --json >/dev/null
+}

--- a/scripts/live-tests/sheets.sh
+++ b/scripts/live-tests/sheets.sh
@@ -12,6 +12,7 @@ run_sheets_tests() {
   sheet_json=$(gog sheets create "gogcli-smoke-sheet-$TS" --json)
   sheet_id=$(extract_id "$sheet_json")
   [ -n "$sheet_id" ] || { echo "Failed to parse sheet id" >&2; exit 1; }
+  register_drive_cleanup "$sheet_id"
 
   run_required "sheets" "sheets metadata" gog sheets metadata "$sheet_id" --json >/dev/null
   run_required "sheets" "sheets update" gog sheets update "$sheet_id" "Sheet1!A1:B2" --values-json '[["A1","B1"],["A2","B2"]]' --json >/dev/null
@@ -19,6 +20,49 @@ run_sheets_tests() {
   run_required "sheets" "sheets get" gog sheets get "$sheet_id" "Sheet1!A1:B2" --json >/dev/null
   run_required "sheets" "sheets append" gog sheets append "$sheet_id" "Sheet1!A3:B3" --values-json '[["A3","B3"]]' --json >/dev/null
   run_required "sheets" "sheets format" gog sheets format "$sheet_id" "Sheet1!A1:B1" --format-json '{"textFormat":{"bold":true}}' --format-fields textFormat.bold --json >/dev/null
+
+  run_required "sheets" "sheets links set" gog sheets links set "$sheet_id" \
+    "Sheet1!C1" https://example.com/a "Link A" --json >/dev/null
+  run_required "sheets" "sheets rich links set" gog sheets links set "$sheet_id" \
+    "Sheet1!D1" --runs-json '[{"text":"One","uri":"https://example.com/one"},{"text":" + "},{"text":"Two","uri":"https://example.com/two"}]' --json >/dev/null
+  run_required "sheets" "sheets batch links set" gog sheets links set "$sheet_id" \
+    --cells-json '[{"cell":"Sheet1!E1","url":"mailto:test@example.com","text":"Mail"}]' --json >/dev/null
+  local links_json
+  links_json=$(gog sheets links get "$sheet_id" "Sheet1!C1:E1" --json)
+  "$PY" -c 'import json,sys
+links={item["link"] for item in json.load(sys.stdin).get("links", [])}
+assert {"https://example.com/a","https://example.com/one","https://example.com/two","mailto:test@example.com"} <= links' <<<"$links_json"
+
+  run_required "sheets" "sheets validation set" gog sheets validation set "$sheet_id" \
+    "Sheet1!A2:A3" --type ONE_OF_LIST --value Open --value Done --strict --json >/dev/null
+  local validation_json
+  validation_json=$(gog sheets validation get "$sheet_id" "Sheet1!A2:A3" --json)
+  "$PY" -c 'import json,sys
+rules=json.load(sys.stdin).get("validations", [])
+assert rules and all(v.get("rule",{}).get("condition",{}).get("type") == "ONE_OF_LIST" for v in rules)' <<<"$validation_json"
+  run_required "sheets" "sheets validation clear" gog sheets validation clear "$sheet_id" \
+    "Sheet1!A2:A3" --json >/dev/null
+
+  run_required "sheets" "sheets table seed" gog sheets update "$sheet_id" \
+    "Sheet1!A5:C9" --values-json '[["Task","Amount","Done"],["one",1,false],["two",2,false],["three",3,true],["four",4,false]]' --json >/dev/null
+  run_required "sheets" "sheets table create" gog sheets table create "$sheet_id" \
+    "Sheet1!A5:C9" --name SmokeTable \
+    --columns-json '[{"columnName":"Task","columnType":"TEXT"},{"columnName":"Amount","columnType":"DOUBLE"},{"columnName":"Done","columnType":"BOOLEAN"}]' --json >/dev/null
+  local table_delete_rc
+  if gog sheets table delete "$sheet_id" SmokeTable --force --json \
+    >/dev/null 2>"$LIVE_TMP/sheets-table-delete-$TS.err"; then
+    echo "Expected table delete without --discard-data to fail" >&2
+    exit 1
+  else
+    table_delete_rc=$?
+  fi
+  [ "$table_delete_rc" -eq 2 ] || { echo "Unexpected table delete guard exit: $table_delete_rc" >&2; exit 1; }
+  run_required "sheets" "sheets table-aware row delete" gog sheets delete-dimension "$sheet_id" \
+    "Sheet1!7:7" --dimension ROWS --force --json >/dev/null
+  local table_json
+  table_json=$(gog sheets table get "$sheet_id" SmokeTable --json)
+  "$PY" -c 'import json,sys; assert json.load(sys.stdin)["table"]["a1"] == "Sheet1!A5:C8"' <<<"$table_json"
+
   run_required "sheets" "sheets clear" gog sheets clear "$sheet_id" "Sheet1!A1:B3" --json >/dev/null
 
   export_path="$LIVE_TMP/sheets-export-$TS.xlsx"
@@ -27,6 +71,7 @@ run_sheets_tests() {
   copy_json=$(gog sheets copy "$sheet_id" "gogcli-smoke-sheet-copy-$TS" --json)
   copy_id=$(extract_id "$copy_json")
   [ -n "$copy_id" ] || { echo "Failed to parse sheet copy id" >&2; exit 1; }
+  register_drive_cleanup "$copy_id"
 
   run_required "sheets" "drive delete sheet copy" gog drive delete "$copy_id" --force >/dev/null
   run_required "sheets" "drive delete sheet" gog drive delete "$sheet_id" --force >/dev/null

--- a/scripts/live-tests/slides.sh
+++ b/scripts/live-tests/slides.sh
@@ -12,8 +12,20 @@ run_slides_tests() {
   slides_json=$(gog slides create "gogcli-smoke-slides-$TS" --json)
   slides_id=$(extract_id "$slides_json")
   [ -n "$slides_id" ] || { echo "Failed to parse slides id" >&2; exit 1; }
+  register_drive_cleanup "$slides_id"
 
   run_required "slides" "slides info" gog slides info "$slides_id" --json >/dev/null
+
+  local add_json slide_id read_json
+  add_json=$(gog slides add-slide "$slides_id" "$ROOT_DIR/docs/social-card.png" \
+    --notes "gogcli live $TS" --json)
+  slide_id=$(extract_field "$add_json" slideObjectId)
+  [ -n "$slide_id" ] || { echo "Failed to parse slide object id" >&2; exit 1; }
+  run_required "slides" "slides insert image" gog slides insert-image "$slides_id" \
+    "$slide_id" "$ROOT_DIR/docs/assets/readme-banner.jpg" \
+    --x 24 --y 24 --width 180 --json >/dev/null
+  read_json=$(gog slides read-slide "$slides_id" "$slide_id" --json)
+  "$PY" -c 'import json,sys; assert len(json.load(sys.stdin).get("images", [])) >= 2' <<<"$read_json"
 
   export_path="$LIVE_TMP/slides-export-$TS.pdf"
   run_required "slides" "slides export" gog slides export "$slides_id" --format pdf --out "$export_path" >/dev/null
@@ -21,6 +33,7 @@ run_slides_tests() {
   copy_json=$(gog slides copy "$slides_id" "gogcli-smoke-slides-copy-$TS" --json)
   copy_id=$(extract_id "$copy_json")
   [ -n "$copy_id" ] || { echo "Failed to parse slides copy id" >&2; exit 1; }
+  register_drive_cleanup "$copy_id"
 
   run_required "slides" "drive delete slides copy" gog drive delete "$copy_id" --force >/dev/null
   run_required "slides" "drive delete slides" gog drive delete "$slides_id" --force >/dev/null

--- a/scripts/live-tests/workspace.sh
+++ b/scripts/live-tests/workspace.sh
@@ -4,6 +4,19 @@ set -euo pipefail
 
 run_workspace_tests() {
   if is_consumer_account "$ACCOUNT"; then
+    echo "==> chat attachment (skipped; Workspace only)"
+  elif [ -n "${GOG_LIVE_CHAT_SPACE:-}" ]; then
+    local chat_attachment
+    chat_attachment="$LIVE_TMP/chat-attachment-$TS.txt"
+    printf "chat attachment %s\n" "$TS" >"$chat_attachment"
+    run_required "chat" "chat attachment send" gog chat messages send \
+      "$GOG_LIVE_CHAT_SPACE" --text "gogcli live $TS" \
+      --attach "$chat_attachment" --json >/dev/null
+  else
+    echo "==> chat attachment (skipped; set GOG_LIVE_CHAT_SPACE)"
+  fi
+
+  if is_consumer_account "$ACCOUNT"; then
     echo "==> groups (skipped; Workspace only)"
   else
     run_optional "groups" "groups list" gog groups list --json --max 5 >/dev/null


### PR DESCRIPTION
## Summary

- expand the dedicated-account live suite across recent Docs, Sheets, Slides, Drive, Gmail, Calendar, CLI automation, Chat, and Photos Picker workflows
- add cleanup registration and bounded retries so failed live runs leave less test data behind
- fix valid one-column Markdown tables and preserve separator-shaped data rows after the delimiter
- fix default-tab named-range replace/delete failures in multi-tab Google Docs
- update feature and live-testing documentation

## Live proof

Ran the complete suite against `clawdbot@gmail.com`:

```text
scripts/live-test.sh --account clawdbot@gmail.com
Live tests complete.
```

Verified live read-back for:

- Docs UTF-16 ranges, links, tab Markdown/export, one-column tables, literal separator-shaped table data, nested table-cell lists, named ranges, comments, orphan guards, anchored mutators, batches, table operations, URL images, and enumerators
- Sheets rich links, validation, destructive table guard, and table-aware row deletion
- Slides local image insertion and read-back
- Drive shortcuts, revisions, comment filtering, and persisted changes polling
- Gmail threaded drafts, attachment preservation/clearing, and full-thread archive
- Calendar attachment replacement/read-back/clearing
- CLI schema exit codes, Git-style help, output precedence, and stderr-only validation

Expected capability skips:

- Google Chat attachment send requires a Workspace account; the dedicated account is consumer Gmail
- Photos Picker requires explicit OAuth scope; no reauthorization was performed to avoid unnecessary account security alerts
- Gmail watch pull, Meet, and other optional infrastructure remain opt-in

## Validation

- focused regression tests
- `make ci`
- autoreview: no accepted/actionable findings
