### PR TITLE
fix(backup): keep read commands non-mutating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Backup: make status, verify, cat, and export use read-only repository setup, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
+- Backup: make status, verify, cat, and export use read-only repository setup, keep failed clones atomic, disable Git credential prompts under `--no-input`, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Backup: make status, verify, cat, and export use read-only repository setup, keep failed clones atomic, disable Git credential prompts under `--no-input`, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
+- Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, keep failed clones atomic, disable Git credential prompts under `--no-input`, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Backup: make status, verify, cat, and export use read-only repository setup, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags without write-only options.
+- Backup: make status, verify, cat, and export use read-only repository setup, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, keep failed clones atomic, disable Git credential prompts under `--no-input`, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
+- Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, keep failed clones atomic, disable Git credential prompts under `--no-input`, redact credentials from Git errors, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Backup: make status, verify, cat, and export use read-only repository setup, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags without write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixed
 
-- Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, keep failed clones atomic, disable Git credential prompts under `--no-input`, redact credentials from Git errors, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
+- Backup: make status, verify, cat, and export use read-only repository setup and file-free dry-run plans, support pre-created empty repository directories, keep failed clones clean, disable Git credential prompts under `--no-input`, redact credentials from Git errors, preserve clone failures instead of initializing a new repository, and give status/verify the existing `--no-pull` flags while retaining hidden compatibility for legacy write-only options.
 - Auth: make `auth manage --dry-run` preview the browser flow without touching the keyring or server, and fail fast when real execution uses `--no-input`.
 - Docs: make `docs cell-style` table, row, and column coordinates one-based like adjacent table commands, with negative table indexes counting from the end.
 - Auth: clarify that `auth import` always requires a refresh-token source and only optionally accepts a current access token plus expiry.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -76,6 +76,8 @@ Read commands never initialize a new Git repository when the repository is
 missing or a clone fails.
 With `--no-input`, backup Git operations disable credential/UI prompts and SSH
 password prompts; failed read-side clones leave the configured path untouched.
+With `--dry-run`, all four read commands print their resolved repository/pull
+plan without cloning, pulling, decrypting, or writing plaintext output.
 
 Supported services:
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -74,6 +74,8 @@ remote.
 configured remote before reading. Use `--no-pull` to read local state directly.
 Read commands never initialize a new Git repository when the repository is
 missing or a clone fails.
+With `--no-input`, backup Git operations disable credential/UI prompts and SSH
+password prompts; failed read-side clones leave the configured path untouched.
 
 Supported services:
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -70,6 +70,11 @@ gog backup export --no-pull --out ~/Library/CloudStorage/Dropbox/backup/gog --gm
 Use `--no-push` on `init` or `push` to commit locally without pushing to the
 remote.
 
+`status`, `verify`, `cat`, and `export` pull an existing repository or clone the
+configured remote before reading. Use `--no-pull` to read local state directly.
+Read commands never initialize a new Git repository when the repository is
+missing or a clone fails.
+
 Supported services:
 
 - `gmail`: labels and raw MIME messages. Fetched raw messages are cached under

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -76,6 +76,8 @@ Read commands never initialize a new Git repository when the repository is
 missing or a clone fails.
 With `--no-input`, backup Git operations disable credential/UI prompts and SSH
 password prompts; failed read-side clones leave the configured path untouched.
+Git errors redact credentials embedded in remote URLs before printing command
+arguments or captured diagnostics.
 With `--dry-run`, all four read commands print their resolved repository/pull
 plan without cloning, pulling, decrypting, or writing plaintext output.
 

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -76,6 +76,8 @@ Read commands never initialize a new Git repository when the repository is
 missing or a clone fails.
 With `--no-input`, backup Git operations disable credential/UI prompts and SSH
 password prompts; failed read-side clones leave the configured path untouched.
+Pre-created empty repository directories are supported, including mounted
+paths; failed clones clean their partial contents while preserving the directory.
 Git errors redact credentials embedded in remote URLs before printing command
 arguments or captured diagnostics.
 With `--dry-run`, all four read commands print their resolved repository/pull

--- a/docs/commands/gog-backup-status.md
+++ b/docs/commands/gog-backup-status.md
@@ -34,9 +34,8 @@ gog backup status [flags]
 | `--identity` | `string` |  | Local age identity path |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--no-push` | `bool` |  | Commit locally but do not push to the remote |
+| `--no-pull` | `bool` |  | Use local backup repository state without pulling first |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--recipient` | `[]string` |  | Public age recipient (repeatable) |
 | `--remote` | `string` |  | Backup Git remote URL |
 | `--repo` | `string` |  | Local backup repository path |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |

