### PR TITLE
feat(contacts): apply duplicate merge plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.27.2 - Unreleased
 
+### Added
+
+- Contacts: add guarded `contacts dedupe --apply` merging with exact dry-run plans, confirmation, full updatable-field preservation, etag checks before deletion, and refusal of ambiguous or unmergeable groups. (#815) — thanks @privatenumber.
+
 ### Changed
 
 - Gmail: show ordinary message bodies in full by default in text output, retain a generous cap for unusually large messages, and point truncated output to `--full` or `--json`. (#807) — thanks @privatenumber.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Contacts: add guarded `contacts dedupe --apply` merging with exact dry-run plans, confirmation, full updatable-field preservation, etag checks before deletion, and refusal of ambiguous or unmergeable groups. (#815) — thanks @privatenumber.
+- Contacts: add guarded `contacts dedupe --apply` merging with exact dry-run plans, repeatable `--resource` scoping, confirmation, full updatable-field preservation, etag checks before deletion, and refusal of ambiguous or unmergeable groups. (#815) — thanks @privatenumber.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -316,9 +316,13 @@ Docs: [contacts dedupe](docs/contacts-dedupe.md),
 gog contacts search alice --json
 gog contacts export --all --out contacts.vcf
 
-# Preview only: no merge/delete/update call is made.
+# Preview by default.
 gog contacts dedupe --json
-gog contacts dedupe --match email,phone,name --dry-run
+gog contacts dedupe --match email,phone,name
+
+# Inspect the mutation plan, then apply with confirmation.
+gog contacts dedupe --apply --dry-run --json
+gog contacts dedupe --apply
 ```
 
 ### Docs

--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ gog contacts dedupe --match email,phone,name
 # Inspect the mutation plan, then apply with confirmation.
 gog contacts dedupe --apply --dry-run --json
 gog contacts dedupe --apply
+
+# Scope automation to exact reviewed contact resources.
+gog contacts dedupe --resource people/123 --resource people/456 --apply --force --json
 ```
 
 ### Docs

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -208,7 +208,7 @@ Generated from `gog schema --json`.
     - [`gog config unset (rm,del,remove) <key>`](commands/gog-config-unset.md) - Unset a config value
   - [`gog contacts (contact) <command> [flags]`](commands/gog-contacts.md) - Google Contacts
     - [`gog contacts (contact) create (add,new) [flags]`](commands/gog-contacts-create.md) - Create a contact
-    - [`gog contacts (contact) dedupe [flags]`](commands/gog-contacts-dedupe.md) - Find likely duplicate contacts (preview only)
+    - [`gog contacts (contact) dedupe [flags]`](commands/gog-contacts-dedupe.md) - Find likely duplicate contacts and optionally merge them
     - [`gog contacts (contact) delete (rm,del,remove) <resourceName>`](commands/gog-contacts-delete.md) - Delete a contact
     - [`gog contacts (contact) directory <command>`](commands/gog-contacts-directory.md) - Directory contacts
       - [`gog contacts (contact) directory list [flags]`](commands/gog-contacts-directory-list.md) - List people from the Workspace directory

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -259,7 +259,7 @@ Generated pages: 646.
     - [gog config unset](gog-config-unset.md) - Unset a config value
   - [gog contacts](gog-contacts.md) - Google Contacts
     - [gog contacts create](gog-contacts-create.md) - Create a contact
-    - [gog contacts dedupe](gog-contacts-dedupe.md) - Find likely duplicate contacts (preview only)
+    - [gog contacts dedupe](gog-contacts-dedupe.md) - Find likely duplicate contacts and optionally merge them
     - [gog contacts delete](gog-contacts-delete.md) - Delete a contact
     - [gog contacts directory](gog-contacts-directory.md) - Directory contacts
       - [gog contacts directory list](gog-contacts-directory-list.md) - List people from the Workspace directory

--- a/docs/commands/gog-contacts-dedupe.md
+++ b/docs/commands/gog-contacts-dedupe.md
@@ -37,6 +37,7 @@ gog contacts (contact) dedupe [flags]
 | `--max`<br>`--limit` | `int64` | 0 | Max contacts to scan (0 = all) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--resource` | `[]string` |  | Limit dedupe to exact contact resource names (people/...); repeatable |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/commands/gog-contacts-dedupe.md
+++ b/docs/commands/gog-contacts-dedupe.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find likely duplicate contacts (preview only)
+Find likely duplicate contacts and optionally merge them
 
 ## Usage
 
@@ -20,6 +20,7 @@ gog contacts (contact) dedupe [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--apply`<br>`--merge` | `bool` |  | Merge duplicate groups and delete redundant contacts (requires confirmation) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/docs/commands/gog-contacts.md
+++ b/docs/commands/gog-contacts.md
@@ -17,7 +17,7 @@ gog contacts (contact) <command> [flags]
 ## Subcommands
 
 - [gog contacts create](gog-contacts-create.md) - Create a contact
-- [gog contacts dedupe](gog-contacts-dedupe.md) - Find likely duplicate contacts (preview only)
+- [gog contacts dedupe](gog-contacts-dedupe.md) - Find likely duplicate contacts and optionally merge them
 - [gog contacts delete](gog-contacts-delete.md) - Delete a contact
 - [gog contacts directory](gog-contacts-directory.md) - Directory contacts
 - [gog contacts export](gog-contacts-export.md) - Export contacts as vCard (.vcf)

--- a/docs/contacts-dedupe.md
+++ b/docs/contacts-dedupe.md
@@ -1,11 +1,11 @@
-# Contacts Dedupe Preview
+# Contacts Dedupe
 
 read_when:
 - Finding duplicate Google Contacts.
 - Reviewing or changing `gog contacts dedupe`.
 
 `gog contacts dedupe` finds likely duplicate personal contacts and prints a
-merge plan. It is preview-only: it does not merge, update, or delete contacts.
+merge plan. Preview is the default; `--apply` performs the reviewed plan.
 
 ## Command Page
 
@@ -31,6 +31,32 @@ Name matching is opt-in because it can produce false positives:
 gog contacts dedupe --match email,phone,name
 ```
 
+## Apply A Merge
+
+Review the plan first:
+
+```bash
+gog contacts dedupe --json
+```
+
+Then inspect the exact mutation plan without changing contacts:
+
+```bash
+gog contacts dedupe --apply --dry-run --json
+```
+
+Apply interactively:
+
+```bash
+gog contacts dedupe --apply
+```
+
+Non-interactive automation must explicitly skip confirmation:
+
+```bash
+gog contacts dedupe --apply --force --json
+```
+
 ## Output
 
 The command groups contacts that share a matching key. JSON output includes:
@@ -42,16 +68,34 @@ The command groups contacts that share a matching key. JSON output includes:
 - `matched_on`: duplicate email/phone/name keys that caused the group
 - `members`: all contacts in the group
 
+Applied output also includes:
+
+- `applied`: whether mutations ran
+- `groups_merged`: groups completed
+- `contacts_deleted`: redundant contacts deleted
+- `update_fields`: People API fields unioned into the primary contact
+- `delete`: redundant contacts removed after their data was copied
+
 ## Safety
 
-`contacts dedupe` is read-only. There is no apply flag.
+`contacts dedupe` remains read-only unless `--apply` is present. Apply mode:
 
-Use `--dry-run` in automation anyway when you want a uniform safety habit across
-commands:
+- requires confirmation unless `--force` is present
+- honors `--dry-run`
+- reads contact-source data only
+- refreshes each contact before planning
+- updates the selected primary before deleting anything
+- rechecks each redundant contact's etag immediately before deletion
+- refuses groups with conflicting singleton fields (`names`, `birthdays`,
+  `biographies`, or `genders`)
+- refuses secondary contacts with photos or other fields the People API cannot
+  preserve through `updateContact`
 
-```bash
-gog contacts dedupe --dry-run --json
-```
+The People API does not expose Google Contacts' native merge operation. gog
+therefore unions all API-updatable fields into the selected primary, then
+deletes redundant contacts sequentially. If a request fails, the command stops
+and reports completed groups/deletions; copied data remains on the primary and
+undeleted contacts remain intact.
 
 Use `--fail-empty` in scheduled checks when "no duplicates" should be reported
 as a distinct exit code:

--- a/docs/contacts-dedupe.md
+++ b/docs/contacts-dedupe.md
@@ -45,6 +45,18 @@ Then inspect the exact mutation plan without changing contacts:
 gog contacts dedupe --apply --dry-run --json
 ```
 
+For automation, copy the contact resource names from the reviewed preview and
+scope both dry-run and apply to that exact set:
+
+```bash
+gog contacts dedupe \
+  --resource people/123 \
+  --resource people/456 \
+  --apply \
+  --dry-run \
+  --json
+```
+
 Apply interactively:
 
 ```bash
@@ -54,7 +66,12 @@ gog contacts dedupe --apply
 Non-interactive automation must explicitly skip confirmation:
 
 ```bash
-gog contacts dedupe --apply --force --json
+gog contacts dedupe \
+  --resource people/123 \
+  --resource people/456 \
+  --apply \
+  --force \
+  --json
 ```
 
 ## Output
@@ -82,6 +99,8 @@ Applied output also includes:
 
 - requires confirmation unless `--force` is present
 - honors `--dry-run`
+- supports repeatable `--resource` scoping so automation can apply an exact
+  reviewed contact set
 - reads contact-source data only
 - refreshes each contact before planning
 - updates the selected primary before deleting anything

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Runtime discovery.** `gog schema --json` exposes command shape, stable exit codes, output modes, and effective safety state.
 - **Multi-account, multi-client.** Many Google accounts and OAuth client projects in one config; OAuth, direct access tokens, ADC, and Workspace service accounts all supported.
 - **One automation contract.** Humans, scripts, CI, and agents use the same commands, with JSON/TSV output, non-interactive operation, stable exit codes, untrusted-content wrapping, runtime command guards, and baked safety profiles.
-- **Read-only audits.** Drive `tree`, `du`, `inventory`; Contacts `dedupe` preview; raw API JSON dumps without ever mutating remote state.
+- **Preview-first audits.** Drive `tree`, `du`, `inventory`; Contacts `dedupe` previews by default and requires explicit `--apply` for guarded merges; raw API JSON dumps never mutate remote state.
 - **Generated reference.** Every command has a docs page produced from `gog schema --json`.
 
 ## Pick your path

--- a/docs/live-testing.md
+++ b/docs/live-testing.md
@@ -34,6 +34,7 @@ available services. Recent-feature coverage includes:
 - Drive shortcuts, revisions, and persisted changes polling.
 - Gmail thread-aware drafts, attachment metadata preservation/clearing, and
   explicit thread archive semantics.
+- Contacts duplicate merge dry-run, apply, merged-field readback, and cleanup.
 - CLI schema exit codes, Git-style help, output-mode precedence, and early
   validation errors.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -370,7 +370,7 @@ after the bounded retry window, the command exits with retryable code `8`.
 - `gog classroom guardian-invitations get <studentId> <invitationId>`
 - `gog classroom guardian-invitations create <studentId> --email EMAIL`
 - `gog classroom profile [userId]`
-- `gog contacts dedupe [--match email,phone,name] [--max N] [--apply]`
+- `gog contacts dedupe [--match email,phone,name] [--max N] [--resource people/...] [--apply]`
 - `gog gmail search <query> [--max N] [--page TOKEN]`
 - `gog gmail messages search <query> [--max N] [--page TOKEN] [--include-body] [--body-format text|html] [--full]`
 - `gog gmail autoreply <query> [--max N] [--subject S] [--body B|--body-file PATH|--body-html HTML] [--from addr] [--reply-to addr] [--label L] [--archive] [--mark-read] [--skip-bulk] [--allow-self]`

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -370,7 +370,7 @@ after the bounded retry window, the command exits with retryable code `8`.
 - `gog classroom guardian-invitations get <studentId> <invitationId>`
 - `gog classroom guardian-invitations create <studentId> --email EMAIL`
 - `gog classroom profile [userId]`
-- `gog contacts dedupe [--match email,phone,name] [--max N]`
+- `gog contacts dedupe [--match email,phone,name] [--max N] [--apply]`
 - `gog gmail search <query> [--max N] [--page TOKEN]`
 - `gog gmail messages search <query> [--max N] [--page TOKEN] [--include-body] [--body-format text|html] [--full]`
 - `gog gmail autoreply <query> [--max N] [--subject S] [--body B|--body-file PATH|--body-html HTML] [--from addr] [--reply-to addr] [--label L] [--archive] [--mark-read] [--skip-bulk] [--allow-self]`

--- a/internal/cmd/contacts.go
+++ b/internal/cmd/contacts.go
@@ -16,7 +16,7 @@ type ContactsCmd struct {
 	List      ContactsListCmd      `cmd:"" name:"list" aliases:"ls" help:"List contacts"`
 	Get       ContactsGetCmd       `cmd:"" name:"get" aliases:"info,show" help:"Get a contact"`
 	Export    ContactsExportCmd    `cmd:"" name:"export" help:"Export contacts as vCard (.vcf)"`
-	Dedupe    ContactsDedupeCmd    `cmd:"" name:"dedupe" help:"Find likely duplicate contacts (preview only)"`
+	Dedupe    ContactsDedupeCmd    `cmd:"" name:"dedupe" help:"Find likely duplicate contacts and optionally merge them"`
 	Create    ContactsCreateCmd    `cmd:"" name:"create" aliases:"add,new" help:"Create a contact"`
 	Update    ContactsUpdateCmd    `cmd:"" name:"update" aliases:"edit,set" help:"Update a contact"`
 	Delete    ContactsDeleteCmd    `cmd:"" name:"delete" aliases:"rm,del,remove" help:"Delete a contact"`

--- a/internal/cmd/contacts_dedupe.go
+++ b/internal/cmd/contacts_dedupe.go
@@ -12,10 +12,11 @@ import (
 )
 
 type ContactsDedupeCmd struct {
-	Match     string `name:"match" help:"Match fields: email,phone,name" default:"email,phone"`
-	Max       int64  `name:"max" aliases:"limit" help:"Max contacts to scan (0 = all)" default:"0"`
-	Apply     bool   `name:"apply" aliases:"merge" help:"Merge duplicate groups and delete redundant contacts (requires confirmation)"`
-	FailEmpty bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no duplicates"`
+	Match     string   `name:"match" help:"Match fields: email,phone,name" default:"email,phone"`
+	Max       int64    `name:"max" aliases:"limit" help:"Max contacts to scan (0 = all)" default:"0"`
+	Resources []string `name:"resource" help:"Limit dedupe to exact contact resource names (people/...); repeatable"`
+	Apply     bool     `name:"apply" aliases:"merge" help:"Merge duplicate groups and delete redundant contacts (requires confirmation)"`
+	FailEmpty bool     `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no duplicates"`
 }
 
 func (c *ContactsDedupeCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -32,12 +33,24 @@ func (c *ContactsDedupeCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if c.Max < 0 {
 		return usage("--max must be >= 0")
 	}
+	resources, err := normalizeContactsDedupeResources(c.Resources)
+	if err != nil {
+		return err
+	}
+	if len(resources) > 0 && c.Max != 0 {
+		return usage("--max cannot be combined with --resource")
+	}
 
 	svc, err := peopleContactsService(ctx, account)
 	if err != nil {
 		return err
 	}
-	contacts, err := contactsDedupeList(ctx, svc, c.Max)
+	var contacts []*people.Person
+	if len(resources) > 0 {
+		contacts, err = contactsDedupeGetResources(ctx, svc, resources)
+	} else {
+		contacts, err = contactsDedupeList(ctx, svc, c.Max)
+	}
 	if err != nil {
 		return wrapPeopleAPIError(err)
 	}
@@ -99,6 +112,39 @@ func parseContactsDedupeMatch(value string) (contactsDedupeMatch, error) {
 		return contactsDedupeMatch{}, usage("invalid --match (no fields enabled)")
 	}
 	return out, nil
+}
+
+func normalizeContactsDedupeResources(values []string) ([]string, error) {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		resource := strings.TrimSpace(value)
+		if !strings.HasPrefix(resource, "people/") || len(resource) == len("people/") {
+			return nil, usagef("invalid --resource %q (expected people/...)", value)
+		}
+		if seen[resource] {
+			continue
+		}
+		seen[resource] = true
+		out = append(out, resource)
+	}
+	return out, nil
+}
+
+func contactsDedupeGetResources(ctx context.Context, svc *people.Service, resources []string) ([]*people.Person, error) {
+	contacts := make([]*people.Person, 0, len(resources))
+	for _, resource := range resources {
+		person, err := svc.People.Get(resource).
+			PersonFields(contactsReadMask).
+			Sources(contactsDedupeContactSource).
+			Context(ctx).
+			Do()
+		if err != nil {
+			return nil, err
+		}
+		contacts = append(contacts, person)
+	}
+	return contacts, nil
 }
 
 func contactsDedupeList(ctx context.Context, svc *people.Service, maxResults int64) ([]*people.Person, error) {

--- a/internal/cmd/contacts_dedupe.go
+++ b/internal/cmd/contacts_dedupe.go
@@ -14,6 +14,7 @@ import (
 type ContactsDedupeCmd struct {
 	Match     string `name:"match" help:"Match fields: email,phone,name" default:"email,phone"`
 	Max       int64  `name:"max" aliases:"limit" help:"Max contacts to scan (0 = all)" default:"0"`
+	Apply     bool   `name:"apply" aliases:"merge" help:"Merge duplicate groups and delete redundant contacts (requires confirmation)"`
 	FailEmpty bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no duplicates"`
 }
 
@@ -42,13 +43,34 @@ func (c *ContactsDedupeCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	groups := buildContactsDedupeGroups(contacts, match)
-	if err := writeContactsDedupe(ctx, u, groups, len(contacts)); err != nil {
-		return err
-	}
 	if len(groups) == 0 {
+		if writeErr := writeContactsDedupe(ctx, u, groups, len(contacts)); writeErr != nil {
+			return writeErr
+		}
 		return failEmptyExit(c.FailEmpty)
 	}
-	return nil
+	if !c.Apply {
+		return writeContactsDedupe(ctx, u, groups, len(contacts))
+	}
+
+	plans, err := prepareContactsDedupeApply(ctx, svc, groups, match)
+	if err != nil {
+		return err
+	}
+	deleteCount := contactsDedupeDeleteCount(plans)
+	if u != nil {
+		u.Err().Linef("Prepared %d duplicate group(s); %d redundant contact(s) will be deleted", len(plans), deleteCount)
+	}
+	if confirmErr := dryRunAndConfirmDestructive(ctx, flags, "contacts.dedupe.apply", contactsDedupeApplyPayload(len(contacts), plans),
+		contactsDedupeApplyAction(len(plans), deleteCount)); confirmErr != nil {
+		return confirmErr
+	}
+
+	result, err := applyContactsDedupePlans(ctx, svc, len(contacts), plans)
+	if err != nil {
+		return err
+	}
+	return writeContactsDedupeApplyResult(ctx, u, result)
 }
 
 type contactsDedupeMatch struct {
@@ -92,6 +114,7 @@ func contactsDedupeList(ctx context.Context, svc *people.Service, maxResults int
 			PageSize(pageSize).
 			PageToken(pageToken).
 			RequestSyncToken(false).
+			Sources("READ_SOURCE_TYPE_CONTACT").
 			Context(ctx).
 			Do()
 		if err != nil {

--- a/internal/cmd/contacts_dedupe_apply.go
+++ b/internal/cmd/contacts_dedupe_apply.go
@@ -1,0 +1,483 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"google.golang.org/api/people/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+const contactsDedupeContactSource = "READ_SOURCE_TYPE_CONTACT"
+
+var contactsDedupeMutableFields = []string{
+	"addresses",
+	"biographies",
+	"birthdays",
+	"calendarUrls",
+	"clientData",
+	"emailAddresses",
+	"events",
+	"externalIds",
+	"genders",
+	"imClients",
+	"interests",
+	"locales",
+	"locations",
+	"memberships",
+	"miscKeywords",
+	"names",
+	"nicknames",
+	"occupations",
+	"organizations",
+	"phoneNumbers",
+	"relations",
+	"sipAddresses",
+	"urls",
+	"userDefined",
+}
+
+type contactsDedupeApplyPlan struct {
+	Group        contactsDedupeGroup
+	Merged       *people.Person
+	UpdateFields []string
+	Delete       []*people.Person
+}
+
+type contactsDedupeApplyResult struct {
+	Scanned         int
+	Plans           []contactsDedupeApplyPlan
+	GroupsMerged    int
+	ContactsDeleted int
+}
+
+func contactsDedupeApplyReadMask() string {
+	return strings.Join(append(append([]string{}, contactsDedupeMutableFields...), "coverPhotos", "metadata", "photos", "skills"), ",")
+}
+
+func prepareContactsDedupeApply(
+	ctx context.Context,
+	svc *people.Service,
+	groups []contactsDedupeGroup,
+	match contactsDedupeMatch,
+) ([]contactsDedupeApplyPlan, error) {
+	plans := make([]contactsDedupeApplyPlan, 0, len(groups))
+	for i, group := range groups {
+		fresh, err := refreshContactsDedupeGroup(ctx, svc, group, match)
+		if err != nil {
+			return nil, fmt.Errorf("prepare duplicate group %d: %w", i+1, err)
+		}
+		plan, err := buildContactsDedupeApplyPlan(fresh)
+		if err != nil {
+			return nil, fmt.Errorf("prepare duplicate group %d: %w", i+1, err)
+		}
+		plans = append(plans, plan)
+	}
+	return plans, nil
+}
+
+func refreshContactsDedupeGroup(
+	ctx context.Context,
+	svc *people.Service,
+	group contactsDedupeGroup,
+	match contactsDedupeMatch,
+) (contactsDedupeGroup, error) {
+	members := make([]*people.Person, 0, len(group.Members))
+	for _, member := range group.Members {
+		resource := contactsDedupeResource(member)
+		if resource == "" {
+			return contactsDedupeGroup{}, fmt.Errorf("member is missing a resource name")
+		}
+		fresh, err := svc.People.Get(resource).
+			PersonFields(contactsDedupeApplyReadMask()).
+			Sources(contactsDedupeContactSource).
+			Context(ctx).
+			Do()
+		if err != nil {
+			return contactsDedupeGroup{}, wrapPeopleAPIError(err)
+		}
+		members = append(members, fresh)
+	}
+
+	freshGroups := buildContactsDedupeGroups(members, match)
+	if len(freshGroups) != 1 || len(freshGroups[0].Members) != len(members) {
+		return contactsDedupeGroup{}, fmt.Errorf("contacts changed and no longer form the same duplicate group; rerun without --apply to review")
+	}
+	return freshGroups[0], nil
+}
+
+func buildContactsDedupeApplyPlan(group contactsDedupeGroup) (contactsDedupeApplyPlan, error) {
+	if group.Primary == nil {
+		return contactsDedupeApplyPlan{}, fmt.Errorf("duplicate group has no primary contact")
+	}
+	if contactSourceETag(group.Primary) == "" {
+		return contactsDedupeApplyPlan{}, fmt.Errorf("primary contact %s is missing a contact-source etag", contactsDedupeResource(group.Primary))
+	}
+
+	ordered := orderContactsDedupeMembers(group.Primary, group.Members)
+	for _, member := range ordered[1:] {
+		if hasContactPhoto(member) {
+			return contactsDedupeApplyPlan{}, fmt.Errorf(
+				"contact %s has a photo that the People API cannot merge; remove or move the photo before applying",
+				contactsDedupeResource(member),
+			)
+		}
+		if len(member.CoverPhotos) > 0 || len(member.Skills) > 0 {
+			return contactsDedupeApplyPlan{}, fmt.Errorf(
+				"contact %s contains data that the People API cannot update during a merge; merge this group in Google Contacts",
+				contactsDedupeResource(member),
+			)
+		}
+		if contactSourceETag(member) == "" {
+			return contactsDedupeApplyPlan{}, fmt.Errorf("contact %s is missing a contact-source etag", contactsDedupeResource(member))
+		}
+	}
+
+	merged, err := cloneContactPerson(group.Primary)
+	if err != nil {
+		return contactsDedupeApplyPlan{}, err
+	}
+	clearNonMutableContactFields(merged)
+	if err := mergeContactsDedupeFields(merged, ordered); err != nil {
+		return contactsDedupeApplyPlan{}, err
+	}
+
+	updateFields := populatedContactsDedupeFields(merged)
+	if len(updateFields) == 0 {
+		return contactsDedupeApplyPlan{}, fmt.Errorf("duplicate group has no mergeable contact fields")
+	}
+
+	return contactsDedupeApplyPlan{
+		Group:        group,
+		Merged:       merged,
+		UpdateFields: updateFields,
+		Delete:       append([]*people.Person(nil), ordered[1:]...),
+	}, nil
+}
+
+func mergeContactsDedupeFields(dst *people.Person, members []*people.Person) error {
+	var err error
+	if dst.Addresses, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Address { return p.Addresses })...); err != nil {
+		return err
+	}
+	if dst.Biographies, err = mergeContactsDedupeSingleton("biographies", contactFieldSlices(members, func(p *people.Person) []*people.Biography { return p.Biographies })...); err != nil {
+		return err
+	}
+	if dst.Birthdays, err = mergeContactsDedupeSingleton("birthdays", contactFieldSlices(members, func(p *people.Person) []*people.Birthday { return p.Birthdays })...); err != nil {
+		return err
+	}
+	if dst.CalendarUrls, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.CalendarUrl { return p.CalendarUrls })...); err != nil {
+		return err
+	}
+	if dst.ClientData, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.ClientData { return p.ClientData })...); err != nil {
+		return err
+	}
+	if dst.EmailAddresses, err = mergeContactsDedupeKeyedItems(
+		func(item *people.EmailAddress) string { return normalizeContactEmail(item.Value) },
+		contactFieldSlices(members, func(p *people.Person) []*people.EmailAddress { return p.EmailAddresses })...,
+	); err != nil {
+		return err
+	}
+	if dst.Events, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Event { return p.Events })...); err != nil {
+		return err
+	}
+	if dst.ExternalIds, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.ExternalId { return p.ExternalIds })...); err != nil {
+		return err
+	}
+	if dst.Genders, err = mergeContactsDedupeSingleton("genders", contactFieldSlices(members, func(p *people.Person) []*people.Gender { return p.Genders })...); err != nil {
+		return err
+	}
+	if dst.ImClients, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.ImClient { return p.ImClients })...); err != nil {
+		return err
+	}
+	if dst.Interests, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Interest { return p.Interests })...); err != nil {
+		return err
+	}
+	if dst.Locales, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Locale { return p.Locales })...); err != nil {
+		return err
+	}
+	if dst.Locations, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Location { return p.Locations })...); err != nil {
+		return err
+	}
+	if dst.Memberships, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Membership { return p.Memberships })...); err != nil {
+		return err
+	}
+	if dst.MiscKeywords, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.MiscKeyword { return p.MiscKeywords })...); err != nil {
+		return err
+	}
+	if dst.Names, err = mergeContactsDedupeSingleton("names", contactFieldSlices(members, func(p *people.Person) []*people.Name { return p.Names })...); err != nil {
+		return err
+	}
+	if dst.Nicknames, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Nickname { return p.Nicknames })...); err != nil {
+		return err
+	}
+	if dst.Occupations, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Occupation { return p.Occupations })...); err != nil {
+		return err
+	}
+	if dst.Organizations, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Organization { return p.Organizations })...); err != nil {
+		return err
+	}
+	if dst.PhoneNumbers, err = mergeContactsDedupeKeyedItems(
+		func(item *people.PhoneNumber) string { return normalizeContactPhone(item.Value) },
+		contactFieldSlices(members, func(p *people.Person) []*people.PhoneNumber { return p.PhoneNumbers })...,
+	); err != nil {
+		return err
+	}
+	if dst.Relations, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Relation { return p.Relations })...); err != nil {
+		return err
+	}
+	if dst.SipAddresses, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.SipAddress { return p.SipAddresses })...); err != nil {
+		return err
+	}
+	if dst.Urls, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.Url { return p.Urls })...); err != nil {
+		return err
+	}
+	if dst.UserDefined, err = mergeContactsDedupeItems(contactFieldSlices(members, func(p *people.Person) []*people.UserDefined { return p.UserDefined })...); err != nil {
+		return err
+	}
+	return nil
+}
+
+func contactFieldSlices[T any](members []*people.Person, field func(*people.Person) []*T) [][]*T {
+	out := make([][]*T, 0, len(members))
+	for _, member := range members {
+		out = append(out, field(member))
+	}
+	return out
+}
+
+func mergeContactsDedupeSingleton[T any](field string, lists ...[]*T) ([]*T, error) {
+	merged, err := mergeContactsDedupeItems(lists...)
+	if err != nil {
+		return nil, err
+	}
+	if len(merged) > 1 {
+		return nil, fmt.Errorf("conflicting %s cannot be merged safely; resolve this group in Google Contacts", field)
+	}
+	return merged, nil
+}
+
+func mergeContactsDedupeItems[T any](lists ...[]*T) ([]*T, error) {
+	return mergeContactsDedupeKeyedItems[T](nil, lists...)
+}
+
+func mergeContactsDedupeKeyedItems[T any](keyFn func(*T) string, lists ...[]*T) ([]*T, error) {
+	var out []*T
+	seen := map[string]bool{}
+	for _, list := range lists {
+		for _, item := range list {
+			if item == nil {
+				continue
+			}
+			clean, key, err := cleanContactsDedupeItem(item)
+			if err != nil {
+				return nil, err
+			}
+			if keyFn != nil {
+				key = keyFn(clean)
+			}
+			if key == "" || seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, clean)
+		}
+	}
+	return out, nil
+}
+
+func cleanContactsDedupeItem[T any](item *T) (*T, string, error) {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode contact field: %w", err)
+	}
+	var object map[string]any
+	if decodeErr := json.Unmarshal(data, &object); decodeErr != nil {
+		return nil, "", fmt.Errorf("decode contact field: %w", decodeErr)
+	}
+	delete(object, "metadata")
+	delete(object, "formattedType")
+	cleanData, err := json.Marshal(object)
+	if err != nil {
+		return nil, "", fmt.Errorf("encode cleaned contact field: %w", err)
+	}
+	var clean T
+	if err := json.Unmarshal(cleanData, &clean); err != nil {
+		return nil, "", fmt.Errorf("decode cleaned contact field: %w", err)
+	}
+	return &clean, string(cleanData), nil
+}
+
+func cloneContactPerson(person *people.Person) (*people.Person, error) {
+	data, err := json.Marshal(person)
+	if err != nil {
+		return nil, fmt.Errorf("encode contact %s: %w", contactsDedupeResource(person), err)
+	}
+	var clone people.Person
+	if err := json.Unmarshal(data, &clone); err != nil {
+		return nil, fmt.Errorf("decode contact %s: %w", contactsDedupeResource(person), err)
+	}
+	return &clone, nil
+}
+
+func clearNonMutableContactFields(person *people.Person) {
+	if person == nil {
+		return
+	}
+	person.AgeRange = ""
+	person.AgeRanges = nil
+	person.BraggingRights = nil
+	person.CoverPhotos = nil
+	person.FileAses = nil
+	person.Photos = nil
+	person.RelationshipInterests = nil
+	person.RelationshipStatuses = nil
+	person.Residences = nil
+	person.Skills = nil
+	person.Taglines = nil
+}
+
+func populatedContactsDedupeFields(person *people.Person) []string {
+	value := reflect.ValueOf(person)
+	if !value.IsValid() || value.IsNil() {
+		return nil
+	}
+	value = value.Elem()
+	var fields []string
+	for _, field := range contactsDedupeMutableFields {
+		goField := contactsPersonFieldToGoField(field)
+		current := value.FieldByName(goField)
+		if current.IsValid() && current.Kind() == reflect.Slice && current.Len() > 0 {
+			fields = append(fields, field)
+		}
+	}
+	sort.Strings(fields)
+	return fields
+}
+
+func hasContactPhoto(person *people.Person) bool {
+	if person == nil {
+		return false
+	}
+	for _, photo := range person.Photos {
+		if photo != nil && !photo.Default {
+			return true
+		}
+	}
+	return false
+}
+
+func applyContactsDedupePlans(
+	ctx context.Context,
+	svc *people.Service,
+	scanned int,
+	plans []contactsDedupeApplyPlan,
+) (contactsDedupeApplyResult, error) {
+	result := contactsDedupeApplyResult{Scanned: scanned, Plans: plans}
+	for index, plan := range plans {
+		resource := contactsDedupeResource(plan.Merged)
+		if _, err := svc.People.UpdateContact(resource, plan.Merged).
+			UpdatePersonFields(strings.Join(plan.UpdateFields, ",")).
+			PersonFields("metadata").
+			Sources(contactsDedupeContactSource).
+			Context(ctx).
+			Do(); err != nil {
+			return result, fmt.Errorf(
+				"contacts dedupe apply stopped after %d/%d groups and %d deletions: update primary %s: %w",
+				result.GroupsMerged, len(plans), result.ContactsDeleted, resource, wrapPeopleAPIError(err),
+			)
+		}
+
+		for _, redundant := range plan.Delete {
+			redundantResource := contactsDedupeResource(redundant)
+			latest, err := svc.People.Get(redundantResource).
+				PersonFields("metadata").
+				Sources(contactsDedupeContactSource).
+				Context(ctx).
+				Do()
+			if err != nil {
+				return result, fmt.Errorf(
+					"contacts dedupe apply stopped in group %d/%d after %d deletions: recheck %s: %w",
+					index+1, len(plans), result.ContactsDeleted, redundantResource, wrapPeopleAPIError(err),
+				)
+			}
+			if contactSourceETag(latest) != contactSourceETag(redundant) {
+				return result, fmt.Errorf(
+					"contacts dedupe apply stopped in group %d/%d after %d deletions: contact %s changed after preview and was not deleted; rerun the command",
+					index+1, len(plans), result.ContactsDeleted, redundantResource,
+				)
+			}
+			if _, err := svc.People.DeleteContact(redundantResource).Context(ctx).Do(); err != nil {
+				return result, fmt.Errorf(
+					"contacts dedupe apply stopped in group %d/%d after %d deletions: delete %s: %w",
+					index+1, len(plans), result.ContactsDeleted, redundantResource, wrapPeopleAPIError(err),
+				)
+			}
+			result.ContactsDeleted++
+		}
+		result.GroupsMerged++
+	}
+	return result, nil
+}
+
+func contactsDedupeDeleteCount(plans []contactsDedupeApplyPlan) int {
+	total := 0
+	for _, plan := range plans {
+		total += len(plan.Delete)
+	}
+	return total
+}
+
+func contactsDedupeApplyAction(groups, contacts int) string {
+	return fmt.Sprintf("merge %d duplicate contact group(s) and delete %d redundant contact(s)", groups, contacts)
+}
+
+func contactsDedupeApplyPayload(scanned int, plans []contactsDedupeApplyPlan) map[string]any {
+	groups := make([]map[string]any, 0, len(plans))
+	for _, plan := range plans {
+		deleted := make([]contactsDedupeSummary, 0, len(plan.Delete))
+		for _, member := range plan.Delete {
+			deleted = append(deleted, summarizeContactsDedupeContact(member))
+		}
+		groups = append(groups, map[string]any{
+			"primary":       summarizeContactsDedupeContact(plan.Group.Primary),
+			"merged":        summarizeContactsDedupeContact(plan.Merged),
+			"matched_on":    plan.Group.MatchedOn,
+			"update_fields": plan.UpdateFields,
+			"delete":        deleted,
+		})
+	}
+	return map[string]any{
+		"scanned":          scanned,
+		"groups":           groups,
+		"groups_merged":    len(plans),
+		"contacts_deleted": contactsDedupeDeleteCount(plans),
+	}
+}
+
+func writeContactsDedupeApplyResult(ctx context.Context, u *ui.UI, result contactsDedupeApplyResult) error {
+	payload := contactsDedupeApplyPayload(result.Scanned, result.Plans)
+	payload["applied"] = true
+	payload["groups_merged"] = result.GroupsMerged
+	payload["contacts_deleted"] = result.ContactsDeleted
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+	}
+	if outfmt.IsPlain(ctx) {
+		out := stdoutWriter(ctx)
+		fmt.Fprintf(out, "applied\ttrue\n")
+		fmt.Fprintf(out, "groups_merged\t%d\n", result.GroupsMerged)
+		fmt.Fprintf(out, "contacts_deleted\t%d\n", result.ContactsDeleted)
+		return nil
+	}
+	if u != nil {
+		u.Out().Successf("Merged %d duplicate contact group(s); deleted %d redundant contact(s)", result.GroupsMerged, result.ContactsDeleted)
+	}
+	return nil
+}

