### PR TITLE
refactor(config): remove unused state helpers

### DIFF
--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -34,10 +34,6 @@ func Dir() (string, error) {
 	return currentLayoutDir(PathKindConfig)
 }
 
-func HasExplicitConfigOverride() bool {
-	return currentLayoutEnv().hasExplicit(PathKindConfig)
-}
-
 func HasExplicitDataOverride() bool {
 	return currentLayoutEnv().hasExplicit(PathKindData)
 }

--- a/internal/config/paths.go
+++ b/internal/config/paths.go
@@ -38,10 +38,6 @@ func HasExplicitConfigOverride() bool {
 	return currentLayoutEnv().hasExplicit(PathKindConfig)
 }
 
-func HasExplicitStateOverride() bool {
-	return currentLayoutEnv().hasExplicit(PathKindState)
-}
-
 func HasExplicitDataOverride() bool {
 	return currentLayoutEnv().hasExplicit(PathKindData)
 }
@@ -78,19 +74,6 @@ func EnsureDataDir() (string, error) {
 	}
 
 	return layout.EnsureDataDir()
-}
-
-func EnsureStateDir() (string, error) {
-	dir, err := StateDir()
-	if err != nil {
-		return "", err
-	}
-
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", fmt.Errorf("ensure state dir: %w", err)
-	}
-
-	return dir, nil
 }
 
 // KeyringDir is where the keyring "file" backend stores encrypted entries.

--- a/internal/zoom/store_test.go
+++ b/internal/zoom/store_test.go
@@ -3,6 +3,7 @@ package zoom
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -102,7 +103,7 @@ func TestStoreCredentialsRoundTrip(t *testing.T) {
 		t.Fatalf("stat metadata: %v", err)
 	}
 
-	if info.Mode().Perm() != metadataFileMode {
+	if runtime.GOOS != "windows" && info.Mode().Perm() != metadataFileMode {
 		t.Fatalf("metadata mode = %v", info.Mode().Perm())
 	}
 }


### PR DESCRIPTION
## Summary

- remove three internal config/state path helpers left unused by the tracking and backup config-store refactors
- skip the POSIX metadata-mode assertion on Windows, where Go reports synthesized permission bits
- restore the repository deadcode and Windows gates on pull-request merge commits

## Verification

- `make ci`
- `GOOS=windows GOARCH=amd64 go test -c ./internal/zoom`
- autoreview: clean
