### PR TITLE
docs(auth): clarify import token sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.
 - Calendar: make alias set/unset dry-runs preview config changes without writing `config.json`.
 - Dry-run safety: keep Drive, Contacts, Slides thumbnail, backup plaintext, OAuth token, Gmail filter, Photos, and Photos Picker downloads/exports offline and prevent local file or secret output.
 - Auth: make `auth credentials set --dry-run` preview credential and domain writes without opening the keyring or changing files, and validate every domain before storing credentials.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -41,7 +41,7 @@ Generated from `gog schema --json`.
       - [`gog auth credentials remove [<client>]`](commands/gog-auth-credentials-remove.md) - Remove stored OAuth client credentials
       - [`gog auth credentials set <credentials> [flags]`](commands/gog-auth-credentials-set.md) - Store OAuth client credentials
     - [`gog auth doctor [flags]`](commands/gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
-    - [`gog auth import --email=STRING [flags]`](commands/gog-auth-import.md) - Import a refresh token non-interactively from stdin, file, or env
+    - [`gog auth import --email=STRING [flags]`](commands/gog-auth-import.md) - Import a required refresh token and optional current access token non-interactively
     - [`gog auth keep --key=STRING <email>`](commands/gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
     - [`gog auth keyring [<backend> [<backend2>]]`](commands/gog-auth-keyring.md) - Configure keyring backend
     - [`gog auth list [flags]`](commands/gog-auth-list.md) - List stored accounts

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -92,7 +92,7 @@ Generated pages: 643.
       - [gog auth credentials remove](gog-auth-credentials-remove.md) - Remove stored OAuth client credentials
       - [gog auth credentials set](gog-auth-credentials-set.md) - Store OAuth client credentials
     - [gog auth doctor](gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
-    - [gog auth import](gog-auth-import.md) - Import a refresh token non-interactively from stdin, file, or env
+    - [gog auth import](gog-auth-import.md) - Import a required refresh token and optional current access token non-interactively
     - [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
     - [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
     - [gog auth list](gog-auth-list.md) - List stored accounts

--- a/docs/commands/gog-auth-import.md
+++ b/docs/commands/gog-auth-import.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Import a refresh token non-interactively from stdin, file, or env
+Import a required refresh token and optional current access token non-interactively
 
 ## Usage
 
@@ -19,10 +19,10 @@ gog auth import --email=STRING [flags]
 | Flag | Type | Default | Help |
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
-| `--access-token-env` | `string` |  | Read OAuth access token from the named environment variable |
-| `--access-token-expires-at` | `string` |  | Access token expiry timestamp (RFC3339; default: now+1h when an access token is provided) |
-| `--access-token-file` | `string` |  | Read OAuth access token from file |
-| `--access-token-stdin` | `bool` |  | Read OAuth access token from stdin |
+| `--access-token-env` | `string` |  | Also read a current OAuth access token from the named environment variable (requires a refresh-token source) |
+| `--access-token-expires-at` | `string` |  | Expiry for the optional access token (RFC3339; default: now+1h when provided) |
+| `--access-token-file` | `string` |  | Also read a current OAuth access token from file (requires a refresh-token source) |
+| `--access-token-stdin` | `bool` |  | Also read a current OAuth access token from stdin (requires a refresh-token source) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |

--- a/docs/commands/gog-auth.md
+++ b/docs/commands/gog-auth.md
@@ -20,7 +20,7 @@ gog auth <command> [flags]
 - [gog auth alias](gog-auth-alias.md) - Manage account aliases
 - [gog auth credentials](gog-auth-credentials.md) - Manage OAuth client credentials
 - [gog auth doctor](gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
-- [gog auth import](gog-auth-import.md) - Import a refresh token non-interactively from stdin, file, or env
+- [gog auth import](gog-auth-import.md) - Import a required refresh token and optional current access token non-interactively
 - [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
 - [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
 - [gog auth list](gog-auth-list.md) - List stored accounts

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -92,7 +92,7 @@ const (
 type AuthCmd struct {
 	Credentials AuthCredentialsCmd    `cmd:"" name:"credentials" help:"Manage OAuth client credentials"`
 	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize and store a refresh token"`
-	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a refresh token non-interactively from stdin, file, or env"`
+	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a required refresh token and optional current access token non-interactively"`
 	Services    AuthServicesCmd       `cmd:"" name:"services" help:"List supported auth services and scopes"`
 	List        AuthListCmd           `cmd:"" name:"list" help:"List stored accounts"`
 	Doctor      AuthDoctorCmd         `cmd:"" name:"doctor" help:"Diagnose auth, keyring, and refresh-token issues"`

--- a/internal/cmd/auth_import.go
+++ b/internal/cmd/auth_import.go
@@ -23,10 +23,10 @@ type AuthImportCmd struct {
 	RefreshTokenStdin    bool   `name:"refresh-token-stdin" help:"Read OAuth refresh token from stdin"`
 	RefreshTokenFile     string `name:"refresh-token-file" type:"path" help:"Read OAuth refresh token from file"`
 	RefreshTokenEnv      string `name:"refresh-token-env" help:"Read OAuth refresh token from the named environment variable"`
-	AccessTokenStdin     bool   `name:"access-token-stdin" help:"Read OAuth access token from stdin"`
-	AccessTokenFile      string `name:"access-token-file" type:"path" help:"Read OAuth access token from file"`
-	AccessTokenEnv       string `name:"access-token-env" help:"Read OAuth access token from the named environment variable"`
-	AccessTokenExpiresAt string `name:"access-token-expires-at" help:"Access token expiry timestamp (RFC3339; default: now+1h when an access token is provided)"`
+	AccessTokenStdin     bool   `name:"access-token-stdin" help:"Also read a current OAuth access token from stdin (requires a refresh-token source)"`
+	AccessTokenFile      string `name:"access-token-file" type:"path" help:"Also read a current OAuth access token from file (requires a refresh-token source)"`
+	AccessTokenEnv       string `name:"access-token-env" help:"Also read a current OAuth access token from the named environment variable (requires a refresh-token source)"`
+	AccessTokenExpiresAt string `name:"access-token-expires-at" help:"Expiry for the optional access token (RFC3339; default: now+1h when provided)"`
 	ServicesCSV          string `name:"services" help:"Comma-separated services to record on the token (informational; does not affect scopes)"`
 }
 
@@ -136,7 +136,7 @@ func (c *AuthImportCmd) resolveRefreshToken(ctx context.Context) (string, error)
 		sources++
 	}
 	if sources == 0 {
-		return "", usage("provide refresh token with --refresh-token-stdin, --refresh-token-file, or --refresh-token-env")
+		return "", usage("provide required refresh token with --refresh-token-stdin, --refresh-token-file, or --refresh-token-env; access-token sources are optional and cannot replace it")
 	}
 	if sources > 1 {
 		return "", usage("provide exactly one refresh token source")

--- a/internal/cmd/auth_import_test.go
+++ b/internal/cmd/auth_import_test.go
@@ -75,6 +75,9 @@ func TestAuthImportCmd_RejectsMissingRefreshTokenSource(t *testing.T) {
 	if !strings.Contains(err.Error(), "--refresh-token-stdin") {
 		t.Fatalf("expected safe source hint in error, got %q", err.Error())
 	}
+	if !strings.Contains(err.Error(), "required refresh token") || !strings.Contains(err.Error(), "cannot replace it") {
+		t.Fatalf("expected refresh/access dependency guidance, got %q", err.Error())
+	}
 }
 
 func TestAuthImportCmd_RejectsMultipleRefreshTokenSources(t *testing.T) {

--- a/internal/cmd/help_snapshot_test.go
+++ b/internal/cmd/help_snapshot_test.go
@@ -35,6 +35,15 @@ func TestHelpSnapshot_Auth(t *testing.T) {
 	)
 }
 
+func TestHelpSnapshot_AuthImport(t *testing.T) {
+	out := captureHelpOutput(t, "auth", "import", "--help")
+	requireHelpContains(t, out,
+		"required refresh token",
+		"requires a refresh-token source",
+		"optional access token",
+	)
+}
+
 func TestHelpSnapshot_DocsUpdate(t *testing.T) {
 	out := captureHelpOutput(t, "docs", "update", "--help")
 	requireHelpContains(t, out,


### PR DESCRIPTION
## Summary

- state that `auth import` requires a refresh-token source
- describe access-token source flags as optional additions, not alternatives
- improve the access-only usage error and regenerate command docs

## Verification

- focused auth-import and help snapshot tests
- generated 643 command pages
- `make ci`
- structured autoreview: clean
- runtime proof: access-only invocation exits 2 with explicit recovery guidance
