### PR TITLE
fix(gmail): preflight permanent delete scope

### DIFF
--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -156,6 +156,10 @@ For Google Docs tab work:
 When testing creation commands, name artifacts with a clear temporary prefix and
 delete or trash them after verification.
 
+`gmail batch delete` permanently deletes messages and requires the broader
+`https://mail.google.com/` OAuth scope. Prefer `gmail trash`; when permanent
+deletion is required, follow the exact reauthorization command printed by `gog`.
+
 For larger Sheets writes, prefer `sheets batch-update` over loops of
 `sheets update`; it sends multiple value ranges in one Sheets API request and
 accepts inline JSON or `@file` input.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ### Fixed
 
+- Gmail: preflight the broader OAuth grant required by permanent batch deletion and report an exact reauthorization command instead of a generic API 403.
+
 - Docs: recognize valid one-column Markdown tables, while preserving separator-shaped rows after the delimiter as table data.
 - Docs: scope default-tab named-range replace and delete requests correctly in multi-tab documents.
 - Forms: serialize `--quiz=false` explicitly so updating a form can disable quiz mode.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ gog gmail settings filters export --out filters.xml
 gog --gmail-no-send gmail drafts create --to you@example.com --subject test
 ```
 
+Permanent deletion with `gog gmail batch delete` requires the broader
+`https://mail.google.com/` OAuth scope. The command reports an exact
+`gog auth add ... --extra-scopes https://mail.google.com/ --force-consent`
+reauthorization command when a known stored grant lacks it. Prefer
+`gog gmail trash` unless permanent deletion is intentional.
+
 ### Calendar
 
 Docs: [`gog calendar`](docs/commands/gog-calendar.md),

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -373,7 +373,7 @@ Generated from `gog schema --json`.
     - [`gog gmail (mail,email) attachment <messageId> <attachmentId> [flags]`](commands/gog-gmail-attachment.md) - Download a single attachment
     - [`gog gmail (mail,email) autoreply <query> ... [flags]`](commands/gog-gmail-autoreply.md) - Reply once to matching messages
     - [`gog gmail (mail,email) batch <command>`](commands/gog-gmail-batch.md) - Batch operations (permanent delete requires broader Gmail scope; use gmail trash for normal trashing)
-      - [`gog gmail (mail,email) batch delete (rm,del,remove) <messageId> ...`](commands/gog-gmail-batch-delete.md) - Permanently delete multiple messages; use 'gmail trash' to move messages to trash with the default gmail.modify scope
+      - [`gog gmail (mail,email) batch delete (rm,del,remove) <messageId> ...`](commands/gog-gmail-batch-delete.md) - Permanently delete messages; requires https://mail.google.com/ OAuth scope (use 'gmail trash' with the default scope)
       - [`gog gmail (mail,email) batch modify (update,edit,set) <messageId> ... [flags]`](commands/gog-gmail-batch-modify.md) - Modify labels on multiple messages
     - [`gog gmail (mail,email) drafts (draft) <command>`](commands/gog-gmail-drafts.md) - Draft operations
       - [`gog gmail (mail,email) drafts (draft) create (add,new) [flags]`](commands/gog-gmail-drafts-create.md) - Create a draft

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -424,7 +424,7 @@ Generated pages: 642.
     - [gog gmail attachment](gog-gmail-attachment.md) - Download a single attachment
     - [gog gmail autoreply](gog-gmail-autoreply.md) - Reply once to matching messages
     - [gog gmail batch](gog-gmail-batch.md) - Batch operations (permanent delete requires broader Gmail scope; use gmail trash for normal trashing)
-      - [gog gmail batch delete](gog-gmail-batch-delete.md) - Permanently delete multiple messages; use 'gmail trash' to move messages to trash with the default gmail.modify scope
+      - [gog gmail batch delete](gog-gmail-batch-delete.md) - Permanently delete messages; requires https://mail.google.com/ OAuth scope (use 'gmail trash' with the default scope)
       - [gog gmail batch modify](gog-gmail-batch-modify.md) - Modify labels on multiple messages
     - [gog gmail drafts](gog-gmail-drafts.md) - Draft operations
       - [gog gmail drafts create](gog-gmail-drafts-create.md) - Create a draft

