### PR TITLE
fix(classroom): enforce course deletion lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixed
 
 - Drive: preserve repeated folder placements in tree, inventory, and size summaries; reject cyclic folder graphs instead of collapsing paths or scanning indefinitely.
+- Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
 
 ## 0.25.0 - 2026-06-12
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -132,7 +132,7 @@ Generated from `gog schema --json`.
     - [`gog classroom (class) courses (course) <command>`](commands/gog-classroom-courses.md) - Courses
       - [`gog classroom (class) courses (course) archive (arch) <courseId>`](commands/gog-classroom-courses-archive.md) - Archive a course
       - [`gog classroom (class) courses (course) create (add,new) --name=STRING [flags]`](commands/gog-classroom-courses-create.md) - Create a course
-      - [`gog classroom (class) courses (course) delete (rm,del,remove) <courseId>`](commands/gog-classroom-courses-delete.md) - Delete a course
+      - [`gog classroom (class) courses (course) delete (rm,del,remove) <courseId>`](commands/gog-classroom-courses-delete.md) - Delete an archived course
       - [`gog classroom (class) courses (course) get (info,show) <courseId>`](commands/gog-classroom-courses-get.md) - Get a course
       - [`gog classroom (class) courses (course) join (enroll) <courseId> [flags]`](commands/gog-classroom-courses-join.md) - Join a course
       - [`gog classroom (class) courses (course) leave (unenroll) <courseId> [flags]`](commands/gog-classroom-courses-leave.md) - Leave a course

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -183,7 +183,7 @@ Generated pages: 642.
     - [gog classroom courses](gog-classroom-courses.md) - Courses
       - [gog classroom courses archive](gog-classroom-courses-archive.md) - Archive a course
       - [gog classroom courses create](gog-classroom-courses-create.md) - Create a course
-      - [gog classroom courses delete](gog-classroom-courses-delete.md) - Delete a course
+      - [gog classroom courses delete](gog-classroom-courses-delete.md) - Delete an archived course
       - [gog classroom courses get](gog-classroom-courses-get.md) - Get a course
       - [gog classroom courses join](gog-classroom-courses-join.md) - Join a course
       - [gog classroom courses leave](gog-classroom-courses-leave.md) - Leave a course

--- a/docs/commands/gog-classroom-courses-delete.md
+++ b/docs/commands/gog-classroom-courses-delete.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Delete a course
+Delete an archived course
 
 ## Usage
 

--- a/docs/commands/gog-classroom-courses.md
+++ b/docs/commands/gog-classroom-courses.md
@@ -18,7 +18,7 @@ gog classroom (class) courses (course) <command>
 
 - [gog classroom courses archive](gog-classroom-courses-archive.md) - Archive a course
 - [gog classroom courses create](gog-classroom-courses-create.md) - Create a course
-- [gog classroom courses delete](gog-classroom-courses-delete.md) - Delete a course
+- [gog classroom courses delete](gog-classroom-courses-delete.md) - Delete an archived course
 - [gog classroom courses get](gog-classroom-courses-get.md) - Get a course
 - [gog classroom courses join](gog-classroom-courses-join.md) - Join a course
 - [gog classroom courses leave](gog-classroom-courses-leave.md) - Leave a course

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -299,7 +299,7 @@ Drive hierarchy semantics:
 - `gog classroom courses get <courseId>`
 - `gog classroom courses create --name NAME [--owner me] [--state ACTIVE|...]`
 - `gog classroom courses update <courseId> [--name ...] [--state ...]`
-- `gog classroom courses delete <courseId>`
+- `gog classroom courses delete <archivedCourseId>`
 - `gog classroom courses archive <courseId>`
 - `gog classroom courses unarchive <courseId>`
 - `gog classroom courses join <courseId> [--role student|teacher] [--user me]`

