### PR TITLE
feat(slides): add structural table operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Slides: add structured element geometry, styled text runs, table-cell content, image source URLs, native presentation metadata, and read-only text location with exact UTF-16 ranges. (#822) — thanks @sebsnyk.
 - Slides: add range-scoped styling, links, bullets, and object-scoped replacement; `replace-text` now requires explicit `--object`, `--page`, or `--all` scope instead of silently changing the whole deck. (#823, #835) — thanks @sebsnyk.
 - Slides: add native table creation and zero-based table-cell targeting for `insert-text`, including atomic cell replacement. (#824, #834) — thanks @sebsnyk.
-- Slides: add revision-locked native table row/column insertion and deletion plus merge/unmerge operations with provider bounds checks. (#824) — thanks @sebsnyk.
+- Slides: add revision-locked native table row/column insertion and deletion plus merge/unmerge operations with provider bounds checks. (#824, #847) — thanks @sebsnyk.
 - Slides: add native themed slide creation, duplication, and reordering with predefined or exact custom layouts and explicit zero-based positions. (#826, #833) — thanks @sebsnyk.
 - Slides: add native shape and line creation plus element transforms, fill/outline styling, z-order, grouping, alt text, and guarded deletion. (#826) — thanks @sebsnyk.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Slides: add structured element geometry, styled text runs, table-cell content, image source URLs, native presentation metadata, and read-only text location with exact UTF-16 ranges. (#822) — thanks @sebsnyk.
 - Slides: add range-scoped styling, links, bullets, and object-scoped replacement; `replace-text` now requires explicit `--object`, `--page`, or `--all` scope instead of silently changing the whole deck. (#823, #835) — thanks @sebsnyk.
 - Slides: add native table creation and zero-based table-cell targeting for `insert-text`, including atomic cell replacement. (#824, #834) — thanks @sebsnyk.
+- Slides: add revision-locked native table row/column insertion and deletion plus merge/unmerge operations with provider bounds checks. (#824) — thanks @sebsnyk.
 - Slides: add native themed slide creation, duplication, and reordering with predefined or exact custom layouts and explicit zero-based positions. (#826, #833) — thanks @sebsnyk.
 - Slides: add native shape and line creation plus element transforms, fill/outline styling, z-order, grouping, alt text, and guarded deletion. (#826) — thanks @sebsnyk.
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -618,7 +618,15 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) replace-text <presentationId> <find> <replacement> [flags]`](commands/gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
     - [`gog slides (slide) style-text --range=STRING <presentationId> <objectId> [flags]`](commands/gog-slides-style-text.md) - Apply range-scoped text styling to one page element
     - [`gog slides (slide) table <command>`](commands/gog-slides-table.md) - Create and update native tables
+      - [`gog slides (slide) table column (col) <command>`](commands/gog-slides-table-column.md) - Insert or delete table columns
+        - [`gog slides (slide) table column (col) delete (rm,remove,del) --col=INT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-column-delete.md) - Delete the column containing a zero-based table cell
+        - [`gog slides (slide) table column (col) insert (add) --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-column-insert.md) - Insert columns left or right of a zero-based column
       - [`gog slides (slide) table create (add) --rows=INT-64 --cols=INT-64 <presentationId> <slideId> [flags]`](commands/gog-slides-table-create.md) - Create an auto-sized native table on a slide
+      - [`gog slides (slide) table merge --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-merge.md) - Merge a rectangular table cell range
+      - [`gog slides (slide) table row <command>`](commands/gog-slides-table-row.md) - Insert or delete table rows
+        - [`gog slides (slide) table row delete (rm,remove,del) --row=INT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
+        - [`gog slides (slide) table row insert (add) --row=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
+      - [`gog slides (slide) table unmerge (split) --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
     - [`gog slides (slide) thumbnail (thumb) <presentationId> <slideId> [flags]`](commands/gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
     - [`gog slides (slide) update-notes <presentationId> <slideId> [flags]`](commands/gog-slides-update-notes.md) - Update speaker notes on an existing slide
   - [`gog status (st) [flags]`](commands/gog-status.md) - Show auth/config status (alias for 'auth status')

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 665.
+Generated pages: 673.
 
 ## Top-level Commands
 
@@ -669,7 +669,15 @@ Generated pages: 665.
     - [gog slides replace-text](gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
     - [gog slides style-text](gog-slides-style-text.md) - Apply range-scoped text styling to one page element
     - [gog slides table](gog-slides-table.md) - Create and update native tables
+      - [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
+        - [gog slides table column delete](gog-slides-table-column-delete.md) - Delete the column containing a zero-based table cell
+        - [gog slides table column insert](gog-slides-table-column-insert.md) - Insert columns left or right of a zero-based column
       - [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
+      - [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
+      - [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
+        - [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
+        - [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
+      - [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
     - [gog slides thumbnail](gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
     - [gog slides update-notes](gog-slides-update-notes.md) - Update speaker notes on an existing slide
   - [gog status](gog-status.md) - Show auth/config status (alias for 'auth status')

--- a/docs/commands/gog-slides-table-column-delete.md
+++ b/docs/commands/gog-slides-table-column-delete.md
@@ -1,26 +1,18 @@
-# `gog slides table`
+# `gog slides table column delete`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Delete the column containing a zero-based table cell
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table column (col) delete (rm,remove,del) --col=INT-64 <presentationId> <tableObjectId>
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
-
-## Subcommands
-
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table column](gog-slides-table-column.md)
 
 ## Flags
 
@@ -29,6 +21,7 @@ gog slides (slide) table <command>
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based column to delete |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -49,5 +42,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table column](gog-slides-table-column.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-column-insert.md
+++ b/docs/commands/gog-slides-table-column-insert.md
@@ -1,26 +1,18 @@
-# `gog slides table`
+# `gog slides table column insert`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Insert columns left or right of a zero-based column
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table column (col) insert (add) --col=INT-64 <presentationId> <tableObjectId> [flags]
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
-
-## Subcommands
-
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table column](gog-slides-table-column.md)
 
 ## Flags
 
@@ -29,7 +21,9 @@ gog slides (slide) table <command>
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based reference column |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--count` | `int64` | 1 | Number of columns to insert (1-20) |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -42,6 +36,7 @@ gog slides (slide) table <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--right` | `bool` |  | Insert right of the reference column instead of left |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -49,5 +44,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table column](gog-slides-table-column.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-column.md
+++ b/docs/commands/gog-slides-table-column.md
@@ -1,26 +1,23 @@
-# `gog slides table`
+# `gog slides table column`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Insert or delete table columns
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table column (col) <command>
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
+- [gog slides table](gog-slides-table.md)
 
 ## Subcommands
 
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table column delete](gog-slides-table-column-delete.md) - Delete the column containing a zero-based table cell
+- [gog slides table column insert](gog-slides-table-column-insert.md) - Insert columns left or right of a zero-based column
 
 ## Flags
 
@@ -49,5 +46,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table](gog-slides-table.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-merge.md
+++ b/docs/commands/gog-slides-table-merge.md
@@ -1,26 +1,18 @@
-# `gog slides table`
+# `gog slides table merge`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Merge a rectangular table cell range
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table merge --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
-
-## Subcommands
-
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table](gog-slides-table.md)
 
 ## Flags
 
@@ -29,6 +21,8 @@ gog slides (slide) table <command>
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based starting column |
+| `--col-span` | `int64` | 1 | Number of columns in the range |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -42,6 +36,8 @@ gog slides (slide) table <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based starting row |
+| `--row-span` | `int64` | 1 | Number of rows in the range |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -49,5 +45,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table](gog-slides-table.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-row-delete.md
+++ b/docs/commands/gog-slides-table-row-delete.md
@@ -1,26 +1,18 @@
-# `gog slides table`
+# `gog slides table row delete`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Delete the row containing a zero-based table cell
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table row delete (rm,remove,del) --row=INT-64 <presentationId> <tableObjectId>
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
-
-## Subcommands
-
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table row](gog-slides-table-row.md)
 
 ## Flags
 
@@ -42,6 +34,7 @@ gog slides (slide) table <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based row to delete |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -49,5 +42,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table row](gog-slides-table-row.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-row-insert.md
+++ b/docs/commands/gog-slides-table-row-insert.md
@@ -1,26 +1,18 @@
-# `gog slides table`
+# `gog slides table row insert`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Insert rows above or below a zero-based row
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table row insert (add) --row=INT-64 <presentationId> <tableObjectId> [flags]
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
-
-## Subcommands
-
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table row](gog-slides-table-row.md)
 
 ## Flags
 
@@ -28,8 +20,10 @@ gog slides (slide) table <command>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--below` | `bool` |  | Insert below the reference row instead of above |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--count` | `int64` | 1 | Number of rows to insert (1-20) |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -42,6 +36,7 @@ gog slides (slide) table <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based reference row |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -49,5 +44,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table row](gog-slides-table-row.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-row.md
+++ b/docs/commands/gog-slides-table-row.md
@@ -1,26 +1,23 @@
-# `gog slides table`
+# `gog slides table row`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Insert or delete table rows
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table row <command>
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
+- [gog slides table](gog-slides-table.md)
 
 ## Subcommands
 
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
+- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
 
 ## Flags
 
@@ -49,5 +46,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table](gog-slides-table.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-unmerge.md
+++ b/docs/commands/gog-slides-table-unmerge.md
@@ -1,26 +1,18 @@
-# `gog slides table`
+# `gog slides table unmerge`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Create and update native tables
+Unmerge cells in a rectangular table range
 
 ## Usage
 
 ```bash
-gog slides (slide) table <command>
+gog slides (slide) table unmerge (split) --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]
 ```
 
 ## Parent
 
-- [gog slides](gog-slides.md)
-
-## Subcommands
-
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
-- [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
-- [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
-- [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
+- [gog slides table](gog-slides-table.md)
 
 ## Flags
 
@@ -29,6 +21,8 @@ gog slides (slide) table <command>
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based starting column |
+| `--col-span` | `int64` | 1 | Number of columns in the range |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -42,6 +36,8 @@ gog slides (slide) table <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based starting row |
+| `--row-span` | `int64` | 1 | Number of rows in the range |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -49,5 +45,5 @@ gog slides (slide) table <command>
 
 ## See Also
 
-- [gog slides](gog-slides.md)
+- [gog slides table](gog-slides-table.md)
 - [Command index](README.md)

--- a/docs/slides-tables.md
+++ b/docs/slides-tables.md
@@ -27,6 +27,29 @@ within the selected cell in one Slides batch update; it does not alter other
 cells. `--insertion-index` selects an index within the cell when appending or
 inserting without `--replace`.
 
+## Rows, columns, and merged cells
+
+Table structure commands also use zero-based coordinates:
+
+```bash
+gog slides table row insert <presentationId> <tableId> --row 1 --below --count 2
+gog slides table row delete <presentationId> <tableId> --row 3 --force
+gog slides table column insert <presentationId> <tableId> --col 0 --right
+gog slides table column delete <presentationId> <tableId> --col 2 --force
+gog slides table merge <presentationId> <tableId> --row 0 --col 0 --row-span 1 --col-span 3
+gog slides table unmerge <presentationId> <tableId> --row 0 --col 0 --row-span 1 --col-span 3
+```
+
+Insertions accept 1-20 rows or columns per request and default to inserting
+above or left of the reference cell. The commands fetch current provider
+dimensions before mutation, reject ranges outside the table, and submit the
+write against the fetched presentation revision.
+
+Row and column deletion require `--force`. Google deletes every row or column
+spanned by the reference cell, so an anchor inside a merged cell can remove
+multiple dimensions. Deleting the last remaining row or column deletes the
+whole table.
+
 Use `--dry-run --json` to inspect the exact Slides `batchUpdate` request without
 contacting Google. Use `slides read-slide --detail --json` to verify the table
 dimensions, cell coordinates, and text returned by the provider.

--- a/internal/cmd/slides_table.go
+++ b/internal/cmd/slides_table.go
@@ -12,7 +12,11 @@ import (
 )
 
 type SlidesTableCmd struct {
-	Create SlidesTableCreateCmd `cmd:"" name:"create" aliases:"add" help:"Create an auto-sized native table on a slide"`
+	Create  SlidesTableCreateCmd  `cmd:"" name:"create" aliases:"add" help:"Create an auto-sized native table on a slide"`
+	Row     SlidesTableRowCmd     `cmd:"" name:"row" help:"Insert or delete table rows"`
+	Column  SlidesTableColumnCmd  `cmd:"" name:"column" aliases:"col" help:"Insert or delete table columns"`
+	Merge   SlidesTableMergeCmd   `cmd:"" name:"merge" help:"Merge a rectangular table cell range"`
+	Unmerge SlidesTableUnmergeCmd `cmd:"" name:"unmerge" aliases:"split" help:"Unmerge cells in a rectangular table range"`
 }
 
 type SlidesTableCreateCmd struct {

--- a/internal/cmd/slides_table_structure.go
+++ b/internal/cmd/slides_table_structure.go
@@ -1,0 +1,411 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type SlidesTableRowCmd struct {
+	Insert SlidesTableRowInsertCmd `cmd:"" name:"insert" aliases:"add" help:"Insert rows above or below a zero-based row"`
+	Delete SlidesTableRowDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete the row containing a zero-based table cell"`
+}
+
+type SlidesTableColumnCmd struct {
+	Insert SlidesTableColumnInsertCmd `cmd:"" name:"insert" aliases:"add" help:"Insert columns left or right of a zero-based column"`
+	Delete SlidesTableColumnDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete the column containing a zero-based table cell"`
+}
+
+type SlidesTableRowInsertCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row            int64  `name:"row" required:"" help:"Zero-based reference row"`
+	Count          int64  `name:"count" default:"1" help:"Number of rows to insert (1-20)"`
+	Below          bool   `name:"below" help:"Insert below the reference row instead of above"`
+}
+
+type SlidesTableRowDeleteCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row            int64  `name:"row" required:"" help:"Zero-based row to delete"`
+}
+
+type SlidesTableColumnInsertCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Col            int64  `name:"col" required:"" help:"Zero-based reference column"`
+	Count          int64  `name:"count" default:"1" help:"Number of columns to insert (1-20)"`
+	Right          bool   `name:"right" help:"Insert right of the reference column instead of left"`
+}
+
+type SlidesTableColumnDeleteCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Col            int64  `name:"col" required:"" help:"Zero-based column to delete"`
+}
+
+type SlidesTableMergeCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row            int64  `name:"row" required:"" help:"Zero-based starting row"`
+	Col            int64  `name:"col" required:"" help:"Zero-based starting column"`
+	RowSpan        int64  `name:"row-span" default:"1" help:"Number of rows in the range"`
+	ColSpan        int64  `name:"col-span" default:"1" help:"Number of columns in the range"`
+}
+
+type SlidesTableUnmergeCmd struct {
+	PresentationID string `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row            int64  `name:"row" required:"" help:"Zero-based starting row"`
+	Col            int64  `name:"col" required:"" help:"Zero-based starting column"`
+	RowSpan        int64  `name:"row-span" default:"1" help:"Number of rows in the range"`
+	ColSpan        int64  `name:"col-span" default:"1" help:"Number of columns in the range"`
+}
+
+func (c *SlidesTableRowInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if err := validateSlidesTableInsert(c.Row, c.Count, "row"); err != nil {
+		return err
+	}
+	request := &slides.Request{InsertTableRows: &slides.InsertTableRowsRequest{
+		TableObjectId:   tableID,
+		CellLocation:    slidesTableCellLocation(c.Row, 0),
+		InsertBelow:     c.Below,
+		Number:          c.Count,
+		ForceSendFields: []string{"InsertBelow"},
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.row.insert",
+		Action:         "insert table rows",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"row": c.Row, "count": c.Count, "below": c.Below},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "row": c.Row, "count": c.Count, "below": c.Below},
+		Text:           fmt.Sprintf("Inserted %d row(s) in table %s", c.Count, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, c.Row, 0)
+		},
+	})
+}
+
+func (c *SlidesTableRowDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Row < 0 {
+		return usage("--row must be >= 0")
+	}
+	request := &slides.Request{DeleteTableRow: &slides.DeleteTableRowRequest{
+		TableObjectId: tableID,
+		CellLocation:  slidesTableCellLocation(c.Row, 0),
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.row.delete",
+		Action:         "delete table row",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"row": c.Row},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "row": c.Row, "deleted": true},
+		Text:           fmt.Sprintf("Deleted row %d from table %s", c.Row, tableID),
+		Destructive:    fmt.Sprintf("delete the row containing cell [%d,0] from table %s (a merged cell may span multiple rows)", c.Row, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, c.Row, 0)
+		},
+	})
+}
+
+func (c *SlidesTableColumnInsertCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if err := validateSlidesTableInsert(c.Col, c.Count, "col"); err != nil {
+		return err
+	}
+	request := &slides.Request{InsertTableColumns: &slides.InsertTableColumnsRequest{
+		TableObjectId:   tableID,
+		CellLocation:    slidesTableCellLocation(0, c.Col),
+		InsertRight:     c.Right,
+		Number:          c.Count,
+		ForceSendFields: []string{"InsertRight"},
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.column.insert",
+		Action:         "insert table columns",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"col": c.Col, "count": c.Count, "right": c.Right},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "col": c.Col, "count": c.Count, "right": c.Right},
+		Text:           fmt.Sprintf("Inserted %d column(s) in table %s", c.Count, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, 0, c.Col)
+		},
+	})
+}
+
+func (c *SlidesTableColumnDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Col < 0 {
+		return usage("--col must be >= 0")
+	}
+	request := &slides.Request{DeleteTableColumn: &slides.DeleteTableColumnRequest{
+		TableObjectId: tableID,
+		CellLocation:  slidesTableCellLocation(0, c.Col),
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.column.delete",
+		Action:         "delete table column",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"col": c.Col},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "col": c.Col, "deleted": true},
+		Text:           fmt.Sprintf("Deleted column %d from table %s", c.Col, tableID),
+		Destructive:    fmt.Sprintf("delete the column containing cell [0,%d] from table %s (a merged cell may span multiple columns)", c.Col, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, 0, c.Col)
+		},
+	})
+}
+
+func (c *SlidesTableMergeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	if c.RowSpan == 1 && c.ColSpan == 1 {
+		return usage("merge range must span more than one cell")
+	}
+	return runSlidesTableRangeCommand(ctx, flags, slidesTableRangeCommand{
+		presentationID: c.PresentationID,
+		tableObjectID:  c.TableObjectID,
+		row:            c.Row,
+		col:            c.Col,
+		rowSpan:        c.RowSpan,
+		colSpan:        c.ColSpan,
+		merge:          true,
+	})
+}
+
+func (c *SlidesTableUnmergeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runSlidesTableRangeCommand(ctx, flags, slidesTableRangeCommand{
+		presentationID: c.PresentationID,
+		tableObjectID:  c.TableObjectID,
+		row:            c.Row,
+		col:            c.Col,
+		rowSpan:        c.RowSpan,
+		colSpan:        c.ColSpan,
+	})
+}
+
+type slidesTableRangeCommand struct {
+	presentationID string
+	tableObjectID  string
+	row            int64
+	col            int64
+	rowSpan        int64
+	colSpan        int64
+	merge          bool
+}
+
+func runSlidesTableRangeCommand(ctx context.Context, flags *RootFlags, command slidesTableRangeCommand) error {
+	presentationID, tableID, err := slidesTableTarget(command.presentationID, command.tableObjectID)
+	if err != nil {
+		return err
+	}
+	if command.row < 0 {
+		return usage("--row must be >= 0")
+	}
+	if command.col < 0 {
+		return usage("--col must be >= 0")
+	}
+	if command.rowSpan < 1 {
+		return usage("--row-span must be >= 1")
+	}
+	if command.colSpan < 1 {
+		return usage("--col-span must be >= 1")
+	}
+	tableRange := &slides.TableRange{
+		Location:   slidesTableCellLocation(command.row, command.col),
+		RowSpan:    command.rowSpan,
+		ColumnSpan: command.colSpan,
+	}
+	op := unmergeOp
+	action := "unmerge table cells"
+	request := &slides.Request{UnmergeTableCells: &slides.UnmergeTableCellsRequest{ObjectId: tableID, TableRange: tableRange}}
+	if command.merge {
+		op = mergeOp
+		action = "merge table cells"
+		request = &slides.Request{MergeTableCells: &slides.MergeTableCellsRequest{ObjectId: tableID, TableRange: tableRange}}
+	}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table." + op,
+		Action:         action,
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"row": command.row, "col": command.col, "row_span": command.rowSpan, "col_span": command.colSpan},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "row": command.row, "col": command.col, "rowSpan": command.rowSpan, "colSpan": command.colSpan, "operation": op},
+		Text:           fmt.Sprintf("%s cells in table %s", strings.ToUpper(op[:1])+op[1:], tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableRange(table, command.row, command.col, command.rowSpan, command.colSpan)
+		},
+	})
+}
+
+type slidesTableMutation struct {
+	Op             string
+	Action         string
+	PresentationID string
+	TableObjectID  string
+	Request        *slides.Request
+	Payload        map[string]any
+	Output         map[string]any
+	Text           string
+	Destructive    string
+	Validate       func(*slides.Table) error
+}
+
+func runSlidesTableMutation(ctx context.Context, flags *RootFlags, mutation slidesTableMutation) error {
+	body := &slides.BatchUpdatePresentationRequest{Requests: []*slides.Request{mutation.Request}}
+	payload := mutation.Payload
+	if payload == nil {
+		payload = make(map[string]any)
+	}
+	payload["presentation_id"] = mutation.PresentationID
+	payload["table_object_id"] = mutation.TableObjectID
+	payload["batch_update"] = body
+	var err error
+	if mutation.Destructive != "" {
+		err = dryRunAndConfirmDestructive(ctx, flags, mutation.Op, payload, mutation.Destructive)
+	} else {
+		err = dryRunExit(ctx, flags, mutation.Op, payload)
+	}
+	if err != nil {
+		return err
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	svc, err := slidesService(ctx, account)
+	if err != nil {
+		return err
+	}
+	pres, err := svc.Presentations.Get(mutation.PresentationID).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("get presentation: %w", err)
+	}
+	table := findSlidesTableByID(pres, mutation.TableObjectID)
+	if table == nil {
+		return fmt.Errorf("table %q not found in presentation", mutation.TableObjectID)
+	}
+	if mutation.Validate != nil {
+		if err := mutation.Validate(table); err != nil {
+			return err
+		}
+	}
+	if pres.RevisionId != "" {
+		body.WriteControl = &slides.WriteControl{RequiredRevisionId: pres.RevisionId}
+	}
+	if _, err := svc.Presentations.BatchUpdate(mutation.PresentationID, body).Context(ctx).Do(); err != nil {
+		return fmt.Errorf("%s: %w", mutation.Action, err)
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), mutation.Output)
+	}
+	ui.FromContext(ctx).Out().Linef("%s", mutation.Text)
+	return nil
+}
+
+func slidesTableTarget(presentationID, tableObjectID string) (string, string, error) {
+	presentationID = strings.TrimSpace(presentationID)
+	if presentationID == "" {
+		return "", "", usage("empty presentationId")
+	}
+	tableObjectID = strings.TrimSpace(tableObjectID)
+	if tableObjectID == "" {
+		return "", "", usage("empty tableObjectId")
+	}
+	return presentationID, tableObjectID, nil
+}
+
+func validateSlidesTableInsert(index, count int64, dimension string) error {
+	if index < 0 {
+		return usagef("--%s must be >= 0", dimension)
+	}
+	if count < 1 || count > 20 {
+		return usage("--count must be between 1 and 20")
+	}
+	return nil
+}
+
+func validateSlidesTableAnchor(table *slides.Table, row, col int64) error {
+	if table.Rows < 1 || table.Columns < 1 {
+		return fmt.Errorf("provider returned invalid table dimensions %dx%d", table.Rows, table.Columns)
+	}
+	if row < 0 || row >= table.Rows {
+		return usagef("--row must be between 0 and %d", table.Rows-1)
+	}
+	if col < 0 || col >= table.Columns {
+		return usagef("--col must be between 0 and %d", table.Columns-1)
+	}
+	return nil
+}
+
+func validateSlidesTableRange(table *slides.Table, row, col, rowSpan, colSpan int64) error {
+	if err := validateSlidesTableAnchor(table, row, col); err != nil {
+		return err
+	}
+	if rowSpan > table.Rows-row {
+		return usagef("--row-span exceeds table row count %d from row %d", table.Rows, row)
+	}
+	if colSpan > table.Columns-col {
+		return usagef("--col-span exceeds table column count %d from column %d", table.Columns, col)
+	}
+	return nil
+}
+
+func findSlidesTableByID(pres *slides.Presentation, objectID string) *slides.Table {
+	if pres == nil {
+		return nil
+	}
+	for _, page := range pres.Slides {
+		if page == nil {
+			continue
+		}
+		if table := findSlidesTableInElements(page.PageElements, objectID); table != nil {
+			return table
+		}
+	}
+	return nil
+}
+
+func findSlidesTableInElements(elements []*slides.PageElement, objectID string) *slides.Table {
+	for _, element := range elements {
+		if element == nil {
+			continue
+		}
+		if element.ObjectId == objectID && element.Table != nil {
+			return element.Table
+		}
+		if element.ElementGroup != nil {
+			if table := findSlidesTableInElements(element.ElementGroup.Children, objectID); table != nil {
+				return table
+			}
+		}
+	}
+	return nil
+}

--- a/internal/cmd/slides_table_structure_test.go
+++ b/internal/cmd/slides_table_structure_test.go
@@ -1,0 +1,261 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/slides/v1"
+)
+
+func TestSlidesTableStructure_DryRunRequests(t *testing.T) {
+	tests := []struct {
+		name string
+		op   string
+		run  func(context.Context, *RootFlags) error
+		want func(*testing.T, *slides.Request)
+	}{
+		{
+			name: "insert rows",
+			op:   "slides.table.row.insert",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableRowInsertCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 2, Count: 3, Below: true}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, request *slides.Request) {
+				t.Helper()
+				got := request.InsertTableRows
+				if got == nil || got.TableObjectId != "table1" || got.CellLocation.RowIndex != 2 || got.CellLocation.ColumnIndex != 0 || !got.InsertBelow || got.Number != 3 {
+					t.Fatalf("unexpected insert rows request: %+v", got)
+				}
+			},
+		},
+		{
+			name: "delete row",
+			op:   "slides.table.row.delete",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableRowDeleteCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 1}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, request *slides.Request) {
+				t.Helper()
+				got := request.DeleteTableRow
+				if got == nil || got.TableObjectId != "table1" || got.CellLocation.RowIndex != 1 || got.CellLocation.ColumnIndex != 0 {
+					t.Fatalf("unexpected delete row request: %+v", got)
+				}
+			},
+		},
+		{
+			name: "insert columns",
+			op:   "slides.table.column.insert",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableColumnInsertCmd{PresentationID: "pres1", TableObjectID: "table1", Col: 2, Count: 2, Right: true}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, request *slides.Request) {
+				t.Helper()
+				got := request.InsertTableColumns
+				if got == nil || got.TableObjectId != "table1" || got.CellLocation.RowIndex != 0 || got.CellLocation.ColumnIndex != 2 || !got.InsertRight || got.Number != 2 {
+					t.Fatalf("unexpected insert columns request: %+v", got)
+				}
+			},
+		},
+		{
+			name: "delete column",
+			op:   "slides.table.column.delete",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableColumnDeleteCmd{PresentationID: "pres1", TableObjectID: "table1", Col: 3}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, request *slides.Request) {
+				t.Helper()
+				got := request.DeleteTableColumn
+				if got == nil || got.TableObjectId != "table1" || got.CellLocation.RowIndex != 0 || got.CellLocation.ColumnIndex != 3 {
+					t.Fatalf("unexpected delete column request: %+v", got)
+				}
+			},
+		},
+		{
+			name: "merge",
+			op:   "slides.table.merge",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableMergeCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 1, Col: 2, RowSpan: 2, ColSpan: 3}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, request *slides.Request) {
+				t.Helper()
+				got := request.MergeTableCells
+				if got == nil || got.ObjectId != "table1" || got.TableRange.Location.RowIndex != 1 || got.TableRange.Location.ColumnIndex != 2 || got.TableRange.RowSpan != 2 || got.TableRange.ColumnSpan != 3 {
+					t.Fatalf("unexpected merge request: %+v", got)
+				}
+			},
+		},
+		{
+			name: "unmerge",
+			op:   "slides.table.unmerge",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableUnmergeCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 1, Col: 2, RowSpan: 2, ColSpan: 3}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, request *slides.Request) {
+				t.Helper()
+				got := request.UnmergeTableCells
+				if got == nil || got.ObjectId != "table1" || got.TableRange.Location.RowIndex != 1 || got.TableRange.Location.ColumnIndex != 2 || got.TableRange.RowSpan != 2 || got.TableRange.ColumnSpan != 3 {
+					t.Fatalf("unexpected unmerge request: %+v", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			ctx := withSlidesTestServiceFactory(
+				newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard),
+				func(context.Context, string) (*slides.Service, error) {
+					t.Fatal("dry-run must not create a Slides service")
+					return nil, context.Canceled
+				},
+			)
+			err := tt.run(ctx, &RootFlags{Account: "a@b.com", DryRun: true, Force: true})
+			if err != nil && ExitCode(err) != 0 {
+				t.Fatalf("Run: %v", err)
+			}
+			var got struct {
+				Op      string `json:"op"`
+				Request struct {
+					BatchUpdate slides.BatchUpdatePresentationRequest `json:"batch_update"`
+				} `json:"request"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("decode dry-run: %v\n%s", err, stdout.String())
+			}
+			if got.Op != tt.op {
+				t.Fatalf("op = %q, want %q", got.Op, tt.op)
+			}
+			if len(got.Request.BatchUpdate.Requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(got.Request.BatchUpdate.Requests))
+			}
+			tt.want(t, got.Request.BatchUpdate.Requests[0])
+		})
+	}
+}
+
+func TestSlidesTableStructure_UsesRevisionAndProviderDimensions(t *testing.T) {
+	var captured slides.BatchUpdatePresentationRequest
+	batchCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/presentations/pres1"):
+			_ = json.NewEncoder(w).Encode(slidesTableTestPresentation())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			batchCalled = true
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"presentationId": "pres1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := withSlidesTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), newSlidesServiceFromServer(t, srv))
+	cmd := &SlidesTableRowInsertCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 2, Count: 1, Below: true}
+	if err := cmd.Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !batchCalled {
+		t.Fatal("batch update was not called")
+	}
+	if captured.WriteControl == nil || captured.WriteControl.RequiredRevisionId != "rev1" {
+		t.Fatalf("write control = %+v, want rev1", captured.WriteControl)
+	}
+}
+
+func TestSlidesTableStructure_RejectsProviderOutOfBounds(t *testing.T) {
+	batchCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(slidesTableTestPresentation())
+			return
+		}
+		batchCalled = true
+		_ = json.NewEncoder(w).Encode(map[string]any{"presentationId": "pres1"})
+	}))
+	defer srv.Close()
+
+	ctx := withSlidesTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), newSlidesServiceFromServer(t, srv))
+	cmd := &SlidesTableMergeCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 2, Col: 1, RowSpan: 2, ColSpan: 2}
+	err := cmd.Run(ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "--row-span exceeds table row count 3 from row 2") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if batchCalled {
+		t.Fatal("out-of-bounds request reached batchUpdate")
+	}
+}
+
+func TestSlidesTableStructure_LocalValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *RootFlags) error
+		want string
+	}{
+		{name: "empty presentation", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableRowInsertCmd{TableObjectID: "table1", Row: 0, Count: 1}).Run(ctx, flags)
+		}, want: "empty presentationId"},
+		{name: "empty table", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableRowInsertCmd{PresentationID: "pres1", Row: 0, Count: 1}).Run(ctx, flags)
+		}, want: "empty tableObjectId"},
+		{name: "negative row", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableRowInsertCmd{PresentationID: "pres1", TableObjectID: "table1", Row: -1, Count: 1}).Run(ctx, flags)
+		}, want: "--row must be >= 0"},
+		{name: "too many", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableColumnInsertCmd{PresentationID: "pres1", TableObjectID: "table1", Col: 0, Count: 21}).Run(ctx, flags)
+		}, want: "--count must be between 1 and 20"},
+		{name: "negative column", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableColumnDeleteCmd{PresentationID: "pres1", TableObjectID: "table1", Col: -1}).Run(ctx, flags)
+		}, want: "--col must be >= 0"},
+		{name: "single-cell merge", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableMergeCmd{PresentationID: "pres1", TableObjectID: "table1", RowSpan: 1, ColSpan: 1}).Run(ctx, flags)
+		}, want: "merge range must span more than one cell"},
+		{name: "bad unmerge span", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableUnmergeCmd{PresentationID: "pres1", TableObjectID: "table1", RowSpan: 0, ColSpan: 1}).Run(ctx, flags)
+		}, want: "--row-span must be >= 1"},
+	}
+
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("invalid command must not create a Slides service")
+			return nil, context.Canceled
+		},
+	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(ctx, &RootFlags{Account: "a@b.com", Force: true})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+func slidesTableTestPresentation() map[string]any {
+	return map[string]any{
+		"presentationId": "pres1",
+		"revisionId":     "rev1",
+		"slides": []any{map[string]any{
+			"objectId": "slide1",
+			"pageElements": []any{map[string]any{
+				"objectId": "table1",
+				"table": map[string]any{
+					"rows":    3,
+					"columns": 4,
+				},
+			}},
+		}},
+	}
+}

