### PR TITLE
fix(auth): make credential dry-run side-effect free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Auth: make `auth credentials set --dry-run` preview credential and domain writes without opening the keyring or changing files, and validate every domain before storing credentials.
 - CLI: replace the stale hard-coded `--account` service list with concise email, alias, and auto-selection guidance that applies across authenticated Google API commands.
 - Calendar: remove the dead `calendar appointments` command, which could only report an API limitation; existing invocations now return unknown-command usage, while the limitation remains documented.
 - Drive: preserve repeated folder placements in tree, inventory, and size summaries; reject cyclic folder graphs instead of collapsing paths or scanning indefinitely.

--- a/internal/cmd/auth_credentials.go
+++ b/internal/cmd/auth_credentials.go
@@ -32,7 +32,7 @@ type AuthCredentialsSetCmd struct {
 	Insecure  bool   `name:"insecure" help:"Store OAuth client_secret in credentials.json instead of the keyring"`
 }
 
-func (c *AuthCredentialsSetCmd) Run(ctx context.Context, _ *RootFlags) error {
+func (c *AuthCredentialsSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	client, err := normalizeClientForFlag(authclient.ClientOverrideFromContext(ctx))
 	if err != nil {
@@ -60,6 +60,37 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context, _ *RootFlags) error {
 		return err
 	}
 
+	domains := splitCommaList(c.Domains)
+	var (
+		configStore *config.ConfigStore
+		cfg         config.File
+	)
+	if len(domains) > 0 {
+		configStore, err = commandConfigStore(ctx)
+		if err != nil {
+			return err
+		}
+		cfg, err = configStore.Read()
+		if err != nil {
+			return err
+		}
+		for _, domain := range domains {
+			if setErr := config.SetClientDomain(&cfg, domain, client); setErr != nil {
+				return setErr
+			}
+		}
+	}
+
+	if dryRunErr := dryRunExit(ctx, flags, "auth.credentials.set", map[string]any{
+		"client":                   client,
+		"credentials_source":       inPath,
+		"domains":                  domains,
+		"expand_env":               c.ExpandEnv,
+		"client_secret_in_keyring": !c.Insecure,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
 	credentialStore, err := commandOAuthCredentialsStore(ctx)
 	if err != nil {
 		return err
@@ -72,20 +103,7 @@ func (c *AuthCredentialsSetCmd) Run(ctx context.Context, _ *RootFlags) error {
 	if err != nil {
 		return err
 	}
-	if strings.TrimSpace(c.Domains) != "" {
-		configStore, err := commandConfigStore(ctx)
-		if err != nil {
-			return err
-		}
-		cfg, err := configStore.Read()
-		if err != nil {
-			return err
-		}
-		for _, domain := range splitCommaList(c.Domains) {
-			if err := config.SetClientDomain(&cfg, domain, client); err != nil {
-				return err
-			}
-		}
+	if configStore != nil {
 		if err := configStore.Write(cfg); err != nil {
 			return err
 		}

--- a/internal/cmd/execute_auth_credentials_test.go
+++ b/internal/cmd/execute_auth_credentials_test.go
@@ -162,6 +162,119 @@ func TestExecute_AuthCredentials_UsesInjectedStores(t *testing.T) {
 	}
 }
 
+func TestExecute_AuthCredentials_DryRunDoesNotWriteOrOpenSecretStore(t *testing.T) {
+	root := t.TempDir()
+	layout := config.Layout{
+		ConfigDir:      filepath.Join(root, "config"),
+		DataDir:        filepath.Join(root, "data"),
+		ExplicitConfig: true,
+		ExplicitData:   true,
+	}
+	configStore := config.NewConfigStore(layout)
+	in := filepath.Join(t.TempDir(), "creds.json")
+	if err := os.WriteFile(in, []byte(`{"installed":{"client_id":"id","client_secret":"super-secret-value"}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	secretStoreOpened := false
+	runtime := &app.Runtime{
+		IO: app.IO{
+			In:  strings.NewReader(""),
+			Out: &stdout,
+			Err: &stderr,
+		},
+		Config: configStore,
+		Auth: app.AuthOperations{
+			OpenSecretStore: func() (secrets.SecretStore, error) {
+				secretStoreOpened = true
+				return nil, errors.New("unexpected secret store open")
+			},
+		},
+	}
+	if err := executeWithRuntime([]string{"--json", "--dry-run", "--client", "work", "auth", "credentials", in, "--domain", "example.com"}, runtime); err != nil {
+		t.Fatalf("executeWithRuntime: %v\nstderr=%s", err, stderr.String())
+	}
+	if secretStoreOpened {
+		t.Fatal("dry-run opened the secret store")
+	}
+
+	var result struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			Client                string   `json:"client"`
+			Domains               []string `json:"domains"`
+			ClientSecretInKeyring bool     `json:"client_secret_in_keyring"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, stdout.String())
+	}
+	if !result.DryRun || result.Op != "auth.credentials.set" || result.Request.Client != "work" {
+		t.Fatalf("unexpected dry-run result: %#v", result)
+	}
+	if len(result.Request.Domains) != 1 || result.Request.Domains[0] != "example.com" || !result.Request.ClientSecretInKeyring {
+		t.Fatalf("unexpected dry-run request: %#v", result.Request)
+	}
+	if strings.Contains(stdout.String(), "super-secret-value") {
+		t.Fatalf("dry-run output leaked client secret: %s", stdout.String())
+	}
+	if _, err := os.Stat(configStore.Path()); !os.IsNotExist(err) {
+		t.Fatalf("dry-run wrote config: %v", err)
+	}
+	metadataPath, err := config.NewClientCredentialsStore(layout).PathFor("work")
+	if err != nil {
+		t.Fatalf("credential metadata path: %v", err)
+	}
+	if _, err := os.Stat(metadataPath); !os.IsNotExist(err) {
+		t.Fatalf("dry-run wrote credential metadata: %v", err)
+	}
+}
+
+func TestExecute_AuthCredentials_InvalidDomainDoesNotWrite(t *testing.T) {
+	root := t.TempDir()
+	layout := config.Layout{
+		ConfigDir:      filepath.Join(root, "config"),
+		DataDir:        filepath.Join(root, "data"),
+		ExplicitConfig: true,
+		ExplicitData:   true,
+	}
+	configStore := config.NewConfigStore(layout)
+	in := filepath.Join(t.TempDir(), "creds.json")
+	if err := os.WriteFile(in, []byte(`{"installed":{"client_id":"id","client_secret":"sec"}}`), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	secretStoreOpened := false
+	runtime := &app.Runtime{
+		Config: configStore,
+		Auth: app.AuthOperations{
+			OpenSecretStore: func() (secrets.SecretStore, error) {
+				secretStoreOpened = true
+				return nil, errors.New("unexpected secret store open")
+			},
+		},
+	}
+	err := executeWithRuntime([]string{"--client", "work", "auth", "credentials", in, "--domain", "bad domain"}, runtime)
+	if err == nil {
+		t.Fatal("expected invalid domain error")
+	}
+	if secretStoreOpened {
+		t.Fatal("invalid domain opened the secret store")
+	}
+	if _, err := os.Stat(configStore.Path()); !os.IsNotExist(err) {
+		t.Fatalf("invalid domain wrote config: %v", err)
+	}
+	metadataPath, pathErr := config.NewClientCredentialsStore(layout).PathFor("work")
+	if pathErr != nil {
+		t.Fatalf("credential metadata path: %v", pathErr)
+	}
+	if _, err := os.Stat(metadataPath); !os.IsNotExist(err) {
+		t.Fatalf("invalid domain wrote credential metadata: %v", err)
+	}
+}
+
 func TestExecute_AuthCredentials_Stdin_JSON(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

- make `auth credentials set --dry-run` emit a redacted plan without opening the keyring or writing credentials/config
- validate all `--domain` values before any credential write
- add no-write and no-secret-leak regression coverage

## Verification

- `go test ./internal/cmd -run 'TestExecute_AuthCredentials_(DryRunDoesNotWriteOrOpenSecretStore|InvalidDomainDoesNotWrite|UsesInjectedStores)$'`
- `make ci`
- structured autoreview: clean
- isolated binary smoke: dry-run wrote zero files; invalid domain exited 1 and wrote zero files