--- a/docs/commands/gog-gmail-batch-delete.md
+++ b/docs/commands/gog-gmail-batch-delete.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Permanently delete multiple messages; use 'gmail trash' to move messages to trash with the default gmail.modify scope
+Permanently delete messages; requires https://mail.google.com/ OAuth scope (use 'gmail trash' with the default scope)
 
 ## Usage
 

--- a/docs/commands/gog-gmail-batch.md
+++ b/docs/commands/gog-gmail-batch.md
@@ -16,7 +16,7 @@ gog gmail (mail,email) batch <command>
 
 ## Subcommands
 
-- [gog gmail batch delete](gog-gmail-batch-delete.md) - Permanently delete multiple messages; use 'gmail trash' to move messages to trash with the default gmail.modify scope
+- [gog gmail batch delete](gog-gmail-batch-delete.md) - Permanently delete messages; requires https://mail.google.com/ OAuth scope (use 'gmail trash' with the default scope)
 - [gog gmail batch modify](gog-gmail-batch-modify.md) - Modify labels on multiple messages
 
 ## Flags

--- a/internal/app/runtime.go
+++ b/internal/app/runtime.go
@@ -103,6 +103,7 @@ type Services struct {
 	DriveLabels     DriveLabelsServiceFactory
 	Forms           FormsServiceFactory
 	Gmail           GmailServiceFactory
+	GmailDelete     GmailServiceFactory
 	Keep            KeepServiceAccountFactory
 	Meet            MeetServiceFactory
 	PeopleContacts  PeopleServiceFactory

--- a/internal/cmd/exit_codes.go
+++ b/internal/cmd/exit_codes.go
@@ -69,6 +69,11 @@ func stableExitCode(err error) error {
 		return &ExitError{Code: exitCodeAuthRequired, Err: err}
 	}
 
+	var scopeErr *gogapi.InsufficientScopeError
+	if errors.As(err, &scopeErr) {
+		return &ExitError{Code: exitCodeAuthRequired, Err: err}
+	}
+
 	var credErr *config.CredentialsMissingError
 	if errors.As(err, &credErr) {
 		return &ExitError{Code: exitCodeConfig, Err: err}

--- a/internal/cmd/exit_codes_test.go
+++ b/internal/cmd/exit_codes_test.go
@@ -31,6 +31,18 @@ func TestStableExitCode_AuthRequired(t *testing.T) {
 	}
 }
 
+func TestStableExitCode_InsufficientScope(t *testing.T) {
+	in := &gogapi.InsufficientScopeError{
+		Service:        "gmail",
+		Email:          "a@b.com",
+		RequiredScopes: []string{"https://mail.google.com/"},
+	}
+	out := stableExitCode(in)
+	if got := ExitCode(out); got != exitCodeAuthRequired {
+		t.Fatalf("expected exit code %d, got %d", exitCodeAuthRequired, got)
+	}
+}
+
 func TestStableExitCode_CredentialsMissing(t *testing.T) {
 	in := &config.CredentialsMissingError{Path: "/tmp/credentials.json", Cause: errors.New("missing")}
 	out := stableExitCode(in)

--- a/internal/cmd/gmail_batch.go
+++ b/internal/cmd/gmail_batch.go
@@ -10,7 +10,7 @@ import (
 )
 
 type GmailBatchCmd struct {
-	Delete GmailBatchDeleteCmd `cmd:"" name:"delete" aliases:"rm,del,remove" help:"Permanently delete multiple messages; use 'gmail trash' to move messages to trash with the default gmail.modify scope"`
+	Delete GmailBatchDeleteCmd `cmd:"" name:"delete" aliases:"rm,del,remove" help:"Permanently delete messages; requires https://mail.google.com/ OAuth scope (use 'gmail trash' with the default scope)"`
 	Modify GmailBatchModifyCmd `cmd:"" name:"modify" aliases:"update,edit,set" help:"Modify labels on multiple messages"`
 }
 
@@ -44,7 +44,7 @@ func (c *GmailBatchDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	svc, err := gmailService(ctx, account)
+	svc, err := gmailBatchDeleteService(ctx, account)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/gmail_sendas_test.go
+++ b/internal/cmd/gmail_sendas_test.go
@@ -1,11 +1,17 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"google.golang.org/api/gmail/v1"
+
+	"github.com/steipete/gogcli/internal/app"
 )
 
 func TestGmailSendAsListCmd_JSON(t *testing.T) {
@@ -156,6 +162,44 @@ func TestGmailBatchDeleteCmd_JSON(t *testing.T) {
 	}
 	if parsed.Count != 3 {
 		t.Fatalf("unexpected count: %d", parsed.Count)
+	}
+}
+
+func TestGmailBatchDeleteCmd_UsesDedicatedServiceFactory(t *testing.T) {
+	var genericCalled bool
+	var deleteCalled bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/messages/batchDelete") && r.Method == http.MethodPost {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc := newGmailServiceFromServer(t, srv)
+	result := executeWithTestRuntime(
+		t,
+		[]string{"--json", "--force", "--account", "a@b.com", "gmail", "batch", "delete", "msg1"},
+		&app.Runtime{Services: app.Services{
+			Gmail: func(context.Context, string) (*gmail.Service, error) {
+				genericCalled = true
+				return nil, errors.New("generic Gmail factory called")
+			},
+			GmailDelete: func(context.Context, string) (*gmail.Service, error) {
+				deleteCalled = true
+				return svc, nil
+			},
+		}},
+	)
+	if result.err != nil {
+		t.Fatalf("execute: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if genericCalled {
+		t.Fatal("generic Gmail factory was called")
+	}
+	if !deleteCalled {
+		t.Fatal("dedicated Gmail delete factory was not called")
 	}
 }
 

--- a/internal/cmd/runtime.go
+++ b/internal/cmd/runtime.go
@@ -70,6 +70,7 @@ func newDefaultRuntime() *app.Runtime {
 			DriveLabels:     googleapi.NewDriveLabels,
 			Forms:           googleapi.NewForms,
 			Gmail:           googleapi.NewGmail,
+			GmailDelete:     googleapi.NewGmailBatchDelete,
 			Keep:            googleapi.NewKeepWithServiceAccount,
 			Meet:            googleapi.NewMeet,
 			PeopleContacts:  googleapi.NewPeopleContacts,
@@ -160,6 +161,13 @@ func normalizedRuntime(runtime *app.Runtime) *app.Runtime {
 	}
 	if normalized.Services.Forms == nil {
 		normalized.Services.Forms = defaults.Services.Forms
+	}
+	if normalized.Services.GmailDelete == nil {
+		if normalized.Services.Gmail != nil {
+			normalized.Services.GmailDelete = normalized.Services.Gmail
+		} else {
+			normalized.Services.GmailDelete = defaults.Services.GmailDelete
+		}
 	}
 	if normalized.Services.Gmail == nil {
 		normalized.Services.Gmail = defaults.Services.Gmail
@@ -611,6 +619,13 @@ func gmailServiceFactory(ctx context.Context) app.GmailServiceFactory {
 		return runtime.Services.Gmail
 	}
 	return googleapi.NewGmail
+}
+
+func gmailBatchDeleteService(ctx context.Context, account string) (*gmail.Service, error) {
+	if runtime, ok := app.FromContext(ctx); ok && runtime.Services.GmailDelete != nil {
+		return runtime.Services.GmailDelete(ctx, account)
+	}
+	return googleapi.NewGmailBatchDelete(ctx, account)
 }
 
 func peopleContactsService(ctx context.Context, account string) (*people.Service, error) {

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -74,6 +74,22 @@ func newGoogleServiceForScopes[T any](
 	return newGoogleService(ctx, errorLabel, opts, factory)
 }
 
+func newGoogleServiceForRequiredScopes[T any](
+	ctx context.Context,
+	email string,
+	serviceLabel string,
+	errorLabel string,
+	scopes []string,
+	factory googleServiceFactory[T],
+) (*T, error) {
+	opts, err := optionsForAccountScopesRequiringStoredGrant(ctx, serviceLabel, email, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("%s options: %w", errorLabel, err)
+	}
+
+	return newGoogleService(ctx, errorLabel, opts, factory)
+}
+
 func newGoogleService[T any](
 	ctx context.Context,
 	label string,
@@ -98,6 +114,16 @@ func IsADCMode() bool {
 }
 
 func authenticatedTransport(ctx context.Context, serviceLabel string, email string, scopes []string) (http.RoundTripper, error) {
+	return authenticatedTransportWithStoredScopeCheck(ctx, serviceLabel, email, scopes, false)
+}
+
+func authenticatedTransportWithStoredScopeCheck(
+	ctx context.Context,
+	serviceLabel string,
+	email string,
+	scopes []string,
+	requireStoredGrant bool,
+) (http.RoundTripper, error) {
 	var ts oauth2.TokenSource
 
 	if IsADCMode() {
@@ -112,7 +138,7 @@ func authenticatedTransport(ctx context.Context, serviceLabel string, email stri
 	} else {
 		var err error
 
-		ts, err = tokenSourceForAvailableAccountAuth(ctx, serviceLabel, email, scopes)
+		ts, err = tokenSourceForAvailableAccountAuthWithStoredScopeCheck(ctx, serviceLabel, email, scopes, requireStoredGrant)
 		if err != nil {
 			return nil, err
 		}
@@ -125,9 +151,23 @@ func authenticatedTransport(ctx context.Context, serviceLabel string, email stri
 }
 
 func optionsForAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
+	return optionsForAccountScopesWithStoredScopeCheck(ctx, serviceLabel, email, scopes, false)
+}
+
+func optionsForAccountScopesRequiringStoredGrant(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
+	return optionsForAccountScopesWithStoredScopeCheck(ctx, serviceLabel, email, scopes, true)
+}
+
+func optionsForAccountScopesWithStoredScopeCheck(
+	ctx context.Context,
+	serviceLabel string,
+	email string,
+	scopes []string,
+	requireStoredGrant bool,
+) ([]option.ClientOption, error) {
 	slog.Debug("creating client options with custom scopes", "serviceLabel", serviceLabel, "email", email)
 
-	transport, err := authenticatedTransport(ctx, serviceLabel, email, scopes)
+	transport, err := authenticatedTransportWithStoredScopeCheck(ctx, serviceLabel, email, scopes, requireStoredGrant)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -182,7 +182,13 @@ func clientCredentialsForAccount(ctx context.Context, email string) (string, con
 	return client, creds, nil
 }
 
-func tokenSourceForAvailableAccountAuth(ctx context.Context, serviceLabel string, email string, scopes []string) (oauth2.TokenSource, error) {
+func tokenSourceForAvailableAccountAuthWithStoredScopeCheck(
+	ctx context.Context,
+	serviceLabel string,
+	email string,
+	scopes []string,
+	requireStoredGrant bool,
+) (oauth2.TokenSource, error) {
 	if accessToken := authclient.AccessTokenFromContext(ctx); accessToken != "" {
 		slog.Debug("using direct access token", "serviceLabel", serviceLabel)
 		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken}), nil
@@ -200,7 +206,16 @@ func tokenSourceForAvailableAccountAuth(ctx context.Context, serviceLabel string
 		return nil, err
 	}
 
-	tokenSource, err := tokenSourceForAccountScopes(ctx, serviceLabel, email, client, creds.ClientID, creds.ClientSecret, scopes)
+	tokenSource, err := tokenSourceForAccountScopesWithStoredScopeCheck(
+		ctx,
+		serviceLabel,
+		email,
+		client,
+		creds.ClientID,
+		creds.ClientSecret,
+		scopes,
+		requireStoredGrant,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("token source: %w", err)
 	}
@@ -209,6 +224,28 @@ func tokenSourceForAvailableAccountAuth(ctx context.Context, serviceLabel string
 }
 
 func tokenSourceForAccountScopes(ctx context.Context, serviceLabel string, email string, client string, clientID string, clientSecret string, requiredScopes []string) (oauth2.TokenSource, error) {
+	return tokenSourceForAccountScopesWithStoredScopeCheck(
+		ctx,
+		serviceLabel,
+		email,
+		client,
+		clientID,
+		clientSecret,
+		requiredScopes,
+		false,
+	)
+}
+
+func tokenSourceForAccountScopesWithStoredScopeCheck(
+	ctx context.Context,
+	serviceLabel string,
+	email string,
+	client string,
+	clientID string,
+	clientSecret string,
+	requiredScopes []string,
+	requireStoredGrant bool,
+) (oauth2.TokenSource, error) {
 	var store secrets.Store
 
 	if s, err := openSecretsStore(); err != nil {
@@ -227,6 +264,27 @@ func tokenSourceForAccountScopes(ctx context.Context, serviceLabel string, email
 		return nil, fmt.Errorf("get token for %s: %w", email, err)
 	} else {
 		tok = t
+	}
+
+	if requireStoredGrant && len(tok.Scopes) > 0 && !scopesContainAll(tok.Scopes, requiredScopes) {
+		services := normalizeScopeList(tok.Services)
+		if len(services) == 0 {
+			services = []string{serviceLabel}
+		}
+		requiredScopes = normalizeScopeList(requiredScopes)
+
+		return nil, &InsufficientScopeError{
+			Service:        serviceLabel,
+			Email:          email,
+			RequiredScopes: requiredScopes,
+			GrantedScopes:  normalizeScopeList(tok.Scopes),
+			ReauthorizeCommand: fmt.Sprintf(
+				"gog auth add %s --services %s --extra-scopes %s --force-consent",
+				email,
+				strings.Join(services, ","),
+				strings.Join(requiredScopes, ","),
+			),
+		}
 	}
 
 	cfg := oauth2.Config{

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -185,6 +185,104 @@ func TestTokenSourceForAccountScopes_HappyPath(t *testing.T) {
 	}
 }
 
+func TestTokenSourceForAccountScopes_RequiredStoredGrantMissing(t *testing.T) {
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() { openSecretsStore = origOpen })
+
+	openSecretsStore = func() (secrets.Store, error) {
+		return &stubStore{tok: secrets.Token{
+			Email:        "a@b.com",
+			RefreshToken: "rt",
+			Services:     []string{"gmail", "drive"},
+			Scopes:       []string{"https://www.googleapis.com/auth/gmail.modify"},
+		}}, nil
+	}
+
+	_, err := tokenSourceForAccountScopesWithStoredScopeCheck(
+		context.Background(),
+		"gmail",
+		"a@b.com",
+		"default",
+		"id",
+		"secret",
+		[]string{scopeGmailFullAccess},
+		true,
+	)
+	if err == nil {
+		t.Fatal("expected insufficient scope error")
+	}
+
+	var scopeErr *InsufficientScopeError
+	if !errors.As(err, &scopeErr) {
+		t.Fatalf("expected InsufficientScopeError, got %T: %v", err, err)
+	}
+
+	if got := scopeErr.ReauthorizeCommand; got != "gog auth add a@b.com --services drive,gmail --extra-scopes https://mail.google.com/ --force-consent" {
+		t.Fatalf("reauthorize command = %q", got)
+	}
+}
+
+func TestTokenSourceForAccountScopes_RequiredStoredGrantPresent(t *testing.T) {
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() { openSecretsStore = origOpen })
+
+	openSecretsStore = func() (secrets.Store, error) {
+		return &stubStore{tok: secrets.Token{
+			Email:        "a@b.com",
+			RefreshToken: "rt",
+			Scopes:       []string{scopeGmailFullAccess},
+		}}, nil
+	}
+
+	ts, err := tokenSourceForAccountScopesWithStoredScopeCheck(
+		context.Background(),
+		"gmail",
+		"a@b.com",
+		"default",
+		"id",
+		"secret",
+		[]string{scopeGmailFullAccess},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if ts == nil {
+		t.Fatal("expected token source")
+	}
+}
+
+func TestTokenSourceForAccountScopes_RequiredStoredGrantAllowsLegacyMetadata(t *testing.T) {
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() { openSecretsStore = origOpen })
+
+	openSecretsStore = func() (secrets.Store, error) {
+		return &stubStore{tok: secrets.Token{Email: "a@b.com", RefreshToken: "rt"}}, nil
+	}
+
+	ts, err := tokenSourceForAccountScopesWithStoredScopeCheck(
+		context.Background(),
+		"gmail",
+		"a@b.com",
+		"default",
+		"id",
+		"secret",
+		[]string{scopeGmailFullAccess},
+		true,
+	)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if ts == nil {
+		t.Fatal("expected token source")
+	}
+}
+
 func TestPersistingTokenSource_PersistsRotatedRefreshToken(t *testing.T) {
 	stored := secrets.Token{
 		Client:       config.DefaultClientName,
@@ -641,6 +739,36 @@ func TestOptionsForAccountScopes_AccessTokenBypassesStoredAuth(t *testing.T) {
 
 	if len(opts) == 0 {
 		t.Fatalf("expected client options")
+	}
+}
+
+func TestOptionsForAccountScopes_RequiredStoredGrantAllowsDirectAccessToken(t *testing.T) {
+	origRead := readClientCredentials
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() {
+		readClientCredentials = origRead
+		openSecretsStore = origOpen
+	})
+
+	readClientCredentials = func(string) (config.ClientCredentials, error) {
+		t.Fatal("readClientCredentials should not be called when access token is provided")
+		return config.ClientCredentials{}, nil
+	}
+	openSecretsStore = func() (secrets.Store, error) {
+		t.Fatal("openSecretsStore should not be called when access token is provided")
+		return nil, errBoom
+	}
+
+	ctx := authclient.WithAccessToken(context.Background(), "ya29.test-access-token")
+
+	opts, err := optionsForAccountScopesRequiringStoredGrant(ctx, "gmail", "a@b.com", []string{scopeGmailFullAccess})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	if len(opts) == 0 {
+		t.Fatal("expected client options")
 	}
 }
 

--- a/internal/googleapi/errors.go
+++ b/internal/googleapi/errors.go
@@ -3,6 +3,7 @@ package googleapi
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -23,6 +24,28 @@ func (e *AuthRequiredError) Error() string {
 
 func (e *AuthRequiredError) Unwrap() error {
 	return e.Cause
+}
+
+type InsufficientScopeError struct {
+	Service            string
+	Email              string
+	RequiredScopes     []string
+	GrantedScopes      []string
+	ReauthorizeCommand string
+}
+
+func (e *InsufficientScopeError) Error() string {
+	message := fmt.Sprintf(
+		"OAuth grant for %s is missing required %s scope: %s",
+		e.Email,
+		e.Service,
+		strings.Join(e.RequiredScopes, ", "),
+	)
+	if e.ReauthorizeCommand != "" {
+		message += "; re-authenticate with: " + e.ReauthorizeCommand
+	}
+
+	return message
 }
 
 // RateLimitError indicates rate limit was exceeded
@@ -90,6 +113,12 @@ func (e *PermissionDeniedError) Error() string {
 // IsAuthRequiredError checks if the error is an auth required error
 func IsAuthRequiredError(err error) bool {
 	var e *AuthRequiredError
+	return errors.As(err, &e)
+}
+
+// IsInsufficientScopeError checks if the stored OAuth grant lacks a required scope.
+func IsInsufficientScopeError(err error) bool {
+	var e *InsufficientScopeError
 	return errors.As(err, &e)
 }
 

--- a/internal/googleapi/errors_test.go
+++ b/internal/googleapi/errors_test.go
@@ -14,6 +14,10 @@ func TestErrors_IsHelpers(t *testing.T) {
 		t.Fatalf("expected IsAuthRequiredError")
 	}
 
+	if !IsInsufficientScopeError(&InsufficientScopeError{Service: "gmail", Email: "a@b.com"}) {
+		t.Fatalf("expected IsInsufficientScopeError")
+	}
+
 	if !IsRateLimitError(&RateLimitError{RetryAfter: time.Second, Retries: 2}) {
 		t.Fatalf("expected IsRateLimitError")
 	}
@@ -43,6 +47,16 @@ func TestErrors_Messages(t *testing.T) {
 
 	if !errors.Is(authErr, errBase) {
 		t.Fatalf("expected unwrap to match base")
+	}
+
+	scopeErr := &InsufficientScopeError{
+		Service:            "gmail",
+		Email:              "a@b.com",
+		RequiredScopes:     []string{"https://mail.google.com/"},
+		ReauthorizeCommand: "gog auth add a@b.com --services gmail --extra-scopes https://mail.google.com/ --force-consent",
+	}
+	if got := scopeErr.Error(); !strings.Contains(got, scopeErr.ReauthorizeCommand) {
+		t.Fatalf("unexpected: %q", got)
 	}
 
 	if got := (&RateLimitError{RetryAfter: 2 * time.Second, Retries: 3}).Error(); !strings.Contains(got, "retry after 2s") {

--- a/internal/googleapi/gmail.go
+++ b/internal/googleapi/gmail.go
@@ -8,6 +8,19 @@ import (
 	"github.com/steipete/gogcli/internal/googleauth"
 )
 
+const scopeGmailFullAccess = "https://mail.google.com/"
+
 func NewGmail(ctx context.Context, email string) (*gmail.Service, error) {
 	return newGoogleServiceForAccount(ctx, email, googleauth.ServiceGmail, "gmail", gmail.NewService)
+}
+
+func NewGmailBatchDelete(ctx context.Context, email string) (*gmail.Service, error) {
+	return newGoogleServiceForRequiredScopes(
+		ctx,
+		email,
+		string(googleauth.ServiceGmail),
+		"gmail batch delete",
+		[]string{scopeGmailFullAccess},
+		gmail.NewService,
+	)
 }

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -35,6 +35,10 @@ func TestNewServicesWithStoredToken(t *testing.T) {
 		t.Fatalf("NewGmail: %v", err)
 	}
 
+	if _, err := NewGmailBatchDelete(ctx, "a@b.com"); err != nil {
+		t.Fatalf("NewGmailBatchDelete: %v", err)
+	}
+
 	if _, err := NewDrive(ctx, "a@b.com"); err != nil {
 		t.Fatalf("NewDrive: %v", err)
 	}


### PR DESCRIPTION
## Summary

- add a dedicated Gmail client path for permanent batch deletion
- preflight known stored OAuth grants for `https://mail.google.com/`
- return auth-required exit code 4 with an exact scope-preserving reauthorization command
- document the broader scope in help, generated command docs, README, changelog, and the bundled skill

## Verification

- `make ci`
- autoreview: clean, no actionable findings
- narrow-grant live test: command stopped before the API call with exit code 4 and exact reauthorization guidance
- full-scope live test with `clawdbot@gmail.com`: created and read two disposable self-addressed messages, permanently batch-deleted both, verified direct reads returned exit code 5, and verified subject search returned empty-results exit code 3