--- a/internal/cmd/classroom_courses.go
+++ b/internal/cmd/classroom_courses.go
@@ -11,12 +11,19 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+const (
+	classroomCourseStateActive      = "ACTIVE"
+	classroomCourseStateArchived    = "ARCHIVED"
+	classroomCourseStateProvisioned = "PROVISIONED"
+	classroomCourseStateDeclined    = "DECLINED"
+)
+
 type ClassroomCoursesCmd struct {
 	List      ClassroomCoursesListCmd      `cmd:"" default:"withargs" aliases:"ls" help:"List courses"`
 	Get       ClassroomCoursesGetCmd       `cmd:"" aliases:"info,show" help:"Get a course"`
 	Create    ClassroomCoursesCreateCmd    `cmd:"" aliases:"add,new" help:"Create a course"`
 	Update    ClassroomCoursesUpdateCmd    `cmd:"" aliases:"edit,set" help:"Update a course"`
-	Delete    ClassroomCoursesDeleteCmd    `cmd:"" aliases:"rm,del,remove" help:"Delete a course"`
+	Delete    ClassroomCoursesDeleteCmd    `cmd:"" aliases:"rm,del,remove" help:"Delete an archived course"`
 	Archive   ClassroomCoursesArchiveCmd   `cmd:"" aliases:"arch" help:"Archive a course"`
 	Unarchive ClassroomCoursesUnarchiveCmd `cmd:"" aliases:"unarch,restore" help:"Unarchive a course"`
 	Join      ClassroomCoursesJoinCmd      `cmd:"" aliases:"enroll" help:"Join a course"`
@@ -311,6 +318,14 @@ func (c *ClassroomCoursesDeleteCmd) Run(ctx context.Context, flags *RootFlags) e
 		return wrapClassroomError(err)
 	}
 
+	course, err := svc.Courses.Get(courseID).Context(ctx).Do()
+	if err != nil {
+		return wrapClassroomError(err)
+	}
+	if course.CourseState != classroomCourseStateArchived {
+		return classroomCourseDeleteStateError(courseID, course.CourseState)
+	}
+
 	if _, err := svc.Courses.Delete(courseID).Context(ctx).Do(); err != nil {
 		return wrapClassroomError(err)
 	}
@@ -321,12 +336,36 @@ func (c *ClassroomCoursesDeleteCmd) Run(ctx context.Context, flags *RootFlags) e
 	)
 }
 
