### PR TITLE
fix(cli): keep output dry-runs side-effect free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Dry-run safety: keep Drive, Contacts, Slides thumbnail, backup plaintext, OAuth token, Gmail filter, Photos, and Photos Picker downloads/exports offline and prevent local file or secret output.
 - Auth: make `auth credentials set --dry-run` preview credential and domain writes without opening the keyring or changing files, and validate every domain before storing credentials.
 - CLI: replace the stale hard-coded `--account` service list with concise email, alias, and auto-selection guidance that applies across authenticated Google API commands.
 - Calendar: remove the dead `calendar appointments` command, which could only report an API limitation; existing invocations now return unknown-command usage, while the limitation remains documented.

--- a/internal/cmd/auth_tokens.go
+++ b/internal/cmd/auth_tokens.go
@@ -123,7 +123,7 @@ type tokenNoMigrateGetter interface {
 	GetTokenNoMigrate(client string, email string) (secrets.Token, error)
 }
 
-func (c *AuthTokensExportCmd) Run(ctx context.Context, _ *RootFlags) error {
+func (c *AuthTokensExportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	email := strings.TrimSpace(c.Email)
 	if email == "" {
@@ -132,6 +132,18 @@ func (c *AuthTokensExportCmd) Run(ctx context.Context, _ *RootFlags) error {
 	outPath := strings.TrimSpace(c.Output.Path)
 	if outPath == "" {
 		return usage("empty outPath")
+	}
+	outPath, err := config.ExpandPath(outPath)
+	if err != nil {
+		return err
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "auth.tokens.export", map[string]any{
+		"email":            email,
+		"out":              outPath,
+		"overwrite":        c.Overwrite,
+		"contains_secrets": true,
+	}); dryRunErr != nil {
+		return dryRunErr
 	}
 
 	store, err := openAuthSecretsStore(ctx)

--- a/internal/cmd/backup_cmd_test.go
+++ b/internal/cmd/backup_cmd_test.go
@@ -176,7 +176,7 @@ func TestBackupExportReportsManifestSemanticCounts(t *testing.T) {
 	err = (&BackupExportCmd{
 		backupReadFlags: backupReadFlags{Config: config, Repo: repo, NoPull: true},
 		Out:             filepath.Join(t.TempDir(), "export"),
-	}).Run(newCmdOutputContext(t, &stdout, io.Discard))
+	}).Run(newCmdOutputContext(t, &stdout, io.Discard), &RootFlags{})
 	if err != nil {
 		t.Fatalf("BackupExportCmd.Run: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestBackupExportReportsManifestCountsForSemanticCollisions(t *testing.T) {
 	err = (&BackupExportCmd{
 		backupReadFlags: backupReadFlags{Config: config, Repo: repo, NoPull: true},
 		Out:             filepath.Join(t.TempDir(), "export"),
-	}).Run(newCmdOutputContext(t, &stdout, io.Discard))
+	}).Run(newCmdOutputContext(t, &stdout, io.Discard), &RootFlags{})
 	if err != nil {
 		t.Fatalf("BackupExportCmd.Run: %v", err)
 	}

--- a/internal/cmd/backup_export.go
+++ b/internal/cmd/backup_export.go
@@ -24,12 +24,39 @@ type BackupCatCmd struct {
 	Out    string `name:"out" help:"Write decrypted JSONL to this file instead of stdout"`
 }
 
-func (c *BackupCatCmd) Run(ctx context.Context) error {
+func (c *BackupCatCmd) Run(ctx context.Context, flags *RootFlags) error {
+	shardPath := strings.TrimSpace(c.Shard)
+	if shardPath == "" {
+		return usage("empty shard")
+	}
 	opts := c.options()
 	if err := bindBackupConfigStore(ctx, &opts); err != nil {
 		return err
 	}
-	shard, err := backup.Cat(ctx, opts, c.Shard)
+	outPath := strings.TrimSpace(c.Out)
+	if outPath != "" {
+		var expandErr error
+		outPath, expandErr = expandUserPath(outPath)
+		if expandErr != nil {
+			return expandErr
+		}
+	}
+	if flags != nil && flags.DryRun {
+		cfg, resolveErr := backup.ResolveOptions(opts)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		if dryRunErr := dryRunExit(ctx, flags, "backup.cat", map[string]any{
+			"shard":  shardPath,
+			"out":    outputPathOrStdout(outPath),
+			"pretty": c.Pretty,
+			"repo":   cfg.Repo,
+			"pull":   !c.NoPull,
+		}); dryRunErr != nil {
+			return dryRunErr
+		}
+	}
+	shard, err := backup.Cat(ctx, opts, shardPath)
 	if err != nil {
 		return err
 	}
@@ -40,15 +67,11 @@ func (c *BackupCatCmd) Run(ctx context.Context) error {
 			return fmt.Errorf("pretty-print shard: %w", err)
 		}
 	}
-	if strings.TrimSpace(c.Out) != "" {
-		out, expandErr := expandUserPath(c.Out)
-		if expandErr != nil {
-			return expandErr
-		}
-		if mkdirErr := os.MkdirAll(filepath.Dir(out), 0o700); mkdirErr != nil {
+	if outPath != "" {
+		if mkdirErr := os.MkdirAll(filepath.Dir(outPath), 0o700); mkdirErr != nil {
 			return mkdirErr
 		}
-		return os.WriteFile(out, data, 0o600)
+		return os.WriteFile(outPath, data, 0o600)
 	}
 	_, err = stdoutWriter(ctx).Write(data)
 	return err
@@ -74,7 +97,7 @@ type backupExportOptions struct {
 	GmailAttachments string
 }
 
-func (c *BackupExportCmd) Run(ctx context.Context) error {
+func (c *BackupExportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	backupOpts := c.options()
 	if err := bindBackupConfigStore(ctx, &backupOpts); err != nil {
 		return err
@@ -86,6 +109,24 @@ func (c *BackupExportCmd) Run(ctx context.Context) error {
 	exportOpts := backupExportOptions{
 		GmailFormat:      c.GmailFormat,
 		GmailAttachments: c.GmailAttachments,
+	}
+	if flags != nil && flags.DryRun {
+		cfg, resolveErr := backup.ResolveOptions(backupOpts)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		if outsideErr := ensureExportOutsideRepo(outDir, cfg.Repo); outsideErr != nil {
+			return outsideErr
+		}
+		if dryRunErr := dryRunExit(ctx, flags, "backup.export", map[string]any{
+			"out":               outDir,
+			"repo":              cfg.Repo,
+			"pull":              !c.NoPull,
+			"gmail_format":      exportOpts.GmailFormat,
+			"gmail_attachments": exportOpts.GmailAttachments,
+		}); dryRunErr != nil {
+			return dryRunErr
+		}
 	}
 	result := backupExportResult{
 		Out:    outDir,

--- a/internal/cmd/contacts_export.go
+++ b/internal/cmd/contacts_export.go
@@ -26,13 +26,29 @@ type ContactsExportCmd struct {
 
 func (c *ContactsExportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
-	account, err := requireAccount(flags)
-	if err != nil {
-		return err
-	}
 	validateErr := c.validate()
 	if validateErr != nil {
 		return validateErr
+	}
+	outPath := strings.TrimSpace(c.Out)
+	if outPath == "" {
+		outPath = stdoutPath
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "contacts.export", map[string]any{
+		"selector":  strings.TrimSpace(c.Selector),
+		"query":     strings.TrimSpace(c.Query),
+		"all":       c.All,
+		"out":       outPath,
+		"max":       c.Max,
+		"page_size": c.PageSize,
+		"page":      strings.TrimSpace(c.Page),
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
 	}
 
 	svc, err := peopleContactsService(ctx, account)
@@ -58,14 +74,14 @@ func (c *ContactsExportCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if writeErr != nil {
 		return writeErr
 	}
-	if c.Out == "-" || strings.TrimSpace(c.Out) == "" {
+	if isStdoutPath(outPath) {
 		_, err = stdoutWriter(ctx).Write(buf.Bytes())
 		return err
 	}
-	if err := os.WriteFile(c.Out, buf.Bytes(), 0o600); err != nil {
+	if err := os.WriteFile(outPath, buf.Bytes(), 0o600); err != nil {
 		return err
 	}
-	u.Err().Linef("Exported %d contact%s to %s", len(contacts), pluralS(len(contacts)), c.Out)
+	u.Err().Linef("Exported %d contact%s to %s", len(contacts), pluralS(len(contacts)), outPath)
 	return nil
 }
 

--- a/internal/cmd/drive_download.go
+++ b/internal/cmd/drive_download.go
@@ -48,6 +48,34 @@ func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return formatErr
 	}
 
+	outPathFlag := strings.TrimSpace(c.Output.Path)
+	if outPathFlag != "" {
+		expanded, expandErr := config.ExpandPath(outPathFlag)
+		if expandErr != nil {
+			return expandErr
+		}
+		outPathFlag = expanded
+	}
+	if outfmt.IsJSON(ctx) && isStdoutPath(outPathFlag) {
+		return usage("can't combine --json with --out -")
+	}
+	defaultDir := ""
+	if outPathFlag == "" {
+		layout, layoutErr := commandLayout(ctx, config.PathKindConfig)
+		if layoutErr != nil {
+			return layoutErr
+		}
+		defaultDir = layout.DriveDownloadsDir()
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "drive.download", map[string]any{
+		"file_id":               fileID,
+		"out":                   outPathFlag,
+		"default_downloads_dir": defaultDir,
+		"format":                strings.ToLower(strings.TrimSpace(c.Format)),
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
 	account, err := requireAccount(flags)
 	if err != nil {
 		return err
@@ -73,20 +101,9 @@ func (c *DriveDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return fileFormatErr
 	}
 
-	defaultDir := ""
-	if strings.TrimSpace(c.Output.Path) == "" {
-		layout, layoutErr := commandLayout(ctx, config.PathKindConfig)
-		if layoutErr != nil {
-			return layoutErr
-		}
-		defaultDir = layout.DriveDownloadsDir()
-	}
-	destPath, err := resolveDriveDownloadDestPath(meta, c.Output.Path, defaultDir)
+	destPath, err := resolveDriveDownloadDestPath(meta, outPathFlag, defaultDir)
 	if err != nil {
 		return err
-	}
-	if outfmt.IsJSON(ctx) && isStdoutPath(destPath) {
-		return usage("can't combine --json with --out -")
 	}
 
 	downloadedPath, size, err := downloadDriveFile(ctx, svc, meta, destPath, c.Format)

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
+func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 	imagePath := filepath.Join(t.TempDir(), "dryrun.png")
 	if err := os.WriteFile(imagePath, []byte("dry-run image placeholder"), 0o644); err != nil {
 		t.Fatalf("write dry-run image: %v", err)
@@ -25,11 +26,16 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 	if err := os.WriteFile(markdownPath, []byte("## Slide\nBody"), 0o600); err != nil {
 		t.Fatalf("write dry-run markdown: %v", err)
 	}
+	outputDir := t.TempDir()
+	outputPath := func(name string) string {
+		return filepath.Join(outputDir, name)
+	}
 
 	cases := []struct {
-		name string
-		args []string
-		op   string
+		name    string
+		args    []string
+		op      string
+		outPath string
 	}{
 		{
 			name: "contacts create",
@@ -192,6 +198,12 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			op:   "docs.tab-export",
 		},
 		{
+			name:    "drive download",
+			args:    []string{"drive", "download", "file123", "--out", outputPath("drive.bin")},
+			op:      "drive.download",
+			outPath: outputPath("drive.bin"),
+		},
+		{
 			name: "drive changes watch",
 			args: []string{"drive", "changes", "watch", "--token", "token123", "--webhook-url", "https://example.com/hook", "--channel-id", "channel123"},
 			op:   "drive.changes.watch",
@@ -230,6 +242,12 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			name: "auth tokens import",
 			args: []string{"auth", "tokens", "import", tokenPath},
 			op:   "auth.tokens.import",
+		},
+		{
+			name:    "auth tokens export",
+			args:    []string{"auth", "tokens", "export", "user@example.com", "--out", outputPath("token-export.json")},
+			op:      "auth.tokens.export",
+			outPath: outputPath("token-export.json"),
 		},
 		{
 			name: "auth service account set",
@@ -651,6 +669,48 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			args: []string{"forms", "delete-question", "form123", "0"},
 			op:   "forms.delete-question",
 		},
+		{
+			name:    "contacts export",
+			args:    []string{"contacts", "export", "people/123", "--out", outputPath("contacts.vcf")},
+			op:      "contacts.export",
+			outPath: outputPath("contacts.vcf"),
+		},
+		{
+			name:    "slides thumbnail",
+			args:    []string{"slides", "thumbnail", "presentation123", "slide123", "--out", outputPath("thumbnail.png")},
+			op:      "slides.thumbnail",
+			outPath: outputPath("thumbnail.png"),
+		},
+		{
+			name:    "backup cat",
+			args:    []string{"backup", "cat", "data/test.jsonl.gz.age", "--repo", outputPath("backup-repo"), "--no-pull", "--out", outputPath("backup.jsonl")},
+			op:      "backup.cat",
+			outPath: outputPath("backup.jsonl"),
+		},
+		{
+			name:    "backup export",
+			args:    []string{"backup", "export", "--repo", outputPath("backup-repo"), "--no-pull", "--out", outputPath("backup-export")},
+			op:      "backup.export",
+			outPath: outputPath("backup-export"),
+		},
+		{
+			name:    "gmail filters export",
+			args:    []string{"gmail", "filters", "export", "--format", "xml", "--out", outputPath("filters.xml")},
+			op:      "gmail.filters.export",
+			outPath: outputPath("filters.xml"),
+		},
+		{
+			name:    "photos download",
+			args:    []string{"photos", "download", "media123", "--out", outputPath("photo.jpg")},
+			op:      "photos.download",
+			outPath: outputPath("photo.jpg"),
+		},
+		{
+			name:    "photos picker download",
+			args:    []string{"photos", "picker", "download", "session123", "media123", "--out", outputPath("picked.jpg")},
+			op:      "photos.picker.download",
+			outPath: outputPath("picked.jpg"),
+		},
 	}
 
 	for _, tc := range cases {
@@ -681,6 +741,11 @@ func TestDryRunE2E_MutatingCommandsSkipAuthAndAPI(t *testing.T) {
 			}
 			if len(payload.Request) == 0 || string(payload.Request) == "null" {
 				t.Fatalf("dry-run output missing structured request: %s", out)
+			}
+			if tc.outPath != "" {
+				if _, statErr := os.Stat(tc.outPath); !errors.Is(statErr, os.ErrNotExist) {
+					t.Fatalf("dry-run wrote output path %s: %v", tc.outPath, statErr)
+				}
 			}
 		})
 	}

--- a/internal/cmd/gmail_filters.go
+++ b/internal/cmd/gmail_filters.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -146,6 +147,31 @@ type GmailFiltersExportCmd struct {
 }
 
 func (c *GmailFiltersExportCmd) Run(ctx context.Context, flags *RootFlags) error {
+	format := strings.ToLower(strings.TrimSpace(c.Format))
+	outPath := strings.TrimSpace(c.Out)
+	if format == "" {
+		format = "xml"
+		if outPath == "" && outfmt.IsJSON(ctx) {
+			format = "json"
+		}
+	}
+	if format != "xml" && format != "json" {
+		return usage("--format must be xml or json")
+	}
+	if outPath != "" {
+		var err error
+		outPath, err = config.ExpandPath(outPath)
+		if err != nil {
+			return err
+		}
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "gmail.filters.export", map[string]any{
+		"format": format,
+		"out":    outputPathOrStdout(outPath),
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
 	account, svc, err := requireGmailService(ctx, flags)
 	if err != nil {
 		return err
@@ -154,15 +180,6 @@ func (c *GmailFiltersExportCmd) Run(ctx context.Context, flags *RootFlags) error
 	resp, err := svc.Users.Settings.Filters.List("me").Do()
 	if err != nil {
 		return err
-	}
-
-	format := strings.ToLower(strings.TrimSpace(c.Format))
-	outPath := strings.TrimSpace(c.Out)
-	if format == "" {
-		format = "xml"
-		if outPath == "" && outfmt.IsJSON(ctx) {
-			format = "json"
-		}
 	}
 
 	filters := normalizeGmailFilters(resp.Filter)
@@ -191,8 +208,6 @@ func (c *GmailFiltersExportCmd) Run(ctx context.Context, flags *RootFlags) error
 			_, err = stdoutWriter(ctx).Write(data)
 			return err
 		}
-	default:
-		return usage("--format must be xml or json")
 	}
 
 	if outPath == "" {

--- a/internal/cmd/output_file_helpers.go
+++ b/internal/cmd/output_file_helpers.go
@@ -21,6 +21,13 @@ func isStdoutPath(path string) bool {
 	return strings.TrimSpace(path) == stdoutPath
 }
 
+func outputPathOrStdout(path string) string {
+	if strings.TrimSpace(path) == "" {
+		return stdoutPath
+	}
+	return path
+}
+
 func openUserOutputFile(path string, opts outputFileOptions) (*os.File, string, error) {
 	path = strings.TrimSpace(path)
 	if path == "" {

--- a/internal/cmd/photos.go
+++ b/internal/cmd/photos.go
@@ -128,6 +128,32 @@ func (c *PhotosDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if mediaItemID == "" {
 		return usage("empty mediaItemId")
 	}
+	outPathFlag := strings.TrimSpace(c.Out)
+	if outPathFlag != "" {
+		var expandErr error
+		outPathFlag, expandErr = config.ExpandPath(outPathFlag)
+		if expandErr != nil {
+			return expandErr
+		}
+	}
+	defaultDir := ""
+	if outPathFlag == "" {
+		layout, layoutErr := commandLayout(ctx, config.PathKindConfig)
+		if layoutErr != nil {
+			return layoutErr
+		}
+		defaultDir = layout.DriveDownloadsDir()
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "photos.download", map[string]any{
+		"media_item_id":         mediaItemID,
+		"out":                   outPathFlag,
+		"default_downloads_dir": defaultDir,
+		"video":                 c.Video,
+		"overwrite":             c.Overwrite,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
 	client, err := requirePhotosClient(ctx, flags)
 	if err != nil {
 		return err
@@ -167,19 +193,11 @@ func (c *PhotosDownloadCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 
-	if isStdoutPath(c.Out) {
+	if isStdoutPath(outPathFlag) {
 		_, err = io.Copy(stdoutWriter(ctx), resp.Body)
 		return err
 	}
-	defaultDir := ""
-	if strings.TrimSpace(c.Out) == "" {
-		layout, layoutErr := commandLayout(ctx, config.PathKindConfig)
-		if layoutErr != nil {
-			return layoutErr
-		}
-		defaultDir = layout.DriveDownloadsDir()
-	}
-	dest, err := resolvePhotosDownloadDestPath(item, c.Out, defaultDir)
+	dest, err := resolvePhotosDownloadDestPath(item, outPathFlag, defaultDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/photos_picker.go
+++ b/internal/cmd/photos_picker.go
@@ -187,6 +187,32 @@ func (c *PhotosPickerDownloadCmd) Run(ctx context.Context, flags *RootFlags) err
 	if mediaItemID == "" {
 		return usage("empty mediaItemId")
 	}
+	outPathFlag := strings.TrimSpace(c.Out)
+	if outPathFlag != "" {
+		var expandErr error
+		outPathFlag, expandErr = appconfig.ExpandPath(outPathFlag)
+		if expandErr != nil {
+			return expandErr
+		}
+	}
+	defaultDir := ""
+	if outPathFlag == "" {
+		layout, layoutErr := commandLayout(ctx, appconfig.PathKindConfig)
+		if layoutErr != nil {
+			return layoutErr
+		}
+		defaultDir = layout.DriveDownloadsDir()
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "photos.picker.download", map[string]any{
+		"session_id":            sessionID,
+		"media_item_id":         mediaItemID,
+		"out":                   outPathFlag,
+		"default_downloads_dir": defaultDir,
+		"overwrite":             c.Overwrite,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
 	client, err := requirePhotosPickerClient(ctx, flags)
 	if err != nil {
 		return err
@@ -201,7 +227,7 @@ func (c *PhotosPickerDownloadCmd) Run(ctx context.Context, flags *RootFlags) err
 	}
 	defer resp.Body.Close()
 
-	if isStdoutPath(c.Out) {
+	if isStdoutPath(outPathFlag) {
 		_, err = io.Copy(stdoutWriter(ctx), resp.Body)
 		return err
 	}
@@ -209,15 +235,7 @@ func (c *PhotosPickerDownloadCmd) Run(ctx context.Context, flags *RootFlags) err
 	if item.MediaFile != nil {
 		filename = item.MediaFile.Filename
 	}
-	defaultDir := ""
-	if strings.TrimSpace(c.Out) == "" {
-		layout, layoutErr := commandLayout(ctx, appconfig.PathKindConfig)
-		if layoutErr != nil {
-			return layoutErr
-		}
-		defaultDir = layout.DriveDownloadsDir()
-	}
-	dest, err := resolvePhotosDownloadDestPathParts(item.ID, filename, c.Out, defaultDir)
+	dest, err := resolvePhotosDownloadDestPathParts(item.ID, filename, outPathFlag, defaultDir)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/slides_thumbnail.go
+++ b/internal/cmd/slides_thumbnail.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/steipete/gogcli/internal/config"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -22,11 +23,6 @@ type SlidesThumbnailCmd struct {
 func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 
-	account, err := requireAccount(flags)
-	if err != nil {
-		return err
-	}
-
 	presentationID := strings.TrimSpace(c.PresentationID)
 	if presentationID == "" {
 		return usage("empty presentationId")
@@ -41,6 +37,27 @@ func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 	format, err := normalizeSlidesThumbnailFormat(c.Format)
+	if err != nil {
+		return err
+	}
+	outputPath := strings.TrimSpace(c.Output)
+	if outputPath != "" {
+		outputPath, err = config.ExpandPath(outputPath)
+		if err != nil {
+			return err
+		}
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "slides.thumbnail", map[string]any{
+		"presentation_id": presentationID,
+		"slide_id":        slideID,
+		"size":            strings.ToLower(size),
+		"format":          strings.ToLower(format),
+		"out":             outputPath,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	account, err := requireAccount(flags)
 	if err != nil {
 		return err
 	}
@@ -72,7 +89,6 @@ func (c *SlidesThumbnailCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"format":         strings.ToLower(format),
 	}
 
-	outputPath := strings.TrimSpace(c.Output)
 	if outputPath != "" {
 		written, writtenPath, err := downloadSlidesThumbnail(ctx, thumb.ContentUrl, outputPath)
 		if err != nil {


### PR DESCRIPTION
## Summary

- make nine file/secret-producing read commands honor global `--dry-run`
- return structured intent before auth, API calls, backup decryption, downloads, or local writes
- cover Drive, Contacts, Slides thumbnails, backup cat/export, OAuth token export, Gmail filter export, Photos, and Photos Picker

## Verification

- focused existing command suites and expanded dry-run E2E matrix
- `make ci`
- structured autoreview: clean
- `clawdbot@gmail.com` binary smoke: all nine operations returned dry-run envelopes; zero requested output files/directories created
