### PR TITLE
refactor(meet): route services and output through runtime

### DIFF
--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/api/forms/v1"
 	"google.golang.org/api/gmail/v1"
 	"google.golang.org/api/keep/v1"
+	"google.golang.org/api/meet/v2"
 	"google.golang.org/api/people/v1"
 	"google.golang.org/api/searchconsole/v1"
 	"google.golang.org/api/sheets/v4"
@@ -47,6 +48,7 @@ type (
 	FormsServiceFactory          func(context.Context, string) (*forms.Service, error)
 	GmailServiceFactory          func(context.Context, string) (*gmail.Service, error)
 	KeepServiceAccountFactory    func(context.Context, string, string) (*keep.Service, error)
+	MeetServiceFactory           func(context.Context, string) (*meet.Service, error)
 	PeopleServiceFactory         func(context.Context, string) (*people.Service, error)
 	PhotosServiceFactory         func(context.Context, string) (*googleapi.PhotosClient, error)
 	PhotosPickerServiceFactory   func(context.Context, string) (*googleapi.PhotosPickerClient, error)
@@ -80,6 +82,7 @@ type Services struct {
 	Forms           FormsServiceFactory
 	Gmail           GmailServiceFactory
 	Keep            KeepServiceAccountFactory
+	Meet            MeetServiceFactory
 	PeopleContacts  PeopleServiceFactory
 	PeopleDirectory PeopleServiceFactory
 	PeopleOther     PeopleServiceFactory

--- a/internal/cmd/execute_meet_test.go
+++ b/internal/cmd/execute_meet_test.go
@@ -10,13 +10,12 @@ import (
 
 	"google.golang.org/api/meet/v2"
 	"google.golang.org/api/option"
+
+	"github.com/steipete/gogcli/internal/app"
 )
 
-func newTestMeetService(t *testing.T, handler http.Handler) {
+func newTestMeetService(t *testing.T, handler http.Handler) *meet.Service {
 	t.Helper()
-
-	origNew := newMeetService
-	t.Cleanup(func() { newMeetService = origNew })
 
 	srv := httptest.NewServer(handler)
 	t.Cleanup(srv.Close)
@@ -30,7 +29,16 @@ func newTestMeetService(t *testing.T, handler http.Handler) {
 		t.Fatalf("NewService: %v", err)
 	}
 
-	newMeetService = func(context.Context, string) (*meet.Service, error) { return svc, nil }
+	return svc
+}
+
+func executeWithMeetTestService(t *testing.T, args []string, svc *meet.Service) executeTestResult {
+	t.Helper()
+	return executeWithTestRuntime(t, args, &app.Runtime{Services: app.Services{
+		Meet: func(context.Context, string) (*meet.Service, error) {
+			return svc, nil
+		},
+	}})
 }
 
 func meetSpaceResponse() map[string]any {
@@ -46,7 +54,7 @@ func meetSpaceResponse() map[string]any {
 }
 
 func TestExecute_MeetCreate_JSON(t *testing.T) {
-	newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !(r.URL.Path == "/v2/spaces" && r.Method == http.MethodPost) {
 			http.NotFound(w, r)
 			return
@@ -56,13 +64,11 @@ func TestExecute_MeetCreate_JSON(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(meetSpaceResponse())
 	}))
 
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "meet", "create"}); err != nil {
-				t.Fatalf("Execute: %v", err)
-			}
-		})
-	})
+	result := executeWithMeetTestService(t, []string{"--json", "--account", "a@b.com", "meet", "create"}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v, stderr=%q", result.err, result.stderr)
+	}
+	out := result.stdout
 
 	var parsed struct {
 		Created     bool   `json:"created"`
@@ -88,7 +94,7 @@ func TestExecute_MeetCreate_JSON(t *testing.T) {
 }
 
 func TestExecute_MeetCreate_Text(t *testing.T) {
-	newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !(r.URL.Path == "/v2/spaces" && r.Method == http.MethodPost) {
 			http.NotFound(w, r)
 			return
@@ -98,13 +104,11 @@ func TestExecute_MeetCreate_Text(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(meetSpaceResponse())
 	}))
 
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--plain", "--account", "a@b.com", "meet", "create"}); err != nil {
-				t.Fatalf("Execute: %v", err)
-			}
-		})
-	})
+	result := executeWithMeetTestService(t, []string{"--plain", "--account", "a@b.com", "meet", "create"}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v, stderr=%q", result.err, result.stderr)
+	}
+	out := result.stdout
 
 	if !strings.Contains(out, "meeting_code\tabc-defg-hij") {
 		t.Fatalf("expected meeting_code in output, got: %q", out)
@@ -120,19 +124,16 @@ func TestExecute_MeetCreate_Text(t *testing.T) {
 }
 
 func TestExecute_MeetCreate_DryRun(t *testing.T) {
-	newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Fatal("should not call API in dry-run mode")
 		http.Error(w, "unexpected", http.StatusInternalServerError)
 	}))
 
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			err := Execute([]string{"--json", "--dry-run", "--account", "a@b.com", "meet", "create"})
-			if err != nil && ExitCode(err) != 0 {
-				t.Fatalf("Execute: %v", err)
-			}
-		})
-	})
+	result := executeWithMeetTestService(t, []string{"--json", "--dry-run", "--account", "a@b.com", "meet", "create"}, svc)
+	if result.err != nil && ExitCode(result.err) != 0 {
+		t.Fatalf("Execute: %v, stderr=%q", result.err, result.stderr)
+	}
+	out := result.stdout
 
 	var parsed struct {
 		DryRun bool   `json:"dry_run"`
@@ -153,7 +154,7 @@ func TestExecute_MeetCreate_DryRun(t *testing.T) {
 }
 
 func TestExecute_MeetGet_JSON(t *testing.T) {
-	newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !(r.URL.Path == "/v2/spaces/abc-defg-hij" && r.Method == http.MethodGet) {
 			http.NotFound(w, r)
 			return
@@ -163,13 +164,11 @@ func TestExecute_MeetGet_JSON(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(meetSpaceResponse())
 	}))
 
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "meet", "get", "abc-defg-hij"}); err != nil {
-				t.Fatalf("Execute: %v", err)
-			}
-		})
-	})
+	result := executeWithMeetTestService(t, []string{"--json", "--account", "a@b.com", "meet", "get", "abc-defg-hij"}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v, stderr=%q", result.err, result.stderr)
+	}
+	out := result.stdout
 
 	var parsed struct {
 		MeetingCode string `json:"meeting_code"`
@@ -185,7 +184,7 @@ func TestExecute_MeetGet_JSON(t *testing.T) {
 }
 
 func TestExecute_MeetHistory_JSON(t *testing.T) {
-	newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v2/spaces/abc-defg-hij" && r.Method == http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
@@ -211,13 +210,11 @@ func TestExecute_MeetHistory_JSON(t *testing.T) {
 		}
 	}))
 
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "meet", "history", "abc-defg-hij"}); err != nil {
-				t.Fatalf("Execute: %v", err)
-			}
-		})
-	})
+	result := executeWithMeetTestService(t, []string{"--json", "--account", "a@b.com", "meet", "history", "abc-defg-hij"}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v, stderr=%q", result.err, result.stderr)
+	}
+	out := result.stdout
 
 	var parsed struct {
 		MeetingCode string `json:"meeting_code"`
@@ -240,7 +237,7 @@ func TestExecute_MeetHistory_JSON(t *testing.T) {
 }
 
 func TestExecute_MeetParticipants_JSON(t *testing.T) {
-	newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v2/spaces/abc-defg-hij" && r.Method == http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
@@ -281,13 +278,11 @@ func TestExecute_MeetParticipants_JSON(t *testing.T) {
 		}
 	}))
 
