### PR TITLE
test(live): cover consumer other contacts

### DIFF
--- a/scripts/live-test.sh
+++ b/scripts/live-test.sh
@@ -32,7 +32,7 @@ Skip keys (base):
   gmail-attachments, gmail-track, gmail-watch, chat, drive, docs, sheets, slides,
   photos-picker,
   calendar, calendar-enterprise, calendar-respond, calendar-team, calendar-users,
-  tasks, contacts, people, groups, keep, classroom
+  tasks, contacts, contacts-directory, contacts-other, people, groups, keep, classroom
 
 Env:
   GOG_LIVE_EMAIL_TEST=steipete+gogtest@gmail.com

--- a/scripts/live-tests/contacts.sh
+++ b/scripts/live-tests/contacts.sh
@@ -2,6 +2,23 @@
 
 set -euo pipefail
 
+run_contacts_other_tests() {
+  if skip "contacts-other"; then
+    echo "==> contacts other (skipped)"
+    return 0
+  fi
+
+  local other_json other_query
+  echo "==> contacts other list"
+  other_json=$(gog contacts other list --json --max 1)
+  other_query=$(extract_field "$other_json" email)
+  if [ -z "$other_query" ]; then
+    other_query="gogcli-smoke-$TS@example.com"
+  fi
+  run_required "contacts-other" "contacts other search" \
+    gog contacts other search "$other_query" --json --max 1 >/dev/null
+}
+
 run_contacts_tests() {
   if skip "contacts"; then
     echo "==> contacts (skipped)"
@@ -26,11 +43,10 @@ run_contacts_tests() {
 
   if is_consumer_account "$ACCOUNT"; then
     echo "==> contacts directory (skipped; Workspace only)"
-    echo "==> contacts other (skipped; Workspace only)"
   else
     run_optional "contacts-directory" "contacts directory list" gog contacts directory list --json --max 1 >/dev/null
     run_optional "contacts-directory" "contacts directory search" gog contacts directory search "gogcli" --json --max 1 >/dev/null
-    run_optional "contacts-other" "contacts other list" gog contacts other list --json --max 1 >/dev/null
-    run_optional "contacts-other" "contacts other search" gog contacts other search "gogcli" --json --max 1 >/dev/null
   fi
+
+  run_contacts_other_tests
 }

--- a/scripts/live_contacts_test.go
+++ b/scripts/live_contacts_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestContactsLiveOtherContactsRunsForConsumerAccounts(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	tests := []struct {
+		name      string
+		otherJSON string
+		wantQuery string
+	}{
+		{
+			name:      "existing other contact",
+			otherJSON: `{"contacts":[{"email":"friend@example.com"}]}`,
+			wantQuery: "friend@example.com",
+		},
+		{
+			name:      "empty other contacts",
+			otherJSON: `{"contacts":[]}`,
+			wantQuery: "gogcli-smoke-20260613000000@example.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			script := `
+set -euo pipefail
+ROOT_DIR="$1"
+OTHER_JSON="$2"
+PY=python3
+SKIP=""
+TS=20260613000000
+LIVE_TMP=$(mktemp -d)
+TRACE_FILE="$LIVE_TMP/trace"
+trap 'rm -rf "$LIVE_TMP"' EXIT
+source "$ROOT_DIR/scripts/live-tests/common.sh"
+source "$ROOT_DIR/scripts/live-tests/contacts.sh"
+gog() {
+  printf '%s\n' "$*" >>"$TRACE_FILE"
+  case "$*" in
+    "contacts other list"*)
+      printf '%s\n' "$OTHER_JSON"
+      ;;
+    "contacts other search"*)
+      printf '{"contacts":[]}\n'
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+run_contacts_other_tests
+cat "$TRACE_FILE"
+`
+
+			output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root, tt.otherJSON).CombinedOutput()
+			if err != nil {
+				t.Fatalf("run contacts live-test path: %v\n%s", err, output)
+			}
+
+			text := string(output)
+			if !strings.Contains(text, "contacts other list --json --max 1") {
+				t.Fatalf("output missing other contacts list:\n%s", text)
+			}
+
+			if !strings.Contains(text, "contacts other search "+tt.wantQuery+" --json --max 1") {
+				t.Fatalf("output missing expected other contacts search:\n%s", text)
+			}
+		})
+	}
+}
+
+func TestContactsLiveOtherContactsSkipAvoidsAPI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+SKIP="contacts-other"
+TS=20260613000000
+source "$ROOT_DIR/scripts/live-tests/common.sh"
+source "$ROOT_DIR/scripts/live-tests/contacts.sh"
+gog() {
+  echo "unexpected API call" >&2
+  return 1
+}
+run_contacts_other_tests
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run contacts live-test skip path: %v\n%s", err, output)
+	}
+
+	text := string(output)
+	if !strings.Contains(text, "contacts other (skipped)") {
+		t.Fatalf("output missing other contacts skip:\n%s", text)
+	}
+
+	if strings.Contains(text, "unexpected API call") {
+		t.Fatalf("skip path invoked the API:\n%s", text)
+	}
+}


### PR DESCRIPTION
## Summary

- run Other Contacts list/search live coverage for consumer accounts
- keep Workspace Directory contacts separately gated
- document and enforce the `contacts-other` skip key
- add Bash-backed harness regressions for populated, empty, and skipped paths

## Verification

- live `clawdbot@gmail.com` contacts section, including Other Contacts list/search
- `go test ./scripts -run 'TestContactsLiveOtherContacts' -count=1`
- structured autoreview: clean
- `make ci`

Pure live-test harness coverage; no changelog entry.
