### PR TITLE
docs(readme): align Docker auth example with GOG_HOME pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.28.1 - Unreleased
 
+### Fixed
+
+- Docs: update the Docker authentication example to persist file-keyring tokens with `GOG_HOME`. (#828, #830) — thanks @WadydX.
+
 ## 0.28.0 - 2026-06-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,16 +47,17 @@ gog --version
 docker run --rm ghcr.io/openclaw/gogcli:latest version
 ```
 
-Authenticated container runs should use a persistent config volume and the
+Authenticated container runs should use a persistent `GOG_HOME` directory and the
 encrypted file keyring:
 
 ```bash
-docker volume create gogcli-config
+docker volume create gogcli-state
 
 docker run --rm -it \
+  -e GOG_HOME=/persist/gogcli \
   -e GOG_KEYRING_BACKEND=file \
   -e GOG_KEYRING_PASSWORD \
-  -v gogcli-config:/home/gog/.config/gogcli \
+  -v gogcli-state:/persist/gogcli \
   ghcr.io/openclaw/gogcli:latest \
   auth add you@gmail.com --services gmail,calendar,drive
 ```


### PR DESCRIPTION
## Summary

Aligns the README Docker auth example with the `GOG_HOME` pattern already documented in `docs/install.md` and `docs/paths.md`.

Closes #828

## Problem

The README Docker example mounts only `-v gogcli-config:/home/gog/.config/gogcli`, but file-keyring tokens are stored under the **data** directory (`$GOG_DATA_DIR/keyring/`), not the config directory. Users following the README complete `auth add` inside the container, then lose their tokens when the container exits because the data directory was never persisted.

## Change

- Replace the config-only volume with a `GOG_HOME` volume (`gogcli-state:/persist/gogcli`)
- Add `-e GOG_HOME=/persist/gogcli` to the `docker run` command
- Rename the volume from `gogcli-config` to `gogcli-state` for clarity

This matches the exact example already shown in `docs/install.md` (line 30–43).

## Verification

- `docs/install.md` already uses this pattern: `docker volume create gogcli-state` + `GOG_HOME=/persist/gogcli`
- `docs/paths.md` confirms data (including file-keyring entries) lives under the data directory
- No code changes; docs-only PR
