### PR TITLE
fix(groups): require Workspace service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Backup: bind configuration, legacy fallback, and home expansion to the selected runtime layout instead of process-global path state.
 - Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
 - Forms: validate scale question bounds locally and document the Forms API's accepted minimum and maximum values.
-- Groups: reject consumer accounts before Cloud Identity API calls and replace impossible OAuth recovery guidance with the required Workspace service-account setup.
+- Groups: reject consumer accounts and stored user OAuth before Cloud Identity API calls, require an explicit account for direct-token/ADC auth, and replace impossible OAuth recovery guidance with the required Workspace service-account setup.
 - Gmail: bind watch state to the selected runtime state directory and serialize atomic updates across concurrent watch processes.
 - Gmail: bind tracking configuration to the selected runtime state directory and preserve concurrent account updates with shared atomic locking.
 - Gmail: bind tracking encryption and admin keys to the active runtime secret store instead of reopening the ambient keyring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Backup: bind configuration, legacy fallback, and home expansion to the selected runtime layout instead of process-global path state.
 - Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
 - Forms: validate scale question bounds locally and document the Forms API's accepted minimum and maximum values.
+- Groups: reject consumer accounts before Cloud Identity API calls and replace impossible OAuth recovery guidance with the required Workspace service-account setup.
 - Gmail: bind watch state to the selected runtime state directory and serialize atomic updates across concurrent watch processes.
 - Gmail: bind tracking configuration to the selected runtime state directory and preserve concurrent account updates with shared atomic locking.
 - Gmail: bind tracking encryption and admin keys to the active runtime secret store instead of reopening the ambient keyring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Backup: bind configuration, legacy fallback, and home expansion to the selected runtime layout instead of process-global path state.
 - Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
 - Forms: validate scale question bounds locally and document the Forms API's accepted minimum and maximum values.
-- Groups: reject consumer accounts and stored user OAuth before Cloud Identity API calls, require an explicit account for direct-token/ADC auth, and replace impossible OAuth recovery guidance with the required Workspace service-account setup.
+- Groups: reject consumer accounts and stored user OAuth before Cloud Identity API calls, require an explicit account for identity-based direct-token/ADC searches, and provide recovery guidance for service-account, direct-token, and ADC auth.
 - Gmail: bind watch state to the selected runtime state directory and serialize atomic updates across concurrent watch processes.
 - Gmail: bind tracking configuration to the selected runtime state directory and preserve concurrent account updates with shared atomic locking.
 - Gmail: bind tracking encryption and admin keys to the active runtime secret store instead of reopening the ambient keyring.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Backup: bind configuration, legacy fallback, and home expansion to the selected runtime layout instead of process-global path state.
 - Classroom: require an archived course before deletion with actionable lifecycle guidance, and prevent live tests from leaving consumer-account courses behind.
 - Forms: validate scale question bounds locally and document the Forms API's accepted minimum and maximum values.
-- Groups: reject consumer accounts and stored user OAuth before Cloud Identity API calls, require an explicit account for identity-based direct-token/ADC searches, and provide recovery guidance for service-account, direct-token, and ADC auth.
+- Groups and Calendar team: reject consumer accounts and stored user OAuth before Cloud Identity API calls, require an explicit account for identity-based direct-token/ADC searches, keep ADC precedence consistent across services, and provide recovery guidance for service-account, direct-token, and ADC auth.
 - Gmail: bind watch state to the selected runtime state directory and serialize atomic updates across concurrent watch processes.
 - Gmail: bind tracking configuration to the selected runtime state directory and preserve concurrent account updates with shared atomic locking.
 - Gmail: bind tracking encryption and admin keys to the active runtime secret store instead of reopening the ambient keyring.

--- a/docs/auth-clients.md
+++ b/docs/auth-clients.md
@@ -88,13 +88,15 @@ domain-wide delegation, then run:
 ```bash
 gog --account admin@example.com groups list
 gog --account admin@example.com groups members engineering@example.com
+gog --account admin@example.com calendar team engineering@example.com
 ```
 
 Explicit `--access-token` and `GOG_AUTH_MODE=adc` auth remain available for
 advanced environments. `groups list` and Groups backups also require
 `--account <workspace-email>` because their transitive membership searches
 need the Workspace identity; `groups members` can use the active principal
-without that flag. Stored user OAuth tokens are not used for Groups.
+without that flag. `calendar team` shares the same Groups auth boundary.
+Stored user OAuth tokens are not used for these Cloud Identity lookups.
 
 Then run Admin SDK commands with that account:
 

--- a/docs/auth-clients.md
+++ b/docs/auth-clients.md
@@ -90,6 +90,11 @@ gog --account admin@example.com groups list
 gog --account admin@example.com groups members engineering@example.com
 ```
 
+Explicit `--access-token` and `GOG_AUTH_MODE=adc` auth remain available for
+advanced environments, but Groups still require `--account <workspace-email>`
+because membership lookup needs the Workspace identity. Stored user OAuth
+tokens are not used for Groups.
+
 Then run Admin SDK commands with that account:
 
 ```

--- a/docs/auth-clients.md
+++ b/docs/auth-clients.md
@@ -91,9 +91,10 @@ gog --account admin@example.com groups members engineering@example.com
 ```
 
 Explicit `--access-token` and `GOG_AUTH_MODE=adc` auth remain available for
-advanced environments, but Groups still require `--account <workspace-email>`
-because membership lookup needs the Workspace identity. Stored user OAuth
-tokens are not used for Groups.
+advanced environments. `groups list` and Groups backups also require
+`--account <workspace-email>` because their transitive membership searches
+need the Workspace identity; `groups members` can use the active principal
+without that flag. Stored user OAuth tokens are not used for Groups.
 
 Then run Admin SDK commands with that account:
 

--- a/docs/auth-clients.md
+++ b/docs/auth-clients.md
@@ -81,6 +81,15 @@ gog auth service-account set admin@example.com --key ~/Downloads/service-account
 gog auth service-account status admin@example.com
 ```
 
