### PR TITLE
feat(calendar): add --timezone flag to event create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Calendar: add `create --timezone`/`--tz` to apply one IANA timezone to both event endpoints while retaining granular start/end timezone flags. (#844) — thanks @malob.
 - Docs: add non-destructive `insert-image --before` and `--after` anchors while clarifying that `--at` replaces its placeholder. (#839) — thanks @sebsnyk.
 - Slides: allow `insert-image` and `replace-slide` to use public HTTPS image URLs without temporary Drive sharing. (#825) — thanks @sebsnyk.
 - Slides: add structured element geometry, styled text runs, table-cell content, image source URLs, native presentation metadata, and read-only text location with exact UTF-16 ranges. (#822) — thanks @sebsnyk.

--- a/docs/commands/gog-calendar-create.md
+++ b/docs/commands/gog-calendar-create.md
@@ -66,6 +66,7 @@ gog calendar (cal) create (add,new) <calendarId> [flags]
 | `--source-url` | `string` |  | URL where event was created/imported from |
 | `--start-timezone`<br>`--from-timezone` | `string` |  | IANA timezone metadata for --from (e.g., Europe/Rome) |
 | `--summary` | `string` |  | Event summary/title |
+| `--timezone`<br>`--tz` | `string` |  | IANA timezone metadata applied to both --from and --to (e.g., America/Los_Angeles); mutually exclusive with --start-timezone/--end-timezone |
 | `--to` | `string` |  | End time (RFC3339) |
 | `--transparency` | `string` |  | Show as busy (opaque) or free (transparent). Aliases: busy, free |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -274,7 +274,7 @@ Drive hierarchy semantics:
 - `gog calendar events <calendarId> [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339] [--to RFC3339] [--max N] [--page TOKEN] [--query Q] [--weekday]`
 - `gog calendar event|get <calendarId> <eventId>`
 - `GOG_CALENDAR_WEEKDAY=1` defaults `--weekday` for `gog calendar events`
-- `gog calendar create <calendarId> --summary S --from DT --to DT [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees a@b.com,c@d.com] [--all-day] [--event-type TYPE]`
+- `gog calendar create <calendarId> --summary S --from DT --to DT [--timezone TZ] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees a@b.com,c@d.com] [--all-day] [--event-type TYPE]`
 - `gog calendar update <calendarId> <eventId> [--summary S] [--from DT] [--to DT] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees ...] [--add-attendee ...] [--attachment URL ...] [--all-day] [--with-meet|--regenerate-meet] [--event-type TYPE]`
 - `gog calendar delete <calendarId> <eventId>`
 - `gog calendar freebusy [calendarIds] [--cal ID_OR_NAME] [--calendars CSV] [--all] --from RFC3339 --to RFC3339`

--- a/internal/cmd/calendar_build.go
+++ b/internal/cmd/calendar_build.go
@@ -44,6 +44,30 @@ func buildEventDateTimeWithTimezone(value string, allDay bool, timezone, flagNam
 	return edt, nil
 }
 
+// Flag names for the event start/end timezone options. Shared so the unified
+// --timezone resolution can attribute validation errors to the flag the user
+// actually set.
+const (
+	flagStartTimezone = "--start-timezone"
+	flagEndTimezone   = "--end-timezone"
+	flagTimezone      = "--timezone"
+)
+
+// resolveUnifiedTimezone applies a single --timezone/--tz value to both the
+// start and end timezone. It is mutually exclusive with the granular
+// --start-timezone/--end-timezone flags: supplying --timezone alongside either
+// is a usage error. The returned flag names let downstream validation errors
+// (invalid zone, all-day) point at whichever flag the user actually set.
+func resolveUnifiedTimezone(unified, start, end string) (startTZ, startFlag, endTZ, endFlag string, err error) {
+	if strings.TrimSpace(unified) == "" {
+		return start, flagStartTimezone, end, flagEndTimezone, nil
+	}
+	if strings.TrimSpace(start) != "" || strings.TrimSpace(end) != "" {
+		return "", "", "", "", usage("--timezone cannot be combined with --start-timezone or --end-timezone")
+	}
+	return unified, flagTimezone, unified, flagTimezone, nil
+}
+
 func etcGMTForOffsetSeconds(offset int) (string, bool) {
 	if offset == 0 || offset%3600 != 0 {
 		return "", false

--- a/internal/cmd/calendar_build_test.go
+++ b/internal/cmd/calendar_build_test.go
@@ -94,3 +94,41 @@ func TestBuildExtendedProperties(t *testing.T) {
 		t.Fatalf("unexpected shared props: %#v", props.Shared)
 	}
 }
+
+func TestResolveUnifiedTimezone(t *testing.T) {
+	// Unset --timezone: pass the granular values through unchanged.
+	startTZ, startFlag, endTZ, endFlag, err := resolveUnifiedTimezone("", "Europe/Rome", "America/New_York")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if startTZ != "Europe/Rome" || endTZ != "America/New_York" {
+		t.Fatalf("passthrough changed values: start=%q end=%q", startTZ, endTZ)
+	}
+	if startFlag != "--start-timezone" || endFlag != "--end-timezone" {
+		t.Fatalf("unexpected flag names: %q %q", startFlag, endFlag)
+	}
+
+	// --timezone alone: apply it to both endpoints with --timezone error attribution.
+	startTZ, startFlag, endTZ, endFlag, err = resolveUnifiedTimezone("America/Los_Angeles", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if startTZ != "America/Los_Angeles" || endTZ != "America/Los_Angeles" {
+		t.Fatalf("expected both zones set, got start=%q end=%q", startTZ, endTZ)
+	}
+	if startFlag != "--timezone" || endFlag != "--timezone" {
+		t.Fatalf("expected --timezone flag names, got %q %q", startFlag, endFlag)
+	}
+
+	// --timezone combined with --start-timezone is a usage error.
+	if _, _, _, _, err := resolveUnifiedTimezone("America/Los_Angeles", "Europe/Rome", ""); err == nil {
+		t.Fatalf("expected error combining --timezone with --start-timezone")
+	} else if got := ExitCode(err); got != 2 {
+		t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
+	}
+
+	// --timezone combined with --end-timezone is a usage error.
+	if _, _, _, _, err := resolveUnifiedTimezone("America/Los_Angeles", "", "America/New_York"); err == nil {
+		t.Fatalf("expected error combining --timezone with --end-timezone")
+	}
+}

--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -112,6 +112,121 @@ func TestCalendarCreateCmd_WithMeetAndAttachments(t *testing.T) {
 	}
 }
 
+func TestCalendarCreateCmd_UnifiedTimezoneSetsBoth(t *testing.T) {
+	var gotEvent calendar.Event
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
+		if r.Method == http.MethodPost && path == "/calendars/cal@example.com/events" {
+			_ = json.NewDecoder(r.Body).Decode(&gotEvent)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "ev1"})
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc := newCalendarServiceFromServer(t, srv)
+	ctx := withCalendarTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), svc)
+
+	cmd := &CalendarCreateCmd{}
+	if err := runKong(t, cmd, []string{
+		"cal@example.com",
+		"--summary", "Meeting",
+		"--from", "2026-08-13T13:40:00-07:00",
+		"--to", "2026-08-13T14:40:00-07:00",
+		"--tz", "America/Los_Angeles",
+	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	if gotEvent.Start == nil || gotEvent.End == nil {
+		t.Fatalf("missing start/end: %#v", gotEvent)
+	}
+	if gotEvent.Start.TimeZone != "America/Los_Angeles" || gotEvent.End.TimeZone != "America/Los_Angeles" {
+		t.Fatalf("expected both zones America/Los_Angeles, got start=%q end=%q", gotEvent.Start.TimeZone, gotEvent.End.TimeZone)
+	}
+}
+
+func TestCalendarCreateCmd_UnifiedTimezoneConflict(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	svc := newCalendarServiceFromServer(t, srv)
+	ctx := withCalendarTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), svc)
+
+	cmd := &CalendarCreateCmd{}
+	err := runKong(t, cmd, []string{
+		"cal@example.com",
+		"--summary", "Meeting",
+		"--from", "2026-08-13T13:40:00-07:00",
+		"--to", "2026-08-13T14:40:00-07:00",
+		"--timezone", "America/Los_Angeles",
+		"--start-timezone", "Europe/Rome",
+	}, ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil {
+		t.Fatalf("expected error combining --timezone with --start-timezone")
+	}
+	if got := ExitCode(err); got != 2 {
+		t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
+	}
+}
+
+func TestCalendarCreateCmd_UnifiedTimezoneInvalidZoneAttributesFlag(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "invalid zone",
+			args: []string{
+				"cal@example.com",
+				"--summary", "Meeting",
+				"--from", "2026-08-13T13:40:00-07:00",
+				"--to", "2026-08-13T14:40:00-07:00",
+				"--timezone", "Nope/Zone",
+			},
+		},
+		{
+			name: "all-day rejects timezone",
+			args: []string{
+				"cal@example.com",
+				"--summary", "Meeting",
+				"--all-day",
+				"--from", "2026-08-13",
+				"--to", "2026-08-14",
+				"--timezone", "America/Los_Angeles",
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.NotFound(w, r)
+			}))
+			defer srv.Close()
+
+			svc := newCalendarServiceFromServer(t, srv)
+			ctx := withCalendarTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), svc)
+
+			cmd := &CalendarCreateCmd{}
+			err := runKong(t, cmd, tc.args, ctx, &RootFlags{Account: "a@b.com"})
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if got := ExitCode(err); got != 2 {
+				t.Fatalf("expected usage exit code 2, got %d (err=%v)", got, err)
+			}
+			// The whole point of the flag-name plumbing: the error must name
+			// --timezone, not the granular --start-timezone the user didn't use.
+			if msg := err.Error(); !strings.Contains(msg, "--timezone") || strings.Contains(msg, "--start-timezone") {
+				t.Fatalf("expected error to attribute to --timezone, got: %q", msg)
+			}
+		})
+	}
+}
+
 func TestCalendarCreateCmd_RecurringOffsetTimezoneFallback(t *testing.T) {
 	var gotEvent calendar.Event
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -22,6 +22,7 @@ type CalendarCreateCmd struct {
 	To                    string   `name:"to" help:"End time (RFC3339)"`
 	StartTimezone         string   `name:"start-timezone" aliases:"from-timezone" help:"IANA timezone metadata for --from (e.g., Europe/Rome)"`
 	EndTimezone           string   `name:"end-timezone" aliases:"to-timezone" help:"IANA timezone metadata for --to (e.g., America/New_York)"`
+	Timezone              string   `name:"timezone" aliases:"tz" help:"IANA timezone metadata applied to both --from and --to (e.g., America/Los_Angeles); mutually exclusive with --start-timezone/--end-timezone"`
 	Description           string   `name:"description" help:"Description"`
 	Location              string   `name:"location" help:"Location"`
 	LocationSearch        string   `name:"location-search" help:"Resolve a Google Places text search and use the best match as event location"`
@@ -80,6 +81,7 @@ func calendarCreateInputFromCommand(c *CalendarCreateCmd) calendarCreateInput {
 		To:                    c.To,
 		StartTimezone:         c.StartTimezone,
 		EndTimezone:           c.EndTimezone,
+		Timezone:              c.Timezone,
 		Description:           c.Description,
 		Location:              c.Location,
 		Attendees:             c.Attendees,

--- a/internal/cmd/calendar_event_plan.go
+++ b/internal/cmd/calendar_event_plan.go
@@ -35,6 +35,7 @@ type calendarCreateInput struct {
 	To                    string
 	StartTimezone         string
 	EndTimezone           string
+	Timezone              string
 	Description           string
 	Location              string
 	Attendees             string
@@ -358,11 +359,15 @@ func buildCalendarCreatePlan(store *config.ConfigStore, input calendarCreateInpu
 	if err != nil {
 		return nil, err
 	}
-	start, err := buildEventDateTimeWithTimezone(input.From, allDay, input.StartTimezone, "--start-timezone")
+	startTZ, startTZFlag, endTZ, endTZFlag, err := resolveUnifiedTimezone(input.Timezone, input.StartTimezone, input.EndTimezone)
 	if err != nil {
 		return nil, err
 	}
-	end, err := buildEventDateTimeWithTimezone(input.To, allDay, input.EndTimezone, "--end-timezone")
+	start, err := buildEventDateTimeWithTimezone(input.From, allDay, startTZ, startTZFlag)
+	if err != nil {
+		return nil, err
+	}
+	end, err := buildEventDateTimeWithTimezone(input.To, allDay, endTZ, endTZFlag)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

`calendar create` requires `--start-timezone` and `--end-timezone` to be set
separately to label an event's start/end with a named IANA zone. This adds a
single `--timezone`/`--tz` flag that applies one zone to both endpoints.

- `--timezone <IANA>` / `--tz <IANA>` sets the timezone on both `--from` and `--to`.
- Mutually exclusive with `--start-timezone`/`--end-timezone` — passing it
  alongside either is a usage error (the granular flags remain for the
  asymmetric case).
- Mirrors the existing `--timezone`/`--tz` flag on `calendar create-calendar`.
- Invalid-zone / all-day errors are attributed to the flag the user actually set.

This flag is specific to `calendar create`. `calendar update` could gain the same
convenience later, but its timezone handling is more involved — it depends on
which of `--from`/`--to` is being changed — so it's intentionally left out of
scope here.

## Why

For most events the start and end are in the same timezone — wanting different
zones for each is the unusual case. Setting that single zone today means
repeating it across both `--start-timezone` and `--end-timezone`, which is fiddly
and easy to get half-right (one set, the other forgotten). `--timezone` collapses
the common case to one flag and removes that easy mistake, while the
mutual-exclusivity check keeps the rarer split-zone case explicit.

## Behavior proof

Live round-trip against a real account (account/event id redacted; throwaway
event deleted afterward). Both endpoints persist the named zone, and the event
is gone after delete:

```console
$ ./bin/gog calendar create primary --summary "tz flag test" \
    --from 2026-08-13T13:40:00-07:00 --to 2026-08-13T14:40:00-07:00 \
    --timezone America/Los_Angeles --send-updates none --account <redacted> --json
# created — event id <event-id>

# read it back (start/end excerpt of the --json event) — both carry the named zone:
$ ./bin/gog calendar event primary <event-id> --account <redacted> --json
  "start": { "dateTime": "2026-08-13T13:40:00-07:00", "timeZone": "America/Los_Angeles" },
  "end":   { "dateTime": "2026-08-13T14:40:00-07:00", "timeZone": "America/Los_Angeles" },

$ ./bin/gog calendar delete primary <event-id> --force --send-updates none --account <redacted> --json
{"calendarId":"primary","deleted":true,"eventId":"<event-id>"}

# confirm gone (soft-deleted):
$ ./bin/gog calendar event primary <event-id> --account <redacted> --json
  "status": "cancelled"
```

## Testing

- `make fmt-check`, `make lint`, `make docs-check` clean; regenerated the command
  reference with `make docs-commands`.
- `go test ./internal/cmd -run 'UnifiedTimezone|ResolveUnifiedTimezone'` — covers
  set-both, the conflict error (exit 2), and invalid-zone/all-day error attribution.

## Compatibility

Additive and non-breaking — `--timezone` is new and existing
`--start-timezone`/`--end-timezone` usage is unchanged. Kong scopes the `--tz`
alias per command, so there's no collision with `create-calendar`.

No `CHANGELOG.md` entry — left to the release/landing process per repo convention.
