### PR TITLE
fix(mcp): enforce tool input schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- MCP: validate typed tool calls against their closed schemas before command execution, rejecting unknown fields, wrong types, and missing required fields.
 - CLI: classify malformed OAuth token imports as usage errors and missing Gmail tracking setup as configuration errors.
 - CLI: classify invalid Docs batch IDs and incomplete Gmail filter definitions as usage errors with exit code 2.
 - Docs: keep batch list/show, batch target validation, and batch end dry-runs read-only without creating state directories or lock files.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -56,7 +56,8 @@ commands that were not reviewed for MCP use.
 
 - no generic command execution tool
 - no model-supplied argv passthrough
-- fixed tool schemas with unknown fields rejected
+- fixed tool schemas validated before command execution, including required
+  fields, types, and rejection of unknown fields
 - read-only tools by default
 - write tools require explicit server startup flags
 - existing `gog` account, auth, dry-run, no-input, and command safety flags are

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -75,18 +75,10 @@ func (c *McpCmd) Run(ctx context.Context, flags *RootFlags) error {
 	timeout := time.Duration(c.TimeoutSeconds) * time.Second
 	maxOutputBytes := c.MaxOutputBytes
 
-	s := server.NewMCPServer("gog", VersionString(), server.WithToolCapabilities(false))
+	s := newMCPServer()
 	for _, spec := range tools {
 		tool := spec
-		opts := append([]mcp.ToolOption{
-			mcp.WithDescription(tool.Description),
-			mcp.WithReadOnlyHintAnnotation(tool.Risk == mcpRiskRead),
-			mcp.WithDestructiveHintAnnotation(tool.Risk == mcpRiskWrite),
-			mcp.WithIdempotentHintAnnotation(tool.Risk == mcpRiskRead),
-			mcp.WithOpenWorldHintAnnotation(true),
-			mcp.WithSchemaAdditionalProperties(false),
-		}, tool.Options...)
-		s.AddTool(mcp.NewTool(tool.Name, opts...), func(reqCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		s.AddTool(newMCPTool(tool), func(reqCtx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 			childCommandArgs, buildErr := tool.BuildArgs(req)
 			if buildErr != nil {
 				result := mcp.NewToolResultError(buildErr.Error())
@@ -106,6 +98,27 @@ func (c *McpCmd) Run(ctx context.Context, flags *RootFlags) error {
 		})
 	}
 	return server.ServeStdio(s)
+}
+
+func newMCPServer() *server.MCPServer {
+	return server.NewMCPServer(
+		"gog",
+		VersionString(),
+		server.WithToolCapabilities(false),
+		server.WithInputSchemaValidation(),
+	)
+}
+
+func newMCPTool(tool mcpToolSpec) mcp.Tool {
+	opts := append([]mcp.ToolOption{
+		mcp.WithDescription(tool.Description),
+		mcp.WithReadOnlyHintAnnotation(tool.Risk == mcpRiskRead),
+		mcp.WithDestructiveHintAnnotation(tool.Risk == mcpRiskWrite),
+		mcp.WithIdempotentHintAnnotation(tool.Risk == mcpRiskRead),
+		mcp.WithOpenWorldHintAnnotation(true),
+		mcp.WithSchemaAdditionalProperties(false),
+	}, tool.Options...)
+	return mcp.NewTool(tool.Name, opts...)
 }
 
 type mcpRunOptions struct {

--- a/internal/cmd/mcp_test.go
+++ b/internal/cmd/mcp_test.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"strings"
 	"testing"
 
+	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -100,6 +102,105 @@ func TestMCPToolBuildArgsTypedOnly(t *testing.T) {
 	want := []string{"sheets", "update", "--values-json", "[[1,2]]", "--input", "RAW", "--", "sheet1", "Sheet1!A1:B1"}
 	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("args = %#v, want %#v", args, want)
+	}
+}
+
+func TestMCPServerValidatesToolInputSchema(t *testing.T) {
+	s := newMCPServer()
+	handlerCalls := 0
+	s.AddTool(newMCPTool(findMCPTool(t, "docs_write")), func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		handlerCalls++
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	client, err := mcpclient.NewInProcessClient(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := client.Close(); err != nil {
+			t.Errorf("close client: %v", err)
+		}
+	})
+	if err := client.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{Name: "gog-test", Version: "1"}
+	if _, err := client.Initialize(t.Context(), initRequest); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		arguments map[string]any
+		wantError bool
+		wantText  string
+	}{
+		{
+			name: "unknown field",
+			arguments: map[string]any{
+				"document_id": "doc1",
+				"text":        "hello",
+				"argv":        []any{"drive", "delete", "file"},
+			},
+			wantError: true,
+			wantText:  "argv",
+		},
+		{
+			name: "wrong type",
+			arguments: map[string]any{
+				"document_id": "doc1",
+				"text":        "hello",
+				"append":      "yes",
+			},
+			wantError: true,
+			wantText:  "append",
+		},
+		{
+			name: "missing required field",
+			arguments: map[string]any{
+				"text": "hello",
+			},
+			wantError: true,
+			wantText:  "document_id",
+		},
+		{
+			name: "valid",
+			arguments: map[string]any{
+				"document_id": "doc1",
+				"text":        "hello",
+				"append":      true,
+			},
+			wantText: "ok",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := handlerCalls
+			result, err := client.CallTool(t.Context(), mcp.CallToolRequest{
+				Params: mcp.CallToolParams{
+					Name:      "docs_write",
+					Arguments: tt.arguments,
+				},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if result.IsError != tt.wantError {
+				t.Fatalf("IsError = %v, want %v: %#v", result.IsError, tt.wantError, result.Content)
+			}
+			if tt.wantError && handlerCalls != before {
+				t.Fatal("invalid arguments reached the tool handler")
+			}
+			if !strings.Contains(mcpResultText(result), tt.wantText) {
+				t.Fatalf("result = %#v, want text containing %q", result.Content, tt.wantText)
+			}
+		})
+	}
+	if handlerCalls != 1 {
+		t.Fatalf("handler calls = %d, want 1", handlerCalls)
 	}
 }
 
@@ -233,4 +334,14 @@ func findMCPTool(t *testing.T, name string) mcpToolSpec {
 	}
 	t.Fatalf("missing tool %s", name)
 	return mcpToolSpec{}
+}
+
+func mcpResultText(result *mcp.CallToolResult) string {
+	var text strings.Builder
+	for _, content := range result.Content {
+		if item, ok := content.(mcp.TextContent); ok {
+			text.WriteString(item.Text)
+		}
+	}
+	return text.String()
 }


### PR DESCRIPTION
## Summary

- enable mcp-go server-side validation for every registered tool schema
- reject unknown fields, wrong types, and missing required fields before tool handlers or child commands run
- document the enforced contract and add an in-process regression matrix

## Verification

- `go test ./internal/cmd -run 'TestMCP(ServerValidatesToolInputSchema|ToolBuildArgsTypedOnly|DocsWrite)'`
- raw MCP stdio binary smoke: three invalid payload classes rejected; valid Docs write dry-run succeeded
- 556-command offline replay: zero timeouts; command classes and file-touch behavior unchanged
- `make docs-check`
- `make ci`
- structured autoreview: no accepted/actionable findings

Fixes GOG-ALL-030 found during exhaustive CLI testing.
