### PR TITLE
fix(forms): validate scale question bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Drive: preserve repeated folder placements in tree, inventory, and size summaries; reject cyclic folder graphs instead of collapsing paths or scanning indefinitely.
 - Backup: bind configuration, legacy fallback, and home expansion to the selected runtime layout instead of process-global path state.
 - Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
+- Forms: validate scale question bounds locally and document the Forms API's accepted minimum and maximum values.
 - Gmail: bind watch state to the selected runtime state directory and serialize atomic updates across concurrent watch processes.
 - Gmail: bind tracking configuration to the selected runtime state directory and preserve concurrent account updates with shared atomic locking.
 - Zoom: bind credential metadata and encrypted secret/token storage to the selected runtime layout, with consistent alias canonicalization.

--- a/docs/commands/gog-forms-add-question.md
+++ b/docs/commands/gog-forms-add-question.md
@@ -43,9 +43,9 @@ gog forms (form) add-question (add-q,aq) --title=STRING <formId> [flags]
 | `--points` | `int` |  | Positive quiz points for the question when --correct is set |
 | `--required` | `bool` |  | Whether an answer is required |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--scale-high` | `int` | 5 | Scale maximum value |
+| `--scale-high` | `int` | 5 | Scale maximum value: 2 through 10 |
 | `--scale-high-label` | `string` |  | Label for high end of scale |
-| `--scale-low` | `int` | 1 | Scale minimum value |
+| `--scale-low` | `int` | 1 | Scale minimum value: 0 or 1 |
 | `--scale-low-label` | `string` |  | Label for low end of scale |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--title` | `string` |  | Question title/text |

--- a/docs/commands/gog-forms-questions-add.md
+++ b/docs/commands/gog-forms-questions-add.md
@@ -43,9 +43,9 @@ gog forms (form) questions add (create,new) --title=STRING <formId> [flags]
 | `--points` | `int` |  | Positive quiz points for the question when --correct is set |
 | `--required` | `bool` |  | Whether an answer is required |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--scale-high` | `int` | 5 | Scale maximum value |
+| `--scale-high` | `int` | 5 | Scale maximum value: 2 through 10 |
 | `--scale-high-label` | `string` |  | Label for high end of scale |
-| `--scale-low` | `int` | 1 | Scale minimum value |
+| `--scale-low` | `int` | 1 | Scale minimum value: 0 or 1 |
 | `--scale-low-label` | `string` |  | Label for low end of scale |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--title` | `string` |  | Question title/text |

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -771,8 +771,12 @@ func TestDryRunE2E_ValidatesFormsAndSheetsLocalInputs(t *testing.T) {
 			args: []string{"forms", "add-question", "form123", "--title", "Q", "--type", "radio"},
 		},
 		{
-			name: "forms add scale rejects inverted range",
-			args: []string{"forms", "add-question", "form123", "--title", "Q", "--type", "scale", "--scale-low", "5", "--scale-high", "1"},
+			name: "forms add scale rejects invalid lower bound",
+			args: []string{"forms", "add-question", "form123", "--title", "Q", "--type", "scale", "--scale-low", "2"},
+		},
+		{
+			name: "forms add scale rejects invalid upper bound",
+			args: []string{"forms", "add-question", "form123", "--title", "Q", "--type", "scale", "--scale-high", "11"},
 		},
 		{
 			name: "forms update requires a field before auth",

--- a/internal/cmd/forms_modify.go
+++ b/internal/cmd/forms_modify.go
@@ -23,8 +23,8 @@ type FormsAddQuestionCmd struct {
 	Points   int      `name:"points" help:"Positive quiz points for the question when --correct is set"`
 
 	// Scale-specific
-	ScaleLow       int    `name:"scale-low" help:"Scale minimum value" default:"1"`
-	ScaleHigh      int    `name:"scale-high" help:"Scale maximum value" default:"5"`
+	ScaleLow       int    `name:"scale-low" help:"Scale minimum value: 0 or 1" default:"1"`
+	ScaleHigh      int    `name:"scale-high" help:"Scale maximum value: 2 through 10" default:"5"`
 	ScaleLowLabel  string `name:"scale-low-label" help:"Label for low end of scale"`
 	ScaleHighLabel string `name:"scale-high-label" help:"Label for high end of scale"`
 
@@ -139,8 +139,11 @@ func buildQuestion(qType string, input *formsAddQuestionInput) (*formsapi.Questi
 			Options: opts,
 		}
 	case "scale":
-		if input.ScaleLow > input.ScaleHigh {
-			return nil, usage("--scale-low must be <= --scale-high")
+		if input.ScaleLow != 0 && input.ScaleLow != 1 {
+			return nil, usage("--scale-low must be 0 or 1")
+		}
+		if input.ScaleHigh < 2 || input.ScaleHigh > 10 {
+			return nil, usage("--scale-high must be between 2 and 10")
 		}
 		q.ScaleQuestion = &formsapi.ScaleQuestion{
 			Low:       int64(input.ScaleLow),

--- a/internal/cmd/forms_modify_test.go
+++ b/internal/cmd/forms_modify_test.go
@@ -20,15 +20,53 @@ func TestBuildQuestion(t *testing.T) {
 	})
 
 	t.Run("scale question", func(t *testing.T) {
-		q, err := buildQuestion("scale", &formsAddQuestionInput{Required: true, ScaleLow: 1, ScaleHigh: 7, ScaleLowLabel: "low", ScaleHighLabel: "high"})
-		if err != nil {
-			t.Fatalf("buildQuestion: %v", err)
+		for _, tc := range []struct {
+			name string
+			low  int
+			high int
+		}{
+			{name: "minimum bounds", low: 0, high: 2},
+			{name: "maximum bounds", low: 1, high: 10},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				q, err := buildQuestion("scale", &formsAddQuestionInput{
+					Required:       true,
+					ScaleLow:       tc.low,
+					ScaleHigh:      tc.high,
+					ScaleLowLabel:  "low",
+					ScaleHighLabel: "high",
+				})
+				if err != nil {
+					t.Fatalf("buildQuestion: %v", err)
+				}
+				if q.ScaleQuestion == nil || q.ScaleQuestion.Low != int64(tc.low) || q.ScaleQuestion.High != int64(tc.high) {
+					t.Fatalf("unexpected scale question: %#v", q)
+				}
+				if !q.Required {
+					t.Fatalf("expected required question")
+				}
+			})
 		}
-		if q.ScaleQuestion == nil || q.ScaleQuestion.Low != 1 || q.ScaleQuestion.High != 7 {
-			t.Fatalf("unexpected scale question: %#v", q)
-		}
-		if !q.Required {
-			t.Fatalf("expected required question")
+	})
+
+	t.Run("scale question validation", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			low  int
+			high int
+			want string
+		}{
+			{name: "low below range", low: -1, high: 5, want: "--scale-low must be 0 or 1"},
+			{name: "low above range", low: 2, high: 5, want: "--scale-low must be 0 or 1"},
+			{name: "high below range", low: 1, high: 1, want: "--scale-high must be between 2 and 10"},
+			{name: "high above range", low: 1, high: 11, want: "--scale-high must be between 2 and 10"},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := buildQuestion("scale", &formsAddQuestionInput{ScaleLow: tc.low, ScaleHigh: tc.high})
+				if err == nil || !strings.Contains(err.Error(), tc.want) {
+					t.Fatalf("expected %q, got %v", tc.want, err)
+				}
+			})
 		}
 	})
 