-	out := captureStdout(t, func() {
-		_ = captureStderr(t, func() {
-			if err := Execute([]string{"--json", "--account", "a@b.com", "meet", "participants", "abc-defg-hij"}); err != nil {
-				t.Fatalf("Execute: %v", err)
-			}
-		})
-	})
+	result := executeWithMeetTestService(t, []string{"--json", "--account", "a@b.com", "meet", "participants", "abc-defg-hij"}, svc)
+	if result.err != nil {
+		t.Fatalf("Execute: %v, stderr=%q", result.err, result.stderr)
+	}
+	out := result.stdout
 
 	var parsed struct {
 		MeetingCode  string `json:"meeting_code"`

--- a/internal/cmd/meet.go
+++ b/internal/cmd/meet.go
@@ -2,35 +2,13 @@ package cmd
 
 import (
 	"context"
-	"os"
-	"os/exec"
-	"runtime"
 	"strings"
 
 	"google.golang.org/api/meet/v2"
 
-	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
-
-// openMeetBrowser opens the meeting URL in the default browser.
-var openMeetBrowser = func(url string) error {
-	var cmd *exec.Cmd
-
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url) //nolint:gosec // executable is fixed; arg is meeting URL
-	case literalWindows:
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url) //nolint:gosec // executable is fixed; arg is meeting URL
-	default:
-		cmd = exec.Command("xdg-open", url) //nolint:gosec // executable is fixed; arg is meeting URL
-	}
-
-	return cmd.Start()
-}
-
-var newMeetService = googleapi.NewMeet
 
 type MeetCmd struct {
 	Create       MeetCreateCmd       `cmd:"" name:"create" aliases:"new" help:"Create a meeting space"`
@@ -84,7 +62,7 @@ func (c *MeetCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"created":      true,
 			"name":         created.Name,
 			"meeting_uri":  created.MeetingUri,
@@ -94,13 +72,13 @@ func (c *MeetCreateCmd) Run(ctx context.Context, flags *RootFlags) error {
 			return err
 		}
 
-		return openMeetingIfRequested(c.Open, created.MeetingUri)
+		return openMeetingIfRequested(ctx, c.Open, created.MeetingUri)
 	}
 
 	u := ui.FromContext(ctx)
 	printMeetSpace(u, created)
 
-	return openMeetingIfRequested(c.Open, created.MeetingUri)
+	return openMeetingIfRequested(ctx, c.Open, created.MeetingUri)
 }
 
 // MeetGetCmd gets a meeting space by meeting code.