+Cloud Identity Groups commands use the same Workspace service-account setup.
+Include `https://www.googleapis.com/auth/cloud-identity.groups.readonly` in
+domain-wide delegation, then run:
+
+```bash
+gog --account admin@example.com groups list
+gog --account admin@example.com groups members engineering@example.com
+```
+
 Then run Admin SDK commands with that account:
 
 ```

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -100,8 +100,9 @@ Supported services:
 - `classroom`: courses, topics, announcements, coursework, materials, and
   submissions visible to the authenticated account.
 - `groups`: Cloud Identity groups the account belongs to, plus member lists.
-  This is Workspace-only and requires a service account with domain-wide
-  delegation for `cloud-identity.groups.readonly`.
+  This is Workspace-only and requires an explicit Workspace account plus
+  service-account delegation or equivalent direct-token/ADC access for
+  `cloud-identity.groups.readonly`.
 - `admin`: Workspace Admin Directory users, groups, and group members. This is
   Workspace-only and requires the existing Admin SDK/domain-wide delegation
   setup.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -99,8 +99,9 @@ Supported services:
   access.
 - `classroom`: courses, topics, announcements, coursework, materials, and
   submissions visible to the authenticated account.
-- `groups`: Cloud Identity groups the account belongs to, plus member lists
-  when the API permits them.
+- `groups`: Cloud Identity groups the account belongs to, plus member lists.
+  This is Workspace-only and requires a service account with domain-wide
+  delegation for `cloud-identity.groups.readonly`.
 - `admin`: Workspace Admin Directory users, groups, and group members. This is
   Workspace-only and requires the existing Admin SDK/domain-wide delegation
   setup.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -450,7 +450,7 @@ Generated from `gog schema --json`.
     - [`gog gmail (mail,email) trash [<messageId> ...] [flags]`](commands/gog-gmail-trash.md) - Move messages to trash
     - [`gog gmail (mail,email) unread (mark-unread) [<messageId> ...] [flags]`](commands/gog-gmail-unread.md) - Mark messages as unread
     - [`gog gmail (mail,email) url <threadId> ...`](commands/gog-gmail-url.md) - Print Gmail web URLs for threads
-  - [`gog groups (group) <command> [flags]`](commands/gog-groups.md) - Google Groups
+  - [`gog groups (group) <command> [flags]`](commands/gog-groups.md) - Cloud Identity Groups (Workspace only)
     - [`gog groups (group) list (ls) [flags]`](commands/gog-groups-list.md) - List groups you belong to
     - [`gog groups (group) members <groupEmail> [flags]`](commands/gog-groups-members.md) - List members of a group
   - [`gog keep <command> [flags]`](commands/gog-keep.md) - Google Keep (Workspace only)

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -98,7 +98,7 @@ Generated from `gog schema --json`.
     - [`gog calendar (cal) respond (rsvp,reply) <calendarId> <eventId> [flags]`](commands/gog-calendar-respond.md) - Respond to an event invitation
     - [`gog calendar (cal) search (find,query) <query> [flags]`](commands/gog-calendar-search.md) - Search events
     - [`gog calendar (cal) subscribe (sub,add-calendar) <calendarId> [flags]`](commands/gog-calendar-subscribe.md) - Add a calendar to your calendar list
-    - [`gog calendar (cal) team <group-email> [flags]`](commands/gog-calendar-team.md) - Show events for all members of a Google Group
+    - [`gog calendar (cal) team <group-email> [flags]`](commands/gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
     - [`gog calendar (cal) time [flags]`](commands/gog-calendar-time.md) - Show server time
     - [`gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]`](commands/gog-calendar-update.md) - Update an event
     - [`gog calendar (cal) users [flags]`](commands/gog-calendar-users.md) - List workspace users (use their email as calendar ID)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -23,7 +23,7 @@ Generated pages: 642.
 - [gog drive](gog-drive.md) - Google Drive
 - [gog forms](gog-forms.md) - Google Forms
 - [gog gmail](gog-gmail.md) - Gmail
-- [gog groups](gog-groups.md) - Google Groups
+- [gog groups](gog-groups.md) - Cloud Identity Groups (Workspace only)
 - [gog keep](gog-keep.md) - Google Keep (Workspace only)
 - [gog login](gog-login.md) - Authorize and store a refresh token (alias for 'auth add')
 - [gog logout](gog-logout.md) - Remove a stored refresh token (alias for 'auth remove')
@@ -501,7 +501,7 @@ Generated pages: 642.
     - [gog gmail trash](gog-gmail-trash.md) - Move messages to trash
     - [gog gmail unread](gog-gmail-unread.md) - Mark messages as unread
     - [gog gmail url](gog-gmail-url.md) - Print Gmail web URLs for threads
-  - [gog groups](gog-groups.md) - Google Groups
+  - [gog groups](gog-groups.md) - Cloud Identity Groups (Workspace only)
     - [gog groups list](gog-groups-list.md) - List groups you belong to
     - [gog groups members](gog-groups-members.md) - List members of a group
   - [gog keep](gog-keep.md) - Google Keep (Workspace only)

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -149,7 +149,7 @@ Generated pages: 642.
     - [gog calendar respond](gog-calendar-respond.md) - Respond to an event invitation
     - [gog calendar search](gog-calendar-search.md) - Search events
     - [gog calendar subscribe](gog-calendar-subscribe.md) - Add a calendar to your calendar list
-    - [gog calendar team](gog-calendar-team.md) - Show events for all members of a Google Group
+    - [gog calendar team](gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
     - [gog calendar time](gog-calendar-time.md) - Show server time
     - [gog calendar update](gog-calendar-update.md) - Update an event
     - [gog calendar users](gog-calendar-users.md) - List workspace users (use their email as calendar ID)

--- a/docs/commands/gog-calendar-team.md
+++ b/docs/commands/gog-calendar-team.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Show events for all members of a Google Group
+Show events for Workspace group members (service account, direct token, or ADC)
 
 ## Usage
 

--- a/docs/commands/gog-calendar.md
+++ b/docs/commands/gog-calendar.md
@@ -36,7 +36,7 @@ gog calendar (cal) <command> [flags]
 - [gog calendar respond](gog-calendar-respond.md) - Respond to an event invitation
 - [gog calendar search](gog-calendar-search.md) - Search events
 - [gog calendar subscribe](gog-calendar-subscribe.md) - Add a calendar to your calendar list
-- [gog calendar team](gog-calendar-team.md) - Show events for all members of a Google Group
+- [gog calendar team](gog-calendar-team.md) - Show events for Workspace group members (service account, direct token, or ADC)
 - [gog calendar time](gog-calendar-time.md) - Show server time
 - [gog calendar update](gog-calendar-update.md) - Update an event
 - [gog calendar users](gog-calendar-users.md) - List workspace users (use their email as calendar ID)

--- a/docs/commands/gog-groups.md
+++ b/docs/commands/gog-groups.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Google Groups
+Cloud Identity Groups (Workspace only)
 
 ## Usage
 

--- a/docs/commands/gog.md
+++ b/docs/commands/gog.md
@@ -33,7 +33,7 @@ gog <command> [flags]
 - [gog drive](gog-drive.md) - Google Drive
 - [gog forms](gog-forms.md) - Google Forms
 - [gog gmail](gog-gmail.md) - Gmail
-- [gog groups](gog-groups.md) - Google Groups
+- [gog groups](gog-groups.md) - Cloud Identity Groups (Workspace only)
 - [gog keep](gog-keep.md) - Google Keep (Workspace only)
 - [gog login](gog-login.md) - Authorize and store a refresh token (alias for 'auth add')
 - [gog logout](gog-logout.md) - Remove a stored refresh token (alias for 'auth remove')

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -144,6 +144,9 @@ scope:
 gog --account admin@example.com groups list
 ```
 
+With an explicit access token or `GOG_AUTH_MODE=adc`, also pass
+`--account <workspace-email>`; Groups do not fall back to stored user OAuth.
+
 See [Workspace Admin](workspace-admin.md) for service-account setup, generated
 passwords, recovery fields, organizational units, and cleanup commands.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -147,7 +147,8 @@ gog --account admin@example.com groups list
 With an explicit access token or `GOG_AUTH_MODE=adc`, `groups list` and Groups
 backups also need `--account <workspace-email>` for their transitive membership
 search. `groups members` can use the active principal without that flag.