--- a/docs/commands/gog-backup-verify.md
+++ b/docs/commands/gog-backup-verify.md
@@ -34,9 +34,8 @@ gog backup verify [flags]
 | `--identity` | `string` |  | Local age identity path |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--no-push` | `bool` |  | Commit locally but do not push to the remote |
+| `--no-pull` | `bool` |  | Use local backup repository state without pulling first |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
-| `--recipient` | `[]string` |  | Public age recipient (repeatable) |
 | `--remote` | `string` |  | Backup Git remote URL |
 | `--repo` | `string` |  | Local backup repository path |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -229,7 +229,7 @@ func Verify(ctx context.Context, opts Options) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	if err := ensureRepo(ctx, cfg); err != nil {
+	if err := prepareReadRepo(ctx, cfg, opts.SkipPull); err != nil {
 		return Result{}, err
 	}
 	manifest, err := readManifest(cfg.Repo)
@@ -272,7 +272,7 @@ func Status(ctx context.Context, opts Options) (Manifest, string, error) {
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	if err := ensureRepo(ctx, cfg); err != nil {
+	if err := prepareReadRepo(ctx, cfg, opts.SkipPull); err != nil {
 		return Manifest{}, "", err
 	}
 	manifest, err := readManifest(cfg.Repo)

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -16,20 +16,7 @@ func ensureRepo(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("backup repo path is required")
 	}
 	if _, err := os.Stat(filepath.Join(cfg.Repo, ".git")); err == nil {
-		pullErr := git(ctx, cfg.Repo, "pull", "--rebase")
-		if pullErr != nil {
-			hasHead := git(ctx, cfg.Repo, "rev-parse", "--verify", "HEAD") == nil
-			if !hasHead {
-				return nil
-			}
-			if strings.Contains(pullErr.Error(), "no tracking information") ||
-				strings.Contains(pullErr.Error(), "No remote repository specified") ||
-				strings.Contains(pullErr.Error(), "no such ref was fetched") {
-				return nil
-			}
-			return pullErr
-		}
-		return nil
+		return pullRepo(ctx, cfg.Repo)
 	}
 	if strings.TrimSpace(cfg.Remote) != "" {
 		if err := os.MkdirAll(filepath.Dir(cfg.Repo), 0o700); err != nil {
@@ -51,6 +38,47 @@ func ensureRepo(ctx context.Context, cfg Config) error {
 		}
 	}
 	return nil
+}
+
+func prepareReadRepo(ctx context.Context, cfg Config, skipPull bool) error {
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return fmt.Errorf("backup repo path is required")
+	}
+	if skipPull {
+		return nil
+	}
+
+	gitPath := filepath.Join(cfg.Repo, ".git")
+	if _, err := os.Stat(gitPath); err == nil {
+		return pullRepo(ctx, cfg.Repo)
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	if strings.TrimSpace(cfg.Remote) == "" {
+		return fmt.Errorf("backup repo is not initialized at %s; run 'gog backup init' or provide --remote", cfg.Repo)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfg.Repo), 0o700); err != nil {
+		return err
+	}
+	return git(ctx, "", "clone", cfg.Remote, cfg.Repo)
+}
+
+func pullRepo(ctx context.Context, repo string) error {
+	pullErr := git(ctx, repo, "pull", "--rebase")
+	if pullErr == nil {
+		return nil
+	}
+	hasHead := git(ctx, repo, "rev-parse", "--verify", "HEAD") == nil
+	if !hasHead {
+		return nil
+	}
+	if strings.Contains(pullErr.Error(), "no tracking information") ||
+		strings.Contains(pullErr.Error(), "No remote repository specified") ||
+		strings.Contains(pullErr.Error(), "no such ref was fetched") {
+		return nil
+	}
+	return pullErr
 }
 
 func commitAndPush(ctx context.Context, cfg Config, message string, push bool) (bool, error) {

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -8,8 +8,15 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 )
+
+type noInputContextKey struct{}
+
+func WithNoInput(ctx context.Context) context.Context {
+	return context.WithValue(ctx, noInputContextKey{}, true)
+}
 
 func ensureRepo(ctx context.Context, cfg Config) error {
 	if strings.TrimSpace(cfg.Repo) == "" {
@@ -61,7 +68,29 @@ func prepareReadRepo(ctx context.Context, cfg Config, skipPull bool) error {
 	if err := os.MkdirAll(filepath.Dir(cfg.Repo), 0o700); err != nil {
 		return err
 	}
-	return git(ctx, "", "clone", cfg.Remote, cfg.Repo)
+	return cloneReadRepo(ctx, cfg.Remote, cfg.Repo)
+}
+
+func cloneReadRepo(ctx context.Context, remote, repo string) error {
+	parent := filepath.Dir(repo)
+	tempRepo, err := os.MkdirTemp(parent, "."+filepath.Base(repo)+".clone-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if tempRepo != "" {
+			_ = os.RemoveAll(tempRepo)
+		}
+	}()
+
+	if err := git(ctx, "", "clone", remote, tempRepo); err != nil {
+		return err
+	}
+	if err := os.Rename(tempRepo, repo); err != nil {
+		return fmt.Errorf("install cloned backup repo: %w", err)
+	}
+	tempRepo = ""
+	return nil
 }
 
 func pullRepo(ctx context.Context, repo string) error {
@@ -122,14 +151,7 @@ func pushCommit(ctx context.Context, cfg Config, sha string) error {
 }
 
 func git(ctx context.Context, dir string, args ...string) error {
-	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- callers pass fixed git subcommands plus configured repo paths.
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=gog",
-		"GIT_AUTHOR_EMAIL=gog@example.invalid",
-		"GIT_COMMITTER_NAME=gog",
-		"GIT_COMMITTER_EMAIL=gog@example.invalid",
-	)
+	cmd := gitCommand(ctx, dir, args...)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
@@ -142,14 +164,7 @@ func git(ctx context.Context, dir string, args ...string) error {
 }
 
 func gitOutput(ctx context.Context, dir string, args ...string) (string, error) {
-	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- callers pass fixed git subcommands plus configured repo paths.
-	cmd.Dir = dir
-	cmd.Env = append(os.Environ(),
-		"GIT_AUTHOR_NAME=gog",
-		"GIT_AUTHOR_EMAIL=gog@example.invalid",
-		"GIT_COMMITTER_NAME=gog",
-		"GIT_COMMITTER_EMAIL=gog@example.invalid",
-	)
+	cmd := gitCommand(ctx, dir, args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
@@ -160,4 +175,52 @@ func gitOutput(ctx context.Context, dir string, args ...string) (string, error) 
 		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
 	}
 	return stdout.String(), nil
+}
+
+func gitCommand(ctx context.Context, dir string, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "git", args...) // #nosec G204 -- callers pass fixed git subcommands plus configured repo paths.
+	cmd.Dir = dir
+	cmd.Env = gitEnvironment(ctx)
+	return cmd
+}
+
+func gitEnvironment(ctx context.Context) []string {
+	values := map[string]string{
+		"GIT_AUTHOR_NAME":     "gog",
+		"GIT_AUTHOR_EMAIL":    "gog@example.invalid",
+		"GIT_COMMITTER_NAME":  "gog",
+		"GIT_COMMITTER_EMAIL": "gog@example.invalid",
+	}
+	if noInput, _ := ctx.Value(noInputContextKey{}).(bool); noInput {
+		values["GIT_TERMINAL_PROMPT"] = "0"
+		values["GCM_INTERACTIVE"] = "Never"
+		values["GIT_ASKPASS"] = ""
+		values["SSH_ASKPASS"] = ""
+		sshCommand := strings.TrimSpace(os.Getenv("GIT_SSH_COMMAND"))
+		if sshCommand == "" {
+			sshCommand = "ssh"
+		}
+		values["GIT_SSH_COMMAND"] = sshCommand + " -o BatchMode=yes"
+	}
+	return replaceEnvironment(os.Environ(), values)
+}
+
+func replaceEnvironment(base []string, values map[string]string) []string {
+	env := make([]string, 0, len(base)+len(values))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if _, replace := values[key]; ok && replace {
+			continue
+		}
+		env = append(env, entry)
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		env = append(env, key+"="+values[key])
+	}
+	return env
 }

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -4,6 +4,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -76,6 +77,14 @@ func prepareReadRepo(ctx context.Context, cfg Config, skipPull bool) error {
 }
 
 func cloneReadRepo(ctx context.Context, remote, repo string) error {
+	info, statErr := os.Stat(repo)
+	if statErr == nil {
+		return cloneReadRepoIntoExisting(ctx, remote, repo, info)
+	}
+	if !os.IsNotExist(statErr) {
+		return statErr
+	}
+
 	parent := filepath.Dir(repo)
 	tempRepo, err := os.MkdirTemp(parent, "."+filepath.Base(repo)+".clone-*")
 	if err != nil {
@@ -94,6 +103,40 @@ func cloneReadRepo(ctx context.Context, remote, repo string) error {
 		return fmt.Errorf("install cloned backup repo: %w", err)
 	}
 	tempRepo = ""
+	return nil
+}
+
+func cloneReadRepoIntoExisting(ctx context.Context, remote, repo string, info os.FileInfo) error {
+	if !info.IsDir() {
+		return fmt.Errorf("backup repo path exists but is not a directory: %s", repo)
+	}
+	entries, err := os.ReadDir(repo)
+	if err != nil {
+		return err
+	}
+	if len(entries) != 0 {
+		return fmt.Errorf("backup repo path exists but is not a Git repository or empty directory: %s", repo)
+	}
+
+	if err := git(ctx, "", "clone", remote, repo); err != nil {
+		if cleanupErr := removeDirectoryContents(repo); cleanupErr != nil {
+			return errors.Join(err, fmt.Errorf("clean failed clone: %w", cleanupErr))
+		}
+		return err
+	}
+	return nil
+}
+
+func removeDirectoryContents(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, entry.Name())); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/backup/git.go
+++ b/internal/backup/git.go
@@ -5,14 +5,18 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 )
 
 type noInputContextKey struct{}
+
+var gitURLPattern = regexp.MustCompile(`[A-Za-z][A-Za-z0-9+.-]*://[^\s<>"']+`)
 
 func WithNoInput(ctx context.Context) context.Context {
 	return context.WithValue(ctx, noInputContextKey{}, true)
@@ -155,10 +159,7 @@ func git(ctx context.Context, dir string, args ...string) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		if stderr.Len() > 0 {
-			return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
-		}
-		return fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		return gitError(args, err, stderr.String())
 	}
 	return nil
 }