--- a/scripts/live-tests/slides.sh
+++ b/scripts/live-tests/slides.sh
@@ -27,10 +27,41 @@ run_slides_tests() {
   read_json=$(gog slides read-slide "$slides_id" "$slide_id" --json)
   "$PY" -c 'import json,sys; assert len(json.load(sys.stdin).get("images", [])) >= 2' <<<"$read_json"
 
-  local native_json native_slide_id native_read native_after_delete
+  local native_json native_slide_id native_read native_after_delete table_read table_after_delete
   native_json=$(gog slides new-slide "$slides_id" --json)
   native_slide_id=$(extract_field "$native_json" slideObjectId)
   [ -n "$native_slide_id" ] || { echo "Failed to parse native slide object id" >&2; exit 1; }
+
+  run_required "slides" "slides create table" gog slides table create \
+    "$slides_id" "$native_slide_id" --rows 3 --cols 3 --object-id gogTableStruct >/dev/null
+  run_required "slides" "slides insert table row" gog slides table row insert \
+    "$slides_id" gogTableStruct --row 0 --below >/dev/null
+  run_required "slides" "slides insert table column" gog slides table column insert \
+    "$slides_id" gogTableStruct --col 0 --right >/dev/null
+  run_required "slides" "slides merge table cells" gog slides table merge \
+    "$slides_id" gogTableStruct --row 0 --col 0 --row-span 1 --col-span 2 >/dev/null
+  table_read=$(gog slides read-slide "$slides_id" "$native_slide_id" --detail --json)
+  "$PY" -c '
+import json,sys
+elements = {item["objectId"]: item for item in json.load(sys.stdin).get("elements", [])}
+table = elements["gogTableStruct"]["table"]
+assert (table["rows"], table["columns"]) == (4, 4)
+assert any(cell["rowIndex"] == 0 and cell["columnIndex"] == 0 and cell["columnSpan"] == 2 for cell in table["cells"])
+' <<<"$table_read"
+  run_required "slides" "slides unmerge table cells" gog slides table unmerge \
+    "$slides_id" gogTableStruct --row 0 --col 0 --row-span 1 --col-span 2 >/dev/null
+  run_required "slides" "slides delete table row" gog slides table row delete \
+    "$slides_id" gogTableStruct --row 3 --force >/dev/null
+  run_required "slides" "slides delete table column" gog slides table column delete \
+    "$slides_id" gogTableStruct --col 3 --force >/dev/null
+  table_after_delete=$(gog slides read-slide "$slides_id" "$native_slide_id" --detail --json)
+  "$PY" -c '
+import json,sys
+elements = {item["objectId"]: item for item in json.load(sys.stdin).get("elements", [])}
+table = elements["gogTableStruct"]["table"]
+assert (table["rows"], table["columns"]) == (3, 3)
+assert all(cell["rowSpan"] == 1 and cell["columnSpan"] == 1 for cell in table["cells"])
+' <<<"$table_after_delete"
 
   run_required "slides" "slides create shape A" gog slides element create-shape \
     "$slides_id" "$native_slide_id" --type ROUND_RECTANGLE --x 24 --y 24 --width 180 --height 80 \


### PR DESCRIPTION
## Summary

- add nested Slides table row and column insert/delete commands
- add rectangular merge and unmerge commands
- preflight provider dimensions and lock mutations to the fetched presentation revision
- document the structural surface and extend the Slides live lifecycle

## Testing

- `go test ./internal/cmd -run 'TestSlidesTable' -count=1`
- `make ci`
- Slides live suite with `clawdbot@gmail.com`: create table, insert row/column, merge/read back, unmerge, delete row/column, read back, delete deck
- independent Drive cleanup query: zero non-trashed `gogcli-smoke-slides-*` artifacts
- Codex autoreview: clean, no accepted/actionable findings

Refs #824. Sizing, borders, and cell styling remain a separate follow-up slice.