+func classroomCourseDeleteStateError(courseID, state string) error {
+	switch state {
+	case classroomCourseStateActive:
+		return fmt.Errorf(
+			"course %s is ACTIVE; archive it before deleting: gog classroom courses archive %s",
+			courseID,
+			courseID,
+		)
+	case classroomCourseStateProvisioned:
+		return fmt.Errorf(
+			"course %s is PROVISIONED; accept its teaching invitation in Google Classroom, then archive it before deleting",
+			courseID,
+		)
+	case classroomCourseStateDeclined:
+		return fmt.Errorf("course %s is DECLINED; declined courses cannot be deleted or recovered", courseID)
+	default:
+		return fmt.Errorf(
+			"course %s must be ARCHIVED before deletion (current state: %s)",
+			courseID,
+			state,
+		)
+	}
+}
+
 type ClassroomCoursesArchiveCmd struct {
 	CourseID string `arg:"" name:"courseId" help:"Course ID or alias"`
 }
 
 func (c *ClassroomCoursesArchiveCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return updateCourseState(ctx, flags, c.CourseID, "ARCHIVED")
+	return updateCourseState(ctx, flags, c.CourseID, classroomCourseStateArchived)
 }
 
 type ClassroomCoursesUnarchiveCmd struct {
@@ -334,7 +373,7 @@ type ClassroomCoursesUnarchiveCmd struct {
 }
 
 func (c *ClassroomCoursesUnarchiveCmd) Run(ctx context.Context, flags *RootFlags) error {
-	return updateCourseState(ctx, flags, c.CourseID, "ACTIVE")
+	return updateCourseState(ctx, flags, c.CourseID, classroomCourseStateActive)
 }
 
 func updateCourseState(ctx context.Context, flags *RootFlags, courseID, state string) error {
@@ -347,9 +386,9 @@ func updateCourseState(ctx context.Context, flags *RootFlags, courseID, state st
 	course := &classroom.Course{CourseState: state}
 	op := "classroom.courses.update_state"
 	switch state {
-	case "ARCHIVED":
+	case classroomCourseStateArchived:
 		op = "classroom.courses.archive"
-	case "ACTIVE":
+	case classroomCourseStateActive:
 		op = "classroom.courses.unarchive"
 	}
 	if err := dryRunExit(ctx, flags, op, map[string]any{

--- a/internal/cmd/classroom_courses_delete_test.go
+++ b/internal/cmd/classroom_courses_delete_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestClassroomCoursesDeleteRequiresArchivedCourse(t *testing.T) {
+	tests := []struct {
+		state string
+		want  string
+	}{
+		{state: "ACTIVE", want: "archive it before deleting: gog classroom courses archive c1"},
+		{state: "PROVISIONED", want: "accept its teaching invitation in Google Classroom"},
+		{state: "DECLINED", want: "declined courses cannot be deleted or recovered"},
+		{state: "UNKNOWN", want: "must be ARCHIVED before deletion (current state: UNKNOWN)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state, func(t *testing.T) {
+			deleteCalls := 0
+			svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"id":          "c1",
+						"courseState": tt.state,
+					})
+				case http.MethodDelete:
+					deleteCalls++
+					w.WriteHeader(http.StatusNoContent)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer closeService()
+
+			result := executeWithClassroomTestService(t, []string{
+				"--force",
+				"--account", "a@b.com",
+				"classroom", "courses", "delete", "c1",
+			}, svc)
+			if result.err == nil || !strings.Contains(result.err.Error(), tt.want) {
+				t.Fatalf("error = %v, want substring %q", result.err, tt.want)
+			}
+			if deleteCalls != 0 {
+				t.Fatalf("delete calls = %d, want 0", deleteCalls)
+			}
+		})
+	}
+}
+
+func TestClassroomCoursesDeleteArchivedCourse(t *testing.T) {
+	deleteCalls := 0
+	svc, closeService := newClassroomTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":          "c1",
+				"courseState": "ARCHIVED",
+			})
+		case http.MethodDelete:
+			deleteCalls++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeService()
+
+	result := executeWithClassroomTestService(t, []string{
+		"--json",
+		"--force",
+		"--account", "a@b.com",
+		"classroom", "courses", "delete", "c1",
+	}, svc)
+	if result.err != nil {
+		t.Fatalf("delete archived course: %v", result.err)
+	}
+	if deleteCalls != 1 {
+		t.Fatalf("delete calls = %d, want 1", deleteCalls)
+	}
+}