@@ -125,7 +103,7 @@ func (c *MeetGetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"name":         space.Name,
 			"meeting_uri":  space.MeetingUri,
 			"meeting_code": space.MeetingCode,
@@ -180,12 +158,12 @@ func resolveMeetSpace(ctx context.Context, svc *meet.Service, input string) (*me
 	return svc.Spaces.Get(normalizeMeetSpaceName(input)).Context(ctx).Do()
 }
 
-func openMeetingIfRequested(shouldOpen bool, meetingURI string) error {
+func openMeetingIfRequested(ctx context.Context, shouldOpen bool, meetingURI string) error {
 	if !shouldOpen || strings.TrimSpace(meetingURI) == "" {
 		return nil
 	}
 
-	return openMeetBrowser(meetingURI)
+	return openURL(ctx, meetingURI)
 }
 
 func parseMeetAccessType(s string) (string, error) {

--- a/internal/cmd/meet_history.go
+++ b/internal/cmd/meet_history.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"google.golang.org/api/meet/v2"
@@ -83,7 +82,7 @@ func (c *MeetHistoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"meeting_code":  c.MeetingCode,
 			"conferences":   records,
 			"nextPageToken": nextPageToken,

--- a/internal/cmd/meet_participants.go
+++ b/internal/cmd/meet_participants.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"google.golang.org/api/meet/v2"
@@ -82,7 +81,7 @@ func (c *MeetParticipantsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"meeting_code":  c.MeetingCode,
 			"conference":    conferenceName,
 			"participants":  participants,

--- a/internal/cmd/meet_update_end.go
+++ b/internal/cmd/meet_update_end.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"strings"
 
 	"google.golang.org/api/meet/v2"
@@ -78,7 +77,7 @@ func (c *MeetUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"updated":      true,
 			"name":         updated.Name,
 			"meeting_uri":  updated.MeetingUri,
@@ -127,7 +126,7 @@ func (c *MeetEndCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, os.Stdout, map[string]any{
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
 			"ended":        true,
 			"meeting_code": c.MeetingCode,
 		})

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -18,6 +18,7 @@ import (
 	formsapi "google.golang.org/api/forms/v1"
 	"google.golang.org/api/gmail/v1"
 	keepapi "google.golang.org/api/keep/v1"
+	"google.golang.org/api/meet/v2"
 	"google.golang.org/api/people/v1"
 	searchconsoleapi "google.golang.org/api/searchconsole/v1"
 	"google.golang.org/api/sheets/v4"
@@ -53,6 +54,7 @@ func newDefaultRuntime() *app.Runtime {
 			Forms:           googleapi.NewForms,
 			Gmail:           googleapi.NewGmail,
 			Keep:            newKeepServiceWithSA,
+			Meet:            googleapi.NewMeet,
 			PeopleContacts:  googleapi.NewPeopleContacts,
 			PeopleDirectory: googleapi.NewPeopleDirectory,
 			PeopleOther:     googleapi.NewPeopleOtherContacts,
@@ -126,6 +128,9 @@ func normalizedRuntime(runtime *app.Runtime) *app.Runtime {
 	}
 	if normalized.Services.Keep == nil {
 		normalized.Services.Keep = defaults.Services.Keep
+	}
+	if normalized.Services.Meet == nil {
+		normalized.Services.Meet = defaults.Services.Meet
 	}
 	if normalized.Services.PeopleContacts == nil {
 		normalized.Services.PeopleContacts = defaults.Services.PeopleContacts
@@ -321,6 +326,13 @@ func gmailServiceFactory(ctx context.Context) app.GmailServiceFactory {
 		return runtime.Services.Gmail
 	}
 	return googleapi.NewGmail
+}
+
+func meetService(ctx context.Context, account string) (*meet.Service, error) {
+	if runtime, ok := app.FromContext(ctx); ok && runtime.Services.Meet != nil {
+		return runtime.Services.Meet(ctx, account)
+	}
+	return googleapi.NewMeet(ctx, account)
 }
 
 func peopleContactsService(ctx context.Context, account string) (*people.Service, error) {

--- a/internal/cmd/runtime_test.go
+++ b/internal/cmd/runtime_test.go
@@ -18,6 +18,7 @@ import (
 	formsapi "google.golang.org/api/forms/v1"
 	"google.golang.org/api/gmail/v1"
 	keepapi "google.golang.org/api/keep/v1"
+	"google.golang.org/api/meet/v2"
 	"google.golang.org/api/people/v1"
 	searchconsoleapi "google.golang.org/api/searchconsole/v1"
 	"google.golang.org/api/sheets/v4"
@@ -219,6 +220,31 @@ func TestPhotosPickerServiceUsesRuntimeFactory(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("photosPickerService() = %p, want %p", got, want)
+	}
+	if gotAccount != "test@example.com" {
+		t.Fatalf("factory account = %q, want test@example.com", gotAccount)
+	}
+}
+
+func TestMeetServiceUsesRuntimeFactory(t *testing.T) {
+	t.Parallel()
+
+	want := &meet.Service{}
+	var gotAccount string
+	runtime := &app.Runtime{Services: app.Services{
+		Meet: func(_ context.Context, account string) (*meet.Service, error) {
+			gotAccount = account
+			return want, nil
+		},
+	}}
+	ctx := app.WithRuntime(context.Background(), runtime)
+
+	got, err := meetService(ctx, "test@example.com")
+	if err != nil {
+		t.Fatalf("meetService() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("meetService() = %p, want %p", got, want)
 	}
 	if gotAccount != "test@example.com" {
 		t.Fatalf("factory account = %q, want test@example.com", gotAccount)

--- a/internal/cmd/service_helpers.go
+++ b/internal/cmd/service_helpers.go
@@ -42,7 +42,7 @@ func requireClassroomService(ctx context.Context, flags *RootFlags) (string, *cl
 }
 
 func requireMeetService(ctx context.Context, flags *RootFlags) (string, *meet.Service, error) {
-	return requireGoogleService(ctx, flags, newMeetService)
+	return requireGoogleService(ctx, flags, meetService)
 }
 
 func requireSheetsService(ctx context.Context, flags *RootFlags) (string, *sheets.Service, error) {


### PR DESCRIPTION
## Summary

- inject the Google Meet service through the shared command runtime
- route Meet JSON output through runtime-controlled stdout
- reuse the shared URL opener and remove Meet-specific mutable globals
- isolate Meet command tests from process-global service/output mutation

## Verification

- `go test ./internal/cmd -run 'Meet|Runtime' -count=1`
- `go test -race ./internal/cmd -run 'Meet|Runtime' -count=1`
- `make ci`
- `make build && ./bin/gog --json --dry-run --account gog+clawdbot@gmail.com meet create`
- Codex autoreview: clean, no accepted/actionable findings
