### PR TITLE
fix(docs): align cell-style coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.
 - Calendar: make alias set/unset dry-runs preview config changes without writing `config.json`.
 - Dry-run safety: keep Drive, Contacts, Slides thumbnail, backup plaintext, OAuth token, Gmail filter, Photos, and Photos Picker downloads/exports offline and prevent local file or secret output.

--- a/docs/commands/gog-docs-cell-style.md
+++ b/docs/commands/gog-docs-cell-style.md
@@ -24,7 +24,7 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
-| `--col` | `int` |  | 0-based column number |
+| `--col` | `int` |  | 1-based column number |
 | `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
@@ -40,11 +40,11 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--row` | `int` |  | 0-based row number |
+| `--row` | `int` |  | 1-based row number |
 | `--row-span` | `int64` | 1 | Number of rows to style |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
-| `--table-index` | `int` | 0 | 0-based table index in document order |
+| `--table-index` | `int` | 1 | 1-based table index in document order; negative indexes count from the end |
 | `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |
 | `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/internal/cmd/docs_cell_style.go
+++ b/internal/cmd/docs_cell_style.go
@@ -13,9 +13,9 @@ import (
 
 type DocsCellStyleCmd struct {
 	DocID           string `arg:"" name:"docId" help:"Doc ID"`
-	TableIndex      int    `name:"table-index" help:"0-based table index in document order" default:"0"`
-	Row             int    `name:"row" required:"" help:"0-based row number"`
-	Col             int    `name:"col" required:"" help:"0-based column number"`
+	TableIndex      int    `name:"table-index" help:"1-based table index in document order; negative indexes count from the end" default:"1"`
+	Row             int    `name:"row" required:"" help:"1-based row number"`
+	Col             int    `name:"col" required:"" help:"1-based column number"`
 	RowSpan         int64  `name:"row-span" help:"Number of rows to style" default:"1"`
 	ColSpan         int64  `name:"col-span" help:"Number of columns to style" default:"1"`
 	BackgroundColor string `name:"background-color" aliases:"bg-color" help:"Cell background color as #RRGGBB or #RGB"`
@@ -33,14 +33,14 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if docID == "" {
 		return usage("empty docId")
 	}
-	if c.TableIndex < 0 {
-		return usage("--table-index must be >= 0")
+	if c.TableIndex == 0 {
+		return usage("--table-index cannot be 0")
 	}
-	if c.Row < 0 {
-		return usage("--row must be >= 0")
+	if c.Row < 1 {
+		return usage("--row must be >= 1")
 	}
-	if c.Col < 0 {
-		return usage("--col must be >= 0")
+	if c.Col < 1 {
+		return usage("--col must be >= 1")
 	}
 	if c.RowSpan < 1 || c.ColSpan < 1 {
 		return usage("--row-span and --col-span must be >= 1")
@@ -82,18 +82,14 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	c.Tab = loaded.tabID
 
-	tables := collectAllTablesWithIndex(loaded.target)
-	if len(tables) == 0 {
-		return usage("document has no tables")
+	table, resolvedTableIndex, err := resolveDocsTableWithIndex(loaded.target, c.TableIndex)
+	if err != nil {
+		return err
 	}
-	if c.TableIndex >= len(tables) {
-		return usagef("table %d out of range (document has %d tables)", c.TableIndex, len(tables))
-	}
-	table := tables[c.TableIndex]
 	cell, err := findTableCell(loaded.target, &tableCellRef{
-		tableIndex: c.TableIndex + 1,
-		row:        c.Row + 1,
-		col:        c.Col + 1,
+		tableIndex: resolvedTableIndex,
+		row:        c.Row,
+		col:        c.Col,
 	})
 	if err != nil {
 		return err
@@ -119,7 +115,7 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if outfmt.IsJSON(ctx) {
 		payload := map[string]any{
 			"documentId": resp.DocumentId,
-			"tableIndex": c.TableIndex,
+			"tableIndex": resolvedTableIndex,
 			"row":        c.Row,
 			"col":        c.Col,
 			"requests":   len(reqs),
@@ -131,7 +127,7 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
 	u.Out().Linef("documentId\t%s", resp.DocumentId)
-	u.Out().Linef("table_index\t%d", c.TableIndex)
+	u.Out().Linef("table_index\t%d", resolvedTableIndex)
 	u.Out().Linef("row\t%d", c.Row)
 	u.Out().Linef("col\t%d", c.Col)
 	u.Out().Linef("requests\t%d", len(reqs))
@@ -166,8 +162,8 @@ func (c *DocsCellStyleCmd) buildRequests(tableStart int64, cell *docs.TableCell,
 				RowSpan:    c.RowSpan,
 				ColumnSpan: c.ColSpan,
 				TableCellLocation: &docs.TableCellLocation{
-					RowIndex:    int64(c.Row),
-					ColumnIndex: int64(c.Col),
+					RowIndex:    int64(c.Row - 1),
+					ColumnIndex: int64(c.Col - 1),
 					TableStartLocation: &docs.Location{
 						Index: tableStart,
 						TabId: tabID,

--- a/internal/cmd/docs_remaining_features_test.go
+++ b/internal/cmd/docs_remaining_features_test.go
@@ -40,8 +40,8 @@ func TestDocsPageSizeRejectsExplicitDimensions(t *testing.T) {
 
 func TestDocsCellStyleBuildsTableAndTextRequests(t *testing.T) {
 	cmd := &DocsCellStyleCmd{
-		Row:             0,
-		Col:             1,
+		Row:             1,
+		Col:             2,
 		RowSpan:         1,
 		ColSpan:         2,
 		BackgroundColor: "#abc",
@@ -95,12 +95,126 @@ func TestDocsCellStyle_TableSelectionErrorsAreUsage(t *testing.T) {
 
 	cmd := &DocsCellStyleCmd{}
 	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), docSvc)
-	err := runKong(t, cmd, []string{"doc1", "--row", "0", "--col", "0", "--background-color", "#fff"}, ctx, &RootFlags{Account: "a@b.com"})
+	err := runKong(t, cmd, []string{"doc1", "--row", "1", "--col", "1", "--background-color", "#fff"}, ctx, &RootFlags{Account: "a@b.com"})
 	if err == nil || !strings.Contains(err.Error(), "document has no tables") {
 		t.Fatalf("expected no-tables error, got %v", err)
 	}
 	if got := ExitCode(err); got != 2 {
 		t.Fatalf("ExitCode = %d, want 2 (err=%v)", got, err)
+	}
+}
+
+func TestDocsCellStyleValidation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cmd  DocsCellStyleCmd
+		want string
+	}{
+		{
+			name: "zero table index",
+			cmd:  DocsCellStyleCmd{DocID: "doc1", TableIndex: 0, Row: 1, Col: 1, RowSpan: 1, ColSpan: 1, BackgroundColor: "#fff"},
+			want: "--table-index cannot be 0",
+		},
+		{
+			name: "zero row",
+			cmd:  DocsCellStyleCmd{DocID: "doc1", TableIndex: 1, Row: 0, Col: 1, RowSpan: 1, ColSpan: 1, BackgroundColor: "#fff"},
+			want: "--row must be >= 1",
+		},
+		{
+			name: "zero column",
+			cmd:  DocsCellStyleCmd{DocID: "doc1", TableIndex: 1, Row: 1, Col: 0, RowSpan: 1, ColSpan: 1, BackgroundColor: "#fff"},
+			want: "--col must be >= 1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := tt.cmd.Run(
+				newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+				&RootFlags{Account: "a@b.com", DryRun: true},
+			)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Fatalf("ExitCode = %d, want 2 (err=%v)", got, err)
+			}
+		})
+	}
+}
+
+func TestDocsCellStyle_NegativeTableIndexReportsResolvedIndex(t *testing.T) {
+	t.Parallel()
+
+	var got docs.BatchUpdateDocumentRequest
+	doc := &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev1",
+		Body: &docs.Body{Content: []*docs.StructuralElement{
+			{
+				StartIndex: 1,
+				EndIndex:   10,
+				Table: &docs.Table{TableRows: []*docs.TableRow{
+					{TableCells: []*docs.TableCell{cellUpdateTestCell(3, "First\n")}},
+				}},
+			},
+			{
+				StartIndex: 20,
+				EndIndex:   30,
+				Table: &docs.Table{TableRows: []*docs.TableRow{
+					{TableCells: []*docs.TableCell{cellUpdateTestCell(23, "Last\n")}},
+				}},
+			},
+		}},
+	}
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batchUpdate: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	var output strings.Builder
+	ctx := withDocsTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), docSvc)
+	err := runKong(
+		t,
+		&DocsCellStyleCmd{},
+		[]string{"doc1", "--table-index=-1", "--row", "1", "--col", "1", "--background-color", "#fff"},
+		ctx,
+		&RootFlags{Account: "a@b.com"},
+	)
+	if err != nil {
+		t.Fatalf("docs cell-style: %v", err)
+	}
+	if len(got.Requests) != 1 || got.Requests[0].UpdateTableCellStyle == nil {
+		t.Fatalf("unexpected requests: %#v", got.Requests)
+	}
+	loc := got.Requests[0].UpdateTableCellStyle.TableRange.TableCellLocation
+	if loc.TableStartLocation.Index != 20 || loc.RowIndex != 0 || loc.ColumnIndex != 0 {
+		t.Fatalf("unexpected cell location: %#v", loc)
+	}
+	var payload struct {
+		TableIndex int `json:"tableIndex"`
+		Row        int `json:"row"`
+		Col        int `json:"col"`
+	}
+	if err := json.Unmarshal([]byte(output.String()), &payload); err != nil {
+		t.Fatalf("decode output %q: %v", output.String(), err)
+	}
+	if payload.TableIndex != 2 || payload.Row != 1 || payload.Col != 1 {
+		t.Fatalf("unexpected output: %#v", payload)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make `docs cell-style` use one-based table, row, and column coordinates like adjacent Docs table commands
- accept negative table indexes counting from the end
- report the resolved positive table index after a real mutation
- regenerate command docs and document the coordinate migration

## Compatibility

This intentionally corrects the prior inconsistent zero-based interface. Existing `docs cell-style` invocations must add one to positive table, row, and column values. Table index `0` is now invalid.

Maintainer decision: accept this documented breaking migration rather than retain a compatibility shim for the isolated zero-based behavior.

## Verification

- `go test ./internal/cmd -run 'TestDocs(CellStyle|TableColumnWidth)' -count=1`
- `make docs-check`
- rebased exact head `8a67ffd1`
- `make ci` after final rebase
- structured autoreview after final rebase: clean, no actionable findings (confidence 0.86)
- live `clawdbot@gmail.com` proof:
  - created a disposable Doc with two 2x2 tables
  - styled table `1`, row `1`, column `1` red
  - styled table `-1`, row `2`, column `2` blue and bold
  - command output resolved `-1` to table index `2`
  - raw Docs API readback confirmed both exact cells and styles
  - permanently deleted the fixture