--- a/internal/cmd/execute_classroom_more_commands_test.go
+++ b/internal/cmd/execute_classroom_more_commands_test.go
@@ -382,7 +382,11 @@ func TestExecute_ClassroomMoreCommands_JSON(t *testing.T) {
 		case strings.Contains(path, "/courses/"):
 			switch r.Method {
 			case http.MethodGet:
-				writeJSON(map[string]any{"id": "c1", "name": "Biology", "courseState": "ACTIVE", "ownerId": "me", "alternateLink": "https://classroom.google.com/c/c1"})
+				state := "ACTIVE"
+				if strings.HasSuffix(path, "/c-delete") {
+					state = "ARCHIVED"
+				}
+				writeJSON(map[string]any{"id": "c1", "name": "Biology", "courseState": state, "ownerId": "me", "alternateLink": "https://classroom.google.com/c/c1"})
 				return
 			case http.MethodPatch:
 				mask := r.URL.Query().Get("updateMask")
@@ -440,7 +444,7 @@ func TestExecute_ClassroomMoreCommands_JSON(t *testing.T) {
 	runJSONForce("classroom", "courses", "leave", "c1", "--role", "student", "--user", "s1")
 	runJSONForce("classroom", "courses", "leave", "c1", "--role", "teacher", "--user", "t1")
 	runJSON("classroom", "courses", "url", "c1", "c2")
-	runJSONForce("classroom", "courses", "delete", "c1")
+	runJSONForce("classroom", "courses", "delete", "c-delete")
 
 	runJSON("classroom", "students", "c1", "--max", "1", "--page", "p1")
 	runJSON("classroom", "students", "get", "c1", "s1")

--- a/scripts/live-tests/classroom.sh
+++ b/scripts/live-tests/classroom.sh
@@ -37,21 +37,20 @@ run_classroom_tests() {
     echo "==> classroom (optional; set GOG_LIVE_CLASSROOM_COURSE to expand)"
   fi
 
-  # Disabled by default: creator account lacks course state permissions.
+  # Disabled by default: consumer accounts cannot create ACTIVE courses through
+  # the API, and PROVISIONED courses require browser acceptance before cleanup.
   if [ -n "${GOG_LIVE_CLASSROOM_CREATE:-}" ] && [ -n "${GOG_LIVE_CLASSROOM_ALLOW_STATE:-}" ]; then
     local course_json course_id topic_json topic_id announcement_json announcement_id material_json material_id coursework_json coursework_id
 
     echo "==> classroom courses create"
     if course_json=$(gog classroom courses create --name "gogcli-smoke-$TS" --section "gogcli" --state ACTIVE --json 2>/dev/null); then
       :
-    elif course_json=$(gog classroom courses create --name "gogcli-smoke-$TS" --section "gogcli" --state PROVISIONED --json 2>/dev/null); then
-      :
     else
       course_json=""
     fi
     course_id=$(extract_id "$course_json")
     if [ -z "$course_id" ]; then
-      echo "Classroom course create failed; skipping create tests."
+      echo "Classroom ACTIVE course create failed; skipping create tests."
       if [ "${STRICT:-false}" = true ]; then
         return 1
       fi
@@ -95,7 +94,9 @@ run_classroom_tests() {
       run_optional "classroom" "classroom topics delete" gog --force classroom topics delete "$course_id" "$topic_id" --json >/dev/null
     fi
 
-    if gog --force classroom courses delete "$course_id" --json >/dev/null; then
+    echo "==> classroom courses cleanup"
+    if gog classroom courses archive "$course_id" --json >/dev/null &&
+      gog --force classroom courses delete "$course_id" --json >/dev/null; then
       :
     else
       echo "Classroom course delete failed; manual cleanup needed: $course_id" >&2


### PR DESCRIPTION
## Summary

- require Classroom courses to be archived before deletion
- return state-specific guidance for ACTIVE, PROVISIONED, and DECLINED courses
- stop the live suite from creating non-cleanable PROVISIONED fallback courses
- archive ACTIVE smoke-test courses immediately before deleting them
- update generated command docs, spec, and changelog

## Live proof

Test account: `clawdbot@gmail.com`

1. Created a fresh PROVISIONED course through the API.
2. Accepted the teaching invitation in the existing logged-in Classroom UI.
3. Confirmed the course became ACTIVE.
4. Confirmed delete exited 1 without making a delete request and printed the exact archive command.
5. Archived the course and deleted it successfully.
6. Confirmed a subsequent get returned not-found exit 5.
7. Confirmed a DECLINED course now reports that it cannot be deleted or recovered instead of returning Google's opaque failed-precondition error.

## Verification

- `go test ./internal/cmd -run 'TestClassroomCoursesDelete|TestExecute_ClassroomMoreCommands_JSON'`
- `make ci`
- autoreview: no accepted or actionable findings
