### PR TITLE
feat(secrets): make keyring open timeout configurable, default 30s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Auth: make keyring open/operation timeouts configurable with `GOG_KEYRING_OPEN_TIMEOUT`, using a `30s` macOS default for permission prompts while retaining `10s` elsewhere. (#845) — thanks @malob.
 - Calendar: add `create --timezone`/`--tz` to apply one IANA timezone to both event endpoints while retaining granular start/end timezone flags. (#844) — thanks @malob.
 - Docs: add non-destructive `insert-image --before` and `--after` anchors while clarifying that `--at` replaces its placeholder. (#839) — thanks @sebsnyk.
 - Slides: allow `insert-image` and `replace-slide` to use public HTTPS image URLs without temporary Drive sharing. (#825) — thanks @sebsnyk.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -112,7 +112,7 @@ Implementation: `internal/config/*`.
 - Legacy key format: `token:<email>` (migrated on first read)
 - Stored payload is JSON (refresh token + metadata like OIDC subject, current email, selected services/scopes).
 - Email is treated as display/contact state; Google's OIDC `sub` is used to detect the same account after an email rename and migrate aliases/defaults/client mappings on reauthorization.
-- macOS Keychain operations are bounded by a timeout (default `30s`, configurable via `GOG_KEYRING_OPEN_TIMEOUT`) so non-surfacing permission prompts return actionable guidance instead of hanging indefinitely.
+- Keyring operations are bounded by a timeout (default `30s` on macOS and `10s` elsewhere, configurable via `GOG_KEYRING_OPEN_TIMEOUT`) so non-surfacing permission prompts and unresponsive backends return actionable guidance instead of hanging indefinitely.
 - Fallback: if no OS credential store is available, keyring may use its encrypted "file" backend:
   - Directory: `$(os.UserConfigDir())/gogcli/keyring/` (one file per key; gog-managed key names are encoded for portable filenames)
   - Password: prompts on TTY; for non-interactive runs set `GOG_KEYRING_PASSWORD`
@@ -169,7 +169,7 @@ Environment:
 - `GOG_KEYRING_PASSWORD=...` (used when keyring falls back to encrypted file backend in non-interactive environments)
 - `GOG_KEYRING_BACKEND={auto|keychain|file}` (force backend; use `file` to avoid Keychain prompts and pair with `GOG_KEYRING_PASSWORD` for non-interactive)
 - `GOG_KEYRING_SERVICE_NAME=...` (override keyring namespace/service name; default `gogcli`)
-- `GOG_KEYRING_OPEN_TIMEOUT=30s` (max time to wait for a keyring open/operation — e.g. a macOS Keychain permission prompt — before failing; Go duration, default `30s`)
+- `GOG_KEYRING_OPEN_TIMEOUT=30s` (max time to wait for a keyring open/operation — e.g. a macOS Keychain permission prompt — before failing; Go duration, default `30s` on macOS and `10s` elsewhere)
 - `GOG_TIMEZONE=America/New_York` (default output timezone; IANA name or `UTC`; `local` forces local timezone)
 - `GOG_ENABLE_COMMANDS=calendar,tasks,gmail.search` (optional prefix allowlist; dot paths allowed; parent paths allow children)
 - `GOG_ENABLE_COMMANDS_EXACT=calendar.events,gmail.search` (optional exact allowlist; dot paths allowed; parent paths do not allow children)

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -112,7 +112,7 @@ Implementation: `internal/config/*`.
 - Legacy key format: `token:<email>` (migrated on first read)
 - Stored payload is JSON (refresh token + metadata like OIDC subject, current email, selected services/scopes).
 - Email is treated as display/contact state; Google's OIDC `sub` is used to detect the same account after an email rename and migrate aliases/defaults/client mappings on reauthorization.
-- macOS Keychain operations are bounded by a timeout so non-surfacing permission prompts return actionable guidance instead of hanging indefinitely.
+- macOS Keychain operations are bounded by a timeout (default `30s`, configurable via `GOG_KEYRING_OPEN_TIMEOUT`) so non-surfacing permission prompts return actionable guidance instead of hanging indefinitely.
 - Fallback: if no OS credential store is available, keyring may use its encrypted "file" backend:
   - Directory: `$(os.UserConfigDir())/gogcli/keyring/` (one file per key; gog-managed key names are encoded for portable filenames)
   - Password: prompts on TTY; for non-interactive runs set `GOG_KEYRING_PASSWORD`
@@ -169,6 +169,7 @@ Environment:
 - `GOG_KEYRING_PASSWORD=...` (used when keyring falls back to encrypted file backend in non-interactive environments)
 - `GOG_KEYRING_BACKEND={auto|keychain|file}` (force backend; use `file` to avoid Keychain prompts and pair with `GOG_KEYRING_PASSWORD` for non-interactive)
 - `GOG_KEYRING_SERVICE_NAME=...` (override keyring namespace/service name; default `gogcli`)
+- `GOG_KEYRING_OPEN_TIMEOUT=30s` (max time to wait for a keyring open/operation — e.g. a macOS Keychain permission prompt — before failing; Go duration, default `30s`)
 - `GOG_TIMEZONE=America/New_York` (default output timezone; IANA name or `UTC`; `local` forces local timezone)
 - `GOG_ENABLE_COMMANDS=calendar,tasks,gmail.search` (optional prefix allowlist; dot paths allowed; parent paths allow children)
 - `GOG_ENABLE_COMMANDS_EXACT=calendar.events,gmail.search` (optional exact allowlist; dot paths allowed; parent paths do not allow children)

--- a/internal/secrets/backend.go
+++ b/internal/secrets/backend.go
@@ -16,6 +16,7 @@ const (
 	keyringPasswordEnv    = "GOG_KEYRING_PASSWORD" //nolint:gosec // env var name, not a credential
 	keyringBackendEnv     = "GOG_KEYRING_BACKEND"  //nolint:gosec // env var name, not a credential
 	keyringServiceNameEnv = "GOG_KEYRING_SERVICE_NAME"
+	keyringOpenTimeoutEnv = "GOG_KEYRING_OPEN_TIMEOUT"
 )
 
 var (
@@ -68,6 +69,7 @@ func OpenOptionsFromLookup(
 	password, passwordSet := lookup(keyringPasswordEnv)
 	serviceName, _ := lookup(keyringServiceNameEnv)
 	dbusAddress, _ := lookup("DBUS_SESSION_BUS_ADDRESS")
+	openTimeoutRaw, _ := lookup(keyringOpenTimeoutEnv)
 	lockTimeoutRaw, _ := lookup(keyringLockTimeoutEnv)
 
 	return OpenOptions{
@@ -80,7 +82,7 @@ func OpenOptionsFromLookup(
 		GOOS:        goos,
 		DBusAddress: dbusAddress,
 		IsTTY:       isTTY,
-		OpenTimeout: keyringOpenTimeout,
+		OpenTimeout: parseKeyringOpenTimeout(openTimeoutRaw),
 		LockTimeout: parseKeyringLockTimeout(lockTimeoutRaw),
 	}
 }
@@ -161,14 +163,32 @@ func serviceNameFor(options OpenOptions) string {
 	return config.AppName
 }
 
-// keyringOpenTimeout is the maximum time to wait for keyring.Open() to complete.
-// On headless Linux, D-Bus SecretService can hang indefinitely if gnome-keyring
-// is installed but not running.
+// keyringOpenTimeout is the default maximum time to wait for a keyring open or
+// operation to complete; override with GOG_KEYRING_OPEN_TIMEOUT. It guards
+// against backends that can hang indefinitely (headless-Linux D-Bus
+// SecretService when gnome-keyring is installed but not running; an unresponsive
+// macOS Keychain) while still leaving room for an interactive macOS Keychain
+// permission prompt (password entry plus "Always Allow").
 const (
-	keyringOpenTimeout = 10 * time.Second
+	keyringOpenTimeout = 30 * time.Second
 	goosDarwin         = "darwin"
 	goosLinux          = "linux"
 )
+
+// parseKeyringOpenTimeout resolves GOG_KEYRING_OPEN_TIMEOUT, falling back to the
+// default when unset, unparseable, or non-positive.
+func parseKeyringOpenTimeout(raw string) time.Duration {
+	if raw == "" {
+		return keyringOpenTimeout
+	}
+
+	timeout, err := time.ParseDuration(raw)
+	if err != nil || timeout <= 0 {
+		return keyringOpenTimeout
+	}
+
+	return timeout
+}
 
 func shouldForceFileBackend(goos string, backendInfo KeyringBackendInfo, dbusAddr string) bool {
 	return goos == goosLinux && backendInfo.Value == keyringBackendAuto && dbusAddr == ""

--- a/internal/secrets/backend.go
+++ b/internal/secrets/backend.go
@@ -82,7 +82,7 @@ func OpenOptionsFromLookup(
 		GOOS:        goos,
 		DBusAddress: dbusAddress,
 		IsTTY:       isTTY,
-		OpenTimeout: parseKeyringOpenTimeout(openTimeoutRaw),
+		OpenTimeout: parseKeyringOpenTimeout(openTimeoutRaw, goos),
 		LockTimeout: parseKeyringLockTimeout(lockTimeoutRaw),
 	}
 }
@@ -163,28 +163,34 @@ func serviceNameFor(options OpenOptions) string {
 	return config.AppName
 }
 
-// keyringOpenTimeout is the default maximum time to wait for a keyring open or
-// operation to complete; override with GOG_KEYRING_OPEN_TIMEOUT. It guards
-// against backends that can hang indefinitely (headless-Linux D-Bus
-// SecretService when gnome-keyring is installed but not running; an unresponsive
-// macOS Keychain) while still leaving room for an interactive macOS Keychain
-// permission prompt (password entry plus "Always Allow").
+// Keyring timeouts guard against unresponsive backends. macOS gets longer for
+// interactive permission prompts; other platforms retain the existing limit.
 const (
-	keyringOpenTimeout = 30 * time.Second
-	goosDarwin         = "darwin"
-	goosLinux          = "linux"
+	keyringOpenTimeout       = 10 * time.Second
+	darwinKeyringOpenTimeout = 30 * time.Second
+	goosDarwin               = "darwin"
+	goosLinux                = "linux"
 )
 
-// parseKeyringOpenTimeout resolves GOG_KEYRING_OPEN_TIMEOUT, falling back to the
-// default when unset, unparseable, or non-positive.
-func parseKeyringOpenTimeout(raw string) time.Duration {
+func defaultKeyringOpenTimeout(goos string) time.Duration {
+	if goos == goosDarwin {
+		return darwinKeyringOpenTimeout
+	}
+
+	return keyringOpenTimeout
+}
+
+// parseKeyringOpenTimeout resolves GOG_KEYRING_OPEN_TIMEOUT, falling back to
+// the platform default when unset, unparseable, or non-positive.
+func parseKeyringOpenTimeout(raw, goos string) time.Duration {
+	fallback := defaultKeyringOpenTimeout(goos)
 	if raw == "" {
-		return keyringOpenTimeout
+		return fallback
 	}
 
 	timeout, err := time.ParseDuration(raw)
 	if err != nil || timeout <= 0 {
-		return keyringOpenTimeout
+		return fallback
 	}
 
 	return timeout
@@ -269,7 +275,7 @@ func openKeyringWithOptions(options OpenOptions) (keyring.Keyring, error) {
 
 	openTimeout := options.OpenTimeout
 	if openTimeout <= 0 {
-		openTimeout = keyringOpenTimeout
+		openTimeout = defaultKeyringOpenTimeout(options.GOOS)
 	}
 
 	open := options.openKeyringFn
@@ -315,7 +321,7 @@ func prepareKeyring(
 	if shouldUseKeyringOperationTimeout(options.GOOS, backendInfo, options.DBusAddress) {
 		timeout := options.OpenTimeout
 		if timeout <= 0 {
-			timeout = keyringOpenTimeout
+			timeout = defaultKeyringOpenTimeout(options.GOOS)
 		}
 		ring = newTimeoutKeyring(ring, timeout, keyringTimeoutHint(options.GOOS))
 	}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -102,20 +102,24 @@ func TestParseKeyringOpenTimeout(t *testing.T) {
 	tests := []struct {
 		name string
 		raw  string
+		goos string
 		want time.Duration
 	}{
-		{name: "empty falls back to default", raw: "", want: keyringOpenTimeout},
-		{name: "valid duration", raw: "1m", want: time.Minute},
-		{name: "unparseable falls back to default", raw: "nonsense", want: keyringOpenTimeout},
-		{name: "non-positive falls back to default", raw: "-5s", want: keyringOpenTimeout},
+		{name: "darwin default", goos: "darwin", want: darwinKeyringOpenTimeout},
+		{name: "linux default", goos: "linux", want: keyringOpenTimeout},
+		{name: "other default", goos: "windows", want: keyringOpenTimeout},
+		{name: "valid duration overrides darwin", raw: "1m", goos: "darwin", want: time.Minute},
+		{name: "valid duration overrides linux", raw: "45s", goos: "linux", want: 45 * time.Second},
+		{name: "invalid uses darwin default", raw: "nonsense", goos: "darwin", want: darwinKeyringOpenTimeout},
+		{name: "non-positive uses linux default", raw: "-5s", goos: "linux", want: keyringOpenTimeout},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := parseKeyringOpenTimeout(tt.raw); got != tt.want {
-				t.Fatalf("parseKeyringOpenTimeout(%q) = %v, want %v", tt.raw, got, tt.want)
+			if got := parseKeyringOpenTimeout(tt.raw, tt.goos); got != tt.want {
+				t.Fatalf("parseKeyringOpenTimeout(%q, %q) = %v, want %v", tt.raw, tt.goos, got, tt.want)
 			}
 		})
 	}

--- a/internal/secrets/store_test.go
+++ b/internal/secrets/store_test.go
@@ -76,6 +76,51 @@ func TestOpenOptionsFromLookupCapturesEnvironment(t *testing.T) {
 	}
 }
 
+func TestOpenOptionsFromLookupOpenTimeout(t *testing.T) {
+	t.Parallel()
+
+	values := map[string]string{keyringOpenTimeoutEnv: "45s"}
+	options := OpenOptionsFromLookup(
+		config.Layout{ConfigDir: "/config", DataDir: "/data"},
+		config.NewConfigStore(config.Layout{ConfigDir: "/config"}),
+		func(key string) (string, bool) {
+			value, ok := values[key]
+			return value, ok
+		},
+		"darwin",
+		true,
+	)
+
+	if options.OpenTimeout != 45*time.Second {
+		t.Fatalf("OpenTimeout = %v, want 45s", options.OpenTimeout)
+	}
+}
+
+func TestParseKeyringOpenTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want time.Duration
+	}{
+		{name: "empty falls back to default", raw: "", want: keyringOpenTimeout},
+		{name: "valid duration", raw: "1m", want: time.Minute},
+		{name: "unparseable falls back to default", raw: "nonsense", want: keyringOpenTimeout},
+		{name: "non-positive falls back to default", raw: "-5s", want: keyringOpenTimeout},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseKeyringOpenTimeout(tt.raw); got != tt.want {
+				t.Fatalf("parseKeyringOpenTimeout(%q) = %v, want %v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestOpenUsesInjectedOptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/secrets/timeout_keyring.go
+++ b/internal/secrets/timeout_keyring.go
@@ -47,8 +47,8 @@ func withKeyringTimeout[T any](timeout time.Duration, operation string, hint str
 
 func keyringTimeoutError(operation string, timeout time.Duration, hint string) error {
 	return fmt.Errorf("%w after %v while %s (%s); "+
-		"set GOG_KEYRING_BACKEND=file and GOG_KEYRING_PASSWORD=<password> to use encrypted file storage instead",
-		errKeyringTimeout, timeout, operation, hint)
+		"set %s to allow more time, or set GOG_KEYRING_BACKEND=file and GOG_KEYRING_PASSWORD=<password> to use encrypted file storage instead",
+		errKeyringTimeout, timeout, operation, hint, keyringOpenTimeoutEnv)
 }
 
 func IsKeyringTimeout(err error) bool {

--- a/internal/secrets/timeout_keyring_test.go
+++ b/internal/secrets/timeout_keyring_test.go
@@ -68,8 +68,9 @@ func TestTimeoutKeyringTimesOutOperations(t *testing.T) {
 		t.Fatalf("expected timeout error, got %v", err)
 	}
 
-	if !strings.Contains(err.Error(), "listing keyring items") || !strings.Contains(err.Error(), "Always Allow") {
-		t.Fatalf("expected operation and macOS hint in timeout, got %v", err)
+	if !strings.Contains(err.Error(), "listing keyring items") || !strings.Contains(err.Error(), "Always Allow") ||
+		!strings.Contains(err.Error(), "GOG_KEYRING_OPEN_TIMEOUT") {
+		t.Fatalf("expected operation, macOS hint, and timeout env in error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

The keyring open/operation timeout — added so an unresponsive backend can't hang
the CLI forever (#513, #221) — defaults to 10s. This raises that default to 30s
and makes it configurable via `GOG_KEYRING_OPEN_TIMEOUT` (a Go duration),
mirroring the existing `GOG_KEYRING_LOCK_TIMEOUT`.

- `GOG_KEYRING_OPEN_TIMEOUT=45s` (any Go duration) overrides the timeout;
  empty/invalid/non-positive values fall back to the default.
- Default raised 10s → 30s.
- The timeout error now points at `GOG_KEYRING_OPEN_TIMEOUT`.

## Why

On macOS this timeout bounds every Keychain read, including the wait for an
interactive permission prompt. 10s is usually enough to approve one — but it
leaves little margin for the normal frictions: not noticing the prompt for a few
seconds, fumbling and re-entering the login password, or macOS showing two
prompts back to back (client secret + token). When that margin runs out, a
legitimate prompt times out before it's approved and auth fails on a perfectly
healthy machine. 30s gives comfortable headroom for those cases while still
bounding the failure the timeout was created for — an *indefinite* hang
(commands hung until SIGKILL, #513), not a matter of seconds.
`GOG_KEYRING_OPEN_TIMEOUT` then lets anyone tune it further, just like
`GOG_KEYRING_LOCK_TIMEOUT` already does for the lock wait.

If raising the default is contentious, the env var alone is still a worthwhile
addition (parity with the lock-timeout knob) — but I'd argue 30s should be the
default: 10s is too tight for the common interactive-Keychain path, and 30s still
firmly bounds the hang case.

## Behavior proof

With the Keychain permission prompt left unanswered (so the read blocks until the
timeout fires), wall-clock time matches the configured timeout:

```console
# default — read gives up after 30s
$ time ./bin/gog calendar calendars --account <redacted> --json
... keyring connection timed out after 30s while reading keyring item (...);
    set GOG_KEYRING_OPEN_TIMEOUT to allow more time, or set GOG_KEYRING_BACKEND=file ...
# ≈ 30s elapsed

# override — the same read gives up after the configured 5s
$ time GOG_KEYRING_OPEN_TIMEOUT=5s ./bin/gog calendar calendars --account <redacted> --json
... keyring connection timed out after 5s while reading keyring item (...);
    set GOG_KEYRING_OPEN_TIMEOUT to allow more time, or set GOG_KEYRING_BACKEND=file ...
# ≈ 5s elapsed
```

## Testing

- `make fmt-check`, `make lint`, `make docs-check` clean.
- `go test ./internal/secrets -run 'OpenTimeout|ParseKeyringOpenTimeout|TimeoutKeyring'` —
  covers env parsing (valid/empty/invalid/non-positive), the `OpenOptionsFromLookup`
  wiring, and that the timeout error names `GOG_KEYRING_OPEN_TIMEOUT`.
- Documented the env var in `docs/spec.md`.

No `CHANGELOG.md` entry — left to the release/landing process per repo convention.
