### PR TITLE
fix(cli): classify direct Google HTTP failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ### Fixed
 
 - Gmail: preflight the broader OAuth grant required by permanent batch deletion and report an exact reauthorization command instead of a generic API 403.
+- CLI: classify Photos Library, Photos Picker, and Places HTTP failures with the documented stable exit codes instead of generic exit code 1.
 
 - Docs: recognize valid one-column Markdown tables, while preserving separator-shaped rows after the delimiter as table data.
 - Docs: scope default-tab named-range replace and delete requests correctly in multi-tab documents.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -120,6 +120,10 @@ gog auth doctor --check --json --no-input
 | 11 | `orphaned` | Requested Docs comment is no longer attached to content |
 | 130 | `cancelled` | Interrupted with Ctrl-C or context cancellation |
 
+The same classifications apply to direct HTTP integrations such as Photos
+Library, Photos Picker, and Places. For example, an expired or deleted Picker
+session returns `not_found` (`5`) instead of a generic error.
+
 Read the map programmatically:
 
 ```bash

--- a/docs/photos-picker.md
+++ b/docs/photos-picker.md
@@ -77,6 +77,8 @@ gog photos picker delete <sessionId>
 
 Google recommends deleting completed or timed-out sessions to avoid session
 resource limits. `create` and `delete` support the global `--dry-run` flag.
+After a session expires or is deleted, commands that access it return the
+stable `not_found` exit code (`5`).
 
 Command pages:
 

--- a/internal/cmd/exit_codes.go
+++ b/internal/cmd/exit_codes.go
@@ -83,6 +83,13 @@ func stableExitCode(err error) error {
 		return &ExitError{Code: exitCodeAuthRequired, Err: err}
 	}
 
+	var httpErr *gogapi.HTTPStatusError
+	if errors.As(err, &httpErr) {
+		if code := httpStatusExitCode(httpErr.Code, httpErr.Status); code != 1 {
+			return &ExitError{Code: code, Err: err}
+		}
+	}
+
 	var gerr *ggoogleapi.Error
 	if errors.As(err, &gerr) {
 		if code := googleAPIExitCode(gerr); code != 1 {
@@ -121,7 +128,11 @@ func googleAPIExitCode(err *ggoogleapi.Error) int {
 		reason = strings.TrimSpace(strings.ToLower(err.Errors[0].Reason))
 	}
 
-	switch err.Code {
+	return httpStatusExitCode(err.Code, reason)
+}
+
+func httpStatusExitCode(code int, reason string) int {
+	switch code {
 	case 401:
 		return exitCodeAuthRequired
 	case 403:
@@ -134,7 +145,7 @@ func googleAPIExitCode(err *ggoogleapi.Error) int {
 	case 429:
 		return exitCodeRateLimited
 	default:
-		if err.Code >= 500 {
+		if code >= 500 {
 			return exitCodeRetryable
 		}
 	}
@@ -143,7 +154,10 @@ func googleAPIExitCode(err *ggoogleapi.Error) int {
 }
 
 func isQuotaOrRateLimitReason(reason string) bool {
-	switch strings.TrimSpace(strings.ToLower(reason)) {
+	normalized := strings.NewReplacer("_", "", "-", "", " ", "").Replace(
+		strings.TrimSpace(strings.ToLower(reason)),
+	)
+	switch normalized {
 	case "ratelimitexceeded",
 		"userratelimitexceeded",
 		"quotaexceeded",

--- a/internal/cmd/exit_codes_test.go
+++ b/internal/cmd/exit_codes_test.go
@@ -59,6 +59,42 @@ func TestStableExitCode_GoogleAPINotFound(t *testing.T) {
 	}
 }
 
+func TestStableExitCode_HTTPStatusNotFound(t *testing.T) {
+	in := &gogapi.HTTPStatusError{
+		Code:   404,
+		Status: "NOT_FOUND",
+		Err:    errors.New("photos API error"),
+	}
+	out := stableExitCode(in)
+	if got := ExitCode(out); got != exitCodeNotFound {
+		t.Fatalf("expected exit code %d, got %d", exitCodeNotFound, got)
+	}
+}
+
+func TestStableExitCode_HTTPStatusResourceExhausted(t *testing.T) {
+	in := &gogapi.HTTPStatusError{
+		Code:   403,
+		Status: "RESOURCE_EXHAUSTED",
+		Err:    errors.New("places API error"),
+	}
+	out := stableExitCode(in)
+	if got := ExitCode(out); got != exitCodeRateLimited {
+		t.Fatalf("expected exit code %d, got %d", exitCodeRateLimited, got)
+	}
+}
+
+func TestStableExitCode_HTTPStatusRetryable(t *testing.T) {
+	in := &gogapi.HTTPStatusError{
+		Code:   503,
+		Status: "UNAVAILABLE",
+		Err:    errors.New("photos API error"),
+	}
+	out := stableExitCode(in)
+	if got := ExitCode(out); got != exitCodeRetryable {
+		t.Fatalf("expected exit code %d, got %d", exitCodeRetryable, got)
+	}
+}
+
 func TestStableExitCode_GoogleAPIRateLimited(t *testing.T) {
 	in := &ggoogleapi.Error{Code: 429, Message: "too many requests"}
 	out := stableExitCode(in)

--- a/internal/cmd/photos.go
+++ b/internal/cmd/photos.go
@@ -160,7 +160,14 @@ func (c *PhotosDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
-		return fmt.Errorf("download media item: HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(b)))
+		return &googleapi.HTTPStatusError{
+			Code: resp.StatusCode,
+			Err: fmt.Errorf(
+				"download media item: HTTP %d: %s",
+				resp.StatusCode,
+				strings.TrimSpace(string(b)),
+			),
+		}
 	}
 
 	if isStdoutPath(c.Out) {

--- a/internal/cmd/photos_picker_test.go
+++ b/internal/cmd/photos_picker_test.go
@@ -263,6 +263,32 @@ func TestPhotosPickerListRejectsRepeatedPageToken(t *testing.T) {
 	}
 }
 
+func TestPhotosPickerGetNotFoundExitCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, `{"error":{"code":404,"status":"NOT_FOUND","message":"session missing"}}`)
+	}))
+	defer srv.Close()
+
+	client := googleapi.NewPhotosPickerClient(srv.Client(), googleapi.WithPhotosPickerBaseURL(srv.URL))
+	result := runWithPhotosTestServices(t, photosTestServices{
+		PhotosPicker: fixedPhotosPickerTestService(client),
+	}, func(ctx context.Context) error {
+		return (&PhotosPickerGetCmd{SessionID: "deleted-session"}).Run(
+			ctx,
+			&RootFlags{Account: "a@example.com"},
+		)
+	})
+
+	if got := ExitCode(stableExitCode(result.err)); got != exitCodeNotFound {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, exitCodeNotFound, result.err)
+	}
+	if !strings.Contains(result.err.Error(), "404 NOT_FOUND") {
+		t.Fatalf("err = %v", result.err)
+	}
+}
+
 func TestPhotosPickerValidationFailsBeforeClient(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/internal/cmd/photos_test.go
+++ b/internal/cmd/photos_test.go
@@ -101,6 +101,44 @@ func TestPhotosDownloadStreamsToRuntimeOutput(t *testing.T) {
 	}
 }
 
+func TestPhotosDownloadNotFoundExitCode(t *testing.T) {
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/mediaItems/missing":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":       "missing",
+				"filename": "missing.jpg",
+				"baseUrl":  srv.URL + "/media/missing",
+			})
+		case "/media/missing=d":
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = io.WriteString(w, "expired")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	client := googleapi.NewPhotosClient(srv.Client(), googleapi.WithPhotosBaseURL(srv.URL))
+	result := runWithPhotosTestServices(t, photosTestServices{
+		Photos: fixedPhotosTestService(client),
+	}, func(ctx context.Context) error {
+		return (&PhotosDownloadCmd{MediaItemID: "missing", Out: "-"}).Run(
+			ctx,
+			&RootFlags{Account: "a@example.com"},
+		)
+	})
+
+	if got := ExitCode(stableExitCode(result.err)); got != exitCodeNotFound {
+		t.Fatalf("exit code = %d, want %d (err=%v)", got, exitCodeNotFound, result.err)
+	}
+	if !strings.Contains(result.err.Error(), "HTTP 404: expired") {
+		t.Fatalf("err = %v", result.err)
+	}
+}
+
 func TestPhotosValidationFailsBeforeClient(t *testing.T) {
 	testCases := []struct {
 		name string

--- a/internal/googleapi/errors.go
+++ b/internal/googleapi/errors.go
@@ -48,6 +48,26 @@ func (e *InsufficientScopeError) Error() string {
 	return message
 }
 
+// HTTPStatusError preserves status metadata from Google APIs implemented with
+// direct HTTP clients while retaining the service-specific error text.
+type HTTPStatusError struct {
+	Code   int
+	Status string
+	Err    error
+}
+
+func (e *HTTPStatusError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+
+	return fmt.Sprintf("HTTP %d", e.Code)
+}
+
+func (e *HTTPStatusError) Unwrap() error {
+	return e.Err
+}
+
 // RateLimitError indicates rate limit was exceeded
 type RateLimitError struct {
 	RetryAfter time.Duration

--- a/internal/googleapi/photos.go
+++ b/internal/googleapi/photos.go
@@ -256,11 +256,21 @@ func photosAPIError(statusCode int, body []byte) error {
 	}
 	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Error.Message != "" {
 		if parsed.Error.Status != "" {
-			return fmt.Errorf("%w (%d %s): %s", errPhotosAPI, statusCode, parsed.Error.Status, parsed.Error.Message)
+			return &HTTPStatusError{
+				Code:   statusCode,
+				Status: parsed.Error.Status,
+				Err:    fmt.Errorf("%w (%d %s): %s", errPhotosAPI, statusCode, parsed.Error.Status, parsed.Error.Message),
+			}
 		}
 
-		return fmt.Errorf("%w (%d): %s", errPhotosAPI, statusCode, parsed.Error.Message)
+		return &HTTPStatusError{
+			Code: statusCode,
+			Err:  fmt.Errorf("%w (%d): %s", errPhotosAPI, statusCode, parsed.Error.Message),
+		}
 	}
 
-	return fmt.Errorf("%w (%d): %s", errPhotosAPI, statusCode, strings.TrimSpace(string(body)))
+	return &HTTPStatusError{
+		Code: statusCode,
+		Err:  fmt.Errorf("%w (%d): %s", errPhotosAPI, statusCode, strings.TrimSpace(string(body))),
+	}
 }

--- a/internal/googleapi/photos_picker.go
+++ b/internal/googleapi/photos_picker.go
@@ -284,12 +284,15 @@ func (c *PhotosPickerClient) DownloadMedia(ctx context.Context, item *PhotosPick
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
 
-	return nil, fmt.Errorf(
-		"%w: HTTP %d: %s",
-		errPhotosPickerDownloadFailed,
-		resp.StatusCode,
-		strings.TrimSpace(string(body)),
-	)
+	return nil, &HTTPStatusError{
+		Code: resp.StatusCode,
+		Err: fmt.Errorf(
+			"%w: HTTP %d: %s",
+			errPhotosPickerDownloadFailed,
+			resp.StatusCode,
+			strings.TrimSpace(string(body)),
+		),
+	}
 }
 
 func (c *PhotosPickerClient) doJSON(ctx context.Context, method string, endpoint string, body any, out any) error {

--- a/internal/googleapi/photos_picker_test.go
+++ b/internal/googleapi/photos_picker_test.go
@@ -3,6 +3,7 @@ package googleapi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -145,6 +146,36 @@ func TestPhotosPickerDownloadMedia(t *testing.T) {
 
 	if string(body) != "photo-bytes" {
 		t.Fatalf("body = %q", body)
+	}
+}
+
+func TestPhotosPickerDownloadMediaPreservesHTTPStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "expired")
+	}))
+	defer srv.Close()
+
+	client := NewPhotosPickerClient(srv.Client())
+
+	resp, err := client.DownloadMedia(context.Background(), &PhotosPickerMediaItem{
+		ID:   "photo-1",
+		Type: "PHOTO",
+		MediaFile: &PhotosPickerMediaFile{
+			BaseURL: srv.URL + "/photo",
+		},
+	})
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	var statusErr *HTTPStatusError
+	if !errors.As(err, &statusErr) || statusErr.Code != http.StatusNotFound {
+		t.Fatalf("err = %v, want HTTPStatusError 404", err)
+	}
+
+	if !strings.Contains(err.Error(), "HTTP 404: expired") {
+		t.Fatalf("err = %v", err)
 	}
 }
 

--- a/internal/googleapi/places.go
+++ b/internal/googleapi/places.go
@@ -222,11 +222,21 @@ func placesAPIError(statusCode int, body []byte) error {
 	}
 	if err := json.Unmarshal(body, &parsed); err == nil && parsed.Error.Message != "" {
 		if parsed.Error.Status != "" {
-			return fmt.Errorf("%w %d %s: %s", errPlacesAPI, statusCode, parsed.Error.Status, parsed.Error.Message)
+			return &HTTPStatusError{
+				Code:   statusCode,
+				Status: parsed.Error.Status,
+				Err:    fmt.Errorf("%w %d %s: %s", errPlacesAPI, statusCode, parsed.Error.Status, parsed.Error.Message),
+			}
 		}
 
-		return fmt.Errorf("%w %d: %s", errPlacesAPI, statusCode, parsed.Error.Message)
+		return &HTTPStatusError{
+			Code: statusCode,
+			Err:  fmt.Errorf("%w %d: %s", errPlacesAPI, statusCode, parsed.Error.Message),
+		}
 	}
 
-	return fmt.Errorf("%w %d: %s", errPlacesAPI, statusCode, strings.TrimSpace(string(body)))
+	return &HTTPStatusError{
+		Code: statusCode,
+		Err:  fmt.Errorf("%w %d: %s", errPlacesAPI, statusCode, strings.TrimSpace(string(body))),
+	}
 }


### PR DESCRIPTION
## Summary

- preserve HTTP status metadata from direct Google API clients
- apply documented stable exit codes to Photos Library, Photos Picker, and Places failures
- cover JSON requests and Photos media-download paths
- document deleted or expired Picker sessions as exit code 5

## Live proof

- completed Picker create/get, browser upload and selection, wait, list, download, and delete with `clawdbot@gmail.com`
- before fix: post-delete `photos picker get` returned API 404 with exit code 1
- after fix: the same live request returns exit code 5
- live disabled Photos Library API response maps HTTP 403 to exit code 6

## Verification

- focused Photos, Picker, Places, and exit-code tests
- autoreview: no actionable findings
- `make ci`
