### PR TITLE
test(classroom): avoid empty create traceback

### DIFF
--- a/scripts/live-tests/classroom.sh
+++ b/scripts/live-tests/classroom.sh
@@ -48,7 +48,10 @@ run_classroom_tests() {
     else
       course_json=""
     fi
-    course_id=$(extract_id "$course_json")
+    course_id=""
+    if [ -n "$course_json" ]; then
+      course_id=$(extract_id "$course_json")
+    fi
     if [ -z "$course_id" ]; then
       echo "Classroom ACTIVE course create failed; skipping create tests."
       if [ "${STRICT:-false}" = true ]; then

--- a/scripts/live_classroom_test.go
+++ b/scripts/live_classroom_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestClassroomLiveCreateFailureSkipsCleanly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+SKIP=""
+STRICT=false
+TS=20260613000000
+GOG_LIVE_CLASSROOM_CREATE=1
+GOG_LIVE_CLASSROOM_ALLOW_STATE=1
+source "$ROOT_DIR/scripts/live-tests/common.sh"
+source "$ROOT_DIR/scripts/live-tests/classroom.sh"
+gog() { return 1; }
+run_classroom_tests
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run classroom live-test failure path: %v\n%s", err, output)
+	}
+
+	text := string(output)
+	if !strings.Contains(text, "Classroom ACTIVE course create failed; skipping create tests.") {
+		t.Fatalf("output missing clean skip message:\n%s", text)
+	}
+
+	if strings.Contains(text, "Traceback") || strings.Contains(text, "JSONDecodeError") {
+		t.Fatalf("unexpected parser traceback:\n%s", text)
+	}
+}


### PR DESCRIPTION
## Summary

- avoid sending an empty failed Classroom create response to the JSON ID parser
- keep unsupported consumer-account ACTIVE creation as a clean optional skip
- add a Bash-backed regression test for the failure path

## Live proof

On `clawdbot@gmail.com`, ran the Classroom live-test path with course creation enabled. Google rejected ACTIVE creation as expected for a consumer account; the suite printed the intended skip message, exited successfully, emitted no Python traceback, and created no course.

## Verification

- `go test ./scripts -run TestClassroomLiveCreateFailureSkipsCleanly`
- focused Classroom live-test run
- `make fmt-check`
- `make lint`
- `make ci`
- autoreview: no accepted or actionable findings
