### PR TITLE
fix(calendar): make alias dry-run side-effect free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Calendar: make alias set/unset dry-runs preview config changes without writing `config.json`.
 - Dry-run safety: keep Drive, Contacts, Slides thumbnail, backup plaintext, OAuth token, Gmail filter, Photos, and Photos Picker downloads/exports offline and prevent local file or secret output.
 - Auth: make `auth credentials set --dry-run` preview credential and domain writes without opening the keyring or changing files, and validate every domain before storing credentials.
 - CLI: replace the stale hard-coded `--account` service list with concise email, alias, and auto-selection guidance that applies across authenticated Google API commands.

--- a/internal/cmd/calendar_alias.go
+++ b/internal/cmd/calendar_alias.go
@@ -41,7 +41,7 @@ type CalendarAliasSetCmd struct {
 	CalendarID string `arg:"" name:"calendarId" help:"Calendar ID (e.g., abc123@group.calendar.google.com)"`
 }
 
-func (c *CalendarAliasSetCmd) Run(ctx context.Context) error {
+func (c *CalendarAliasSetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	alias := strings.TrimSpace(c.Alias)
 	if alias == "" {
@@ -53,6 +53,12 @@ func (c *CalendarAliasSetCmd) Run(ctx context.Context) error {
 	calendarID := strings.TrimSpace(c.CalendarID)
 	if calendarID == "" {
 		return usage("empty calendar ID")
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "calendar.alias.set", map[string]any{
+		"alias":       strings.ToLower(alias),
+		"calendar_id": calendarID,
+	}); dryRunErr != nil {
+		return dryRunErr
 	}
 	store, err := commandConfigStore(ctx)
 	if err != nil {
@@ -76,11 +82,16 @@ type CalendarAliasUnsetCmd struct {
 	Alias string `arg:"" name:"alias" help:"Alias name"`
 }
 
-func (c *CalendarAliasUnsetCmd) Run(ctx context.Context) error {
+func (c *CalendarAliasUnsetCmd) Run(ctx context.Context, flags *RootFlags) error {
 	u := ui.FromContext(ctx)
 	alias := strings.TrimSpace(c.Alias)
 	if alias == "" {
 		return usage("empty alias")
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "calendar.alias.unset", map[string]any{
+		"alias": strings.ToLower(alias),
+	}); dryRunErr != nil {
+		return dryRunErr
 	}
 	store, err := commandConfigStore(ctx)
 	if err != nil {

--- a/internal/cmd/calendar_alias_test.go
+++ b/internal/cmd/calendar_alias_test.go
@@ -224,3 +224,31 @@ func TestExecuteCalendarAliasCRUDUsesRuntimeConfigStore(t *testing.T) {
 		t.Fatalf("runtime alias after unset: ok=%v err=%v", ok, err)
 	}
 }
+
+func TestExecuteCalendarAliasDryRunDoesNotMutateConfig(t *testing.T) {
+	runtimeStore := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := runtimeStore.SetCalendarAlias("family", "original@group.calendar.google.com"); err != nil {
+		t.Fatalf("set initial alias: %v", err)
+	}
+	runtime := &app.Runtime{Config: runtimeStore}
+
+	setResult := executeWithTestRuntime(t, []string{
+		"--json", "--dry-run", "calendar", "alias", "set", "family", "replacement@group.calendar.google.com",
+	}, runtime)
+	if setResult.err != nil {
+		t.Fatalf("dry-run set: %v", setResult.err)
+	}
+	if calendarID, ok, err := runtimeStore.ResolveCalendarAlias("family"); err != nil || !ok || calendarID != "original@group.calendar.google.com" {
+		t.Fatalf("alias after dry-run set = %q, ok=%v err=%v", calendarID, ok, err)
+	}
+
+	unsetResult := executeWithTestRuntime(t, []string{
+		"--json", "--dry-run", "calendar", "alias", "unset", "family",
+	}, runtime)
+	if unsetResult.err != nil {
+		t.Fatalf("dry-run unset: %v", unsetResult.err)
+	}
+	if calendarID, ok, err := runtimeStore.ResolveCalendarAlias("family"); err != nil || !ok || calendarID != "original@group.calendar.google.com" {
+		t.Fatalf("alias after dry-run unset = %q, ok=%v err=%v", calendarID, ok, err)
+	}
+}

--- a/internal/cmd/dryrun_e2e_test.go
+++ b/internal/cmd/dryrun_e2e_test.go
@@ -325,6 +325,16 @@ func TestDryRunE2E_CommandsSkipAuthAPIAndFileWrites(t *testing.T) {
 			op:   "calendar.delete-calendar",
 		},
 		{
+			name: "calendar alias set",
+			args: []string{"calendar", "alias", "set", "family", "family@group.calendar.google.com"},
+			op:   "calendar.alias.set",
+		},
+		{
+			name: "calendar alias unset",
+			args: []string{"calendar", "alias", "unset", "family"},
+			op:   "calendar.alias.unset",
+		},
+		{
 			name: "calendar focus time",
 			args: []string{"calendar", "focus-time", "primary", "--from", "2030-01-01T10:00:00Z", "--to", "2030-01-01T11:00:00Z"},
 			op:   "calendar.focus-time",


### PR DESCRIPTION
## Summary

- make `calendar alias set/unset --dry-run` emit standard structured plans
- stop before opening or mutating the config store
- add injected-store non-mutation and global dry-run E2E coverage

## Verification

- focused Calendar alias and dry-run E2E tests
- `make ci`
- structured autoreview: clean
- isolated binary smoke: seeded alias remained unchanged after dry-run set and unset