--- a/internal/cmd/contacts_dedupe_apply_test.go
+++ b/internal/cmd/contacts_dedupe_apply_test.go
@@ -1,0 +1,301 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+
+	"google.golang.org/api/people/v1"
+)
+
+func TestBuildContactsDedupeApplyPlanMergesFields(t *testing.T) {
+	primary := testDedupeApplyPerson("people/1", "etag-1", "Ada", "ada@example.com", "+1 555 0100")
+	primary.Memberships = []*people.Membership{{
+		ContactGroupMembership: &people.ContactGroupMembership{ContactGroupResourceName: "contactGroups/friends"},
+	}}
+	duplicate := testDedupeApplyPerson("people/2", "etag-2", "Ada", "ADA@example.com", "+1 555 0200")
+	duplicate.Memberships = []*people.Membership{{
+		ContactGroupMembership: &people.ContactGroupMembership{ContactGroupResourceName: "contactGroups/work"},
+	}}
+
+	group := buildContactsDedupeGroups(
+		[]*people.Person{primary, duplicate},
+		contactsDedupeMatch{Email: true, Phone: true},
+	)[0]
+	plan, err := buildContactsDedupeApplyPlan(group)
+	if err != nil {
+		t.Fatalf("build plan: %v", err)
+	}
+	if contactsDedupeResource(plan.Merged) != "people/1" {
+		t.Fatalf("primary = %q, want people/1", contactsDedupeResource(plan.Merged))
+	}
+	if got := phoneValues(plan.Merged.PhoneNumbers); !reflect.DeepEqual(got, []string{"+1 555 0100", "+1 555 0200"}) {
+		t.Fatalf("phones = %#v", got)
+	}
+	if len(plan.Merged.EmailAddresses) != 1 {
+		t.Fatalf("emails = %#v, want one normalized address", plan.Merged.EmailAddresses)
+	}
+	if len(plan.Merged.Memberships) != 2 {
+		t.Fatalf("memberships = %#v", plan.Merged.Memberships)
+	}
+	if len(plan.Delete) != 1 || contactsDedupeResource(plan.Delete[0]) != "people/2" {
+		t.Fatalf("delete = %#v", plan.Delete)
+	}
+	for _, email := range plan.Merged.EmailAddresses {
+		if email.Metadata != nil {
+			t.Fatalf("merged email retained source metadata: %#v", email.Metadata)
+		}
+	}
+}
+
+func TestBuildContactsDedupeApplyPlanRejectsUnsafeFields(t *testing.T) {
+	t.Run("conflicting singleton", func(t *testing.T) {
+		primary := testDedupeApplyPerson("people/1", "etag-1", "Ada One", "ada@example.com", "")
+		duplicate := testDedupeApplyPerson("people/2", "etag-2", "Ada Two", "ADA@example.com", "")
+		group := contactsDedupeGroup{
+			Primary: primary,
+			Members: []*people.Person{primary, duplicate},
+		}
+		_, err := buildContactsDedupeApplyPlan(group)
+		if err == nil || !strings.Contains(err.Error(), "conflicting names") {
+			t.Fatalf("error = %v, want conflicting names", err)
+		}
+	})
+
+	t.Run("secondary photo", func(t *testing.T) {
+		primary := testDedupeApplyPerson("people/1", "etag-1", "Ada", "ada@example.com", "")
+		duplicate := testDedupeApplyPerson("people/2", "etag-2", "Ada", "ADA@example.com", "")
+		duplicate.Photos = []*people.Photo{{Url: "https://example.com/photo.jpg"}}
+		group := contactsDedupeGroup{
+			Primary: primary,
+			Members: []*people.Person{primary, duplicate},
+		}
+		_, err := buildContactsDedupeApplyPlan(group)
+		if err == nil || !strings.Contains(err.Error(), "photo") {
+			t.Fatalf("error = %v, want photo refusal", err)
+		}
+	})
+}
+
+func TestContactsDedupeApplyExecuteJSON(t *testing.T) {
+	var mu sync.Mutex
+	var updateBody people.Person
+	var updateMask string
+	var deleted []string
+
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/me/connections":
+			if got := r.URL.Query()["sources"]; !reflect.DeepEqual(got, []string{contactsDedupeContactSource}) {
+				t.Fatalf("connections sources = %#v", got)
+			}
+			writeDedupeConnections(t, w)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/1":
+			writeDedupePerson(t, w, testDedupeApplyPerson("people/1", "etag-1", "Ada", "ada@example.com", "+1 555 0100"))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/2" && r.URL.Query().Get("personFields") != "metadata":
+			writeDedupePerson(t, w, testDedupeApplyPerson("people/2", "etag-2", "Ada", "ADA@example.com", "+1 555 0200"))
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/people/1:updateContact":
+			updateMask = r.URL.Query().Get("updatePersonFields")
+			if err := json.NewDecoder(r.Body).Decode(&updateBody); err != nil {
+				t.Fatalf("decode update: %v", err)
+			}
+			writeDedupePerson(t, w, &people.Person{ResourceName: "people/1", Metadata: contactMetadata("etag-updated")})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/2":
+			writeDedupePerson(t, w, &people.Person{ResourceName: "people/2", Metadata: contactMetadata("etag-2")})
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/people/2:deleteContact":
+			mu.Lock()
+			deleted = append(deleted, "people/2")
+			mu.Unlock()
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeSrv()
+
+	result := executeWithPeopleTestServices(
+		t,
+		[]string{"--json", "--account", "a@example.com", "--force", "contacts", "dedupe", "--apply"},
+		peopleTestServices{Contacts: fixedPeopleTestService(svc)},
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	var payload struct {
+		Applied         bool `json:"applied"`
+		GroupsMerged    int  `json:"groups_merged"`
+		ContactsDeleted int  `json:"contacts_deleted"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, result.stdout)
+	}
+	if !payload.Applied || payload.GroupsMerged != 1 || payload.ContactsDeleted != 1 {
+		t.Fatalf("output = %#v", payload)
+	}
+	if !strings.Contains(updateMask, "emailAddresses") || !strings.Contains(updateMask, "phoneNumbers") {
+		t.Fatalf("update mask = %q", updateMask)
+	}
+	if got := phoneValues(updateBody.PhoneNumbers); !reflect.DeepEqual(got, []string{"+1 555 0100", "+1 555 0200"}) {
+		t.Fatalf("updated phones = %#v", got)
+	}
+	if contactSourceETag(&updateBody) != "etag-1" {
+		t.Fatalf("update etag = %q", contactSourceETag(&updateBody))
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if !reflect.DeepEqual(deleted, []string{"people/2"}) {
+		t.Fatalf("deleted = %#v", deleted)
+	}
+}
+
+func TestContactsDedupeApplyDryRunSkipsMutations(t *testing.T) {
+	mutated := false
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/me/connections":
+			writeDedupeConnections(t, w)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/1":
+			writeDedupePerson(t, w, testDedupeApplyPerson("people/1", "etag-1", "Ada", "ada@example.com", "+1 555 0100"))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/2":
+			writeDedupePerson(t, w, testDedupeApplyPerson("people/2", "etag-2", "Ada", "ADA@example.com", "+1 555 0200"))
+		default:
+			mutated = true
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeSrv()
+
+	result := executeWithPeopleTestServices(
+		t,
+		[]string{"--json", "--account", "a@example.com", "--dry-run", "contacts", "dedupe", "--apply"},
+		peopleTestServices{Contacts: fixedPeopleTestService(svc)},
+	)
+	if ExitCode(result.err) != 0 {
+		t.Fatalf("Execute: %v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	var payload struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			GroupsMerged    int `json:"groups_merged"`
+			ContactsDeleted int `json:"contacts_deleted"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, result.stdout)
+	}
+	if !payload.DryRun || payload.Op != "contacts.dedupe.apply" ||
+		payload.Request.GroupsMerged != 1 || payload.Request.ContactsDeleted != 1 {
+		t.Fatalf("output = %#v", payload)
+	}
+	if mutated {
+		t.Fatal("dry-run sent a mutation request")
+	}
+}
+
+func TestContactsDedupeApplyRetainsChangedContact(t *testing.T) {
+	deleted := false
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/me/connections":
+			writeDedupeConnections(t, w)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/1":
+			writeDedupePerson(t, w, testDedupeApplyPerson("people/1", "etag-1", "Ada", "ada@example.com", "+1 555 0100"))
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/2" && r.URL.Query().Get("personFields") != "metadata":
+			writeDedupePerson(t, w, testDedupeApplyPerson("people/2", "etag-2", "Ada", "ADA@example.com", "+1 555 0200"))
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/people/1:updateContact":
+			writeDedupePerson(t, w, &people.Person{ResourceName: "people/1", Metadata: contactMetadata("etag-updated")})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/people/2":
+			writeDedupePerson(t, w, &people.Person{ResourceName: "people/2", Metadata: contactMetadata("etag-changed")})
+		case r.Method == http.MethodDelete:
+			deleted = true
+			_, _ = w.Write([]byte(`{}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer closeSrv()
+
+	result := executeWithPeopleTestServices(
+		t,
+		[]string{"--account", "a@example.com", "--force", "contacts", "dedupe", "--apply"},
+		peopleTestServices{Contacts: fixedPeopleTestService(svc)},
+	)
+	if result.err == nil || !strings.Contains(result.err.Error(), "changed after preview and was not deleted") {
+		t.Fatalf("error = %v", result.err)
+	}
+	if deleted {
+		t.Fatal("changed contact was deleted")
+	}
+}
+
+func testDedupeApplyPerson(resource, etag, name, email, phone string) *people.Person {
+	person := &people.Person{
+		ResourceName: resource,
+		Metadata:     contactMetadata(etag),
+		Memberships: []*people.Membership{{
+			ContactGroupMembership: &people.ContactGroupMembership{ContactGroupResourceName: "contactGroups/myContacts"},
+		}},
+	}
+	if name != "" {
+		person.Names = []*people.Name{{GivenName: name, DisplayName: name}}
+	}
+	if email != "" {
+		person.EmailAddresses = []*people.EmailAddress{{
+			Value:    email,
+			Metadata: &people.FieldMetadata{Source: &people.Source{Type: "CONTACT", Id: resource}},
+		}}
+	}
+	if phone != "" {
+		person.PhoneNumbers = []*people.PhoneNumber{{
+			Value:    phone,
+			Metadata: &people.FieldMetadata{Source: &people.Source{Type: "CONTACT", Id: resource}},
+		}}
+	}
+	return person
+}
+
+func contactMetadata(etag string) *people.PersonMetadata {
+	return &people.PersonMetadata{Sources: []*people.Source{{Type: "CONTACT", Etag: etag}}}
+}
+
+func writeDedupeConnections(t *testing.T, w http.ResponseWriter) {
+	t.Helper()
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"connections": []map[string]any{
+			{
+				"resourceName":   "people/1",
+				"names":          []map[string]any{{"givenName": "Ada", "displayName": "Ada"}},
+				"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+				"phoneNumbers":   []map[string]any{{"value": "+1 555 0100"}},
+			},
+			{
+				"resourceName":   "people/2",
+				"names":          []map[string]any{{"givenName": "Ada", "displayName": "Ada"}},
+				"emailAddresses": []map[string]any{{"value": "ADA@example.com"}},
+				"phoneNumbers":   []map[string]any{{"value": "+1 555 0200"}},
+			},
+		},
+	})
+}
+
+func writeDedupePerson(t *testing.T, w http.ResponseWriter, person *people.Person) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(person); err != nil {
+		t.Fatalf("encode person: %v", err)
+	}
+}
+
+func phoneValues(phones []*people.PhoneNumber) []string {
+	values := make([]string, 0, len(phones))
+	for _, phone := range phones {
+		if phone != nil {
+			values = append(values, phone.Value)
+		}
+	}
+	return values
+}

--- a/internal/cmd/contacts_dedupe_test.go
+++ b/internal/cmd/contacts_dedupe_test.go
@@ -23,6 +23,19 @@ func TestParseContactsDedupeMatch(t *testing.T) {
 	}
 }
 
+func TestNormalizeContactsDedupeResources(t *testing.T) {
+	got, err := normalizeContactsDedupeResources([]string{" people/1 ", "people/2", "people/1"})
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	if !reflect.DeepEqual(got, []string{"people/1", "people/2"}) {
+		t.Fatalf("resources = %#v", got)
+	}
+	if _, err := normalizeContactsDedupeResources([]string{"contacts/1"}); err == nil {
+		t.Fatal("expected invalid resource error")
+	}
+}
+
 func TestBuildContactsDedupeGroupsTransitive(t *testing.T) {
 	contacts := []*people.Person{
 		testDedupePerson("people/1", "Ada One", []string{"ada@example.com"}, nil),
@@ -55,6 +68,47 @@ func TestBuildContactsDedupeGroupsNameOptIn(t *testing.T) {
 	}
 	if groups := buildContactsDedupeGroups(contacts, contactsDedupeMatch{Name: true}); len(groups) != 1 {
 		t.Fatalf("name match should find one group, got %d", len(groups))
+	}
+}
+
+func TestContactsDedupeExecuteScopedResources(t *testing.T) {
+	svc, closeSrv := newPeopleService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || (r.URL.Path != "/v1/people/1" && r.URL.Path != "/v1/people/2") {
+			http.NotFound(w, r)
+			return
+		}
+		resource := strings.TrimPrefix(r.URL.Path, "/v1/")
+		if got := r.URL.Query()["sources"]; !reflect.DeepEqual(got, []string{contactsDedupeContactSource}) {
+			t.Fatalf("sources = %#v", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"resourceName":   resource,
+			"names":          []map[string]any{{"displayName": "Ada"}},
+			"emailAddresses": []map[string]any{{"value": "ada@example.com"}},
+		})
+	}))
+	defer closeSrv()
+
+	result := executeWithPeopleTestServices(
+		t,
+		[]string{
+			"--json", "--account", "a@example.com", "contacts", "dedupe",
+			"--resource", "people/1", "--resource", "people/2",
+		},
+		peopleTestServices{Contacts: fixedPeopleTestService(svc)},
+	)
+	if result.err != nil {
+		t.Fatalf("Execute: %v\nstdout=%s\nstderr=%s", result.err, result.stdout, result.stderr)
+	}
+	var payload struct {
+		Scanned int   `json:"scanned"`
+		Groups  []any `json:"groups"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &payload); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, result.stdout)
+	}
+	if payload.Scanned != 2 || len(payload.Groups) != 1 {
+		t.Fatalf("output = %#v", payload)
 	}
 }
 