@@ -62,7 +100,7 @@ func TestBuildQuestion(t *testing.T) {
 			t.Fatalf("expected points validation, got %v", err)
 		}
 
-		_, err = buildQuestion("scale", &formsAddQuestionInput{Correct: []string{"5"}, Points: 1})
+		_, err = buildQuestion("scale", &formsAddQuestionInput{ScaleLow: 1, ScaleHigh: 5, Correct: []string{"5"}, Points: 1})
 		if err == nil || !strings.Contains(err.Error(), "supported only") {
 			t.Fatalf("expected type validation, got %v", err)
 		}
@@ -138,6 +176,22 @@ func TestFormsAddQuestionRejectsInvalidAppendIndexBeforeDryRun(t *testing.T) {
 	}
 	if got := ExitCode(err); got != 2 {
 		t.Fatalf("ExitCode = %d, want 2 (err=%v)", got, err)
+	}
+}
+
+func TestFormsAddQuestionRejectsInvalidScaleBeforeDryRun(t *testing.T) {
+	ctx := withFormsTestServiceFactory(newQuietUIContext(t), unexpectedFormsTestService(t, "forms service should not be created"))
+	for _, args := range [][]string{
+		{"form1", "--title", "Rating", "--type", "scale", "--scale-low", "2"},
+		{"form1", "--title", "Rating", "--type", "scale", "--scale-high", "11"},
+	} {
+		err := runKong(t, &FormsAddQuestionCmd{}, args, ctx, &RootFlags{Account: "a@b.com", DryRun: true})
+		if err == nil {
+			t.Fatalf("expected scale validation error for %v", args)
+		}
+		if got := ExitCode(err); got != 2 {
+			t.Fatalf("ExitCode = %d, want 2 (err=%v)", got, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate Google Forms scale lower bounds as 0 or 1
- validate scale upper bounds as 2 through 10
- document the accepted values in CLI help and generated command references
- add boundary and pre-auth dry-run regression coverage

## Verification

- `make ci`
- structured autoreview: clean, no actionable findings
- live on `clawdbot@gmail.com`: invalid low/high values fail locally with exit 2
- live on `clawdbot@gmail.com`: scales 0..2 and 1..10 create and read back successfully
- disposable form permanently deleted after proof
