### PR TITLE
test(calendar): handle single-calendar live accounts

### DIFF
--- a/scripts/live-tests/calendar.sh
+++ b/scripts/live-tests/calendar.sh
@@ -2,6 +2,40 @@
 
 set -euo pipefail
 
+run_calendar_conflicts_test() {
+  local calendar_count="$1"
+  local start="$2"
+  local end="$3"
+
+  if [ "$calendar_count" -ge 2 ]; then
+    run_required "calendar" "calendar conflicts" \
+      gog calendar conflicts --from "$start" --to "$end" --json >/dev/null
+    return 0
+  fi
+
+  local stdout_file stderr_file exit_code
+  stdout_file="$LIVE_TMP/calendar-conflicts-single.stdout"
+  stderr_file="$LIVE_TMP/calendar-conflicts-single.stderr"
+  echo "==> calendar conflicts (single-calendar validation)"
+  if gog calendar conflicts --from "$start" --to "$end" --json \
+    >"$stdout_file" 2>"$stderr_file"; then
+    echo "Expected single-calendar conflict detection to fail, but it succeeded" >&2
+    return 1
+  else
+    exit_code=$?
+  fi
+  if [ "$exit_code" -ne 2 ]; then
+    cat "$stderr_file" >&2
+    echo "Expected single-calendar conflict detection to exit 2, got $exit_code" >&2
+    return 1
+  fi
+  [ ! -s "$stdout_file" ] || {
+    echo "Single-calendar conflict validation wrote to stdout" >&2
+    return 1
+  }
+  grep -q "requires at least two calendars" "$stderr_file"
+}
+
 run_calendar_tests() {
   if skip "calendar"; then
     echo "==> calendar (skipped)"
@@ -17,7 +51,10 @@ print(start.strftime('%Y-%m-%dT%H:%M:%SZ'), end.strftime('%Y-%m-%dT%H:%M:%SZ'), 
 PY
 )"
 
-  run_required "calendar" "calendar list" gog calendar calendars --json --max 1 >/dev/null
+  local calendars_json calendar_count
+  echo "==> calendar list"
+  calendars_json=$(gog calendar calendars --json --max 100)
+  calendar_count=$("$PY" -c 'import json,sys; print(len(json.load(sys.stdin).get("calendars", [])))' <<<"$calendars_json")
   run_required "calendar" "calendar acl" gog calendar acl primary --json --max 1 >/dev/null
   run_required "calendar" "calendar colors" gog calendar colors --json >/dev/null
   run_required "calendar" "calendar time" gog calendar time --json >/dev/null
@@ -52,7 +89,7 @@ assert any(a.get("fileUrl") == want for a in attachments)' "$attachment_url" <<<
   run_required "calendar" "calendar events list" gog calendar events primary --from "$START" --to "$END" --json --max 5 >/dev/null
   run_required "calendar" "calendar search" gog calendar search "gogcli-smoke" --from "$START" --to "$END" --json --max 5 >/dev/null
   run_required "calendar" "calendar freebusy" gog calendar freebusy primary --from "$START" --to "$END" --json >/dev/null
-  run_required "calendar" "calendar conflicts" gog calendar conflicts --from "$START" --to "$END" --json >/dev/null
+  run_calendar_conflicts_test "$calendar_count" "$START" "$END"
 
   if [ -n "${GOG_LIVE_CALENDAR_RESPOND:-}" ]; then
     run_optional "calendar-respond" "calendar respond" gog calendar respond primary "$ev_id" --status accepted --json >/dev/null

--- a/scripts/live_calendar_test.go
+++ b/scripts/live_calendar_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestCalendarLiveConflictsHandlesCalendarCount(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	for _, calendarCount := range []string{"1", "2"} {
+		t.Run(calendarCount+" calendars", func(t *testing.T) {
+			script := `
+set -euo pipefail
+ROOT_DIR="$1"
+CALENDAR_COUNT="$2"
+SKIP=""
+LIVE_TMP=$(mktemp -d)
+TRACE_FILE="$LIVE_TMP/trace"
+trap 'rm -rf "$LIVE_TMP"' EXIT
+source "$ROOT_DIR/scripts/live-tests/common.sh"
+source "$ROOT_DIR/scripts/live-tests/calendar.sh"
+gog() {
+  echo invoked >>"$TRACE_FILE"
+  if [ "$CALENDAR_COUNT" -lt 2 ]; then
+    echo "calendar conflicts requires at least two calendars" >&2
+    return 2
+  fi
+  printf '{"conflicts":[],"count":0}\n'
+}
+run_calendar_conflicts_test "$CALENDAR_COUNT" \
+  2026-06-13T00:00:00Z 2026-06-14T00:00:00Z
+cat "$TRACE_FILE"
+`
+
+			output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root, calendarCount).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run calendar conflict live-test path: %v\n%s", err, output)
+			}
+
+			text := string(output)
+			if calendarCount == "1" && !strings.Contains(text, "single-calendar validation") {
+				t.Fatalf("output missing single-calendar validation:\n%s", text)
+			}
+
+			if !strings.Contains(text, "invoked") {
+				t.Fatalf("output missing CLI invocation trace:\n%s", text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- make the Calendar live suite account-aware for conflict detection
- run the real conflicts query when at least two calendars exist
- verify the documented usage exit when only one calendar exists
- add Bash-backed regression coverage for both paths

## Verification

- `go test ./scripts -run TestCalendarLiveConflictsHandlesCalendarCount -count=1`
- `make ci`
- structured Codex autoreview: clean
- full `clawdbot@gmail.com` broad live suite completed through Calendar, Tasks, Contacts, People, Workspace preflights, and Classroom

## Notes

- internal test-harness change only; no user-facing changelog entry
- Meet was skipped in this broad rerun because its empty-result fix was separately live-tested immediately before this PR and creating a Meet space has no cleanup API