--- a/scripts/live-tests/common.sh
+++ b/scripts/live-tests/common.sh
@@ -13,6 +13,7 @@ LIVE_CALENDAR_CLEANUP_EVENTS=()
 LIVE_GMAIL_CLEANUP_DRAFTS=()
 LIVE_GMAIL_CLEANUP_THREADS=()
 LIVE_PHOTOS_PICKER_CLEANUP_IDS=()
+LIVE_CONTACT_CLEANUP_IDS=()
 
 skip() {
   local key="$1"
@@ -256,6 +257,10 @@ register_photos_picker_cleanup() {
   [ -n "${1:-}" ] && LIVE_PHOTOS_PICKER_CLEANUP_IDS+=("$1")
 }
 
+register_contact_cleanup() {
+  [ -n "${1:-}" ] && LIVE_CONTACT_CLEANUP_IDS+=("$1")
+}
+
 cleanup_live_resources() {
   local entry calendar_id event_id id
 
@@ -274,6 +279,9 @@ cleanup_live_resources() {
   done
   for id in "${LIVE_PHOTOS_PICKER_CLEANUP_IDS[@]}"; do
     gog photos picker delete "$id" --force --json >/dev/null 2>&1 || true
+  done
+  for id in "${LIVE_CONTACT_CLEANUP_IDS[@]}"; do
+    gog contacts delete "$id" --force >/dev/null 2>&1 || true
   done
   for id in "${LIVE_DRIVE_CLEANUP_IDS[@]}"; do
     gog drive delete "$id" --force >/dev/null 2>&1 || true

--- a/scripts/live-tests/contacts.sh
+++ b/scripts/live-tests/contacts.sh
@@ -19,6 +19,85 @@ run_contacts_other_tests() {
     gog contacts other search "$other_query" --json --max 1 >/dev/null
 }
 
+run_contacts_dedupe_apply_test() {
+  local email first_json second_json first_id second_id dry_json dry_primary apply_json applied_primary merged_json
+
+  email="gogcli-dedupe-$TS@example.com"
+  first_json=$(gog contacts create \
+    --given "gogcli" \
+    --family "dedupe-$TS" \
+    --email "$email" \
+    --phone "+15550000001" \
+    --json)
+  first_id=$(extract_field "$first_json" resourceName)
+  [ -n "$first_id" ] || { echo "Failed to parse first dedupe contact resourceName" >&2; exit 1; }
+  register_contact_cleanup "$first_id"
+
+  second_json=$(gog contacts create \
+    --given "gogcli" \
+    --family "dedupe-$TS" \
+    --email "$email" \
+    --phone "+15550000002" \
+    --json)
+  second_id=$(extract_field "$second_json" resourceName)
+  [ -n "$second_id" ] || { echo "Failed to parse second dedupe contact resourceName" >&2; exit 1; }
+  register_contact_cleanup "$second_id"
+
+  dry_json=$(gog contacts dedupe \
+    --resource "$first_id" \
+    --resource "$second_id" \
+    --match email \
+    --apply \
+    --dry-run \
+    --json)
+  dry_primary=$($PY -c 'import json,sys
+obj=json.load(sys.stdin)
+first,second=sys.argv[1:3]
+request=obj.get("request") or {}
+groups=request.get("groups") or []
+if not obj.get("dry_run") or obj.get("op") != "contacts.dedupe.apply":
+    raise SystemExit("unexpected dedupe dry-run envelope")
+if request.get("groups_merged") != 1 or request.get("contacts_deleted") != 1 or len(groups) != 1:
+    raise SystemExit("dedupe dry-run found unrelated duplicate groups; refusing live apply")
+group=groups[0]
+primary=(group.get("primary") or {}).get("resource")
+deleted=[item.get("resource") for item in group.get("delete") or []]
+if primary not in (first,second) or deleted != [second if primary == first else first]:
+    raise SystemExit("dedupe dry-run did not target only disposable contacts")
+print(primary)' "$first_id" "$second_id" <<<"$dry_json")
+
+  apply_json=$(gog contacts dedupe \
+    --resource "$first_id" \
+    --resource "$second_id" \
+    --match email \
+    --apply \
+    --force \
+    --json)
+  applied_primary=$($PY -c 'import json,sys
+obj=json.load(sys.stdin)
+want=sys.argv[1]
+groups=obj.get("groups") or []
+if not obj.get("applied") or obj.get("groups_merged") != 1 or obj.get("contacts_deleted") != 1 or len(groups) != 1:
+    raise SystemExit("unexpected dedupe apply result")
+primary=(groups[0].get("primary") or {}).get("resource")
+if primary != want:
+    raise SystemExit("dedupe apply primary changed after dry-run")
+print(primary)' "$dry_primary" <<<"$apply_json")
+
+  merged_json=$(gog contacts get "$applied_primary" --json)
+  $PY -c 'import json,re,sys
+obj=json.load(sys.stdin)
+contact=obj.get("contact") or {}
+emails={str(item.get("value","")).strip().lower() for item in contact.get("emailAddresses") or []}
+phones={"".join(re.findall(r"\d", str(item.get("value","")))) for item in contact.get("phoneNumbers") or []}
+if sys.argv[1].lower() not in emails:
+    raise SystemExit("merged contact missing dedupe email")
+if not {"15550000001","15550000002"}.issubset(phones):
+    raise SystemExit("merged contact missing dedupe phone values")' "$email" <<<"$merged_json"
+
+  run_required "contacts" "contacts dedupe cleanup" gog contacts delete "$applied_primary" --force >/dev/null
+}
+
 run_contacts_tests() {
   if skip "contacts"; then
     echo "==> contacts (skipped)"
@@ -31,6 +110,7 @@ run_contacts_tests() {
   contact_json=$(gog contacts create --given "gogcli" --family "smoke-$TS" --email "gogcli-smoke-$TS@example.com" --phone "+1555555$TS" --json)
   contact_id=$(extract_field "$contact_json" resourceName)
   [ -n "$contact_id" ] || { echo "Failed to parse contact resourceName" >&2; exit 1; }
+  register_contact_cleanup "$contact_id"
 
   run_required "contacts" "contacts get" gog contacts get "$contact_id" --json >/dev/null
   run_required "contacts" "contacts update" gog contacts update "$contact_id" --given "gogcli" --family "smoke-updated-$TS" --email "gogcli-smoke-$TS@example.com" --birthday "1990-05-12" --notes "gogcli smoke $TS" --json >/dev/null
@@ -40,6 +120,7 @@ run_contacts_tests() {
   grep -q "EMAIL:gogcli-smoke-$TS@example.com" "$export_path" || { echo "contacts export missing email" >&2; exit 1; }
   grep -q "BDAY:19900512" "$export_path" || { echo "contacts export missing birthday" >&2; exit 1; }
   run_required "contacts" "contacts delete" gog contacts delete "$contact_id" --force >/dev/null
+  run_required "contacts" "contacts dedupe apply" run_contacts_dedupe_apply_test
 
   if is_consumer_account "$ACCOUNT"; then
     echo "==> contacts directory (skipped; Workspace only)"

--- a/scripts/live_contacts_test.go
+++ b/scripts/live_contacts_test.go
@@ -123,3 +123,135 @@ run_contacts_other_tests
 		t.Fatalf("skip path invoked the API:\n%s", text)
 	}
 }
+
+func TestContactsLiveDedupeApplyWorkflow(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+TS=20260613000000
+LIVE_TMP=$(mktemp -d)
+TRACE_FILE="$LIVE_TMP/trace"
+COUNT_FILE="$LIVE_TMP/create-count"
+printf '0\n' >"$COUNT_FILE"
+trap 'rm -rf "$LIVE_TMP"' EXIT
+source "$ROOT_DIR/scripts/live-tests/common.sh"
+source "$ROOT_DIR/scripts/live-tests/contacts.sh"
+gog() {
+  printf '%s\n' "$*" >>"$TRACE_FILE"
+  case "$*" in
+    "contacts create"*)
+      count=$(cat "$COUNT_FILE")
+      count=$((count + 1))
+      printf '%d\n' "$count" >"$COUNT_FILE"
+      printf '{"resourceName":"people/%d"}\n' "$count"
+      ;;
+    "contacts dedupe --resource people/1 --resource people/2 --match email --apply --dry-run --json")
+      printf '{"dry_run":true,"op":"contacts.dedupe.apply","request":{"groups_merged":1,"contacts_deleted":1,"groups":[{"primary":{"resource":"people/1"},"delete":[{"resource":"people/2"}]}]}}\n'
+      ;;
+    "contacts dedupe --resource people/1 --resource people/2 --match email --apply --force --json")
+      printf '{"applied":true,"groups_merged":1,"contacts_deleted":1,"groups":[{"primary":{"resource":"people/1"}}]}\n'
+      ;;
+    "contacts get people/1 --json")
+      printf '{"contact":{"emailAddresses":[{"value":"gogcli-dedupe-20260613000000@example.com"}],"phoneNumbers":[{"value":"+1 555 000 0001"},{"value":"+1 555 000 0002"}]}}\n'
+      ;;
+    "contacts delete people/1 --force")
+      printf '{}\n'
+      ;;
+    *)
+      echo "unexpected gog call: $*" >&2
+      return 1
+      ;;
+  esac
+}
+run_contacts_dedupe_apply_test
+printf 'cleanup_ids:%s\n' "${LIVE_CONTACT_CLEANUP_IDS[*]}"
+cat "$TRACE_FILE"
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err != nil {
+		t.Fatalf("run contacts dedupe live-test path: %v\n%s", err, output)
+	}
+
+	text := string(output)
+	for _, want := range []string{
+		"cleanup_ids:people/1 people/2",
+		"contacts dedupe --resource people/1 --resource people/2 --match email --apply --dry-run --json",
+		"contacts dedupe --resource people/1 --resource people/2 --match email --apply --force --json",
+		"contacts get people/1 --json",
+		"contacts delete people/1 --force",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestContactsLiveDedupeRefusesUnrelatedGroups(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bash live-test harness is not supported on Windows")
+	}
+
+	root, err := filepath.Abs("..")
+	if err != nil {
+		t.Fatalf("resolve repository root: %v", err)
+	}
+
+	script := `
+set -euo pipefail
+ROOT_DIR="$1"
+PY=python3
+TS=20260613000000
+LIVE_TMP=$(mktemp -d)
+COUNT_FILE="$LIVE_TMP/create-count"
+printf '0\n' >"$COUNT_FILE"
+trap 'rm -rf "$LIVE_TMP"' EXIT
+source "$ROOT_DIR/scripts/live-tests/common.sh"
+source "$ROOT_DIR/scripts/live-tests/contacts.sh"
+gog() {
+  case "$*" in
+    "contacts create"*)
+      count=$(cat "$COUNT_FILE")
+      count=$((count + 1))
+      printf '%d\n' "$count" >"$COUNT_FILE"
+      printf '{"resourceName":"people/%d"}\n' "$count"
+      ;;
+    "contacts dedupe --resource people/1 --resource people/2 --match email --apply --dry-run --json")
+      printf '{"dry_run":true,"op":"contacts.dedupe.apply","request":{"groups_merged":2,"contacts_deleted":2,"groups":[]}}\n'
+      ;;
+    *"--force"*)
+      echo "apply must not run" >&2
+      return 99
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+run_contacts_dedupe_apply_test
+`
+
+	output, err := exec.CommandContext(t.Context(), "bash", "-c", script, "bash", root).CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected unrelated groups to stop live apply:\n%s", output)
+	}
+
+	text := string(output)
+	if !strings.Contains(text, "unrelated duplicate groups") {
+		t.Fatalf("output missing refusal reason:\n%s", text)
+	}
+
+	if strings.Contains(text, "apply must not run") {
+		t.Fatalf("unsafe live apply ran:\n%s", text)
+	}
+}


### PR DESCRIPTION
Closes #815

## Summary

- add guarded `contacts dedupe --apply` / `--merge`
- merge all supported People API fields into the selected primary contact before deleting redundant contacts
- add repeatable `--resource people/...` scoping for exact reviewed automation targets
- reject ambiguous singleton fields and unsupported secondary photo/cover-photo/skill data
- re-read etags before each destructive mutation and preserve undeleted contacts on partial failure
- add command docs, changelog entry, regression coverage, and permanent Contacts live-test coverage

## Validation

- `autoreview --mode local --parallel-tests 'make ci'`: clean, no actionable findings
- `make ci`: pass
- focused Contacts apply/resource and live-harness tests: pass
- live E2E with `clawdbot@gmail.com`: created two disposable duplicate contacts, verified exact-scoped dry-run, applied one merge/delete, read back both phone values from the primary, then cleaned up