@@ -169,12 +170,60 @@ func gitOutput(ctx context.Context, dir string, args ...string) (string, error) 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		if stderr.Len() > 0 {
-			return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
-		}
-		return "", fmt.Errorf("git %s: %w", strings.Join(args, " "), err)
+		return "", gitError(args, err, stderr.String())
 	}
 	return stdout.String(), nil
+}
+
+func gitError(args []string, err error, stderr string) error {
+	safeArgs := make([]string, len(args))
+	safeStderr := redactGitURLsInText(strings.TrimSpace(stderr))
+	for i, arg := range args {
+		safeArgs[i] = redactGitURL(arg)
+		if safeArgs[i] != arg {
+			safeStderr = strings.ReplaceAll(safeStderr, arg, safeArgs[i])
+		}
+	}
+	if safeStderr != "" {
+		return fmt.Errorf("git %s: %w: %s", strings.Join(safeArgs, " "), err, safeStderr)
+	}
+	return fmt.Errorf("git %s: %w", strings.Join(safeArgs, " "), err)
+}
+
+func redactGitURLsInText(value string) string {
+	return gitURLPattern.ReplaceAllStringFunc(value, redactGitURL)
+}
+
+func redactGitURL(value string) string {
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return value
+	}
+
+	redacted := false
+	if parsed.User != nil {
+		parsed.User = url.User("redacted")
+		redacted = true
+	}
+	if parsed.RawQuery != "" {
+		query := parsed.Query()
+		for key, values := range query {
+			for i := range values {
+				values[i] = "redacted"
+			}
+			query[key] = values
+		}
+		parsed.RawQuery = query.Encode()
+		redacted = true
+	}
+	if parsed.Fragment != "" {
+		parsed.Fragment = "redacted"
+		redacted = true
+	}
+	if !redacted {
+		return value
+	}
+	return parsed.String()
 }
 
 func gitCommand(ctx context.Context, dir string, args ...string) *exec.Cmd {

--- a/internal/backup/read.go
+++ b/internal/backup/read.go
@@ -14,13 +14,8 @@ func Cat(ctx context.Context, opts Options, shardPath string) (PlainShard, error
 	if err != nil {
 		return PlainShard{}, err
 	}
-	if !opts.SkipPull {
-		repoErr := ensureRepo(ctx, cfg)
-		if repoErr != nil {
-			return PlainShard{}, repoErr
-		}
-	} else if strings.TrimSpace(cfg.Repo) == "" {
-		return PlainShard{}, fmt.Errorf("backup repo path is required")
+	if repoErr := prepareReadRepo(ctx, cfg, opts.SkipPull); repoErr != nil {
+		return PlainShard{}, repoErr
 	}
 	manifest, err := readManifest(cfg.Repo)
 	if err != nil {
@@ -50,13 +45,8 @@ func WalkSnapshot(ctx context.Context, opts Options, visit func(Manifest, string
 	if err != nil {
 		return Manifest{}, "", err
 	}
-	if !opts.SkipPull {
-		repoErr := ensureRepo(ctx, cfg)
-		if repoErr != nil {
-			return Manifest{}, "", repoErr
-		}
-	} else if strings.TrimSpace(cfg.Repo) == "" {
-		return Manifest{}, "", fmt.Errorf("backup repo path is required")
+	if repoErr := prepareReadRepo(ctx, cfg, opts.SkipPull); repoErr != nil {
+		return Manifest{}, "", repoErr
 	}
 	manifest, err := readManifest(cfg.Repo)
 	if err != nil {

--- a/internal/backup/read_repo_test.go
+++ b/internal/backup/read_repo_test.go
@@ -75,8 +75,47 @@ func TestReadRepoCloneFailureDoesNotInitializeRepo(t *testing.T) {
 		t.Fatalf("error = %v, want clone failure", err)
 	}
 
-	if _, statErr := os.Stat(filepath.Join(repo, ".git")); !errors.Is(statErr, os.ErrNotExist) {
-		t.Fatalf("clone failure initialized repo: %v", statErr)
+	if _, statErr := os.Stat(repo); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("clone failure left repo behind: %v", statErr)
+	}
+
+	matches, globErr := filepath.Glob(filepath.Join(dir, ".repo.clone-*"))
+	if globErr != nil {
+		t.Fatalf("Glob: %v", globErr)
+	}
+
+	if len(matches) != 0 {
+		t.Fatalf("clone failure left temporary repos: %v", matches)
+	}
+}
+
+func TestNoInputGitEnvironmentDisablesPrompts(t *testing.T) {
+	t.Setenv("GIT_TERMINAL_PROMPT", "1")
+	t.Setenv("GCM_INTERACTIVE", "Always")
+	t.Setenv("GIT_ASKPASS", "askpass")
+	t.Setenv("SSH_ASKPASS", "ssh-askpass")
+	t.Setenv("GIT_SSH_COMMAND", "ssh -i test-key")
+
+	env := gitEnvironment(WithNoInput(t.Context()))
+	values := make(map[string][]string)
+
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok {
+			values[key] = append(values[key], value)
+		}
+	}
+
+	for key, want := range map[string]string{
+		"GIT_TERMINAL_PROMPT": "0",
+		"GCM_INTERACTIVE":     "Never",
+		"GIT_ASKPASS":         "",
+		"SSH_ASKPASS":         "",
+		"GIT_SSH_COMMAND":     "ssh -i test-key -o BatchMode=yes",
+	} {
+		if got := values[key]; len(got) != 1 || got[0] != want {
+			t.Fatalf("%s = %q, want [%q]", key, got, want)
+		}
 	}
 }
 

--- a/internal/backup/read_repo_test.go
+++ b/internal/backup/read_repo_test.go
@@ -91,6 +91,80 @@ func TestReadRepoCloneFailureDoesNotInitializeRepo(t *testing.T) {
 	}
 }
 
+func TestReadRepoClonesIntoExistingEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "remote.git")
+	repo := filepath.Join(dir, "repo")
+
+	if err := os.Mkdir(repo, 0o700); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	if err := os.Mkdir(remote, 0o700); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+
+	if err := git(t.Context(), remote, "init", "--bare"); err != nil {
+		t.Fatalf("init bare remote: %v", err)
+	}
+
+	if err := cloneReadRepo(t.Context(), remote, repo); err != nil {
+		t.Fatalf("cloneReadRepo: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(repo, ".git")); err != nil {
+		t.Fatalf("stat cloned .git: %v", err)
+	}
+}
+
+func TestReadRepoCloneFailurePreservesExistingEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "missing-remote.git")
+
+	repo := filepath.Join(dir, "repo")
+	if err := os.Mkdir(repo, 0o700); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	err := cloneReadRepo(t.Context(), remote, repo)
+	if err == nil || !strings.Contains(err.Error(), "git clone") {
+		t.Fatalf("error = %v, want clone failure", err)
+	}
+
+	entries, readErr := os.ReadDir(repo)
+	if readErr != nil {
+		t.Fatalf("read repo: %v", readErr)
+	}
+
+	if len(entries) != 0 {
+		t.Fatalf("clone failure left existing repo contents: %v", entries)
+	}
+}
+
+func TestReadRepoDoesNotModifyExistingNonEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	remote := filepath.Join(dir, "missing-remote.git")
+
+	repo := filepath.Join(dir, "repo")
+	if err := os.Mkdir(repo, 0o700); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	marker := filepath.Join(repo, "keep.txt")
+	if err := os.WriteFile(marker, []byte("keep"), 0o600); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+
+	err := cloneReadRepo(t.Context(), remote, repo)
+	if err == nil || !strings.Contains(err.Error(), "not a Git repository or empty directory") {
+		t.Fatalf("error = %v, want non-empty directory guidance", err)
+	}
+
+	if got, readErr := os.ReadFile(marker); readErr != nil || string(got) != "keep" {
+		t.Fatalf("marker changed: content=%q err=%v", got, readErr)
+	}
+}
+
 func TestGitErrorRedactsCredentialedRemote(t *testing.T) {
 	remote := "https://oauth2:secret-password@example.com/repo.git?access_token=secret-query#secret-fragment"
 	err := gitError(

--- a/internal/backup/read_repo_test.go
+++ b/internal/backup/read_repo_test.go
@@ -1,0 +1,97 @@
+package backup
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReadOperationsDoNotInitializeMissingRepo(t *testing.T) {
+	operations := []struct {
+		name string
+		run  func(context.Context, Options) error
+	}{
+		{
+			name: "status",
+			run: func(ctx context.Context, opts Options) error {
+				_, _, err := Status(ctx, opts)
+				return err
+			},
+		},
+		{
+			name: "verify",
+			run: func(ctx context.Context, opts Options) error {
+				_, err := Verify(ctx, opts)
+				return err
+			},
+		},
+		{
+			name: "cat",
+			run: func(ctx context.Context, opts Options) error {
+				_, err := Cat(ctx, opts, "data/test.jsonl.gz.age")
+				return err
+			},
+		},
+		{
+			name: "walk",
+			run: func(ctx context.Context, opts Options) error {
+				_, _, err := WalkSnapshot(ctx, opts, nil)
+				return err
+			},
+		},
+	}
+
+	for _, operation := range operations {
+		t.Run(operation.name, func(t *testing.T) {
+			dir := t.TempDir()
+			repo := filepath.Join(dir, "repo")
+			configPath := filepath.Join(dir, "backup.json")
+			saveTestConfig(t, configPath, Config{Repo: repo})
+
+			err := operation.run(t.Context(), testOptions(t, Options{ConfigPath: configPath}))
+			if err == nil || !strings.Contains(err.Error(), "backup repo is not initialized") {
+				t.Fatalf("error = %v, want not-initialized guidance", err)
+			}
+
+			if _, statErr := os.Stat(repo); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("read operation created repo: %v", statErr)
+			}
+		})
+	}
+}
+
+func TestReadRepoCloneFailureDoesNotInitializeRepo(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	configPath := filepath.Join(dir, "backup.json")
+	remote := filepath.Join(dir, "missing-remote.git")
+	saveTestConfig(t, configPath, Config{Repo: repo, Remote: remote})
+
+	_, _, err := Status(t.Context(), testOptions(t, Options{ConfigPath: configPath}))
+	if err == nil || !strings.Contains(err.Error(), "git clone") {
+		t.Fatalf("error = %v, want clone failure", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(repo, ".git")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("clone failure initialized repo: %v", statErr)
+	}
+}
+
+func TestReadOperationsSkipPullWithoutCreatingRepo(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	configPath := filepath.Join(dir, "backup.json")
+	saveTestConfig(t, configPath, Config{Repo: repo})
+
+	_, _, err := Status(t.Context(), testOptions(t, Options{ConfigPath: configPath, SkipPull: true}))
+	if err == nil || !strings.Contains(err.Error(), "manifest") {
+		t.Fatalf("error = %v, want missing manifest", err)
+	}
+
+	if _, statErr := os.Stat(repo); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("--no-pull created repo: %v", statErr)
+	}
+}

--- a/internal/backup/read_repo_test.go
+++ b/internal/backup/read_repo_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 )
 
+var errTestGitExit = errors.New("exit status 128")
+
 func TestReadOperationsDoNotInitializeMissingRepo(t *testing.T) {
 	operations := []struct {
 		name string
@@ -86,6 +88,28 @@ func TestReadRepoCloneFailureDoesNotInitializeRepo(t *testing.T) {
 
 	if len(matches) != 0 {
 		t.Fatalf("clone failure left temporary repos: %v", matches)
+	}
+}
+
+func TestGitErrorRedactsCredentialedRemote(t *testing.T) {
+	remote := "https://oauth2:secret-password@example.com/repo.git?access_token=secret-query#secret-fragment"
+	err := gitError(
+		[]string{"clone", remote, "/tmp/repo"},
+		errTestGitExit,
+		"fatal: unable to access 'https://oauth2:secret-password@example.com/repo.git/': authentication failed",
+	)
+
+	got := err.Error()
+	for _, secret := range []string{"oauth2", "secret-password", "secret-query", "secret-fragment"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("git error exposed %q: %s", secret, got)
+		}
+	}
+
+	for _, want := range []string{"git clone", "example.com/repo.git", "redacted", "authentication failed"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("git error = %q, want %q", got, want)
+		}
 	}
 }
 

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -293,7 +293,7 @@ func (c *BackupGmailPushCmd) validate() error {
 }
 
 type BackupStatusCmd struct {
-	backupFlags
+	backupReadFlags
 }
 
 func (c *BackupStatusCmd) Run(ctx context.Context) error {
@@ -327,7 +327,7 @@ func (c *BackupStatusCmd) Run(ctx context.Context) error {
 }
 
 type BackupVerifyCmd struct {
-	backupFlags
+	backupReadFlags
 }
 
 func (c *BackupVerifyCmd) Run(ctx context.Context) error {

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -106,11 +106,19 @@ func bindBackupConfigStore(ctx context.Context, opts *backup.Options) error {
 	return nil
 }
 
+func backupCommandContext(ctx context.Context, flags *RootFlags) context.Context {
+	if flags != nil && flags.NoInput {
+		return backup.WithNoInput(ctx)
+	}
+	return ctx
+}
+
 type BackupInitCmd struct {
 	backupFlags
 }
 
 func (c *BackupInitCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	opts := c.options()
 	if err := bindBackupConfigStore(ctx, &opts); err != nil {
 		return err
@@ -175,6 +183,7 @@ type BackupPushCmd struct {
 }
 
 func (c *BackupPushCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	services := expandBackupServices(splitCSV(c.Services))
 	if len(services) == 0 {
 		return usage("at least one --services value is required")
@@ -250,6 +259,7 @@ type BackupGmailPushCmd struct {
 }
 
 func (c *BackupGmailPushCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	if err := c.validate(); err != nil {
 		return err
 	}
@@ -302,7 +312,8 @@ type BackupStatusCmd struct {
 	backupReadCompatFlags
 }
 
-func (c *BackupStatusCmd) Run(ctx context.Context) error {
+func (c *BackupStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	opts := c.options()
 	if err := bindBackupConfigStore(ctx, &opts); err != nil {
 		return err
@@ -337,7 +348,8 @@ type BackupVerifyCmd struct {
 	backupReadCompatFlags
 }
 
-func (c *BackupVerifyCmd) Run(ctx context.Context) error {
+func (c *BackupVerifyCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	opts := c.options()
 	if err := bindBackupConfigStore(ctx, &opts); err != nil {
 		return err

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -318,6 +318,16 @@ func (c *BackupStatusCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if err := bindBackupConfigStore(ctx, &opts); err != nil {
 		return err
 	}
+	if flags != nil && flags.DryRun {
+		cfg, err := backup.ResolveOptions(opts)
+		if err != nil {
+			return err
+		}
+		return dryRunExit(ctx, flags, "backup.status", map[string]any{
+			"repo": cfg.Repo,
+			"pull": !c.NoPull,
+		})
+	}
 	manifest, repo, err := backup.Status(ctx, opts)
 	if err != nil {
 		return err
@@ -353,6 +363,16 @@ func (c *BackupVerifyCmd) Run(ctx context.Context, flags *RootFlags) error {
 	opts := c.options()
 	if err := bindBackupConfigStore(ctx, &opts); err != nil {
 		return err
+	}
+	if flags != nil && flags.DryRun {
+		cfg, err := backup.ResolveOptions(opts)
+		if err != nil {
+			return err
+		}
+		return dryRunExit(ctx, flags, "backup.verify", map[string]any{
+			"repo": cfg.Repo,
+			"pull": !c.NoPull,
+		})
 	}
 	result, err := backup.Verify(ctx, opts)
 	if err != nil {

--- a/internal/cmd/backup.go
+++ b/internal/cmd/backup.go
@@ -74,6 +74,11 @@ type backupReadFlags struct {
 	NoPull   bool   `name:"no-pull" help:"Use local backup repository state without pulling first"`
 }
 
+type backupReadCompatFlags struct {
+	NoPush     bool     `name:"no-push" hidden:"" help:"(deprecated) Ignored for read commands"`
+	Recipients []string `name:"recipient" hidden:"" help:"(deprecated) Ignored for read commands"`
+}
+
 func (f backupReadFlags) options() backup.Options {
 	return backup.Options{
 		ConfigPath: f.Config,
@@ -294,6 +299,7 @@ func (c *BackupGmailPushCmd) validate() error {
 
 type BackupStatusCmd struct {
 	backupReadFlags
+	backupReadCompatFlags
 }
 
 func (c *BackupStatusCmd) Run(ctx context.Context) error {
@@ -328,6 +334,7 @@ func (c *BackupStatusCmd) Run(ctx context.Context) error {
 
 type BackupVerifyCmd struct {
 	backupReadFlags
+	backupReadCompatFlags
 }
 
 func (c *BackupVerifyCmd) Run(ctx context.Context) error {

--- a/internal/cmd/backup_cmd_test.go
+++ b/internal/cmd/backup_cmd_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -193,6 +194,62 @@ func TestBackupStatusAndVerifyExposeReadFlags(t *testing.T) {
 				if !hiddenFlags[compat] {
 					t.Fatalf("missing hidden compatibility flag --%s", compat)
 				}
+			}
+		})
+	}
+}
+
+func TestBackupStatusAndVerifyDryRunDoNotCreateRepo(t *testing.T) {
+	testCases := []struct {
+		name string
+		run  func(context.Context, *RootFlags, string) error
+	}{
+		{
+			name: "status",
+			run: func(ctx context.Context, flags *RootFlags, repo string) error {
+				return (&BackupStatusCmd{
+					backupReadFlags: backupReadFlags{Repo: repo},
+				}).Run(ctx, flags)
+			},
+		},
+		{
+			name: "verify",
+			run: func(ctx context.Context, flags *RootFlags, repo string) error {
+				return (&BackupVerifyCmd{
+					backupReadFlags: backupReadFlags{Repo: repo},
+				}).Run(ctx, flags)
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			repo := filepath.Join(t.TempDir(), testCase.name+"-repo")
+			var stdout bytes.Buffer
+			ctx := newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard)
+			err := testCase.run(ctx, &RootFlags{DryRun: true, NoInput: true}, repo)
+
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+				t.Fatalf("expected dry-run exit 0, got %#v", err)
+			}
+			var payload struct {
+				DryRun  bool           `json:"dry_run"`
+				Op      string         `json:"op"`
+				Request map[string]any `json:"request"`
+			}
+			if decodeErr := json.Unmarshal(stdout.Bytes(), &payload); decodeErr != nil {
+				t.Fatalf("decode dry-run output: %v\n%s", decodeErr, stdout.String())
+			}
+			if !payload.DryRun || payload.Op != "backup."+testCase.name {
+				t.Fatalf("unexpected dry-run payload: %#v", payload)
+			}
+			requestRepo, ok := payload.Request["repo"].(string)
+			if !ok || requestRepo != repo {
+				t.Fatalf("missing repo in request: %#v", payload.Request)
+			}
+			if _, statErr := os.Stat(repo); !errors.Is(statErr, os.ErrNotExist) {
+				t.Fatalf("dry-run created repo: %v", statErr)
 			}
 		})
 	}

--- a/internal/cmd/backup_cmd_test.go
+++ b/internal/cmd/backup_cmd_test.go
@@ -150,6 +150,36 @@ func TestWriteBackupResultUsesRuntimeOutput(t *testing.T) {
 	}
 }
 
+func TestBackupStatusAndVerifyExposeReadFlags(t *testing.T) {
+	for _, command := range []string{"status", "verify"} {
+		t.Run(command, func(t *testing.T) {
+			result := executeWithTestRuntime(t, []string{"schema", "backup " + command}, nil)
+			if result.err != nil {
+				t.Fatalf("schema: %v", result.err)
+			}
+			var doc schemaDoc
+			if err := json.Unmarshal([]byte(result.stdout), &doc); err != nil {
+				t.Fatalf("decode schema: %v", err)
+			}
+			if doc.Command == nil {
+				t.Fatal("missing command schema")
+			}
+			flags := make(map[string]bool, len(doc.Command.Flags))
+			for _, flag := range doc.Command.Flags {
+				flags[flag.Name] = true
+			}
+			if !flags["no-pull"] {
+				t.Fatal("missing --no-pull")
+			}
+			for _, unexpected := range []string{"no-push", "recipient"} {
+				if flags[unexpected] {
+					t.Fatalf("unexpected --%s", unexpected)
+				}
+			}
+		})
+	}
+}
+
 func TestBackupExportReportsManifestSemanticCounts(t *testing.T) {
 	repo, config, recipients := newBackupConfigForCmdTest(t)
 	shard, err := backup.NewJSONLShard("contacts", "people", "acct", "data/contacts/acct/people/part-0001.jsonl.gz.age", []map[string]string{

--- a/internal/cmd/backup_cmd_test.go
+++ b/internal/cmd/backup_cmd_test.go
@@ -171,9 +171,27 @@ func TestBackupStatusAndVerifyExposeReadFlags(t *testing.T) {
 			if !flags["no-pull"] {
 				t.Fatal("missing --no-pull")
 			}
-			for _, unexpected := range []string{"no-push", "recipient"} {
-				if flags[unexpected] {
-					t.Fatalf("unexpected --%s", unexpected)
+			for _, hidden := range []string{"no-push", "recipient"} {
+				if flags[hidden] {
+					t.Fatalf("hidden compatibility flag --%s appears in default schema", hidden)
+				}
+			}
+
+			hiddenResult := executeWithTestRuntime(t, []string{"schema", "--include-hidden", "backup " + command}, nil)
+			if hiddenResult.err != nil {
+				t.Fatalf("hidden schema: %v", hiddenResult.err)
+			}
+			var hiddenDoc schemaDoc
+			if err := json.Unmarshal([]byte(hiddenResult.stdout), &hiddenDoc); err != nil {
+				t.Fatalf("decode hidden schema: %v", err)
+			}
+			hiddenFlags := make(map[string]bool, len(hiddenDoc.Command.Flags))
+			for _, flag := range hiddenDoc.Command.Flags {
+				hiddenFlags[flag.Name] = flag.Hidden
+			}
+			for _, compat := range []string{"no-push", "recipient"} {
+				if !hiddenFlags[compat] {
+					t.Fatalf("missing hidden compatibility flag --%s", compat)
 				}
 			}
 		})

--- a/internal/cmd/backup_export.go
+++ b/internal/cmd/backup_export.go
@@ -26,6 +26,7 @@ type BackupCatCmd struct {
 }
 
 func (c *BackupCatCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	shardPath := strings.TrimSpace(c.Shard)
 	if shardPath == "" {
 		return usage("empty shard")
@@ -99,6 +100,7 @@ type backupExportOptions struct {
 }
 
 func (c *BackupExportCmd) Run(ctx context.Context, flags *RootFlags) error {
+	ctx = backupCommandContext(ctx, flags)
 	backupOpts := c.options()
 	if err := bindBackupConfigStore(ctx, &backupOpts); err != nil {
 		return err


### PR DESCRIPTION
## Summary

- separate backup read repository preparation from write-oriented initialization
- let status, verify, cat, and export pull existing repos or clone configured remotes without falling back to `git init`
- clone read repositories through a sibling temporary directory and atomically install them, leaving no partial target on failure
- support pre-created empty or mounted repository directories and clean partial contents after failed clones
- make global `--no-input` disable Git credential/UI prompts and force SSH batch mode across backup commands
- redact URL credentials from displayed Git arguments and captured diagnostics
- make status and verify return file-free `--dry-run` plans before repository preparation
- add `--no-pull` to status/verify while retaining legacy `--recipient`/`--no-push` as hidden ignored compatibility flags
- update backup docs, generated command docs, changelog, and regression coverage

## Testing

- `go test ./internal/backup -count=1`
- focused backup command/schema tests
- `make ci`
- structured autoreview: clean, no accepted/actionable findings
- compatibility smoke: legacy flags parse successfully but remain absent from normal help and generated docs
- fake-Git binary smoke: prompt environment disabled, failed clone returns immediately, and neither target nor temp repository remains
- credentialed-remote smoke: fake Git echoed a credentialed URL; returned diagnostics contained only redacted URL components
- existing-directory smoke: real clone populated a pre-created empty directory; fake failed clone preserved it with zero entries
- binary dry-run smoke: status and verify return resolved repo/pull plans without creating their target paths

## Binary proof

Disposable repositories verified:

```text
valid_status_rc=0
valid_verify_rc=0
missing_rc=1
clone_rc=1
cat_rc=1
export_rc=1
missing_repo_exists=no
clone_git_exists=no
export_exists=no
no_input_git_terminal_prompt=0
no_input_gcm_interactive=Never
no_input_ssh_batch_mode=yes
partial_clone_target_exists=no
partial_clone_temp_count=0
credential_leak=no
existing_empty_clone_git=yes
failed_existing_dir_preserved=yes
failed_existing_dir_entries=0
status_dry_run_repo_exists=no
verify_dry_run_repo_exists=no
```

Missing repositories return actionable init/remote guidance. Clone failures preserve the original `git clone` error and do not create a fallback `.git` repository.