-Groups do not fall back to stored user OAuth.
+`calendar team` uses the same Groups auth boundary. These Cloud Identity
+lookups do not fall back to stored user OAuth.
 
 See [Workspace Admin](workspace-admin.md) for service-account setup, generated
 passwords, recovery fields, organizational units, and cleanup commands.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -136,6 +136,14 @@ gog --account admin@example.com admin users create ada@example.com \
 gog --account admin@example.com admin orgunits list --type all
 ```
 
+Cloud Identity Groups also require the Workspace service account and the
+`https://www.googleapis.com/auth/cloud-identity.groups.readonly` delegated
+scope:
+
+```bash
+gog --account admin@example.com groups list
+```
+
 See [Workspace Admin](workspace-admin.md) for service-account setup, generated
 passwords, recovery fields, organizational units, and cleanup commands.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -144,8 +144,10 @@ scope:
 gog --account admin@example.com groups list
 ```
 
-With an explicit access token or `GOG_AUTH_MODE=adc`, also pass
-`--account <workspace-email>`; Groups do not fall back to stored user OAuth.
+With an explicit access token or `GOG_AUTH_MODE=adc`, `groups list` and Groups
+backups also need `--account <workspace-email>` for their transitive membership
+search. `groups members` can use the active principal without that flag.
+Groups do not fall back to stored user OAuth.
 
 See [Workspace Admin](workspace-admin.md) for service-account setup, generated
 passwords, recovery fields, organizational units, and cleanup commands.

--- a/internal/cmd/account.go
+++ b/internal/cmd/account.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	accessTokenPlaceholderAccount = "access-token-user"
+	adcPlaceholderAccount         = "adc"
 	directAccessTokenWarning      = "Note: Using direct access token (expires in ~1 hour; no auto-refresh)" //nolint:gosec // user-facing warning text, not a credential
 )
 
@@ -23,14 +24,14 @@ func requireAccount(flags *RootFlags) (string, error) {
 	if googleapi.IsADCMode() {
 		if v := flagAccount(flags); v != "" {
 			if shouldAutoSelectAccount(v) {
-				return "adc", nil
+				return adcPlaceholderAccount, nil
 			}
 			return v, nil
 		}
 		if v := strings.TrimSpace(os.Getenv("GOG_ACCOUNT")); v != "" {
 			return v, nil
 		}
-		return "adc", nil
+		return adcPlaceholderAccount, nil
 	}
 
 	client := config.DefaultClientName

--- a/internal/cmd/account.go
+++ b/internal/cmd/account.go
@@ -29,6 +29,9 @@ func requireAccount(flags *RootFlags) (string, error) {
 			return v, nil
 		}
 		if v := strings.TrimSpace(os.Getenv("GOG_ACCOUNT")); v != "" {
+			if shouldAutoSelectAccount(v) {
+				return adcPlaceholderAccount, nil
+			}
 			return v, nil
 		}
 		return adcPlaceholderAccount, nil

--- a/internal/cmd/account_test.go
+++ b/internal/cmd/account_test.go
@@ -149,6 +149,24 @@ func TestRequireAccount_ADCNilFlags(t *testing.T) {
 	}
 }
 
+func TestRequireAccount_ADCEnvAutoUsesPlaceholder(t *testing.T) {
+	t.Setenv("GOG_AUTH_MODE", "adc")
+
+	for _, value := range []string{"auto", "default"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("GOG_ACCOUNT", value)
+
+			got, err := requireAccount(nil)
+			if err != nil {
+				t.Fatalf("err: %v", err)
+			}
+			if got != adcPlaceholderAccount {
+				t.Fatalf("got %q", got)
+			}
+		})
+	}
+}
+
 func TestRequireAccount_Missing(t *testing.T) {
 	t.Setenv("GOG_ACCOUNT", "")
 	flags := &RootFlags{}

--- a/internal/cmd/backup_directory_keep.go
+++ b/internal/cmd/backup_directory_keep.go
@@ -26,7 +26,7 @@ type adminBackupMember struct {
 }
 
 func buildGroupsBackupSnapshot(ctx context.Context, flags *RootFlags, shardMaxRows int) (backup.Snapshot, error) {
-	account, err := requireAccount(flags)
+	account, err := requireGroupsAccount(flags)
 	if err != nil {
 		return backup.Snapshot{}, err
 	}

--- a/internal/cmd/calendar.go
+++ b/internal/cmd/calendar.go
@@ -22,7 +22,7 @@ type CalendarCmd struct {
 	Search          CalendarSearchCmd          `cmd:"" name:"search" aliases:"find,query" help:"Search events"`
 	Time            CalendarTimeCmd            `cmd:"" name:"time" help:"Show server time"`
 	Users           CalendarUsersCmd           `cmd:"" name:"users" help:"List workspace users (use their email as calendar ID)"`
-	Team            CalendarTeamCmd            `cmd:"" name:"team" help:"Show events for all members of a Google Group"`
+	Team            CalendarTeamCmd            `cmd:"" name:"team" help:"Show events for Workspace group members (service account, direct token, or ADC)"`
 	FocusTime       CalendarFocusTimeCmd       `cmd:"" name:"focus-time" aliases:"focus" help:"Create a Focus Time block"`
 	OOO             CalendarOOOCmd             `cmd:"" name:"out-of-office" aliases:"ooo" help:"Create an Out of Office event"`
 	WorkingLocation CalendarWorkingLocationCmd `cmd:"" name:"working-location" aliases:"wl" help:"Set working location (home/office/custom)"`

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -46,7 +46,7 @@ func (c *CalendarTeamCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Max <= 0 {
 		return usage("max must be > 0")
 	}
-	account, err := requireAccount(flags)
+	account, err := requireGroupsAccount(flags)
 	if err != nil {
 		return err
 	}
@@ -71,7 +71,7 @@ func (c *CalendarTeamCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	memberEmails, err := collectGroupMemberEmails(ctx, cloudSvc, groupEmail)
 	if err != nil {
-		return fmt.Errorf("failed to list group members: %w", err)
+		return fmt.Errorf("failed to list group members: %w", wrapCloudIdentityError(err, account))
 	}
 
 	if len(memberEmails) == 0 {

--- a/internal/cmd/calendar_team.go
+++ b/internal/cmd/calendar_team.go
@@ -46,7 +46,7 @@ func (c *CalendarTeamCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Max <= 0 {
 		return usage("max must be > 0")
 	}
-	account, err := requireGroupsAccount(flags)
+	account, err := requireGroupsAuthAccount(flags)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/execute_calendar_team_test.go
+++ b/internal/cmd/execute_calendar_team_test.go
@@ -160,6 +160,28 @@ func TestExecute_CalendarTeam_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_CalendarTeam_WrapsGroupPermissionError(t *testing.T) {
+	cloudSvc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "groups:lookup") {
+			writeGroupsPermissionError(t, w)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	calSvc, closeCal := newCalendarServiceForTest(t, withPrimaryCalendar(http.NotFoundHandler()))
+	t.Cleanup(closeCal)
+
+	result := executeCalendarTeamTest(t, []string{
+		"--account", "admin@example.com", "calendar", "team", "engineering@example.com",
+	}, calSvc, cloudSvc)
+	if result.err == nil || ExitCode(result.err) != exitCodePermissionDenied {
+		t.Fatalf("unexpected error: %v\nstderr=%q", result.err, result.stderr)
+	}
+	if !strings.Contains(result.stderr, "gog auth service-account set admin@example.com") {
+		t.Fatalf("unexpected stderr: %q", result.stderr)
+	}
+}
+
 func TestExecute_CalendarTeam_FreeBusy(t *testing.T) {
 	// Mock Cloud Identity server
 	cloudSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/execute_groups_test.go
+++ b/internal/cmd/execute_groups_test.go
@@ -123,6 +123,72 @@ func TestExecute_GroupsMembers_JSON(t *testing.T) {
 	}
 }
 
+func TestExecute_GroupsMembers_PermissionErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		failStage string
+	}{
+		{name: "lookup", failStage: "lookup"},
+		{name: "list", failStage: "list"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case strings.Contains(r.URL.Path, "groups:lookup"):
+					if tc.failStage == "lookup" {
+						writeGroupsPermissionError(t, w)
+						return
+					}
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{"name": "groups/abc123"})
+				case strings.Contains(r.URL.Path, "groups/abc123/memberships"):
+					writeGroupsPermissionError(t, w)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+
+			result := executeWithCloudIdentityTestService(t, []string{
+				"--account", "admin@example.com", "groups", "members", "engineering@example.com",
+			}, svc)
+			if result.err == nil || ExitCode(result.err) != exitCodePermissionDenied {
+				t.Fatalf("unexpected error: %v\nstderr=%q", result.err, result.stderr)
+			}
+			for _, want := range []string{
+				"Insufficient permissions for Cloud Identity API",
+				groupReadonlyScope,
+				"gog auth service-account set admin@example.com",
+			} {
+				if !strings.Contains(result.stderr, want) {
+					t.Fatalf("stderr = %q, want %q", result.stderr, want)
+				}
+			}
+			if strings.Contains(result.stderr, "gog auth add") {
+				t.Fatalf("stderr suggests unsupported OAuth recovery: %q", result.stderr)
+			}
+		})
+	}
+}
+
+func writeGroupsPermissionError(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusForbidden)
+	if err := json.NewEncoder(w).Encode(map[string]any{
+		"error": map[string]any{
+			"code":    http.StatusForbidden,
+			"message": "Request had insufficient authentication scopes.",
+			"errors": []map[string]any{{
+				"reason": "insufficientPermissions",
+			}},
+		},
+	}); err != nil {
+		t.Fatalf("encode error response: %v", err)
+	}
+}
+
 func TestExecute_GroupsList_Text(t *testing.T) {
 	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "groups/-/memberships:searchTransitiveGroups") && r.Method == http.MethodGet {

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -23,6 +23,7 @@ const (
 	groupReadonlyScope        = "https://www.googleapis.com/auth/cloud-identity.groups.readonly"
 
 	groupsWorkspaceRequiredMessage = "Cloud Identity Groups require a Google Workspace/Cloud Identity account; consumer accounts (gmail.com/googlemail.com) are not supported."
+	groupsExplicitAccountMessage   = "Groups require --account <workspace-email> when using a direct access token or Application Default Credentials."
 )
 
 type GroupsCmd struct {
@@ -129,6 +130,9 @@ func requireGroupsAccount(flags *RootFlags) (string, error) {
 	account, err := requireAccount(flags)
 	if err != nil {
 		return "", err
+	}
+	if account == accessTokenPlaceholderAccount || account == adcPlaceholderAccount {
+		return "", usage(groupsExplicitAccountMessage)
 	}
 	if isConsumerAccount(account) {
 		return "", &ExitError{

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/api/cloudidentity/v1"
 
 	"github.com/steipete/gogcli/internal/errfmt"
+	"github.com/steipete/gogcli/internal/googleapi"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -127,12 +128,15 @@ func (c *GroupsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 func requireGroupsAccount(flags *RootFlags) (string, error) {
-	account, err := requireGroupsAuthAccount(flags)
+	account, err := requireAccount(flags)
 	if err != nil {
 		return "", err
 	}
 	if account == accessTokenPlaceholderAccount || account == adcPlaceholderAccount || shouldAutoSelectAccount(account) {
 		return "", usage(groupsExplicitAccountMessage)
+	}
+	if isConsumerAccount(account) {
+		return "", groupsConsumerAccountError()
 	}
 	return account, nil
 }
@@ -142,13 +146,23 @@ func requireGroupsAuthAccount(flags *RootFlags) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	if hasDirectAccessToken(flags) {
+		return accessTokenPlaceholderAccount, nil
+	}
+	if googleapi.IsADCMode() {
+		return adcPlaceholderAccount, nil
+	}
 	if isConsumerAccount(account) {
-		return "", &ExitError{
-			Code: exitCodePermissionDenied,
-			Err:  errfmt.NewUserFacingError(groupsWorkspaceRequiredMessage, nil),
-		}
+		return "", groupsConsumerAccountError()
 	}
 	return account, nil
+}
+
+func groupsConsumerAccountError() error {
+	return &ExitError{
+		Code: exitCodePermissionDenied,
+		Err:  errfmt.NewUserFacingError(groupsWorkspaceRequiredMessage, nil),
+	}
 }
 
 // wrapCloudIdentityError provides helpful error messages for common Cloud Identity API issues.

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -127,12 +127,20 @@ func (c *GroupsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 }
 
 func requireGroupsAccount(flags *RootFlags) (string, error) {
-	account, err := requireAccount(flags)
+	account, err := requireGroupsAuthAccount(flags)
 	if err != nil {
 		return "", err
 	}
-	if account == accessTokenPlaceholderAccount || account == adcPlaceholderAccount {
+	if account == accessTokenPlaceholderAccount || account == adcPlaceholderAccount || shouldAutoSelectAccount(account) {
 		return "", usage(groupsExplicitAccountMessage)
+	}
+	return account, nil
+}
+
+func requireGroupsAuthAccount(flags *RootFlags) (string, error) {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return "", err
 	}
 	if isConsumerAccount(account) {
 		return "", &ExitError{
@@ -152,9 +160,27 @@ func wrapCloudIdentityError(err error, account string) error {
 	}
 	if strings.Contains(errStr, "insufficientPermissions") ||
 		strings.Contains(errStr, "insufficient authentication scopes") {
+		switch account {
+		case accessTokenPlaceholderAccount:
+			return errfmt.NewUserFacingError(
+				fmt.Sprintf(
+					"Insufficient permissions for Cloud Identity API; the direct access token needs Workspace Cloud Identity access and scope %s.",
+					groupReadonlyScope,
+				),
+				err,
+			)
+		case adcPlaceholderAccount:
+			return errfmt.NewUserFacingError(
+				fmt.Sprintf(
+					"Insufficient permissions for Cloud Identity API; the Application Default Credentials principal needs Workspace Cloud Identity access and scope %s. To use a stored delegated service account instead, unset GOG_AUTH_MODE and pass --account <workspace-email>.",
+					groupReadonlyScope,
+				),
+				err,
+			)
+		}
 		return errfmt.NewUserFacingError(
 			fmt.Sprintf(
-				"Insufficient permissions for Cloud Identity API; configure a Workspace service account with domain-wide delegation for %s, then run: gog auth service-account set %s --key <service-account.json>",
+				"Insufficient permissions for Cloud Identity API; the active credential needs Workspace Cloud Identity access and scope %s. Stored user OAuth is not supported. For delegated service-account auth, run: gog auth service-account set %s --key <service-account.json>. Direct-token and ADC callers must grant equivalent access to the active principal.",
 				groupReadonlyScope,
 				strings.TrimSpace(account),
 			),
@@ -206,7 +232,7 @@ func (c *GroupsMembersCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Max <= 0 {
 		return usage("max must be > 0")
 	}
-	account, err := requireGroupsAccount(flags)
+	account, err := requireGroupsAuthAccount(flags)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -20,6 +20,9 @@ const (
 
 	groupLabelDiscussionForum = "cloudidentity.googleapis.com/groups.discussion_forum"
 	groupLabelDynamic         = "cloudidentity.googleapis.com/groups.dynamic"
+	groupReadonlyScope        = "https://www.googleapis.com/auth/cloud-identity.groups.readonly"
+
+	groupsWorkspaceRequiredMessage = "Cloud Identity Groups require a Google Workspace/Cloud Identity account; consumer accounts (gmail.com/googlemail.com) are not supported."
 )
 
 type GroupsCmd struct {
@@ -39,7 +42,7 @@ func (c *GroupsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Max <= 0 {
 		return usage("max must be > 0")
 	}
-	account, err := requireAccount(flags)
+	account, err := requireGroupsAccount(flags)
 	if err != nil {
 		return err
 	}
@@ -122,6 +125,20 @@ func (c *GroupsListCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return nil
 }
 
+func requireGroupsAccount(flags *RootFlags) (string, error) {
+	account, err := requireAccount(flags)
+	if err != nil {
+		return "", err
+	}
+	if isConsumerAccount(account) {
+		return "", &ExitError{
+			Code: exitCodePermissionDenied,
+			Err:  errfmt.NewUserFacingError(groupsWorkspaceRequiredMessage, nil),
+		}
+	}
+	return account, nil
+}
+
 // wrapCloudIdentityError provides helpful error messages for common Cloud Identity API issues.
 func wrapCloudIdentityError(err error, account string) error {
 	errStr := err.Error()
@@ -131,10 +148,17 @@ func wrapCloudIdentityError(err error, account string) error {
 	}
 	if strings.Contains(errStr, "insufficientPermissions") ||
 		strings.Contains(errStr, "insufficient authentication scopes") {
-		return errfmt.NewUserFacingError("Insufficient permissions for Cloud Identity API; re-authenticate with the cloud-identity.groups.readonly scope: gog auth add <account> --services groups", err)
+		return errfmt.NewUserFacingError(
+			fmt.Sprintf(
+				"Insufficient permissions for Cloud Identity API; configure a Workspace service account with domain-wide delegation for %s, then run: gog auth service-account set %s --key <service-account.json>",
+				groupReadonlyScope,
+				strings.TrimSpace(account),
+			),
+			err,
+		)
 	}
 	if isConsumerAccount(account) && (strings.Contains(errStr, "invalid argument") || strings.Contains(errStr, "badRequest")) {
-		return errfmt.NewUserFacingError("Cloud Identity groups require a Google Workspace/Cloud Identity account; consumer accounts (gmail.com/googlemail.com) are not supported.", err)
+		return errfmt.NewUserFacingError(groupsWorkspaceRequiredMessage, err)
 	}
 	return err
 }
@@ -178,7 +202,7 @@ func (c *GroupsMembersCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Max <= 0 {
 		return usage("max must be > 0")
 	}
-	account, err := requireAccount(flags)
+	account, err := requireGroupsAccount(flags)
 	if err != nil {
 		return err
 	}
@@ -191,7 +215,7 @@ func (c *GroupsMembersCmd) Run(ctx context.Context, flags *RootFlags) error {
 	// First, look up the group by email to get its resource name
 	groupName, err := lookupGroupByEmail(ctx, svc, groupEmail)
 	if err != nil {
-		return fmt.Errorf("failed to find group %q: %w", groupEmail, err)
+		return fmt.Errorf("failed to find group %q: %w", groupEmail, wrapCloudIdentityError(err, account))
 	}
 
 	// List members of the group
@@ -204,7 +228,7 @@ func (c *GroupsMembersCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 		resp, callErr := call.Do()
 		if callErr != nil {
-			return nil, "", fmt.Errorf("failed to list members: %w", callErr)
+			return nil, "", fmt.Errorf("failed to list members: %w", wrapCloudIdentityError(callErr, account))
 		}
 		return resp.Memberships, resp.NextPageToken, nil
 	}

--- a/internal/cmd/groups.go
+++ b/internal/cmd/groups.go
@@ -146,11 +146,11 @@ func requireGroupsAuthAccount(flags *RootFlags) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if hasDirectAccessToken(flags) {
-		return accessTokenPlaceholderAccount, nil
-	}
 	if googleapi.IsADCMode() {
 		return adcPlaceholderAccount, nil
+	}
+	if hasDirectAccessToken(flags) {
+		return accessTokenPlaceholderAccount, nil
 	}
 	if isConsumerAccount(account) {
 		return "", groupsConsumerAccountError()

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -57,6 +57,59 @@ func TestGroupsInvalidMaxFailsBeforeService(t *testing.T) {
 	}
 }
 
+func TestRequireGroupsAccount_ConsumerBlocked(t *testing.T) {
+	account, err := requireGroupsAccount(&RootFlags{Account: "person@gmail.com"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if account != "" {
+		t.Fatalf("account = %q, want empty", account)
+	}
+	if ExitCode(err) != exitCodePermissionDenied {
+		t.Fatalf("exit code = %d, want %d: %v", ExitCode(err), exitCodePermissionDenied, err)
+	}
+	if !strings.Contains(err.Error(), groupsWorkspaceRequiredMessage) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestGroupsConsumerPreflightSkipsServices(t *testing.T) {
+	ctx := withCloudIdentityTestServiceFactory(
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		unexpectedCloudIdentityTestService(t, "consumer preflight must not create a Cloud Identity service"),
+	)
+	flags := &RootFlags{Account: "person@gmail.com"}
+
+	tests := []struct {
+		name string
+		run  func() error
+	}{
+		{name: "list", run: func() error { return (&GroupsListCmd{Max: 100}).Run(ctx, flags) }},
+		{name: "members", run: func() error {
+			return (&GroupsMembersCmd{GroupEmail: "engineering@example.com", Max: 100}).Run(ctx, flags)
+		}},
+		{name: "calendar team", run: func() error {
+			return (&CalendarTeamCmd{GroupEmail: "engineering@example.com", Max: 100}).Run(ctx, flags)
+		}},
+		{name: "backup", run: func() error {
+			_, err := buildGroupsBackupSnapshot(ctx, flags, 100)
+			return err
+		}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.run()
+			if err == nil || ExitCode(err) != exitCodePermissionDenied {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !strings.Contains(err.Error(), "Workspace/Cloud Identity account") {
+				t.Fatalf("unexpected guidance: %v", err)
+			}
+		})
+	}
+}
+
 func TestGroupsList_NoGroups_Text(t *testing.T) {
 	svc := newCloudIdentityTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "groups/-/memberships:searchTransitiveGroups") && r.Method == http.MethodGet {
@@ -91,7 +144,11 @@ func TestWrapCloudIdentityError_Messages(t *testing.T) {
 	}
 
 	permErr := errors.New("insufficientPermissions")
-	if err := wrapCloudIdentityError(permErr, "user@company.com"); err == nil || !strings.Contains(err.Error(), "Insufficient permissions") {
+	if err := wrapCloudIdentityError(permErr, "admin@company.com"); err == nil ||
+		!strings.Contains(err.Error(), "Insufficient permissions") ||
+		!strings.Contains(err.Error(), groupReadonlyScope) ||
+		!strings.Contains(err.Error(), "gog auth service-account set admin@company.com") ||
+		strings.Contains(err.Error(), "gog auth add") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -158,6 +158,36 @@ func TestRequireGroupsAuthAccount_AllowsADCWithoutIdentity(t *testing.T) {
 	}
 }
 
+func TestRequireGroupsAuthAccount_IgnoresIdentityHintForDirectAuth(t *testing.T) {
+	tests := []struct {
+		name        string
+		authMode    string
+		accessToken string
+		want        string
+	}{
+		{name: "direct token", accessToken: "direct-token", want: accessTokenPlaceholderAccount},
+		{name: "ADC", authMode: "adc", want: adcPlaceholderAccount},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GOG_AUTH_MODE", tc.authMode)
+			t.Setenv("GOG_ACCOUNT", "person@gmail.com")
+
+			account, err := requireGroupsAuthAccount(&RootFlags{
+				AccessToken: tc.accessToken,
+				diagnostics: io.Discard,
+			})
+			if err != nil {
+				t.Fatalf("requireGroupsAuthAccount: %v", err)
+			}
+			if account != tc.want {
+				t.Fatalf("account = %q, want %q", account, tc.want)
+			}
+		})
+	}
+}
+
 func TestGroupsConsumerPreflightSkipsServices(t *testing.T) {
 	ctx := withCloudIdentityTestServiceFactory(
 		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -73,6 +73,41 @@ func TestRequireGroupsAccount_ConsumerBlocked(t *testing.T) {
 	}
 }
 
+func TestRequireGroupsAccount_ExplicitIdentityRequiredForDirectToken(t *testing.T) {
+	t.Setenv("GOG_ACCOUNT", "")
+	t.Setenv("GOG_AUTH_MODE", "")
+
+	account, err := requireGroupsAccount(&RootFlags{
+		AccessToken: "direct-token",
+		diagnostics: io.Discard,
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if account != "" {
+		t.Fatalf("account = %q, want empty", account)
+	}
+	if ExitCode(err) != 2 || !strings.Contains(err.Error(), groupsExplicitAccountMessage) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRequireGroupsAccount_ExplicitIdentityRequiredForADC(t *testing.T) {
+	t.Setenv("GOG_AUTH_MODE", "adc")
+	t.Setenv("GOG_ACCOUNT", "")
+
+	account, err := requireGroupsAccount(&RootFlags{})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if account != "" {
+		t.Fatalf("account = %q, want empty", account)
+	}
+	if ExitCode(err) != 2 || !strings.Contains(err.Error(), groupsExplicitAccountMessage) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestGroupsConsumerPreflightSkipsServices(t *testing.T) {
 	ctx := withCloudIdentityTestServiceFactory(
 		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -94,17 +94,22 @@ func TestRequireGroupsAccount_ExplicitIdentityRequiredForDirectToken(t *testing.
 
 func TestRequireGroupsAccount_ExplicitIdentityRequiredForADC(t *testing.T) {
 	t.Setenv("GOG_AUTH_MODE", "adc")
-	t.Setenv("GOG_ACCOUNT", "")
 
-	account, err := requireGroupsAccount(&RootFlags{})
-	if err == nil {
-		t.Fatal("expected error")
-	}
-	if account != "" {
-		t.Fatalf("account = %q, want empty", account)
-	}
-	if ExitCode(err) != 2 || !strings.Contains(err.Error(), groupsExplicitAccountMessage) {
-		t.Fatalf("unexpected error: %v", err)
+	for _, value := range []string{"", "auto", "default"} {
+		t.Run(value, func(t *testing.T) {
+			t.Setenv("GOG_ACCOUNT", value)
+
+			account, err := requireGroupsAccount(&RootFlags{})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if account != "" {
+				t.Fatalf("account = %q, want empty", account)
+			}
+			if ExitCode(err) != 2 || !strings.Contains(err.Error(), groupsExplicitAccountMessage) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -167,6 +167,7 @@ func TestRequireGroupsAuthAccount_IgnoresIdentityHintForDirectAuth(t *testing.T)
 	}{
 		{name: "direct token", accessToken: "direct-token", want: accessTokenPlaceholderAccount},
 		{name: "ADC", authMode: "adc", want: adcPlaceholderAccount},
+		{name: "ADC over direct token", authMode: "adc", accessToken: "direct-token", want: adcPlaceholderAccount},
 	}
 
 	for _, tc := range tests {

--- a/internal/cmd/groups_validation_more_test.go
+++ b/internal/cmd/groups_validation_more_test.go
@@ -108,6 +108,56 @@ func TestRequireGroupsAccount_ExplicitIdentityRequiredForADC(t *testing.T) {
 	}
 }
 
+func TestRequireGroupsAccount_ExplicitIdentityRequiredForADCAutoEnv(t *testing.T) {
+	t.Setenv("GOG_AUTH_MODE", "adc")
+
+	for _, accountEnv := range []string{"auto", "default"} {
+		t.Run(accountEnv, func(t *testing.T) {
+			t.Setenv("GOG_ACCOUNT", accountEnv)
+
+			account, err := requireGroupsAccount(&RootFlags{})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if account != "" {
+				t.Fatalf("account = %q, want empty", account)
+			}
+			if ExitCode(err) != 2 || !strings.Contains(err.Error(), groupsExplicitAccountMessage) {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestRequireGroupsAuthAccount_AllowsDirectTokenWithoutIdentity(t *testing.T) {
+	t.Setenv("GOG_ACCOUNT", "")
+	t.Setenv("GOG_AUTH_MODE", "")
+
+	account, err := requireGroupsAuthAccount(&RootFlags{
+		AccessToken: "direct-token",
+		diagnostics: io.Discard,
+	})
+	if err != nil {
+		t.Fatalf("requireGroupsAuthAccount: %v", err)
+	}
+	if account != accessTokenPlaceholderAccount {
+		t.Fatalf("account = %q, want %q", account, accessTokenPlaceholderAccount)
+	}
+}
+
+func TestRequireGroupsAuthAccount_AllowsADCWithoutIdentity(t *testing.T) {
+	t.Setenv("GOG_AUTH_MODE", "adc")
+	t.Setenv("GOG_ACCOUNT", "")
+
+	account, err := requireGroupsAuthAccount(&RootFlags{})
+	if err != nil {
+		t.Fatalf("requireGroupsAuthAccount: %v", err)
+	}
+	if account != adcPlaceholderAccount {
+		t.Fatalf("account = %q, want %q", account, adcPlaceholderAccount)
+	}
+}
+
 func TestGroupsConsumerPreflightSkipsServices(t *testing.T) {
 	ctx := withCloudIdentityTestServiceFactory(
 		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
@@ -190,6 +240,24 @@ func TestWrapCloudIdentityError_Messages(t *testing.T) {
 	other := errors.New("other")
 	if err := wrapCloudIdentityError(other, "user@company.com"); err == nil || err.Error() != "other" {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestWrapCloudIdentityError_AuthModeGuidance(t *testing.T) {
+	permissionErr := errors.New("insufficientPermissions")
+
+	directErr := wrapCloudIdentityError(permissionErr, accessTokenPlaceholderAccount)
+	if !strings.Contains(directErr.Error(), "direct access token") ||
+		!strings.Contains(directErr.Error(), groupReadonlyScope) ||
+		strings.Contains(directErr.Error(), "service-account set access-token-user") {
+		t.Fatalf("unexpected direct-token guidance: %v", directErr)
+	}
+
+	adcErr := wrapCloudIdentityError(permissionErr, adcPlaceholderAccount)
+	if !strings.Contains(adcErr.Error(), "Application Default Credentials principal") ||
+		!strings.Contains(adcErr.Error(), "unset GOG_AUTH_MODE") ||
+		strings.Contains(adcErr.Error(), "service-account set adc") {
+		t.Fatalf("unexpected ADC guidance: %v", adcErr)
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -74,7 +74,7 @@ type CLI struct {
 	Auth          AuthCmd               `cmd:"" help:"Auth and credentials"`
 	Backup        BackupCmd             `cmd:"" help:"Encrypted Google account backups"`
 	Batch         BatchCmd              `cmd:"" help:"Build and submit persisted Google Docs request batches"`
-	Groups        GroupsCmd             `cmd:"" aliases:"group" help:"Google Groups"`
+	Groups        GroupsCmd             `cmd:"" aliases:"group" help:"Cloud Identity Groups (Workspace only)"`
 	Admin         AdminCmd              `cmd:"" help:"Google Workspace Admin (Directory API) - requires domain-wide delegation"`
 	Drive         DriveCmd              `cmd:"" aliases:"drv" help:"Google Drive"`
 	Docs          DocsCmd               `cmd:"" aliases:"doc" help:"Google Docs (export via Drive)"`

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -42,6 +42,9 @@ func TestExecute_Help(t *testing.T) {
 	if strings.Contains(out, "Search Console/Ads/") || strings.Contains(out, "searchconsole/ads/") {
 		t.Fatalf("root help must not advertise ads as a command service, got: %q", out)
 	}
+	if !strings.Contains(out, "Cloud Identity Groups (Workspace only)") {
+		t.Fatalf("root help must identify Groups as Workspace-only, got: %q", out)
+	}
 }
 
 func TestExecute_NoArgsShowsHelp(t *testing.T) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -143,15 +143,6 @@ func (s *ConfigStore) write(cfg File) error {
 	return nil
 }
 
-func UpdateConfig(update func(*File) error) error {
-	store, err := defaultConfigStore()
-	if err != nil {
-		return err
-	}
-
-	return store.Update(update)
-}
-
 func (s *ConfigStore) Update(update func(*File) error) error {
 	unlock, err := s.acquireLock()
 	if err != nil {

--- a/internal/errfmt/errfmt_test.go
+++ b/internal/errfmt/errfmt_test.go
@@ -35,7 +35,7 @@ func TestFormat_AuthRequired(t *testing.T) {
 }
 
 func TestFormat_AuthRequired_ServiceAccountOnly(t *testing.T) {
-	for _, service := range []string{"admin", "admin directory", "admin orgunits"} {
+	for _, service := range []string{"admin", "admin directory", "admin orgunits", "groups", "keep"} {
 		t.Run(service, func(t *testing.T) {
 			err := &gogapi.AuthRequiredError{Service: service, Email: "a@b.com", Cause: keyring.ErrKeyNotFound}
 			got := Format(err)

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/option"
 
+	"github.com/steipete/gogcli/internal/authclient"
 	"github.com/steipete/gogcli/internal/googleauth"
 )
 
@@ -90,6 +91,22 @@ func newGoogleServiceForRequiredScopes[T any](
 	return newGoogleService(ctx, errorLabel, opts, factory)
 }
 
+func newGoogleServiceForServiceAccountScopes[T any](
+	ctx context.Context,
+	email string,
+	serviceLabel string,
+	errorLabel string,
+	scopes []string,
+	factory googleServiceFactory[T],
+) (*T, error) {
+	opts, err := optionsForServiceAccountScopes(ctx, serviceLabel, email, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("%s options: %w", errorLabel, err)
+	}
+
+	return newGoogleService(ctx, errorLabel, opts, factory)
+}
+
 func newGoogleService[T any](
 	ctx context.Context,
 	label string,
@@ -156,6 +173,47 @@ func optionsForAccountScopes(ctx context.Context, serviceLabel string, email str
 
 func optionsForAccountScopesRequiringStoredGrant(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
 	return optionsForAccountScopesWithStoredScopeCheck(ctx, serviceLabel, email, scopes, true)
+}
+
+func optionsForServiceAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
+	if accessToken := authclient.AccessTokenFromContext(ctx); accessToken != "" {
+		slog.Debug("using direct access token", "serviceLabel", serviceLabel)
+
+		return tokenSourceClientOptions(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})), nil
+	}
+
+	if IsADCMode() {
+		slog.Debug("using Application Default Credentials (GOG_AUTH_MODE=adc)", "serviceLabel", serviceLabel)
+
+		ts, err := newADCTokenSource(ctx, scopes...)
+		if err != nil {
+			return nil, fmt.Errorf("ADC token source: %w", err)
+		}
+
+		return tokenSourceClientOptions(ts), nil
+	}
+
+	ts, path, ok, err := tokenSourceForServiceAccountScopes(ctx, serviceLabel, email, scopes)
+	if err != nil {
+		return nil, fmt.Errorf("service account token source: %w", err)
+	}
+
+	if !ok {
+		return nil, &AuthRequiredError{Service: serviceLabel, Email: email}
+	}
+
+	slog.Debug("using required service account credentials", "email", email, "path", path)
+
+	return tokenSourceClientOptions(ts), nil
+}
+
+func tokenSourceClientOptions(ts oauth2.TokenSource) []option.ClientOption {
+	return []option.ClientOption{option.WithHTTPClient(&http.Client{
+		Transport: NewRetryTransport(&oauth2.Transport{
+			Source: ts,
+			Base:   newBaseTransport(),
+		}),
+	})}
 }
 
 func optionsForAccountScopesWithStoredScopeCheck(

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -176,12 +176,6 @@ func optionsForAccountScopesRequiringStoredGrant(ctx context.Context, serviceLab
 }
 
 func optionsForServiceAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {
-	if accessToken := authclient.AccessTokenFromContext(ctx); accessToken != "" {
-		slog.Debug("using direct access token", "serviceLabel", serviceLabel)
-
-		return tokenSourceClientOptions(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})), nil
-	}
-
 	if IsADCMode() {
 		slog.Debug("using Application Default Credentials (GOG_AUTH_MODE=adc)", "serviceLabel", serviceLabel)
 
@@ -191,6 +185,12 @@ func optionsForServiceAccountScopes(ctx context.Context, serviceLabel string, em
 		}
 
 		return tokenSourceClientOptions(ts), nil
+	}
+
+	if accessToken := authclient.AccessTokenFromContext(ctx); accessToken != "" {
+		slog.Debug("using direct access token", "serviceLabel", serviceLabel)
+
+		return tokenSourceClientOptions(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})), nil
 	}
 
 	ts, path, ok, err := tokenSourceForServiceAccountScopes(ctx, serviceLabel, email, scopes)

--- a/internal/googleapi/cloudidentity.go
+++ b/internal/googleapi/cloudidentity.go
@@ -13,5 +13,5 @@ const (
 // NewCloudIdentityGroups creates a Cloud Identity service for reading groups.
 // This API allows non-admin users to list groups they belong to and view group members.
 func NewCloudIdentityGroups(ctx context.Context, email string) (*cloudidentity.Service, error) {
-	return newGoogleServiceForScopes(ctx, email, "cloudidentity", "cloudidentity", []string{scopeCloudIdentityGroupsRO}, cloudidentity.NewService)
+	return newGoogleServiceForScopes(ctx, email, "groups", "cloudidentity", []string{scopeCloudIdentityGroupsRO}, cloudidentity.NewService)
 }

--- a/internal/googleapi/cloudidentity.go
+++ b/internal/googleapi/cloudidentity.go
@@ -13,5 +13,5 @@ const (
 // NewCloudIdentityGroups creates a Cloud Identity service for reading groups.
 // This API allows non-admin users to list groups they belong to and view group members.
 func NewCloudIdentityGroups(ctx context.Context, email string) (*cloudidentity.Service, error) {
-	return newGoogleServiceForScopes(ctx, email, "groups", "cloudidentity", []string{scopeCloudIdentityGroupsRO}, cloudidentity.NewService)
+	return newGoogleServiceForServiceAccountScopes(ctx, email, "groups", "cloudidentity", []string{scopeCloudIdentityGroupsRO}, cloudidentity.NewService)
 }

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -2,9 +2,12 @@ package googleapi
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/99designs/keyring"
 
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/googleauth"
@@ -108,6 +111,37 @@ func TestNewKeepWithServiceAccountErrors(t *testing.T) {
 
 	if !strings.Contains(err.Error(), "read service account file") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNewCloudIdentityGroupsAuthErrorUsesGroupsLabel(t *testing.T) {
+	origRead := readClientCredentials
+	origOpen := openSecretsStore
+
+	t.Cleanup(func() {
+		readClientCredentials = origRead
+		openSecretsStore = origOpen
+	})
+
+	readClientCredentials = func(string) (config.ClientCredentials, error) {
+		return config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}, nil
+	}
+	openSecretsStore = func() (secrets.Store, error) {
+		return &stubStore{err: keyring.ErrKeyNotFound}, nil
+	}
+
+	_, err := NewCloudIdentityGroups(testClientResolverContext(), "admin@example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	var authErr *AuthRequiredError
+	if !errors.As(err, &authErr) {
+		t.Fatalf("expected AuthRequiredError, got %T: %v", err, err)
+	}
+
+	if authErr.Service != "groups" {
+		t.Fatalf("service = %q, want groups", authErr.Service)
 	}
 }
 

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -3,12 +3,14 @@ package googleapi
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	"github.com/99designs/keyring"
+	"golang.org/x/oauth2"
 
+	"github.com/steipete/gogcli/internal/authclient"
 	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/googleauth"
 	"github.com/steipete/gogcli/internal/secrets"
@@ -86,10 +88,6 @@ func TestNewServicesWithStoredToken(t *testing.T) {
 		t.Fatalf("NewKeep: %v", err)
 	}
 
-	if _, err := NewCloudIdentityGroups(ctx, "a@b.com"); err != nil {
-		t.Fatalf("NewCloudIdentityGroups: %v", err)
-	}
-
 	if _, err := NewPeopleContacts(ctx, "a@b.com"); err != nil {
 		t.Fatalf("NewPeopleContacts: %v", err)
 	}
@@ -115,6 +113,10 @@ func TestNewKeepWithServiceAccountErrors(t *testing.T) {
 }
 
 func TestNewCloudIdentityGroupsAuthErrorUsesGroupsLabel(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
 	origRead := readClientCredentials
 	origOpen := openSecretsStore
 
@@ -124,10 +126,12 @@ func TestNewCloudIdentityGroupsAuthErrorUsesGroupsLabel(t *testing.T) {
 	})
 
 	readClientCredentials = func(string) (config.ClientCredentials, error) {
-		return config.ClientCredentials{ClientID: "id", ClientSecret: "secret"}, nil
+		t.Fatal("OAuth client credentials must not be read for Groups")
+		return config.ClientCredentials{}, errBoom
 	}
 	openSecretsStore = func() (secrets.Store, error) {
-		return &stubStore{err: keyring.ErrKeyNotFound}, nil
+		t.Fatal("OAuth token store must not be opened for Groups")
+		return nil, errBoom
 	}
 
 	_, err := NewCloudIdentityGroups(testClientResolverContext(), "admin@example.com")
@@ -142,6 +146,77 @@ func TestNewCloudIdentityGroupsAuthErrorUsesGroupsLabel(t *testing.T) {
 
 	if authErr.Service != "groups" {
 		t.Fatalf("service = %q, want groups", authErr.Service)
+	}
+}
+
+func TestNewCloudIdentityGroupsUsesDirectToken(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	ctx := authclient.WithAccessToken(testClientResolverContext(), "direct-token")
+
+	if _, err := NewCloudIdentityGroups(ctx, "admin@example.com"); err != nil {
+		t.Fatalf("NewCloudIdentityGroups: %v", err)
+	}
+}
+
+func TestNewCloudIdentityGroupsUsesADC(t *testing.T) {
+	t.Setenv("GOG_AUTH_MODE", "adc")
+
+	origADC := newADCTokenSource
+
+	t.Cleanup(func() { newADCTokenSource = origADC })
+
+	newADCTokenSource = func(_ context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		if len(scopes) != 1 || scopes[0] != scopeCloudIdentityGroupsRO {
+			t.Fatalf("scopes = %#v", scopes)
+		}
+
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "adc-token"}), nil
+	}
+
+	if _, err := NewCloudIdentityGroups(testClientResolverContext(), "admin@example.com"); err != nil {
+		t.Fatalf("NewCloudIdentityGroups: %v", err)
+	}
+}
+
+func TestNewCloudIdentityGroupsUsesRequiredServiceAccount(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg-config"))
+
+	saPath, err := config.ServiceAccountPath("admin@example.com")
+	if err != nil {
+		t.Fatalf("ServiceAccountPath: %v", err)
+	}
+
+	if _, err := config.EnsureDataDir(); err != nil {
+		t.Fatalf("EnsureDataDir: %v", err)
+	}
+
+	if err := os.WriteFile(saPath, []byte(`{"type":"service_account"}`), 0o600); err != nil {
+		t.Fatalf("write service account: %v", err)
+	}
+
+	origSA := newServiceAccountTokenSource
+
+	t.Cleanup(func() { newServiceAccountTokenSource = origSA })
+
+	newServiceAccountTokenSource = func(_ context.Context, _ []byte, subject string, scopes []string) (oauth2.TokenSource, error) {
+		if subject != "admin@example.com" {
+			t.Fatalf("subject = %q", subject)
+		}
+
+		if len(scopes) != 1 || scopes[0] != scopeCloudIdentityGroupsRO {
+			t.Fatalf("scopes = %#v", scopes)
+		}
+
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "service-account-token"}), nil
+	}
+
+	if _, err := NewCloudIdentityGroups(testClientResolverContext(), "admin@example.com"); err != nil {
+		t.Fatalf("NewCloudIdentityGroups: %v", err)
 	}
 }
 

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -181,6 +181,32 @@ func TestNewCloudIdentityGroupsUsesADC(t *testing.T) {
 	}
 }
 
+func TestNewCloudIdentityGroupsADCPrecedesDirectToken(t *testing.T) {
+	t.Setenv("GOG_AUTH_MODE", "adc")
+
+	origADC := newADCTokenSource
+
+	t.Cleanup(func() { newADCTokenSource = origADC })
+
+	adcCalled := false
+	newADCTokenSource = func(_ context.Context, scopes ...string) (oauth2.TokenSource, error) {
+		adcCalled = true
+		if len(scopes) != 1 || scopes[0] != scopeCloudIdentityGroupsRO {
+			t.Fatalf("scopes = %#v", scopes)
+		}
+
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "adc-token"}), nil
+	}
+
+	ctx := authclient.WithAccessToken(testClientResolverContext(), "direct-token")
+	if _, err := NewCloudIdentityGroups(ctx, "admin@example.com"); err != nil {
+		t.Fatalf("NewCloudIdentityGroups: %v", err)
+	}
+	if !adcCalled {
+		t.Fatal("expected ADC token source to take precedence")
+	}
+}
+
 func TestNewCloudIdentityGroupsUsesRequiredServiceAccount(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/googleapi/services_more_test.go
+++ b/internal/googleapi/services_more_test.go
@@ -191,6 +191,7 @@ func TestNewCloudIdentityGroupsADCPrecedesDirectToken(t *testing.T) {
 	adcCalled := false
 	newADCTokenSource = func(_ context.Context, scopes ...string) (oauth2.TokenSource, error) {
 		adcCalled = true
+
 		if len(scopes) != 1 || scopes[0] != scopeCloudIdentityGroupsRO {
 			t.Fatalf("scopes = %#v", scopes)
 		}
@@ -202,6 +203,7 @@ func TestNewCloudIdentityGroupsADCPrecedesDirectToken(t *testing.T) {
 	if _, err := NewCloudIdentityGroups(ctx, "admin@example.com"); err != nil {
 		t.Fatalf("NewCloudIdentityGroups: %v", err)
 	}
+
 	if !adcCalled {
 		t.Fatal("expected ADC token source to take precedence")
 	}

--- a/internal/oauthclient/credentials.go
+++ b/internal/oauthclient/credentials.go
@@ -85,15 +85,6 @@ func (s *CredentialsStore) PathFor(client string) (string, error) {
 	return path, nil
 }
 
-func WriteClientCredentialsFor(client string, creds config.ClientCredentials, insecure bool) error {
-	store, err := defaultCredentialsStore()
-	if err != nil {
-		return err
-	}
-
-	return store.Write(client, creds, insecure)
-}
-
 func (s *CredentialsStore) Write(client string, creds config.ClientCredentials, insecure bool) error {
 	normalized, err := config.NormalizeClientNameOrDefault(client)
 	if err != nil {
@@ -159,15 +150,6 @@ func (s *CredentialsStore) Read(client string) (config.ClientCredentials, error)
 		return config.ClientCredentials{}, errEmptyClientSecret
 	}
 	return creds, nil
-}
-
-func DeleteClientCredentialsFor(client string) error {
-	store, err := defaultCredentialsStore()
-	if err != nil {
-		return err
-	}
-
-	return store.Delete(client)
 }
 
 func (s *CredentialsStore) Delete(client string) error {


### PR DESCRIPTION
## Summary

- reject consumer Google accounts before Cloud Identity Groups API calls across `groups`, `calendar team`, and groups backup paths
- replace the impossible OAuth recovery command with Workspace service-account and domain-wide delegation guidance for the exact account and required scope
- classify missing Groups auth under the service-account-only `groups` label and wrap lookup/member-list permission failures consistently
- prevent stored user OAuth from being used for Groups while preserving explicit direct-token and ADC auth
- require `--account <workspace-email>` for direct-token/ADC Groups commands, including `GOG_ACCOUNT=auto/default`
- identify Groups as Workspace-only in CLI help and document setup for direct commands and backups

## Verification

- `make ci`
- autoreview: clean, no actionable findings
- live with isolated `clawdbot@gmail.com` credentials:
  - `groups list`, `groups members`, `calendar team`, and groups-only backup reject the consumer account before API access with exit 6
  - a Workspace-looking account without credentials exits 4 and prints `gog auth service-account set admin@example.com --key <service-account.json>`
  - direct-token and ADC auth without an explicit Workspace account exit 2 before API access
  - direct-token auth with `--account admin@example.com` reaches Cloud Identity rather than falling back to stored OAuth
  - ADC with `GOG_ACCOUNT=auto` or `default` exits 2 with the explicit-account requirement
  - `gog auth add admin@example.com --services groups` remains rejected as service-account-only with exit 2
- mocked coverage for service-account/direct-token/ADC construction, Cloud Identity 403s, membership listing, and Calendar team propagation
