### PR TITLE
feat(slides): add native element operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Slides: add range-scoped styling, links, bullets, and object-scoped replacement; `replace-text` now requires explicit `--object`, `--page`, or `--all` scope instead of silently changing the whole deck. (#823, #835) — thanks @sebsnyk.
 - Slides: add native table creation and zero-based table-cell targeting for `insert-text`, including atomic cell replacement. (#824, #834) — thanks @sebsnyk.
 - Slides: add native themed slide creation, duplication, and reordering with predefined or exact custom layouts and explicit zero-based positions. (#826, #833) — thanks @sebsnyk.
+- Slides: add native shape and line creation plus element transforms, fill/outline styling, z-order, grouping, alt text, and guarded deletion. (#826) — thanks @sebsnyk.
 
 ### Fixed
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -593,6 +593,16 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) create-from-template <templateId> <title> [flags]`](commands/gog-slides-create-from-template.md) - Create a presentation from template with text replacements
     - [`gog slides (slide) delete-slide <presentationId> <slideId>`](commands/gog-slides-delete-slide.md) - Delete a slide by object ID
     - [`gog slides (slide) duplicate-slide <presentationId> <slideId> [flags]`](commands/gog-slides-duplicate-slide.md) - Duplicate a slide by object ID
+    - [`gog slides (slide) element <command>`](commands/gog-slides-element.md) - Create and manipulate native page elements
+      - [`gog slides (slide) element alt-text <presentationId> <objectId> [flags]`](commands/gog-slides-element-alt-text.md) - Set or clear element accessibility text
+      - [`gog slides (slide) element create-line <presentationId> <slideId> [flags]`](commands/gog-slides-element-create-line.md) - Create a native line on a slide
+      - [`gog slides (slide) element create-shape <presentationId> <slideId> [flags]`](commands/gog-slides-element-create-shape.md) - Create a native shape on a slide
+      - [`gog slides (slide) element delete (rm) <presentationId> <objectId>`](commands/gog-slides-element-delete.md) - Delete one page element
+      - [`gog slides (slide) element group <presentationId> <objectId> ... [flags]`](commands/gog-slides-element-group.md) - Group two or more elements
+      - [`gog slides (slide) element style <presentationId> <objectId> [flags]`](commands/gog-slides-element-style.md) - Style a shape fill/outline or a line
+      - [`gog slides (slide) element transform (move,resize,rotate) <presentationId> <objectId> [flags]`](commands/gog-slides-element-transform.md) - Move, resize, rotate, or replace an element transform
+      - [`gog slides (slide) element ungroup <presentationId> <groupId> ...`](commands/gog-slides-element-ungroup.md) - Ungroup one or more element groups
+      - [`gog slides (slide) element z-order --operation=STRING <presentationId> <objectId> ...`](commands/gog-slides-element-z-order.md) - Change element stacking order
     - [`gog slides (slide) export (download,dl) <presentationId> [flags]`](commands/gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
     - [`gog slides (slide) info (get,show) <presentationId>`](commands/gog-slides-info.md) - Get Google Slides presentation metadata
     - [`gog slides (slide) insert-image --width=FLOAT-64 <presentationId> <slideId> [<image>] [flags]`](commands/gog-slides-insert-image.md) - Insert a local or public image at a position and size

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 655.
+Generated pages: 665.
 
 ## Top-level Commands
 
@@ -644,6 +644,16 @@ Generated pages: 655.
     - [gog slides create-from-template](gog-slides-create-from-template.md) - Create a presentation from template with text replacements
     - [gog slides delete-slide](gog-slides-delete-slide.md) - Delete a slide by object ID
     - [gog slides duplicate-slide](gog-slides-duplicate-slide.md) - Duplicate a slide by object ID
+    - [gog slides element](gog-slides-element.md) - Create and manipulate native page elements
+      - [gog slides element alt-text](gog-slides-element-alt-text.md) - Set or clear element accessibility text
+      - [gog slides element create-line](gog-slides-element-create-line.md) - Create a native line on a slide
+      - [gog slides element create-shape](gog-slides-element-create-shape.md) - Create a native shape on a slide
+      - [gog slides element delete](gog-slides-element-delete.md) - Delete one page element
+      - [gog slides element group](gog-slides-element-group.md) - Group two or more elements
+      - [gog slides element style](gog-slides-element-style.md) - Style a shape fill/outline or a line
+      - [gog slides element transform](gog-slides-element-transform.md) - Move, resize, rotate, or replace an element transform
+      - [gog slides element ungroup](gog-slides-element-ungroup.md) - Ungroup one or more element groups
+      - [gog slides element z-order](gog-slides-element-z-order.md) - Change element stacking order
     - [gog slides export](gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
     - [gog slides info](gog-slides-info.md) - Get Google Slides presentation metadata
     - [gog slides insert-image](gog-slides-insert-image.md) - Insert a local or public image at a position and size

--- a/docs/commands/gog-slides-element-alt-text.md
+++ b/docs/commands/gog-slides-element-alt-text.md
@@ -1,0 +1,47 @@
+# `gog slides element alt-text`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Set or clear element accessibility text
+
+## Usage
+
+```bash
+gog slides (slide) element alt-text <presentationId> <objectId> [flags]
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--description` | `*string` |  | Accessibility description; pass an empty value to clear |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--title` | `*string` |  | Accessibility title; pass an empty value to clear |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-create-line.md
+++ b/docs/commands/gog-slides-element-create-line.md
@@ -1,0 +1,52 @@
+# `gog slides element create-line`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Create a native line on a slide
+
+## Usage
+
+```bash
+gog slides (slide) element create-line <presentationId> <slideId> [flags]
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--category` | `string` | STRAIGHT | Line category |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `--height` | `float64` | 0 | Vertical extent |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--object-id` | `string` |  | Optional stable object ID (5-50 allowed characters) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--unit` | `string` | PT | Geometry unit |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--width` | `float64` | 100 | Horizontal extent |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+| `--x` | `float64` | 0 | Start X position |
+| `--y` | `float64` | 0 | Start Y position |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-create-shape.md
+++ b/docs/commands/gog-slides-element-create-shape.md
@@ -1,0 +1,52 @@
+# `gog slides element create-shape`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Create a native shape on a slide
+
+## Usage
+
+```bash
+gog slides (slide) element create-shape <presentationId> <slideId> [flags]
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `--height` | `float64` | 100 | Shape height |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--object-id` | `string` |  | Optional stable object ID (5-50 allowed characters) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--type` | `string` | RECTANGLE | Slides shape type (for example RECTANGLE, TEXT_BOX, ELLIPSE) |
+| `--unit` | `string` | PT | Geometry unit |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--width` | `float64` | 100 | Shape width |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+| `--x` | `float64` | 0 | Left position |
+| `--y` | `float64` | 0 | Top position |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-delete.md
+++ b/docs/commands/gog-slides-element-delete.md
@@ -1,0 +1,45 @@
+# `gog slides element delete`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Delete one page element
+
+## Usage
+
+```bash
+gog slides (slide) element delete (rm) <presentationId> <objectId>
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-group.md
+++ b/docs/commands/gog-slides-element-group.md
@@ -1,0 +1,46 @@
+# `gog slides element group`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Group two or more elements
+
+## Usage
+
+```bash
+gog slides (slide) element group <presentationId> <objectId> ... [flags]
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `--group-id` | `string` |  | Optional stable group object ID |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-style.md
+++ b/docs/commands/gog-slides-element-style.md
@@ -1,0 +1,52 @@
+# `gog slides element style`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Style a shape fill/outline or a line
+
+## Usage
+
+```bash
+gog slides (slide) element style <presentationId> <objectId> [flags]
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fill-color` | `string` |  | Shape fill as #RGB or #RRGGBB |
+| `--fill-transparent` | `bool` |  | Remove the shape fill |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--kind` | `string` | shape | Element kind |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--outline-color` | `string` |  | Shape outline or line color as #RGB or #RRGGBB |
+| `--outline-dash` | `*string` |  | Shape outline or line dash style |
+| `--outline-transparent` | `bool` |  | Remove the shape outline or make the line transparent |
+| `--outline-weight` | `*float64` |  | Shape outline or line weight in points |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-transform.md
+++ b/docs/commands/gog-slides-element-transform.md
@@ -1,0 +1,54 @@
+# `gog slides element transform`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Move, resize, rotate, or replace an element transform
+
+## Usage
+
+```bash
+gog slides (slide) element transform (move,resize,rotate) <presentationId> <objectId> [flags]
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--apply-mode` | `string` | RELATIVE | Compose with or replace the existing transform |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--rotate` | `*float64` |  | Clockwise rotation in degrees around the element origin |
+| `--scale-x` | `*float64` |  | X scale; omitted axis defaults to 1 |
+| `--scale-y` | `*float64` |  | Y scale; omitted axis defaults to 1 |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--shear-x` | `*float64` |  | X shear |
+| `--shear-y` | `*float64` |  | Y shear |
+| `--translate-x` | `*float64` |  | X translation |
+| `--translate-y` | `*float64` |  | Y translation |
+| `--unit` | `string` | PT | Translation unit |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-ungroup.md
+++ b/docs/commands/gog-slides-element-ungroup.md
@@ -1,0 +1,45 @@
+# `gog slides element ungroup`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Ungroup one or more element groups
+
+## Usage
+
+```bash
+gog slides (slide) element ungroup <presentationId> <groupId> ...
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element-z-order.md
+++ b/docs/commands/gog-slides-element-z-order.md
@@ -1,0 +1,46 @@
+# `gog slides element z-order`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Change element stacking order
+
+## Usage
+
+```bash
+gog slides (slide) element z-order --operation=STRING <presentationId> <objectId> ...
+```
+
+## Parent
+
+- [gog slides element](gog-slides-element.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--operation` | `string` |  | Stacking operation |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides element](gog-slides-element.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides-element.md
+++ b/docs/commands/gog-slides-element.md
@@ -1,0 +1,57 @@
+# `gog slides element`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Create and manipulate native page elements
+
+## Usage
+
+```bash
+gog slides (slide) element <command>
+```
+
+## Parent
+
+- [gog slides](gog-slides.md)
+
+## Subcommands
+
+- [gog slides element alt-text](gog-slides-element-alt-text.md) - Set or clear element accessibility text
+- [gog slides element create-line](gog-slides-element-create-line.md) - Create a native line on a slide
+- [gog slides element create-shape](gog-slides-element-create-shape.md) - Create a native shape on a slide
+- [gog slides element delete](gog-slides-element-delete.md) - Delete one page element
+- [gog slides element group](gog-slides-element-group.md) - Group two or more elements
+- [gog slides element style](gog-slides-element-style.md) - Style a shape fill/outline or a line
+- [gog slides element transform](gog-slides-element-transform.md) - Move, resize, rotate, or replace an element transform
+- [gog slides element ungroup](gog-slides-element-ungroup.md) - Ungroup one or more element groups
+- [gog slides element z-order](gog-slides-element-z-order.md) - Change element stacking order
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog slides](gog-slides.md)
+- [Command index](README.md)

--- a/docs/commands/gog-slides.md
+++ b/docs/commands/gog-slides.md
@@ -24,6 +24,7 @@ gog slides (slide) <command> [flags]
 - [gog slides create-from-template](gog-slides-create-from-template.md) - Create a presentation from template with text replacements
 - [gog slides delete-slide](gog-slides-delete-slide.md) - Delete a slide by object ID
 - [gog slides duplicate-slide](gog-slides-duplicate-slide.md) - Duplicate a slide by object ID
+- [gog slides element](gog-slides-element.md) - Create and manipulate native page elements
 - [gog slides export](gog-slides-export.md) - Export a Google Slides deck (pdf|pptx)
 - [gog slides info](gog-slides-info.md) - Get Google Slides presentation metadata
 - [gog slides insert-image](gog-slides-insert-image.md) - Insert a local or public image at a position and size

--- a/docs/slides-structure.md
+++ b/docs/slides-structure.md
@@ -41,3 +41,61 @@ matching the Slides API. An index can range from zero through the slide count.
 
 Use `--dry-run --json` to inspect the exact batch request without contacting
 Google, and `slides list-slides --json` to verify the resulting order.
+
+## Native elements
+
+Create editable shapes and lines on an existing slide:
+
+```bash
+gog slides element create-shape <presentationId> <slideId> \
+  --type ROUND_RECTANGLE --x 24 --y 24 --width 180 --height 80
+gog slides element create-line <presentationId> <slideId> \
+  --category STRAIGHT --x 50 --y 150 --width 240 --height 40
+```
+
+Geometry defaults to points; pass `--unit EMU` for English Metric Units.
+Supplying `--object-id` makes later scripted mutations deterministic. Custom
+object IDs must use the Slides API's 5-50 character object-ID format.
+
+Move, resize, shear, or rotate an element with an affine transform:
+
+```bash
+gog slides element transform <presentationId> <objectId> \
+  --translate-x 12 --translate-y 6
+gog slides element transform <presentationId> <objectId> \
+  --scale-x 1.25 --scale-y 1.25
+gog slides element transform <presentationId> <objectId> --rotate 15
+```
+
+Transforms are relative by default. `--apply-mode ABSOLUTE` replaces the
+existing transform. Rotation is around the element origin and cannot be mixed
+with explicit scale or shear flags in the same request.
+
+Style shape fills/outlines or line strokes:
+
+```bash
+gog slides element style <presentationId> <shapeId> \
+  --fill-color '#3367d6' --outline-color '#ffffff' --outline-weight 2
+gog slides element style <presentationId> <lineId> --kind line \
+  --outline-color '#ea4335' --outline-dash DASH
+```
+
+Colors accept `#RGB` or `#RRGGBB`. Use `--fill-transparent` or
+`--outline-transparent` to remove rendering for that property.
+
+Stack, group, annotate, and delete elements:
+
+```bash
+gog slides element z-order <presentationId> <objectId>... --operation BRING_TO_FRONT
+gog slides element group <presentationId> <objectId> <objectId>... --group-id <groupId>
+gog slides element ungroup <presentationId> <groupId>...
+gog slides element alt-text <presentationId> <objectId> \
+  --title "Chart" --description "Quarterly revenue by region"
+gog slides element delete <presentationId> <objectId> --force
+```
+
+`z-order` targets must share one slide and must not be grouped. `group` needs at
+least two ungrouped elements on one slide; Slides does not permit every element
+kind to be grouped. Passing an empty `--title=` or `--description=` clears that
+alt-text field. Element deletion is destructive and requires confirmation or
+`--force` in non-interactive use. Every mutation supports `--dry-run --json`.

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -266,6 +266,7 @@ Drive hierarchy semantics:
 - Folder scans reject an ancestor cycle instead of following it indefinitely.
 
 - `gog slides thumbnail <presentationId> <slideId> [--size small|medium|large] [--format png|jpeg] [--out PATH]`
+- `gog slides element <create-shape|create-line|transform|style|z-order|group|ungroup|alt-text|delete> ...` (native page-element lifecycle; exact batch payloads available with `--dry-run --json`)
 - `gog calendar calendars`
 - `gog calendar subscribe <calendarId>`
 - `gog calendar unsubscribe <calendarId>`

--- a/internal/cmd/slides.go
+++ b/internal/cmd/slides.go
@@ -35,6 +35,7 @@ type SlidesCmd struct {
 	InsertImage        SlidesInsertImageCmd        `cmd:"" name:"insert-image" help:"Insert a local or public image at a position and size"`
 	InsertText         SlidesInsertTextCmd         `cmd:"" name:"insert-text" help:"Insert text into an existing page element (shape or table) by objectId"`
 	Table              SlidesTableCmd              `cmd:"" name:"table" help:"Create and update native tables"`
+	Element            SlidesElementCmd            `cmd:"" name:"element" help:"Create and manipulate native page elements"`
 	StyleText          SlidesStyleTextCmd          `cmd:"" name:"style-text" help:"Apply range-scoped text styling to one page element"`
 	Link               SlidesLinkCmd               `cmd:"" name:"link" help:"Apply a hyperlink to a text range in one page element"`
 	Bullets            SlidesBulletsCmd            `cmd:"" name:"bullets" help:"Turn paragraph bullets on or off in one page element"`

--- a/internal/cmd/slides_element.go
+++ b/internal/cmd/slides_element.go
@@ -1,0 +1,667 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type SlidesElementCmd struct {
+	CreateShape SlidesElementCreateShapeCmd `cmd:"" name:"create-shape" help:"Create a native shape on a slide"`
+	CreateLine  SlidesElementCreateLineCmd  `cmd:"" name:"create-line" help:"Create a native line on a slide"`
+	Transform   SlidesElementTransformCmd   `cmd:"" name:"transform" aliases:"move,resize,rotate" help:"Move, resize, rotate, or replace an element transform"`
+	Style       SlidesElementStyleCmd       `cmd:"" name:"style" help:"Style a shape fill/outline or a line"`
+	ZOrder      SlidesElementZOrderCmd      `cmd:"" name:"z-order" help:"Change element stacking order"`
+	Group       SlidesElementGroupCmd       `cmd:"" name:"group" help:"Group two or more elements"`
+	Ungroup     SlidesElementUngroupCmd     `cmd:"" name:"ungroup" help:"Ungroup one or more element groups"`
+	AltText     SlidesElementAltTextCmd     `cmd:"" name:"alt-text" help:"Set or clear element accessibility text"`
+	Delete      SlidesElementDeleteCmd      `cmd:"" name:"delete" aliases:"rm" help:"Delete one page element"`
+}
+
+const (
+	slidesElementKindShape = "shape"
+	slidesElementKindLine  = "line"
+)
+
+type SlidesElementCreateShapeCmd struct {
+	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	SlideID        string  `arg:"" name:"slideId" help:"Slide object ID"`
+	Type           string  `name:"type" default:"RECTANGLE" help:"Slides shape type (for example RECTANGLE, TEXT_BOX, ELLIPSE)"`
+	X              float64 `name:"x" default:"0" help:"Left position"`
+	Y              float64 `name:"y" default:"0" help:"Top position"`
+	Width          float64 `name:"width" default:"100" help:"Shape width"`
+	Height         float64 `name:"height" default:"100" help:"Shape height"`
+	Unit           string  `name:"unit" default:"PT" enum:"PT,EMU" help:"Geometry unit"`
+	ObjectID       string  `name:"object-id" help:"Optional stable object ID (5-50 allowed characters)"`
+}
+
+func (c *SlidesElementCreateShapeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, slideID, err := slidesElementPageTarget(c.PresentationID, c.SlideID)
+	if err != nil {
+		return err
+	}
+	shapeType := normalizeSlidesEnum(c.Type)
+	if shapeType == "" {
+		shapeType = "RECTANGLE"
+	}
+	if shapeType == "TYPE_UNSPECIFIED" {
+		return usage("--type must name a concrete Slides shape type")
+	}
+	if c.Width <= 0 || c.Height <= 0 {
+		return usage("--width and --height must be > 0")
+	}
+	objectID, err := slidesElementObjectID(c.ObjectID, "gogShape")
+	if err != nil {
+		return err
+	}
+	unit, err := slidesElementEnum(c.Unit, "PT", "PT", "EMU")
+	if err != nil {
+		return err
+	}
+	request := &slides.Request{CreateShape: &slides.CreateShapeRequest{
+		ObjectId:          objectID,
+		ShapeType:         shapeType,
+		ElementProperties: slidesElementProperties(slideID, c.X, c.Y, c.Width, c.Height, unit),
+	}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.create-shape",
+		Action:         "create shape",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload: map[string]any{
+			"slide_object_id": slideID,
+			"object_id":       objectID,
+			"shape_type":      shapeType,
+		},
+		Output: map[string]any{
+			"presentationId": presentationID,
+			"slideObjectId":  slideID,
+			"objectId":       objectID,
+			"shapeType":      shapeType,
+		},
+		Text: fmt.Sprintf("Created shape %s", objectID),
+	})
+}
+
+type SlidesElementCreateLineCmd struct {
+	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	SlideID        string  `arg:"" name:"slideId" help:"Slide object ID"`
+	Category       string  `name:"category" default:"STRAIGHT" enum:"STRAIGHT,BENT,CURVED" help:"Line category"`
+	X              float64 `name:"x" default:"0" help:"Start X position"`
+	Y              float64 `name:"y" default:"0" help:"Start Y position"`
+	Width          float64 `name:"width" default:"100" help:"Horizontal extent"`
+	Height         float64 `name:"height" default:"0" help:"Vertical extent"`
+	Unit           string  `name:"unit" default:"PT" enum:"PT,EMU" help:"Geometry unit"`
+	ObjectID       string  `name:"object-id" help:"Optional stable object ID (5-50 allowed characters)"`
+}
+
+func (c *SlidesElementCreateLineCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, slideID, err := slidesElementPageTarget(c.PresentationID, c.SlideID)
+	if err != nil {
+		return err
+	}
+	if c.Width < 0 || c.Height < 0 || (c.Width == 0 && c.Height == 0) {
+		return usage("--width and --height must be >= 0, with at least one > 0")
+	}
+	objectID, err := slidesElementObjectID(c.ObjectID, "gogLine")
+	if err != nil {
+		return err
+	}
+	category, err := slidesElementEnum(c.Category, "STRAIGHT", "STRAIGHT", "BENT", "CURVED")
+	if err != nil {
+		return err
+	}
+	unit, err := slidesElementEnum(c.Unit, "PT", "PT", "EMU")
+	if err != nil {
+		return err
+	}
+	request := &slides.Request{CreateLine: &slides.CreateLineRequest{
+		ObjectId:          objectID,
+		Category:          category,
+		ElementProperties: slidesElementProperties(slideID, c.X, c.Y, c.Width, c.Height, unit),
+	}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.create-line",
+		Action:         "create line",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload: map[string]any{
+			"slide_object_id": slideID,
+			"object_id":       objectID,
+			"category":        category,
+		},
+		Output: map[string]any{
+			"presentationId": presentationID,
+			"slideObjectId":  slideID,
+			"objectId":       objectID,
+			"category":       category,
+		},
+		Text: fmt.Sprintf("Created line %s", objectID),
+	})
+}
+
+type SlidesElementTransformCmd struct {
+	PresentationID string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectID       string   `arg:"" name:"objectId" help:"Page element object ID"`
+	ScaleX         *float64 `name:"scale-x" help:"X scale; omitted axis defaults to 1"`
+	ScaleY         *float64 `name:"scale-y" help:"Y scale; omitted axis defaults to 1"`
+	ShearX         *float64 `name:"shear-x" help:"X shear"`
+	ShearY         *float64 `name:"shear-y" help:"Y shear"`
+	TranslateX     *float64 `name:"translate-x" help:"X translation"`
+	TranslateY     *float64 `name:"translate-y" help:"Y translation"`
+	Rotate         *float64 `name:"rotate" help:"Clockwise rotation in degrees around the element origin"`
+	Unit           string   `name:"unit" default:"PT" enum:"PT,EMU" help:"Translation unit"`
+	ApplyMode      string   `name:"apply-mode" default:"RELATIVE" enum:"RELATIVE,ABSOLUTE" help:"Compose with or replace the existing transform"`
+}
+
+func (c *SlidesElementTransformCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectID, err := slidesElementTarget(c.PresentationID, c.ObjectID)
+	if err != nil {
+		return err
+	}
+	if c.ScaleX == nil && c.ScaleY == nil && c.ShearX == nil && c.ShearY == nil && c.TranslateX == nil && c.TranslateY == nil && c.Rotate == nil {
+		return usage("provide at least one transform option")
+	}
+	if c.Rotate != nil && (c.ScaleX != nil || c.ScaleY != nil || c.ShearX != nil || c.ShearY != nil) {
+		return usage("--rotate is mutually exclusive with scale and shear options")
+	}
+
+	var scaleX, scaleY, shearX, shearY float64
+	if c.Rotate != nil {
+		radians := *c.Rotate * math.Pi / 180
+		scaleX, scaleY = math.Cos(radians), math.Cos(radians)
+		shearX, shearY = -math.Sin(radians), math.Sin(radians)
+	} else {
+		scaleX = slidesElementFloat(c.ScaleX, 1)
+		scaleY = slidesElementFloat(c.ScaleY, 1)
+		shearX = slidesElementFloat(c.ShearX, 0)
+		shearY = slidesElementFloat(c.ShearY, 0)
+	}
+	unit, err := slidesElementEnum(c.Unit, "PT", "PT", "EMU")
+	if err != nil {
+		return err
+	}
+	applyMode, err := slidesElementEnum(c.ApplyMode, "RELATIVE", "RELATIVE", "ABSOLUTE")
+	if err != nil {
+		return err
+	}
+	transform := &slides.AffineTransform{
+		ScaleX:          scaleX,
+		ScaleY:          scaleY,
+		ShearX:          shearX,
+		ShearY:          shearY,
+		TranslateX:      slidesElementFloat(c.TranslateX, 0),
+		TranslateY:      slidesElementFloat(c.TranslateY, 0),
+		Unit:            unit,
+		ForceSendFields: []string{"ScaleX", "ScaleY", "ShearX", "ShearY", "TranslateX", "TranslateY"},
+	}
+	request := &slides.Request{UpdatePageElementTransform: &slides.UpdatePageElementTransformRequest{
+		ObjectId:  objectID,
+		ApplyMode: applyMode,
+		Transform: transform,
+	}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.transform",
+		Action:         "transform element",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"object_id": objectID, "apply_mode": applyMode},
+		Output:         map[string]any{"presentationId": presentationID, "objectId": objectID, "applyMode": applyMode, "transform": transform},
+		Text:           fmt.Sprintf("Transformed element %s", objectID),
+	})
+}
+
+type SlidesElementStyleCmd struct {
+	PresentationID     string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectID           string   `arg:"" name:"objectId" help:"Shape or line object ID"`
+	Kind               string   `name:"kind" default:"shape" enum:"shape,line" help:"Element kind"`
+	FillColor          string   `name:"fill-color" help:"Shape fill as #RGB or #RRGGBB"`
+	FillTransparent    bool     `name:"fill-transparent" help:"Remove the shape fill"`
+	OutlineColor       string   `name:"outline-color" help:"Shape outline or line color as #RGB or #RRGGBB"`
+	OutlineTransparent bool     `name:"outline-transparent" help:"Remove the shape outline or make the line transparent"`
+	OutlineWeight      *float64 `name:"outline-weight" help:"Shape outline or line weight in points"`
+	OutlineDash        *string  `name:"outline-dash" enum:"SOLID,DOT,DASH,DASH_DOT,LONG_DASH,LONG_DASH_DOT" help:"Shape outline or line dash style"`
+}
+
+func (c *SlidesElementStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectID, err := slidesElementTarget(c.PresentationID, c.ObjectID)
+	if err != nil {
+		return err
+	}
+	if c.FillColor != "" && c.FillTransparent {
+		return usage("--fill-color and --fill-transparent are mutually exclusive")
+	}
+	if c.OutlineColor != "" && c.OutlineTransparent {
+		return usage("--outline-color and --outline-transparent are mutually exclusive")
+	}
+	if c.OutlineWeight != nil && *c.OutlineWeight <= 0 {
+		return usage("--outline-weight must be > 0")
+	}
+	kind := strings.ToLower(strings.TrimSpace(c.Kind))
+	if kind == "" {
+		kind = slidesElementKindShape
+	}
+	if kind != slidesElementKindShape && kind != slidesElementKindLine {
+		return usage("--kind must be shape or line")
+	}
+	if kind == slidesElementKindLine && (c.FillColor != "" || c.FillTransparent) {
+		return usage("fill options apply only to shapes")
+	}
+	if kind == slidesElementKindShape && c.OutlineTransparent && (c.OutlineWeight != nil || c.OutlineDash != nil) {
+		return usage("--outline-transparent cannot be combined with outline weight or dash")
+	}
+	if c.FillColor == "" && !c.FillTransparent && c.OutlineColor == "" && !c.OutlineTransparent && c.OutlineWeight == nil && c.OutlineDash == nil {
+		return usage("provide at least one style option")
+	}
+
+	request, fields, err := slidesElementStyleRequest(c, objectID, kind)
+	if err != nil {
+		return err
+	}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.style",
+		Action:         "style element",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"object_id": objectID, "kind": kind, "fields": fields},
+		Output:         map[string]any{"presentationId": presentationID, "objectId": objectID, "kind": kind, "fields": fields},
+		Text:           fmt.Sprintf("Styled %s %s", kind, objectID),
+	})
+}
+
+type SlidesElementZOrderCmd struct {
+	PresentationID string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectIDs      []string `arg:"" name:"objectId" help:"One or more page element object IDs"`
+	Operation      string   `name:"operation" required:"" enum:"BRING_TO_FRONT,BRING_FORWARD,SEND_BACKWARD,SEND_TO_BACK" help:"Stacking operation"`
+}
+
+func (c *SlidesElementZOrderCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectIDs, err := slidesElementTargets(c.PresentationID, c.ObjectIDs, 1)
+	if err != nil {
+		return err
+	}
+	operation := normalizeSlidesEnum(c.Operation)
+	request := &slides.Request{UpdatePageElementsZOrder: &slides.UpdatePageElementsZOrderRequest{
+		PageElementObjectIds: objectIDs,
+		Operation:            operation,
+	}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.z-order",
+		Action:         "change element z-order",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"object_ids": objectIDs, "operation": operation},
+		Output:         map[string]any{"presentationId": presentationID, "objectIds": objectIDs, "operation": operation},
+		Text:           fmt.Sprintf("Changed z-order for %d element(s)", len(objectIDs)),
+	})
+}
+
+type SlidesElementGroupCmd struct {
+	PresentationID string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectIDs      []string `arg:"" name:"objectId" help:"Two or more page element object IDs"`
+	GroupID        string   `name:"group-id" help:"Optional stable group object ID"`
+}
+
+func (c *SlidesElementGroupCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectIDs, err := slidesElementTargets(c.PresentationID, c.ObjectIDs, 2)
+	if err != nil {
+		return err
+	}
+	groupID, err := slidesElementObjectID(c.GroupID, "gogGroup")
+	if err != nil {
+		return err
+	}
+	request := &slides.Request{GroupObjects: &slides.GroupObjectsRequest{
+		ChildrenObjectIds: objectIDs,
+		GroupObjectId:     groupID,
+	}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.group",
+		Action:         "group elements",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"object_ids": objectIDs, "group_object_id": groupID},
+		Output:         map[string]any{"presentationId": presentationID, "objectIds": objectIDs, "groupObjectId": groupID},
+		Text:           fmt.Sprintf("Created group %s", groupID),
+	})
+}
+
+type SlidesElementUngroupCmd struct {
+	PresentationID string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	GroupIDs       []string `arg:"" name:"groupId" help:"One or more top-level group object IDs"`
+}
+
+func (c *SlidesElementUngroupCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, groupIDs, err := slidesElementTargets(c.PresentationID, c.GroupIDs, 1)
+	if err != nil {
+		return err
+	}
+	request := &slides.Request{UngroupObjects: &slides.UngroupObjectsRequest{ObjectIds: groupIDs}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.ungroup",
+		Action:         "ungroup elements",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"group_object_ids": groupIDs},
+		Output:         map[string]any{"presentationId": presentationID, "groupObjectIds": groupIDs, "ungrouped": true},
+		Text:           fmt.Sprintf("Ungrouped %d group(s)", len(groupIDs)),
+	})
+}
+
+type SlidesElementAltTextCmd struct {
+	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectID       string  `arg:"" name:"objectId" help:"Page element object ID"`
+	Title          *string `name:"title" help:"Accessibility title; pass an empty value to clear"`
+	Description    *string `name:"description" help:"Accessibility description; pass an empty value to clear"`
+}
+
+func (c *SlidesElementAltTextCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectID, err := slidesElementTarget(c.PresentationID, c.ObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Title == nil && c.Description == nil {
+		return usage("provide --title and/or --description")
+	}
+	update := &slides.UpdatePageElementAltTextRequest{ObjectId: objectID}
+	fields := make([]string, 0, 2)
+	if c.Title != nil {
+		update.Title = *c.Title
+		update.ForceSendFields = append(update.ForceSendFields, "Title")
+		fields = append(fields, "title")
+	}
+	if c.Description != nil {
+		update.Description = *c.Description
+		update.ForceSendFields = append(update.ForceSendFields, "Description")
+		fields = append(fields, "description")
+	}
+	request := &slides.Request{UpdatePageElementAltText: update}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.alt-text",
+		Action:         "update element alt text",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"object_id": objectID, "fields": fields},
+		Output:         map[string]any{"presentationId": presentationID, "objectId": objectID, "fields": fields},
+		Text:           fmt.Sprintf("Updated alt text for element %s", objectID),
+	})
+}
+
+type SlidesElementDeleteCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	ObjectID       string `arg:"" name:"objectId" help:"Page element object ID"`
+}
+
+func (c *SlidesElementDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, objectID, err := slidesElementTarget(c.PresentationID, c.ObjectID)
+	if err != nil {
+		return err
+	}
+	request := &slides.Request{DeleteObject: &slides.DeleteObjectRequest{ObjectId: objectID}}
+	return runSlidesElementMutation(ctx, flags, slidesElementMutation{
+		Op:             "slides.element.delete",
+		Action:         "delete element",
+		PresentationID: presentationID,
+		Request:        request,
+		Payload:        map[string]any{"object_id": objectID},
+		Output:         map[string]any{"presentationId": presentationID, "objectId": objectID, "deleted": true},
+		Text:           fmt.Sprintf("Deleted element %s", objectID),
+		Destructive:    fmt.Sprintf("delete element %s from presentation %s", objectID, presentationID),
+	})
+}
+
+type slidesElementMutation struct {
+	Op             string
+	Action         string
+	PresentationID string
+	Request        *slides.Request
+	Payload        map[string]any
+	Output         map[string]any
+	Text           string
+	Destructive    string
+}
+
+func runSlidesElementMutation(ctx context.Context, flags *RootFlags, mutation slidesElementMutation) error {
+	body := &slides.BatchUpdatePresentationRequest{Requests: []*slides.Request{mutation.Request}}
+	payload := mutation.Payload
+	if payload == nil {
+		payload = make(map[string]any)
+	}
+	payload["presentation_id"] = mutation.PresentationID
+	payload["batch_update"] = body
+	var err error
+	if mutation.Destructive != "" {
+		err = dryRunAndConfirmDestructive(ctx, flags, mutation.Op, payload, mutation.Destructive)
+	} else {
+		err = dryRunExit(ctx, flags, mutation.Op, payload)
+	}
+	if err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := slidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+	if _, err := svc.Presentations.BatchUpdate(mutation.PresentationID, body).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("%s: %w", mutation.Action, err)
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), mutation.Output)
+	}
+	ui.FromContext(ctx).Out().Linef("%s", mutation.Text)
+	return nil
+}
+
+func slidesElementProperties(slideID string, x, y, width, height float64, unit string) *slides.PageElementProperties {
+	return &slides.PageElementProperties{
+		PageObjectId: slideID,
+		Size: &slides.Size{
+			Width:  slidesElementDimension(width, unit),
+			Height: slidesElementDimension(height, unit),
+		},
+		Transform: &slides.AffineTransform{
+			ScaleX:          1,
+			ScaleY:          1,
+			TranslateX:      x,
+			TranslateY:      y,
+			Unit:            unit,
+			ForceSendFields: []string{"ScaleX", "ScaleY", "ShearX", "ShearY", "TranslateX", "TranslateY"},
+		},
+	}
+}
+
+func slidesElementDimension(value float64, unit string) *slides.Dimension {
+	return &slides.Dimension{Magnitude: value, Unit: unit, ForceSendFields: []string{"Magnitude"}}
+}
+
+func slidesElementStyleRequest(c *SlidesElementStyleCmd, objectID, kind string) (*slides.Request, []string, error) {
+	if kind == slidesElementKindLine {
+		properties := &slides.LineProperties{}
+		fields := make([]string, 0, 3)
+		if c.OutlineColor != "" || c.OutlineTransparent {
+			fill, err := slidesElementSolidFill(c.OutlineColor, c.OutlineTransparent)
+			if err != nil {
+				return nil, nil, usage("--outline-color must be a #RRGGBB or #RGB hex color")
+			}
+			properties.LineFill = &slides.LineFill{SolidFill: fill}
+			fields = append(fields, "lineFill.solidFill.color", "lineFill.solidFill.alpha")
+		}
+		if c.OutlineWeight != nil {
+			properties.Weight = slidesElementDimension(*c.OutlineWeight, "PT")
+			fields = append(fields, "weight")
+		}
+		if c.OutlineDash != nil {
+			properties.DashStyle = normalizeSlidesEnum(*c.OutlineDash)
+			fields = append(fields, "dashStyle")
+		}
+		return &slides.Request{UpdateLineProperties: &slides.UpdateLinePropertiesRequest{
+			ObjectId:       objectID,
+			LineProperties: properties,
+			Fields:         strings.Join(fields, ","),
+		}}, fields, nil
+	}
+
+	properties := &slides.ShapeProperties{}
+	fields := make([]string, 0, 8)
+	if c.FillColor != "" || c.FillTransparent {
+		if c.FillTransparent {
+			properties.ShapeBackgroundFill = &slides.ShapeBackgroundFill{PropertyState: "NOT_RENDERED"}
+			fields = append(fields, "shapeBackgroundFill.propertyState")
+		} else {
+			fill, err := slidesElementSolidFill(c.FillColor, false)
+			if err != nil {
+				return nil, nil, usage("--fill-color must be a #RRGGBB or #RGB hex color")
+			}
+			properties.ShapeBackgroundFill = &slides.ShapeBackgroundFill{PropertyState: "RENDERED", SolidFill: fill}
+			fields = append(fields, "shapeBackgroundFill.propertyState", "shapeBackgroundFill.solidFill.color", "shapeBackgroundFill.solidFill.alpha")
+		}
+	}
+	if c.OutlineColor != "" || c.OutlineTransparent || c.OutlineWeight != nil || c.OutlineDash != nil {
+		outline := &slides.Outline{}
+		if c.OutlineTransparent {
+			outline.PropertyState = "NOT_RENDERED"
+			fields = append(fields, "outline.propertyState")
+		} else {
+			outline.PropertyState = "RENDERED"
+			fields = append(fields, "outline.propertyState")
+			if c.OutlineColor != "" {
+				fill, err := slidesElementSolidFill(c.OutlineColor, false)
+				if err != nil {
+					return nil, nil, usage("--outline-color must be a #RRGGBB or #RGB hex color")
+				}
+				outline.OutlineFill = &slides.OutlineFill{SolidFill: fill}
+				fields = append(fields, "outline.outlineFill.solidFill.color", "outline.outlineFill.solidFill.alpha")
+			}
+			if c.OutlineWeight != nil {
+				outline.Weight = slidesElementDimension(*c.OutlineWeight, "PT")
+				fields = append(fields, "outline.weight")
+			}
+			if c.OutlineDash != nil {
+				outline.DashStyle = normalizeSlidesEnum(*c.OutlineDash)
+				fields = append(fields, "outline.dashStyle")
+			}
+		}
+		properties.Outline = outline
+	}
+	return &slides.Request{UpdateShapeProperties: &slides.UpdateShapePropertiesRequest{
+		ObjectId:        objectID,
+		ShapeProperties: properties,
+		Fields:          strings.Join(fields, ","),
+	}}, fields, nil
+}
+
+func slidesElementSolidFill(color string, transparent bool) (*slides.SolidFill, error) {
+	alpha := 1.0
+	if transparent {
+		alpha = 0
+		color = "#000000"
+	}
+	r, g, b, ok := parseHexColor(color)
+	if !ok {
+		return nil, fmt.Errorf("invalid color")
+	}
+	return &slides.SolidFill{
+		Alpha:           alpha,
+		Color:           &slides.OpaqueColor{RgbColor: &slides.RgbColor{Red: r, Green: g, Blue: b}},
+		ForceSendFields: []string{"Alpha"},
+	}, nil
+}
+
+var slidesElementObjectIDPattern = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9_:-]{4,49}$`)
+
+func slidesElementObjectID(value, prefix string) (string, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return newSlidesStructuralObjectID(prefix), nil
+	}
+	if !slidesElementObjectIDPattern.MatchString(value) {
+		return "", usage("object ID must be 5-50 characters and contain only letters, digits, _, -, or :")
+	}
+	return value, nil
+}
+
+func slidesElementPageTarget(presentationID, slideID string) (string, string, error) {
+	presentationID = strings.TrimSpace(presentationID)
+	if presentationID == "" {
+		return "", "", usage("empty presentationId")
+	}
+	slideID = strings.TrimSpace(slideID)
+	if slideID == "" {
+		return "", "", usage("empty slideId")
+	}
+	return presentationID, slideID, nil
+}
+
+func slidesElementTarget(presentationID, objectID string) (string, string, error) {
+	presentationID = strings.TrimSpace(presentationID)
+	if presentationID == "" {
+		return "", "", usage("empty presentationId")
+	}
+	objectID = strings.TrimSpace(objectID)
+	if objectID == "" {
+		return "", "", usage("empty objectId")
+	}
+	return presentationID, objectID, nil
+}
+
+func slidesElementTargets(presentationID string, objectIDs []string, minimum int) (string, []string, error) {
+	presentationID = strings.TrimSpace(presentationID)
+	if presentationID == "" {
+		return "", nil, usage("empty presentationId")
+	}
+	clean := make([]string, 0, len(objectIDs))
+	seen := make(map[string]bool, len(objectIDs))
+	for _, objectID := range objectIDs {
+		objectID = strings.TrimSpace(objectID)
+		if objectID == "" {
+			return "", nil, usage("empty objectId")
+		}
+		if seen[objectID] {
+			return "", nil, usagef("duplicate objectId %q", objectID)
+		}
+		seen[objectID] = true
+		clean = append(clean, objectID)
+	}
+	if len(clean) < minimum {
+		return "", nil, usagef("at least %d objectId value(s) required", minimum)
+	}
+	return presentationID, clean, nil
+}
+
+func slidesElementFloat(value *float64, fallback float64) float64 {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func normalizeSlidesEnum(value string) string {
+	value = strings.TrimSpace(strings.ToUpper(value))
+	value = strings.NewReplacer("-", "_", " ", "_").Replace(value)
+	return value
+}
+
+func slidesElementEnum(value, fallback string, allowed ...string) (string, error) {
+	value = normalizeSlidesEnum(value)
+	if value == "" {
+		value = fallback
+	}
+	for _, candidate := range allowed {
+		if value == candidate {
+			return value, nil
+		}
+	}
+	return "", usagef("invalid value %q; expected one of %s", value, strings.Join(allowed, ", "))
+}

--- a/internal/cmd/slides_element_test.go
+++ b/internal/cmd/slides_element_test.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"math"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/slides/v1"
+)
+
+type slidesElementTestRunner interface {
+	Run(context.Context, *RootFlags) error
+}
+
+func float64ElementTestPtr(value float64) *float64 { return &value }
+
+func captureSlidesElementRequest(t *testing.T, runner slidesElementTestRunner, flags *RootFlags) *slides.Request {
+	t.Helper()
+	var captured []*slides.Request
+	srv := mockSlidesBatchUpdateServer(t, &captured, map[string]any{"presentationId": "pres1", "replies": []any{map[string]any{}}})
+	defer srv.Close()
+
+	ctx := withSlidesTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), newSlidesServiceFromServer(t, srv))
+	if err := runner.Run(ctx, flags); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("captured %d requests, want 1", len(captured))
+	}
+	return captured[0]
+}
+
+func TestSlidesElementCreateShape(t *testing.T) {
+	request := captureSlidesElementRequest(t, &SlidesElementCreateShapeCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide1",
+		Type:           "round-rectangle",
+		X:              12,
+		Y:              24,
+		Width:          200,
+		Height:         80,
+		Unit:           "PT",
+		ObjectID:       "shape_123",
+	}, &RootFlags{Account: "a@b.com"})
+
+	create := request.CreateShape
+	if create == nil {
+		t.Fatalf("expected createShape, got %+v", request)
+	}
+	if create.ObjectId != "shape_123" || create.ShapeType != "ROUND_RECTANGLE" {
+		t.Fatalf("unexpected createShape: %+v", create)
+	}
+	properties := create.ElementProperties
+	if properties.PageObjectId != "slide1" || properties.Size.Width.Magnitude != 200 || properties.Size.Height.Magnitude != 80 {
+		t.Fatalf("unexpected element properties: %+v", properties)
+	}
+	if properties.Transform.TranslateX != 12 || properties.Transform.TranslateY != 24 || properties.Transform.ScaleX != 1 || properties.Transform.ScaleY != 1 {
+		t.Fatalf("unexpected transform: %+v", properties.Transform)
+	}
+}
+
+func TestSlidesElementCreateLinePreservesZeroExtent(t *testing.T) {
+	properties := slidesElementProperties("slide1", 0, 0, 120, 0, "PT")
+	encoded, err := json.Marshal(properties)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !bytes.Contains(encoded, []byte(`"magnitude":0`)) || !bytes.Contains(encoded, []byte(`"translateX":0`)) {
+		t.Fatalf("zero geometry omitted from request: %s", encoded)
+	}
+
+	request := captureSlidesElementRequest(t, &SlidesElementCreateLineCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide1",
+		Category:       "curved",
+		Width:          120,
+		Height:         0,
+		Unit:           "PT",
+		ObjectID:       "line_1234",
+	}, &RootFlags{Account: "a@b.com"})
+	if request.CreateLine == nil || request.CreateLine.Category != "CURVED" || request.CreateLine.ObjectId != "line_1234" {
+		t.Fatalf("unexpected createLine: %+v", request.CreateLine)
+	}
+}
+
+func TestSlidesElementTransformRotation(t *testing.T) {
+	request := captureSlidesElementRequest(t, &SlidesElementTransformCmd{
+		PresentationID: "pres1",
+		ObjectID:       "shape1",
+		Rotate:         float64ElementTestPtr(90),
+		TranslateX:     float64ElementTestPtr(10),
+		Unit:           "PT",
+		ApplyMode:      "RELATIVE",
+	}, &RootFlags{Account: "a@b.com"})
+
+	update := request.UpdatePageElementTransform
+	if update == nil || update.ObjectId != "shape1" || update.ApplyMode != "RELATIVE" {
+		t.Fatalf("unexpected transform update: %+v", update)
+	}
+	if math.Abs(update.Transform.ScaleX) > 1e-9 || math.Abs(update.Transform.ScaleY) > 1e-9 || update.Transform.ShearX != -1 || update.Transform.ShearY != 1 {
+		t.Fatalf("unexpected rotation matrix: %+v", update.Transform)
+	}
+	if update.Transform.TranslateX != 10 || update.Transform.TranslateY != 0 {
+		t.Fatalf("unexpected translation: %+v", update.Transform)
+	}
+}
+
+func TestSlidesElementStyleShape(t *testing.T) {
+	dash := "DASH"
+	request := captureSlidesElementRequest(t, &SlidesElementStyleCmd{
+		PresentationID: "pres1",
+		ObjectID:       "shape1",
+		Kind:           "shape",
+		FillColor:      "#123",
+		OutlineColor:   "#abcdef",
+		OutlineWeight:  float64ElementTestPtr(2.5),
+		OutlineDash:    &dash,
+	}, &RootFlags{Account: "a@b.com"})
+
+	update := request.UpdateShapeProperties
+	if update == nil || update.ObjectId != "shape1" {
+		t.Fatalf("unexpected shape style request: %+v", update)
+	}
+	for _, field := range []string{"shapeBackgroundFill.solidFill.color", "outline.outlineFill.solidFill.color", "outline.weight", "outline.dashStyle"} {
+		if !strings.Contains(update.Fields, field) {
+			t.Errorf("field mask %q missing %q", update.Fields, field)
+		}
+	}
+	fill := update.ShapeProperties.ShapeBackgroundFill.SolidFill
+	if fill.Color.RgbColor.Red != 1.0/15 || fill.Color.RgbColor.Green != 2.0/15 || fill.Color.RgbColor.Blue != 3.0/15 {
+		t.Fatalf("unexpected #123 expansion: %+v", fill.Color.RgbColor)
+	}
+	if update.ShapeProperties.Outline.Weight.Magnitude != 2.5 || update.ShapeProperties.Outline.DashStyle != "DASH" {
+		t.Fatalf("unexpected outline: %+v", update.ShapeProperties.Outline)
+	}
+}
+
+func TestSlidesElementStyleLineTransparent(t *testing.T) {
+	request := captureSlidesElementRequest(t, &SlidesElementStyleCmd{
+		PresentationID:     "pres1",
+		ObjectID:           "line1",
+		Kind:               "line",
+		OutlineTransparent: true,
+	}, &RootFlags{Account: "a@b.com"})
+
+	update := request.UpdateLineProperties
+	if update == nil || update.LineProperties.LineFill == nil {
+		t.Fatalf("unexpected line style request: %+v", update)
+	}
+	if update.LineProperties.LineFill.SolidFill.Alpha != 0 || !strings.Contains(update.Fields, "lineFill.solidFill.alpha") {
+		t.Fatalf("line transparency not encoded: %+v", update)
+	}
+}
+
+func TestSlidesElementStructuralRequests(t *testing.T) {
+	t.Run("z-order", func(t *testing.T) {
+		request := captureSlidesElementRequest(t, &SlidesElementZOrderCmd{
+			PresentationID: "pres1",
+			ObjectIDs:      []string{"shape1", "line1"},
+			Operation:      "BRING_TO_FRONT",
+		}, &RootFlags{Account: "a@b.com"})
+		if request.UpdatePageElementsZOrder == nil || len(request.UpdatePageElementsZOrder.PageElementObjectIds) != 2 {
+			t.Fatalf("unexpected z-order request: %+v", request)
+		}
+	})
+
+	t.Run("group", func(t *testing.T) {
+		request := captureSlidesElementRequest(t, &SlidesElementGroupCmd{
+			PresentationID: "pres1",
+			ObjectIDs:      []string{"shape1", "line1"},
+			GroupID:        "group_123",
+		}, &RootFlags{Account: "a@b.com"})
+		if request.GroupObjects == nil || request.GroupObjects.GroupObjectId != "group_123" || len(request.GroupObjects.ChildrenObjectIds) != 2 {
+			t.Fatalf("unexpected group request: %+v", request)
+		}
+	})
+
+	t.Run("ungroup", func(t *testing.T) {
+		request := captureSlidesElementRequest(t, &SlidesElementUngroupCmd{
+			PresentationID: "pres1",
+			GroupIDs:       []string{"group_123"},
+		}, &RootFlags{Account: "a@b.com"})
+		if request.UngroupObjects == nil || len(request.UngroupObjects.ObjectIds) != 1 {
+			t.Fatalf("unexpected ungroup request: %+v", request)
+		}
+	})
+
+	t.Run("alt-text-clear", func(t *testing.T) {
+		empty := ""
+		request := captureSlidesElementRequest(t, &SlidesElementAltTextCmd{
+			PresentationID: "pres1",
+			ObjectID:       "shape1",
+			Title:          &empty,
+		}, &RootFlags{Account: "a@b.com"})
+		if request.UpdatePageElementAltText == nil || request.UpdatePageElementAltText.Title != "" {
+			t.Fatalf("unexpected alt text request: %+v", request)
+		}
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		request := captureSlidesElementRequest(t, &SlidesElementDeleteCmd{
+			PresentationID: "pres1",
+			ObjectID:       "shape1",
+		}, &RootFlags{Account: "a@b.com", Force: true})
+		if request.DeleteObject == nil || request.DeleteObject.ObjectId != "shape1" {
+			t.Fatalf("unexpected delete request: %+v", request)
+		}
+	})
+}
+
+func TestSlidesElementDryRunSkipsService(t *testing.T) {
+	var out bytes.Buffer
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeJSONOutputContext(t, &out, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("slides service should not be created during dry-run")
+			return nil, context.Canceled
+		},
+	)
+	cmd := &SlidesElementCreateShapeCmd{
+		PresentationID: "pres1",
+		SlideID:        "slide1",
+		Width:          100,
+		Height:         50,
+		ObjectID:       "shape_123",
+	}
+	if err := cmd.Run(ctx, &RootFlags{DryRun: true}); err != nil && ExitCode(err) != 0 {
+		t.Fatalf("Run: %v", err)
+	}
+	if !strings.Contains(out.String(), `"op": "slides.element.create-shape"`) || !strings.Contains(out.String(), `"createShape"`) {
+		t.Fatalf("unexpected dry-run output: %s", out.String())
+	}
+}
+
+func TestSlidesElementValidation(t *testing.T) {
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("slides service should not be created")
+			return nil, context.Canceled
+		},
+	)
+	tests := []struct {
+		name string
+		cmd  slidesElementTestRunner
+		want string
+	}{
+		{"shape size", &SlidesElementCreateShapeCmd{PresentationID: "p", SlideID: "s", Width: 0, Height: 10}, "width and --height"},
+		{"line size", &SlidesElementCreateLineCmd{PresentationID: "p", SlideID: "s"}, "at least one > 0"},
+		{"object ID", &SlidesElementCreateShapeCmd{PresentationID: "p", SlideID: "s", Width: 10, Height: 10, ObjectID: "bad!"}, "object ID"},
+		{"empty transform", &SlidesElementTransformCmd{PresentationID: "p", ObjectID: "o"}, "at least one transform"},
+		{"rotate conflict", &SlidesElementTransformCmd{PresentationID: "p", ObjectID: "o", Rotate: float64ElementTestPtr(1), ScaleX: float64ElementTestPtr(1)}, "mutually exclusive"},
+		{"shape transparent outline conflict", &SlidesElementStyleCmd{PresentationID: "p", ObjectID: "o", Kind: "shape", OutlineTransparent: true, OutlineWeight: float64ElementTestPtr(1)}, "cannot be combined"},
+		{"line fill", &SlidesElementStyleCmd{PresentationID: "p", ObjectID: "o", Kind: "line", FillColor: "#fff"}, "only to shapes"},
+		{"group count", &SlidesElementGroupCmd{PresentationID: "p", ObjectIDs: []string{"one"}}, "at least 2"},
+		{"duplicate IDs", &SlidesElementZOrderCmd{PresentationID: "p", ObjectIDs: []string{"one", "one"}, Operation: "SEND_TO_BACK"}, "duplicate"},
+		{"alt text missing", &SlidesElementAltTextCmd{PresentationID: "p", ObjectID: "o"}, "provide --title"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cmd.Run(ctx, &RootFlags{Account: "a@b.com"})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected %q error, got %v", tc.want, err)
+			}
+			if ExitCode(err) != 2 {
+				t.Fatalf("ExitCode = %d, want 2", ExitCode(err))
+			}
+		})
+	}
+}

--- a/scripts/live-tests/slides.sh
+++ b/scripts/live-tests/slides.sh
@@ -27,6 +27,59 @@ run_slides_tests() {
   read_json=$(gog slides read-slide "$slides_id" "$slide_id" --json)
   "$PY" -c 'import json,sys; assert len(json.load(sys.stdin).get("images", [])) >= 2' <<<"$read_json"
 
+  local native_json native_slide_id native_read native_after_delete
+  native_json=$(gog slides new-slide "$slides_id" --json)
+  native_slide_id=$(extract_field "$native_json" slideObjectId)
+  [ -n "$native_slide_id" ] || { echo "Failed to parse native slide object id" >&2; exit 1; }
+
+  run_required "slides" "slides create shape A" gog slides element create-shape \
+    "$slides_id" "$native_slide_id" --type ROUND_RECTANGLE --x 24 --y 24 --width 180 --height 80 \
+    --object-id gogShapeA >/dev/null
+  run_required "slides" "slides create shape B" gog slides element create-shape \
+    "$slides_id" "$native_slide_id" --type ELLIPSE --x 240 --y 24 --width 100 --height 80 \
+    --object-id gogShapeB >/dev/null
+  run_required "slides" "slides create line" gog slides element create-line \
+    "$slides_id" "$native_slide_id" --category STRAIGHT --x 50 --y 150 --width 240 --height 40 \
+    --object-id gogLineA >/dev/null
+  run_required "slides" "slides style shape" gog slides element style \
+    "$slides_id" gogShapeA --fill-color '#3367d6' --outline-color '#ffffff' \
+    --outline-weight 2 --outline-dash SOLID >/dev/null
+  run_required "slides" "slides style line" gog slides element style \
+    "$slides_id" gogLineA --kind line --outline-color '#ea4335' --outline-weight 3 \
+    --outline-dash DASH >/dev/null
+  run_required "slides" "slides transform element" gog slides element transform \
+    "$slides_id" gogShapeA --translate-x 12 --translate-y 6 >/dev/null
+  run_required "slides" "slides set alt text" gog slides element alt-text \
+    "$slides_id" gogShapeA --title "gogcli live shape" --description "Slides element lifecycle proof" >/dev/null
+  run_required "slides" "slides change z-order" gog slides element z-order \
+    "$slides_id" gogShapeA gogShapeB --operation BRING_TO_FRONT >/dev/null
+  run_required "slides" "slides group elements" gog slides element group \
+    "$slides_id" gogShapeA gogShapeB --group-id gogGroupA >/dev/null
+
+  native_read=$(gog slides read-slide "$slides_id" "$native_slide_id" --detail --json)
+  "$PY" -c '
+import json,sys
+elements = {item["objectId"]: item for item in json.load(sys.stdin).get("elements", [])}
+assert {"gogShapeA", "gogShapeB", "gogLineA", "gogGroupA"} <= elements.keys()
+assert elements["gogShapeA"].get("parentObjectId") == "gogGroupA"
+assert elements["gogShapeA"].get("title") == "gogcli live shape"
+' <<<"$native_read"
+
+  run_required "slides" "slides ungroup elements" gog slides element ungroup \
+    "$slides_id" gogGroupA >/dev/null
+  run_required "slides" "slides delete line" gog slides element delete \
+    "$slides_id" gogLineA --force >/dev/null
+  run_required "slides" "slides delete shape A" gog slides element delete \
+    "$slides_id" gogShapeA --force >/dev/null
+  run_required "slides" "slides delete shape B" gog slides element delete \
+    "$slides_id" gogShapeB --force >/dev/null
+  native_after_delete=$(gog slides read-slide "$slides_id" "$native_slide_id" --detail --json)
+  "$PY" -c '
+import json,sys
+ids = {item["objectId"] for item in json.load(sys.stdin).get("elements", [])}
+assert not ({"gogShapeA", "gogShapeB", "gogLineA", "gogGroupA"} & ids)
+' <<<"$native_after_delete"
+
   export_path="$LIVE_TMP/slides-export-$TS.pdf"
   run_required "slides" "slides export" gog slides export "$slides_id" --format pdf --out "$export_path" >/dev/null
 


### PR DESCRIPTION
## Summary

- add `slides element` commands for shape/line creation, affine transforms, styling, z-order, grouping, alt text, and guarded deletion
- validate geometry, object IDs, enum values, conflicting style/transform options, and destructive confirmation locally
- add request-level regression coverage, generated command references, usage docs, changelog, and a live create/read/delete lifecycle

Closes #826.

## Testing

- `make ci`
- focused `go test ./internal/cmd -run 'TestSlidesElement' -count=1`
- CLI help and `--dry-run --json` request checks
- autoreview: clean, no actionable findings
- live Slides lifecycle attempted with `clawdbot@gmail.com`; blocked before API access because the encrypted file keyring requires `GOG_KEYRING_PASSWORD` in this non-interactive session
