### PR TITLE
fix(auth): make manage automation-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.
 - Calendar: make alias set/unset dry-runs preview config changes without writing `config.json`.

--- a/docs/automation.md
+++ b/docs/automation.md
@@ -49,6 +49,10 @@ Use `--no-input` in CI and unattended processes. Use `--wrap-untrusted` when
 Google-hosted free text will be consumed by an LLM or another instruction-aware
 system.
 
+Interactive browser commands fail fast under `--no-input`. Preview
+`gog auth manage` with `--dry-run`; use `gog auth import` for unattended token
+installation.
+
 ## Schema automation metadata
 
 The top-level `automation` object has three parts:

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -45,7 +45,7 @@ Generated from `gog schema --json`.
     - [`gog auth keep --key=STRING <email>`](commands/gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
     - [`gog auth keyring [<backend> [<backend2>]]`](commands/gog-auth-keyring.md) - Configure keyring backend
     - [`gog auth list [flags]`](commands/gog-auth-list.md) - List stored accounts
-    - [`gog auth manage (login) [flags]`](commands/gog-auth-manage.md) - Open accounts manager in browser
+    - [`gog auth manage (login) [flags]`](commands/gog-auth-manage.md) - Open interactive accounts manager in browser
     - [`gog auth remove <email>`](commands/gog-auth-remove.md) - Remove a stored refresh token
     - [`gog auth service-account <command>`](commands/gog-auth-service-account.md) - Configure service account (Workspace only; domain-wide delegation)
       - [`gog auth service-account set <email> [flags]`](commands/gog-auth-service-account-set.md) - Store a service account key for impersonation

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -96,7 +96,7 @@ Generated pages: 643.
     - [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
     - [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
     - [gog auth list](gog-auth-list.md) - List stored accounts
-    - [gog auth manage](gog-auth-manage.md) - Open accounts manager in browser
+    - [gog auth manage](gog-auth-manage.md) - Open interactive accounts manager in browser
     - [gog auth remove](gog-auth-remove.md) - Remove a stored refresh token
     - [gog auth service-account](gog-auth-service-account.md) - Configure service account (Workspace only; domain-wide delegation)
       - [gog auth service-account set](gog-auth-service-account-set.md) - Store a service account key for impersonation

--- a/docs/commands/gog-auth-manage.md
+++ b/docs/commands/gog-auth-manage.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Open accounts manager in browser
+Open interactive accounts manager in browser
 
 ## Usage
 

--- a/docs/commands/gog-auth.md
+++ b/docs/commands/gog-auth.md
@@ -24,7 +24,7 @@ gog auth <command> [flags]
 - [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
 - [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
 - [gog auth list](gog-auth-list.md) - List stored accounts
-- [gog auth manage](gog-auth-manage.md) - Open accounts manager in browser
+- [gog auth manage](gog-auth-manage.md) - Open interactive accounts manager in browser
 - [gog auth remove](gog-auth-remove.md) - Remove a stored refresh token
 - [gog auth service-account](gog-auth-service-account.md) - Configure service account (Workspace only; domain-wide delegation)
 - [gog auth services](gog-auth-services.md) - List supported auth services and scopes

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -196,7 +196,7 @@ Flag aliases:
 - `gog --client <name> auth credentials <credentials.json|->`
 - `gog auth add <email> [--services user|all-user|all|gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,photos,photospicker,appscript,analytics,searchconsole,ads,youtube] [--readonly] [--drive-scope full|readonly|file] [--gmail-scope full|readonly] [--extra-scopes CSV] [--manual] [--remote] [--step 1|2] [--auth-url URL] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--timeout DURATION] [--force-consent]`
 - `gog auth services [--markdown]`
-- `gog auth manage [--services ...] [--listen-addr HOST[:PORT]] [--redirect-host HOST]`
+- `gog auth manage [--services ...] [--listen-addr HOST[:PORT]] [--redirect-host HOST] [--dry-run]` (interactive browser flow; real execution fails with usage exit code 2 under `--no-input`)
 - `gog auth keep <email> --key <service-account.json>` (Google Keep; Workspace only)
 - `gog auth list`
 - `gog auth doctor [--check]` (diagnose keyring/password drift and refresh-token failures)

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -101,7 +101,7 @@ type AuthCmd struct {
 	Keyring     AuthKeyringCmd        `cmd:"" name:"keyring" help:"Configure keyring backend"`
 	Remove      AuthRemoveCmd         `cmd:"" name:"remove" help:"Remove a stored refresh token"`
 	Tokens      AuthTokensCmd         `cmd:"" name:"tokens" help:"Manage stored refresh tokens"`
-	Manage      AuthManageCmd         `cmd:"" name:"manage" help:"Open accounts manager in browser" aliases:"login"`
+	Manage      AuthManageCmd         `cmd:"" name:"manage" help:"Open interactive accounts manager in browser" aliases:"login"`
 	ServiceAcct AuthServiceAccountCmd `cmd:"" name:"service-account" help:"Configure service account (Workspace only; domain-wide delegation)"`
 	Keep        AuthKeepCmd           `cmd:"" name:"keep" help:"Configure service account for Google Keep (Workspace only)"`
 }

--- a/internal/cmd/auth_accounts.go
+++ b/internal/cmd/auth_accounts.go
@@ -263,7 +263,7 @@ type AuthManageCmd struct {
 	RedirectHost string        `name:"redirect-host" help:"Hostname for OAuth callback; builds https://{host}/oauth2/callback"`
 }
 
-func (c *AuthManageCmd) Run(ctx context.Context, _ *RootFlags) error {
+func (c *AuthManageCmd) Run(ctx context.Context, flags *RootFlags) error {
 	services, err := parseAuthServices(c.ServicesCSV)
 	if err != nil {
 		return err
@@ -276,14 +276,29 @@ func (c *AuthManageCmd) Run(ctx context.Context, _ *RootFlags) error {
 		}
 	}
 
-	return startAuthManageServer(ctx, googleauth.ManageServerOptions{
+	opts := googleauth.ManageServerOptions{
 		Timeout:      c.Timeout,
 		Services:     services,
 		ForceConsent: c.ForceConsent,
 		Client:       authclient.ClientOverrideFromContext(ctx),
 		ListenAddr:   strings.TrimSpace(c.ListenAddr),
 		RedirectURI:  redirectURI,
-	})
+	}
+	if err := dryRunExit(ctx, flags, "auth.manage", map[string]any{
+		"client":        opts.Client,
+		"force_consent": opts.ForceConsent,
+		"listen_addr":   opts.ListenAddr,
+		"redirect_uri":  opts.RedirectURI,
+		"services":      opts.Services,
+		"timeout":       opts.Timeout.String(),
+	}); err != nil {
+		return err
+	}
+	if flags != nil && flags.NoInput {
+		return usage("auth manage requires interactive browser input; omit --no-input or use 'gog auth import' for unattended token installation")
+	}
+
+	return startAuthManageServer(ctx, opts)
 }
 
 type AuthKeepCmd struct {

--- a/internal/cmd/auth_manage_test.go
+++ b/internal/cmd/auth_manage_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -40,6 +43,82 @@ func TestAuthManageCmd_ServicesAndOptions(t *testing.T) {
 	}
 	if len(got.Services) != 2 {
 		t.Fatalf("expected de-duped services, got %#v", got.Services)
+	}
+}
+
+func TestAuthManageCmd_DryRunNoInputSkipsServer(t *testing.T) {
+	var stdout bytes.Buffer
+	called := false
+	ctx := authclient.WithClient(newCmdRuntimeJSONOutputContext(t, &stdout, &bytes.Buffer{}), "work")
+	ctx = withTestRuntime(ctx, func(runtime *app.Runtime) {
+		runtime.Auth.StartManageServer = func(context.Context, googleauth.ManageServerOptions) error {
+			called = true
+			return nil
+		}
+	})
+
+	err := (&AuthManageCmd{
+		ServicesCSV:  string(googleauth.ServiceGmail) + "," + string(googleauth.ServiceDrive),
+		ForceConsent: true,
+		Timeout:      2 * time.Minute,
+		ListenAddr:   " 127.0.0.1:8080 ",
+		RedirectHost: "gog.example.com",
+	}).Run(ctx, &RootFlags{DryRun: true, NoInput: true})
+	if ExitCode(err) != 0 {
+		t.Fatalf("exit code = %d, want 0: %v", ExitCode(err), err)
+	}
+	if called {
+		t.Fatal("manage server was called during dry-run")
+	}
+
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			Client       string   `json:"client"`
+			ForceConsent bool     `json:"force_consent"`
+			ListenAddr   string   `json:"listen_addr"`
+			RedirectURI  string   `json:"redirect_uri"`
+			Services     []string `json:"services"`
+			Timeout      string   `json:"timeout"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode dry-run: %v\noutput=%q", err, stdout.String())
+	}
+	if !got.DryRun || got.Op != "auth.manage" {
+		t.Fatalf("unexpected dry-run envelope: %#v", got)
+	}
+	if got.Request.Client != "work" ||
+		!got.Request.ForceConsent ||
+		got.Request.ListenAddr != "127.0.0.1:8080" ||
+		got.Request.RedirectURI != "https://gog.example.com/oauth2/callback" ||
+		got.Request.Timeout != "2m0s" ||
+		len(got.Request.Services) != 2 ||
+		got.Request.Services[0] != string(googleauth.ServiceGmail) ||
+		got.Request.Services[1] != string(googleauth.ServiceDrive) {
+		t.Fatalf("unexpected dry-run request: %#v", got.Request)
+	}
+}
+
+func TestAuthManageCmd_NoInputFailsBeforeServer(t *testing.T) {
+	called := false
+	ctx := withTestRuntime(context.Background(), func(runtime *app.Runtime) {
+		runtime.Auth.StartManageServer = func(context.Context, googleauth.ManageServerOptions) error {
+			called = true
+			return nil
+		}
+	})
+
+	err := (&AuthManageCmd{}).Run(ctx, &RootFlags{NoInput: true})
+	if ExitCode(err) != 2 {
+		t.Fatalf("exit code = %d, want 2: %v", ExitCode(err), err)
+	}
+	if called {
+		t.Fatal("manage server was called with --no-input")
+	}
+	if !strings.Contains(err.Error(), "use 'gog auth import'") {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make `auth manage --dry-run` emit a structured `auth.manage` plan before keyring, server, or browser access
- make real `auth manage --no-input` fail immediately with usage exit code 2 and unattended-import guidance
- update automation/spec/generated command docs and changelog

## Testing

- `go test ./internal/cmd -run 'TestAuthManageCmd' -count=1`
- `make ci`
- structured autoreview: clean, no accepted/actionable findings
- disposable-home binary smoke: dry-run exit 0; real no-input exit 2; no files created

## Live proof

```text
dry_rc=0
real_rc=2
created_paths: <empty>
```

Dry-run JSON included the selected client, services, consent mode, listener, redirect URI, and timeout. No live Google mutation applies; this change prevents the interactive browser flow from starting in automation.
