### PR TITLE
fix(meet): normalize empty participant results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 
+- Meet: return empty history and participant collections as JSON arrays, and make `participants --fail-empty` control the no-conference exit instead of misclassifying it as invalid usage.
 - MCP: validate typed tool calls against their closed schemas before command execution, rejecting unknown fields, wrong types, and missing required fields.
 - CLI: classify malformed OAuth token imports as usage errors and missing Gmail tracking setup as configuration errors.
 - CLI: classify invalid Docs batch IDs and incomplete Gmail filter definitions as usage errors with exit code 2.

--- a/internal/cmd/execute_meet_test.go
+++ b/internal/cmd/execute_meet_test.go
@@ -387,3 +387,70 @@ func TestExecute_MeetParticipants_JSON(t *testing.T) {
 		t.Fatalf("unexpected participants: %#v", parsed.Participants)
 	}
 }
+
+func TestExecute_MeetEmptyLists_JSON(t *testing.T) {
+	participantListCalled := false
+	svc := newTestMeetService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v2/spaces/abc-defg-hij" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(meetSpaceResponse())
+		case r.URL.Path == "/v2/conferenceRecords" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{})
+		case strings.Contains(r.URL.Path, "/participants"):
+			participantListCalled = true
+			http.Error(w, "unexpected participant list", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+
+	tests := []struct {
+		name  string
+		args  []string
+		field string
+	}{
+		{
+			name:  "history",
+			args:  []string{"meet", "history", "abc-defg-hij"},
+			field: "conferences",
+		},
+		{
+			name:  "participants",
+			args:  []string{"meet", "participants", "abc-defg-hij"},
+			field: "participants",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			baseArgs := append([]string{"--json", "--account", "a@b.com"}, tt.args...)
+			result := executeWithMeetTestService(t, baseArgs, svc)
+			if result.err != nil {
+				t.Fatalf("Execute: %v", result.err)
+			}
+			assertMeetEmptyJSONArray(t, result.stdout, tt.field)
+
+			failEmptyArgs := append(append([]string{}, baseArgs...), "--fail-empty")
+			failEmptyResult := executeWithMeetTestService(t, failEmptyArgs, svc)
+			if code := ExitCode(failEmptyResult.err); code != 3 {
+				t.Fatalf("fail-empty exit = %d, want 3; err=%v", code, failEmptyResult.err)
+			}
+			assertMeetEmptyJSONArray(t, failEmptyResult.stdout, tt.field)
+		})
+	}
+	if participantListCalled {
+		t.Fatal("participant list API called without a conference record")
+	}
+}
+
+func assertMeetEmptyJSONArray(t *testing.T, output, field string) {
+	t.Helper()
+	var parsed map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(output), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nout=%q", err, output)
+	}
+	if got := string(parsed[field]); got != "[]" {
+		t.Fatalf("%s = %s, want []", field, got)
+	}
+}

--- a/internal/cmd/meet_history.go
+++ b/internal/cmd/meet_history.go
@@ -62,7 +62,6 @@ func (c *MeetHistoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	var records []*meet.ConferenceRecord
-
 	nextPageToken := ""
 
 	if c.All {
@@ -79,6 +78,9 @@ func (c *MeetHistoryCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if err != nil {
 			return err
 		}
+	}
+	if records == nil {
+		records = make([]*meet.ConferenceRecord, 0)
 	}
 
 	if outfmt.IsJSON(ctx) {

--- a/internal/cmd/meet_participants.go
+++ b/internal/cmd/meet_participants.go
@@ -44,40 +44,44 @@ func (c *MeetParticipantsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	fetch := func(pageToken string) ([]*meet.Participant, string, error) {
-		call := svc.ConferenceRecords.Participants.List(conferenceName).
-			PageSize(int64(c.Max)).
-			Context(ctx)
-		if strings.TrimSpace(pageToken) != "" {
-			call = call.PageToken(pageToken)
-		}
-
-		resp, err := call.Do()
-		if err != nil {
-			return nil, "", wrapMeetError(err)
-		}
-
-		return resp.Participants, resp.NextPageToken, nil
-	}
-
-	var participants []*meet.Participant
-
+	participants := make([]*meet.Participant, 0)
 	nextPageToken := ""
 
-	if c.All {
-		all, err := collectAllPages(c.Page, fetch)
-		if err != nil {
-			return err
+	if conferenceName != "" {
+		fetch := func(pageToken string) ([]*meet.Participant, string, error) {
+			call := svc.ConferenceRecords.Participants.List(conferenceName).
+				PageSize(int64(c.Max)).
+				Context(ctx)
+			if strings.TrimSpace(pageToken) != "" {
+				call = call.PageToken(pageToken)
+			}
+
+			resp, err := call.Do()
+			if err != nil {
+				return nil, "", wrapMeetError(err)
+			}
+
+			return resp.Participants, resp.NextPageToken, nil
 		}
 
-		participants = all
-	} else {
-		var err error
+		if c.All {
+			all, err := collectAllPages(c.Page, fetch)
+			if err != nil {
+				return err
+			}
 
-		participants, nextPageToken, err = fetch(c.Page)
-		if err != nil {
-			return err
+			participants = all
+		} else {
+			var err error
+
+			participants, nextPageToken, err = fetch(c.Page)
+			if err != nil {
+				return err
+			}
 		}
+	}
+	if participants == nil {
+		participants = make([]*meet.Participant, 0)
 	}
 
 	if outfmt.IsJSON(ctx) {
@@ -156,7 +160,7 @@ func resolveConference(ctx context.Context, svc *meet.Service, meetingCode, conf
 	}
 
 	if len(resp.ConferenceRecords) == 0 {
-		return "", usagef("no past calls found for %s", meetingCode)
+		return "", nil
 	}
 
 	return resp.ConferenceRecords[0].Name, nil

--- a/scripts/live-tests/meet.sh
+++ b/scripts/live-tests/meet.sh
@@ -23,5 +23,9 @@ run_meet_tests() {
 
   run_required "meet" "meet get" gog meet get "$meeting_code" --json >/dev/null
   run_required "meet" "meet update" gog meet update "$meeting_code" --access open --json >/dev/null
-  run_required "meet" "meet history" gog meet history "$meeting_code" --json --max 1 >/dev/null
+  local history_json participants_json
+  history_json=$(gog meet history "$meeting_code" --json --max 1)
+  echo "$history_json" | "$PY" -c 'import json,sys; value=json.load(sys.stdin)["conferences"]; assert isinstance(value,list)'
+  participants_json=$(gog meet participants "$meeting_code" --json --max 1)
+  echo "$participants_json" | "$PY" -c 'import json,sys; value=json.load(sys.stdin)["participants"]; assert isinstance(value,list)'
 }


### PR DESCRIPTION
## Summary

- serialize empty Meet history and participant collections as JSON arrays
- treat a valid meeting with no conference as an empty participant result
- let `participants --fail-empty` control the empty-result exit code
- extend unit and live-test coverage for empty Meet collections

## Verification

- `go test ./internal/cmd -run Meet -count=1`
- `make docs-check`
- `make ci`
- structured Codex autoreview: clean
- 556-path offline replay: 556 rows, zero timeouts, unchanged exit classes
- live `clawdbot@gmail.com` Meet space:
  - history JSON contains `conferences: []`
  - participants JSON contains `participants: []`
  - normal participants exit `0`
  - participants `--fail-empty` exit `3`
  - no participant-list request when no conference exists

## External limits

- `RESTRICTED` access remains unavailable to this consumer account
- active-conference participant/end proof remains blocked by the detached existing-profile Chrome bridge
