### PR TITLE
feat(slides): add table sizing and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Slides: add range-scoped styling, links, bullets, and object-scoped replacement; `replace-text` now requires explicit `--object`, `--page`, or `--all` scope instead of silently changing the whole deck. (#823, #835) — thanks @sebsnyk.
 - Slides: add native table creation and zero-based table-cell targeting for `insert-text`, including atomic cell replacement. (#824, #834) — thanks @sebsnyk.
 - Slides: add revision-locked native table row/column insertion and deletion plus merge/unmerge operations with provider bounds checks. (#824, #847) — thanks @sebsnyk.
+- Slides: add revision-locked table row/column sizing, cell fill/alignment/text styling, and range-scoped border styling. (#824) — thanks @sebsnyk.
 - Slides: add native themed slide creation, duplication, and reordering with predefined or exact custom layouts and explicit zero-based positions. (#826, #833) — thanks @sebsnyk.
 - Slides: add native shape and line creation plus element transforms, fill/outline styling, z-order, grouping, alt text, and guarded deletion. (#826) — thanks @sebsnyk.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Slides: add range-scoped styling, links, bullets, and object-scoped replacement; `replace-text` now requires explicit `--object`, `--page`, or `--all` scope instead of silently changing the whole deck. (#823, #835) — thanks @sebsnyk.
 - Slides: add native table creation and zero-based table-cell targeting for `insert-text`, including atomic cell replacement. (#824, #834) — thanks @sebsnyk.
 - Slides: add revision-locked native table row/column insertion and deletion plus merge/unmerge operations with provider bounds checks. (#824, #847) — thanks @sebsnyk.
-- Slides: add revision-locked table row/column sizing, cell fill/alignment/text styling, and range-scoped border styling. (#824) — thanks @sebsnyk.
+- Slides: add revision-locked table row/column sizing, cell fill/alignment/text styling, and range-scoped border styling. (#824, #848) — thanks @sebsnyk.
 - Slides: add native themed slide creation, duplication, and reordering with predefined or exact custom layouts and explicit zero-based positions. (#826, #833) — thanks @sebsnyk.
 - Slides: add native shape and line creation plus element transforms, fill/outline styling, z-order, grouping, alt text, and guarded deletion. (#826) — thanks @sebsnyk.
 

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -618,14 +618,20 @@ Generated from `gog schema --json`.
     - [`gog slides (slide) replace-text <presentationId> <find> <replacement> [flags]`](commands/gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
     - [`gog slides (slide) style-text --range=STRING <presentationId> <objectId> [flags]`](commands/gog-slides-style-text.md) - Apply range-scoped text styling to one page element
     - [`gog slides (slide) table <command>`](commands/gog-slides-table.md) - Create and update native tables
-      - [`gog slides (slide) table column (col) <command>`](commands/gog-slides-table-column.md) - Insert or delete table columns
+      - [`gog slides (slide) table border <command>`](commands/gog-slides-table-border.md) - Style table borders
+        - [`gog slides (slide) table border style --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-border-style.md) - Style borders around or within a table cell range
+      - [`gog slides (slide) table cell <command>`](commands/gog-slides-table-cell.md) - Style table cells
+        - [`gog slides (slide) table cell style --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-cell-style.md) - Style one zero-based table cell
+      - [`gog slides (slide) table column (col) <command>`](commands/gog-slides-table-column.md) - Insert, delete, or size table columns
         - [`gog slides (slide) table column (col) delete (rm,remove,del) --col=INT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-column-delete.md) - Delete the column containing a zero-based table cell
         - [`gog slides (slide) table column (col) insert (add) --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-column-insert.md) - Insert columns left or right of a zero-based column
+        - [`gog slides (slide) table column (col) size --col=INT-64 --width=FLOAT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-column-size.md) - Set a column's width
       - [`gog slides (slide) table create (add) --rows=INT-64 --cols=INT-64 <presentationId> <slideId> [flags]`](commands/gog-slides-table-create.md) - Create an auto-sized native table on a slide
       - [`gog slides (slide) table merge --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-merge.md) - Merge a rectangular table cell range
-      - [`gog slides (slide) table row <command>`](commands/gog-slides-table-row.md) - Insert or delete table rows
+      - [`gog slides (slide) table row <command>`](commands/gog-slides-table-row.md) - Insert, delete, or size table rows
         - [`gog slides (slide) table row delete (rm,remove,del) --row=INT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
         - [`gog slides (slide) table row insert (add) --row=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
+        - [`gog slides (slide) table row size --row=INT-64 --height=FLOAT-64 <presentationId> <tableObjectId>`](commands/gog-slides-table-row-size.md) - Set a row's minimum height
       - [`gog slides (slide) table unmerge (split) --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]`](commands/gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
     - [`gog slides (slide) thumbnail (thumb) <presentationId> <slideId> [flags]`](commands/gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
     - [`gog slides (slide) update-notes <presentationId> <slideId> [flags]`](commands/gog-slides-update-notes.md) - Update speaker notes on an existing slide

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 673.
+Generated pages: 679.
 
 ## Top-level Commands
 
@@ -669,14 +669,20 @@ Generated pages: 673.
     - [gog slides replace-text](gog-slides-replace-text.md) - Find-and-replace text in an explicit object, slide, or presentation scope
     - [gog slides style-text](gog-slides-style-text.md) - Apply range-scoped text styling to one page element
     - [gog slides table](gog-slides-table.md) - Create and update native tables
-      - [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
+      - [gog slides table border](gog-slides-table-border.md) - Style table borders
+        - [gog slides table border style](gog-slides-table-border-style.md) - Style borders around or within a table cell range
+      - [gog slides table cell](gog-slides-table-cell.md) - Style table cells
+        - [gog slides table cell style](gog-slides-table-cell-style.md) - Style one zero-based table cell
+      - [gog slides table column](gog-slides-table-column.md) - Insert, delete, or size table columns
         - [gog slides table column delete](gog-slides-table-column-delete.md) - Delete the column containing a zero-based table cell
         - [gog slides table column insert](gog-slides-table-column-insert.md) - Insert columns left or right of a zero-based column
+        - [gog slides table column size](gog-slides-table-column-size.md) - Set a column's width
       - [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
       - [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-      - [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
+      - [gog slides table row](gog-slides-table-row.md) - Insert, delete, or size table rows
         - [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
         - [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
+        - [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
       - [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
     - [gog slides thumbnail](gog-slides-thumbnail.md) - Get or download a rendered thumbnail for a slide
     - [gog slides update-notes](gog-slides-update-notes.md) - Update speaker notes on an existing slide

--- a/docs/commands/gog-slides-table-border-style.md
+++ b/docs/commands/gog-slides-table-border-style.md
@@ -1,24 +1,18 @@
-# `gog slides table row`
+# `gog slides table border style`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or size table rows
+Style borders around or within a table cell range
 
 ## Usage
 
 ```bash
-gog slides (slide) table row <command>
+gog slides (slide) table border style --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]
 ```
 
 ## Parent
 
-- [gog slides table](gog-slides-table.md)
-
-## Subcommands
-
-- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
-- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
-- [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
+- [gog slides table border](gog-slides-table-border.md)
 
 ## Flags
 
@@ -26,8 +20,12 @@ gog slides (slide) table row <command>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--border-color` | `string` |  | Border color as #RGB or #RRGGBB |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based starting column |
+| `--col-span` | `int64` | 1 | Number of columns in the range |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--dash` | `*string` |  | Border dash style |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -39,13 +37,18 @@ gog slides (slide) table row <command>
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--position` | `string` | ALL | Borders within the selected range to update |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based starting row |
+| `--row-span` | `int64` | 1 | Number of rows in the range |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--transparent` | `bool` |  | Make selected borders transparent |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--weight` | `*float64` |  | Border weight in points |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog slides table](gog-slides-table.md)
+- [gog slides table border](gog-slides-table-border.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-border.md
+++ b/docs/commands/gog-slides-table-border.md
@@ -1,13 +1,13 @@
-# `gog slides table row`
+# `gog slides table border`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or size table rows
+Style table borders
 
 ## Usage
 
 ```bash
-gog slides (slide) table row <command>
+gog slides (slide) table border <command>
 ```
 
 ## Parent
@@ -16,9 +16,7 @@ gog slides (slide) table row <command>
 
 ## Subcommands
 
-- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
-- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
-- [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
+- [gog slides table border style](gog-slides-table-border-style.md) - Style borders around or within a table cell range
 
 ## Flags
 

--- a/docs/commands/gog-slides-table-cell-style.md
+++ b/docs/commands/gog-slides-table-cell-style.md
@@ -1,24 +1,18 @@
-# `gog slides table row`
+# `gog slides table cell style`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or size table rows
+Style one zero-based table cell
 
 ## Usage
 
 ```bash
-gog slides (slide) table row <command>
+gog slides (slide) table cell style --row=INT-64 --col=INT-64 <presentationId> <tableObjectId> [flags]
 ```
 
 ## Parent
 
-- [gog slides table](gog-slides-table.md)
-
-## Subcommands
-
-- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
-- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
-- [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
+- [gog slides table cell](gog-slides-table-cell.md)
 
 ## Flags
 
@@ -26,26 +20,41 @@ gog slides (slide) table row <command>
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--bold` | `bool` |  | Set cell text bold |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based column |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--content-align` | `*string` |  | Vertical content alignment |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fill-color` | `string` |  | Cell fill as #RGB or #RRGGBB |
+| `--fill-transparent` | `bool` |  | Remove the cell fill |
+| `--font` | `string` |  | Cell text font family |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-bold` | `bool` |  | Clear cell text bold |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--no-italic` | `bool` |  | Clear cell text italic |
+| `--no-underline` | `bool` |  | Clear cell text underline |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--range` | `string` |  | Optional UTF-16 text range as start:end; defaults to all cell text |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based row |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--size` | `float64` |  | Cell text size in points |
+| `--text-color` | `string` |  | Cell text color as #RGB or #RRGGBB |
+| `--underline` | `bool` |  | Set cell text underline |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog slides table](gog-slides-table.md)
+- [gog slides table cell](gog-slides-table-cell.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-cell.md
+++ b/docs/commands/gog-slides-table-cell.md
@@ -1,13 +1,13 @@
-# `gog slides table row`
+# `gog slides table cell`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or size table rows
+Style table cells
 
 ## Usage
 
 ```bash
-gog slides (slide) table row <command>
+gog slides (slide) table cell <command>
 ```
 
 ## Parent
@@ -16,9 +16,7 @@ gog slides (slide) table row <command>
 
 ## Subcommands
 
-- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
-- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
-- [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
+- [gog slides table cell style](gog-slides-table-cell-style.md) - Style one zero-based table cell
 
 ## Flags
 

--- a/docs/commands/gog-slides-table-column-size.md
+++ b/docs/commands/gog-slides-table-column-size.md
@@ -1,24 +1,18 @@
-# `gog slides table row`
+# `gog slides table column size`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or size table rows
+Set a column's width
 
 ## Usage
 
 ```bash
-gog slides (slide) table row <command>
+gog slides (slide) table column (col) size --col=INT-64 --width=FLOAT-64 <presentationId> <tableObjectId>
 ```
 
 ## Parent
 
-- [gog slides table](gog-slides-table.md)
-
-## Subcommands
-
-- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
-- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
-- [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
+- [gog slides table column](gog-slides-table-column.md)
 
 ## Flags
 
@@ -27,6 +21,7 @@ gog slides (slide) table row <command>
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--col` | `int64` |  | Zero-based column |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
@@ -43,9 +38,10 @@ gog slides (slide) table row <command>
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--width` | `float64` |  | Column width in points (>=32) |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog slides table](gog-slides-table.md)
+- [gog slides table column](gog-slides-table-column.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table-column.md
+++ b/docs/commands/gog-slides-table-column.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert or delete table columns
+Insert, delete, or size table columns
 
 ## Usage
 
@@ -18,6 +18,7 @@ gog slides (slide) table column (col) <command>
 
 - [gog slides table column delete](gog-slides-table-column-delete.md) - Delete the column containing a zero-based table cell
 - [gog slides table column insert](gog-slides-table-column-insert.md) - Insert columns left or right of a zero-based column
+- [gog slides table column size](gog-slides-table-column-size.md) - Set a column's width
 
 ## Flags
 

--- a/docs/commands/gog-slides-table-row-size.md
+++ b/docs/commands/gog-slides-table-row-size.md
@@ -1,24 +1,18 @@
-# `gog slides table row`
+# `gog slides table row size`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or size table rows
+Set a row's minimum height
 
 ## Usage
 
 ```bash
-gog slides (slide) table row <command>
+gog slides (slide) table row size --row=INT-64 --height=FLOAT-64 <presentationId> <tableObjectId>
 ```
 
 ## Parent
 
-- [gog slides table](gog-slides-table.md)
-
-## Subcommands
-
-- [gog slides table row delete](gog-slides-table-row-delete.md) - Delete the row containing a zero-based table cell
-- [gog slides table row insert](gog-slides-table-row-insert.md) - Insert rows above or below a zero-based row
-- [gog slides table row size](gog-slides-table-row-size.md) - Set a row's minimum height
+- [gog slides table row](gog-slides-table-row.md)
 
 ## Flags
 
@@ -34,12 +28,14 @@ gog slides (slide) table row <command>
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `--height` | `float64` |  | Minimum row height in points (>=0) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `int64` |  | Zero-based row |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
@@ -47,5 +43,5 @@ gog slides (slide) table row <command>
 
 ## See Also
 
-- [gog slides table](gog-slides-table.md)
+- [gog slides table row](gog-slides-table-row.md)
 - [Command index](README.md)

--- a/docs/commands/gog-slides-table.md
+++ b/docs/commands/gog-slides-table.md
@@ -16,10 +16,12 @@ gog slides (slide) table <command>
 
 ## Subcommands
 
-- [gog slides table column](gog-slides-table-column.md) - Insert or delete table columns
+- [gog slides table border](gog-slides-table-border.md) - Style table borders
+- [gog slides table cell](gog-slides-table-cell.md) - Style table cells
+- [gog slides table column](gog-slides-table-column.md) - Insert, delete, or size table columns
 - [gog slides table create](gog-slides-table-create.md) - Create an auto-sized native table on a slide
 - [gog slides table merge](gog-slides-table-merge.md) - Merge a rectangular table cell range
-- [gog slides table row](gog-slides-table-row.md) - Insert or delete table rows
+- [gog slides table row](gog-slides-table-row.md) - Insert, delete, or size table rows
 - [gog slides table unmerge](gog-slides-table-unmerge.md) - Unmerge cells in a rectangular table range
 
 ## Flags

--- a/docs/slides-tables.md
+++ b/docs/slides-tables.md
@@ -53,3 +53,37 @@ whole table.
 Use `--dry-run --json` to inspect the exact Slides `batchUpdate` request without
 contacting Google. Use `slides read-slide --detail --json` to verify the table
 dimensions, cell coordinates, and text returned by the provider.
+
+## Sizing and style
+
+Set row and column dimensions in points:
+
+```bash
+gog slides table row size <presentationId> <tableId> --row 0 --height 48
+gog slides table column size <presentationId> <tableId> --col 0 --width 120
+```
+
+Row height is a minimum; Slides may render a taller row to fit its content.
+Column width must be at least 32 points, matching the provider minimum.
+
+Style one cell's fill, vertical content alignment, and text in one atomic batch:
+
+```bash
+gog slides table cell style <presentationId> <tableId> --row 0 --col 0 \
+  --fill-color '#3367d6' --content-align MIDDLE \
+  --bold --text-color '#ffffff' --size 18 --font Cambria
+```
+
+Text options default to all text in the cell. Pass `--range start:end` to style
+one UTF-16 text range. `--fill-transparent` removes the cell fill.
+
+Style borders for a rectangular cell range:
+
+```bash
+gog slides table border style <presentationId> <tableId> \
+  --row 0 --col 0 --row-span 1 --col-span 3 --position OUTER \
+  --border-color '#ea4335' --weight 2 --dash DASH
+```
+
+`--position` accepts `ALL`, `OUTER`, `INNER`, individual sides, or inner
+horizontal/vertical borders. `--transparent` hides the selected borders.

--- a/internal/cmd/slides_table.go
+++ b/internal/cmd/slides_table.go
@@ -13,8 +13,10 @@ import (
 
 type SlidesTableCmd struct {
 	Create  SlidesTableCreateCmd  `cmd:"" name:"create" aliases:"add" help:"Create an auto-sized native table on a slide"`
-	Row     SlidesTableRowCmd     `cmd:"" name:"row" help:"Insert or delete table rows"`
-	Column  SlidesTableColumnCmd  `cmd:"" name:"column" aliases:"col" help:"Insert or delete table columns"`
+	Row     SlidesTableRowCmd     `cmd:"" name:"row" help:"Insert, delete, or size table rows"`
+	Column  SlidesTableColumnCmd  `cmd:"" name:"column" aliases:"col" help:"Insert, delete, or size table columns"`
+	Cell    SlidesTableCellCmd    `cmd:"" name:"cell" help:"Style table cells"`
+	Border  SlidesTableBorderCmd  `cmd:"" name:"border" help:"Style table borders"`
 	Merge   SlidesTableMergeCmd   `cmd:"" name:"merge" help:"Merge a rectangular table cell range"`
 	Unmerge SlidesTableUnmergeCmd `cmd:"" name:"unmerge" aliases:"split" help:"Unmerge cells in a rectangular table range"`
 }

--- a/internal/cmd/slides_table_structure.go
+++ b/internal/cmd/slides_table_structure.go
@@ -14,11 +14,13 @@ import (
 type SlidesTableRowCmd struct {
 	Insert SlidesTableRowInsertCmd `cmd:"" name:"insert" aliases:"add" help:"Insert rows above or below a zero-based row"`
 	Delete SlidesTableRowDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete the row containing a zero-based table cell"`
+	Size   SlidesTableRowSizeCmd   `cmd:"" name:"size" help:"Set a row's minimum height"`
 }
 
 type SlidesTableColumnCmd struct {
 	Insert SlidesTableColumnInsertCmd `cmd:"" name:"insert" aliases:"add" help:"Insert columns left or right of a zero-based column"`
 	Delete SlidesTableColumnDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete the column containing a zero-based table cell"`
+	Size   SlidesTableColumnSizeCmd   `cmd:"" name:"size" help:"Set a column's width"`
 }
 
 type SlidesTableRowInsertCmd struct {
@@ -270,6 +272,7 @@ type slidesTableMutation struct {
 	PresentationID string
 	TableObjectID  string
 	Request        *slides.Request
+	Requests       []*slides.Request
 	Payload        map[string]any
 	Output         map[string]any
 	Text           string
@@ -278,7 +281,14 @@ type slidesTableMutation struct {
 }
 
 func runSlidesTableMutation(ctx context.Context, flags *RootFlags, mutation slidesTableMutation) error {
-	body := &slides.BatchUpdatePresentationRequest{Requests: []*slides.Request{mutation.Request}}
+	requests := mutation.Requests
+	if len(requests) == 0 && mutation.Request != nil {
+		requests = []*slides.Request{mutation.Request}
+	}
+	if len(requests) == 0 {
+		return fmt.Errorf("%s: no Slides requests provided", mutation.Action)
+	}
+	body := &slides.BatchUpdatePresentationRequest{Requests: requests}
 	payload := mutation.Payload
 	if payload == nil {
 		payload = make(map[string]any)

--- a/internal/cmd/slides_table_style.go
+++ b/internal/cmd/slides_table_style.go
@@ -1,0 +1,349 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/slides/v1"
+)
+
+var slidesTableAll = strings.ToUpper("all")
+
+type SlidesTableCellCmd struct {
+	Style SlidesTableCellStyleCmd `cmd:"" name:"style" help:"Style one zero-based table cell"`
+}
+
+type SlidesTableBorderCmd struct {
+	Style SlidesTableBorderStyleCmd `cmd:"" name:"style" help:"Style borders around or within a table cell range"`
+}
+
+type SlidesTableRowSizeCmd struct {
+	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string  `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row            int64   `name:"row" required:"" help:"Zero-based row"`
+	Height         float64 `name:"height" required:"" help:"Minimum row height in points (>=0)"`
+}
+
+type SlidesTableColumnSizeCmd struct {
+	PresentationID string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string  `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Col            int64   `name:"col" required:"" help:"Zero-based column"`
+	Width          float64 `name:"width" required:"" help:"Column width in points (>=32)"`
+}
+
+type SlidesTableCellStyleCmd struct {
+	PresentationID  string  `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID   string  `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row             int64   `name:"row" required:"" help:"Zero-based row"`
+	Col             int64   `name:"col" required:"" help:"Zero-based column"`
+	FillColor       string  `name:"fill-color" help:"Cell fill as #RGB or #RRGGBB"`
+	FillTransparent bool    `name:"fill-transparent" help:"Remove the cell fill"`
+	ContentAlign    *string `name:"content-align" enum:"TOP,MIDDLE,BOTTOM" help:"Vertical content alignment"`
+	Range           string  `name:"range" help:"Optional UTF-16 text range as start:end; defaults to all cell text"`
+	Bold            bool    `name:"bold" help:"Set cell text bold"`
+	NoBold          bool    `name:"no-bold" help:"Clear cell text bold"`
+	Italic          bool    `name:"italic" help:"Set cell text italic"`
+	NoItalic        bool    `name:"no-italic" help:"Clear cell text italic"`
+	Underline       bool    `name:"underline" help:"Set cell text underline"`
+	NoUnderline     bool    `name:"no-underline" help:"Clear cell text underline"`
+	TextColor       string  `name:"text-color" help:"Cell text color as #RGB or #RRGGBB"`
+	Size            float64 `name:"size" help:"Cell text size in points"`
+	Font            string  `name:"font" help:"Cell text font family"`
+}
+
+type SlidesTableBorderStyleCmd struct {
+	PresentationID string   `arg:"" name:"presentationId" help:"Presentation ID"`
+	TableObjectID  string   `arg:"" name:"tableObjectId" help:"Table object ID"`
+	Row            int64    `name:"row" required:"" help:"Zero-based starting row"`
+	Col            int64    `name:"col" required:"" help:"Zero-based starting column"`
+	RowSpan        int64    `name:"row-span" default:"1" help:"Number of rows in the range"`
+	ColSpan        int64    `name:"col-span" default:"1" help:"Number of columns in the range"`
+	Position       string   `name:"position" default:"ALL" enum:"ALL,BOTTOM,INNER,INNER_HORIZONTAL,INNER_VERTICAL,LEFT,OUTER,RIGHT,TOP" help:"Borders within the selected range to update"`
+	BorderColor    string   `name:"border-color" help:"Border color as #RGB or #RRGGBB"`
+	Transparent    bool     `name:"transparent" help:"Make selected borders transparent"`
+	Weight         *float64 `name:"weight" help:"Border weight in points"`
+	Dash           *string  `name:"dash" enum:"SOLID,DOT,DASH,DASH_DOT,LONG_DASH,LONG_DASH_DOT" help:"Border dash style"`
+}
+
+func (c *SlidesTableRowSizeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Row < 0 {
+		return usage("--row must be >= 0")
+	}
+	if c.Height < 0 {
+		return usage("--height must be >= 0")
+	}
+	request := &slides.Request{UpdateTableRowProperties: &slides.UpdateTableRowPropertiesRequest{
+		ObjectId:   tableID,
+		RowIndices: []int64{c.Row},
+		TableRowProperties: &slides.TableRowProperties{
+			MinRowHeight: slidesElementDimension(c.Height, "PT"),
+		},
+		Fields: "minRowHeight",
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.row.size",
+		Action:         "size table row",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"row": c.Row, "height": c.Height},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "row": c.Row, "minHeight": c.Height, "unit": "PT"},
+		Text:           fmt.Sprintf("Set row %d minimum height to %.2f PT in table %s", c.Row, c.Height, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, c.Row, 0)
+		},
+	})
+}
+
+func (c *SlidesTableColumnSizeCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Col < 0 {
+		return usage("--col must be >= 0")
+	}
+	if c.Width < 32 {
+		return usage("--width must be >= 32 points")
+	}
+	request := &slides.Request{UpdateTableColumnProperties: &slides.UpdateTableColumnPropertiesRequest{
+		ObjectId:      tableID,
+		ColumnIndices: []int64{c.Col},
+		TableColumnProperties: &slides.TableColumnProperties{
+			ColumnWidth: slidesElementDimension(c.Width, "PT"),
+		},
+		Fields: "columnWidth",
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.column.size",
+		Action:         "size table column",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"col": c.Col, "width": c.Width},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "col": c.Col, "width": c.Width, "unit": "PT"},
+		Text:           fmt.Sprintf("Set column %d width to %.2f PT in table %s", c.Col, c.Width, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, 0, c.Col)
+		},
+	})
+}
+
+func (c *SlidesTableCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Row < 0 {
+		return usage("--row must be >= 0")
+	}
+	if c.Col < 0 {
+		return usage("--col must be >= 0")
+	}
+	if c.FillColor != "" && c.FillTransparent {
+		return usage("--fill-color and --fill-transparent are mutually exclusive")
+	}
+
+	requests := make([]*slides.Request, 0, 2)
+	fields := make([]string, 0, 8)
+	properties := &slides.TableCellProperties{}
+	cellFields := make([]string, 0, 4)
+	if c.FillColor != "" || c.FillTransparent {
+		if c.FillTransparent {
+			properties.TableCellBackgroundFill = &slides.TableCellBackgroundFill{PropertyState: "NOT_RENDERED"}
+			cellFields = append(cellFields, "tableCellBackgroundFill.propertyState")
+		} else {
+			fill, fillErr := slidesElementSolidFill(c.FillColor, false)
+			if fillErr != nil {
+				return usage("--fill-color must be a #RRGGBB or #RGB hex color")
+			}
+			properties.TableCellBackgroundFill = &slides.TableCellBackgroundFill{PropertyState: "RENDERED", SolidFill: fill}
+			cellFields = append(cellFields, "tableCellBackgroundFill.propertyState", "tableCellBackgroundFill.solidFill.color", "tableCellBackgroundFill.solidFill.alpha")
+		}
+	}
+	if c.ContentAlign != nil {
+		alignment := normalizeSlidesEnum(*c.ContentAlign)
+		if !slidesTableContentAlignments[alignment] {
+			return usage("--content-align must be TOP, MIDDLE, or BOTTOM")
+		}
+		properties.ContentAlignment = alignment
+		cellFields = append(cellFields, "contentAlignment")
+	}
+	if len(cellFields) > 0 {
+		requests = append(requests, &slides.Request{UpdateTableCellProperties: &slides.UpdateTableCellPropertiesRequest{
+			ObjectId:            tableID,
+			TableRange:          slidesTableRange(c.Row, c.Col, 1, 1),
+			TableCellProperties: properties,
+			Fields:              strings.Join(cellFields, ","),
+		}})
+		fields = append(fields, cellFields...)
+	}
+
+	textOptions := slidesStyleTextOptions{
+		Bold:        c.Bold,
+		NoBold:      c.NoBold,
+		Italic:      c.Italic,
+		NoItalic:    c.NoItalic,
+		Underline:   c.Underline,
+		NoUnderline: c.NoUnderline,
+		Color:       c.TextColor,
+		Size:        c.Size,
+		Font:        c.Font,
+	}
+	if slidesTextStyleOptionsProvided(textOptions) {
+		textRange := &slides.Range{Type: slidesTableAll}
+		if strings.TrimSpace(c.Range) != "" {
+			textRange, err = parseSlidesTextRange(c.Range)
+			if err != nil {
+				return err
+			}
+		}
+		textRequest, textFields, textErr := buildSlidesStyleTextRequest(tableID, textRange, textOptions)
+		if textErr != nil {
+			return textErr
+		}
+		textRequest.CellLocation = slidesTableCellLocation(c.Row, c.Col)
+		requests = append(requests, &slides.Request{UpdateTextStyle: textRequest})
+		for _, field := range strings.Split(textFields, ",") {
+			fields = append(fields, "text."+field)
+		}
+	}
+	if len(requests) == 0 {
+		return usage("provide at least one cell or text style option")
+	}
+
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.cell.style",
+		Action:         "style table cell",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Requests:       requests,
+		Payload:        map[string]any{"row": c.Row, "col": c.Col, "fields": fields},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "row": c.Row, "col": c.Col, "fields": fields},
+		Text:           fmt.Sprintf("Styled cell [%d,%d] in table %s", c.Row, c.Col, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableAnchor(table, c.Row, c.Col)
+		},
+	})
+}
+
+func (c *SlidesTableBorderStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
+	presentationID, tableID, err := slidesTableTarget(c.PresentationID, c.TableObjectID)
+	if err != nil {
+		return err
+	}
+	if c.Row < 0 {
+		return usage("--row must be >= 0")
+	}
+	if c.Col < 0 {
+		return usage("--col must be >= 0")
+	}
+	if c.RowSpan < 1 {
+		return usage("--row-span must be >= 1")
+	}
+	if c.ColSpan < 1 {
+		return usage("--col-span must be >= 1")
+	}
+	if c.BorderColor != "" && c.Transparent {
+		return usage("--border-color and --transparent are mutually exclusive")
+	}
+	if c.Weight != nil && *c.Weight <= 0 {
+		return usage("--weight must be > 0")
+	}
+	position := normalizeSlidesEnum(c.Position)
+	if !slidesTableBorderPositions[position] {
+		return usage("invalid --position")
+	}
+
+	properties := &slides.TableBorderProperties{}
+	fields := make([]string, 0, 4)
+	if c.BorderColor != "" || c.Transparent {
+		fill, fillErr := slidesElementSolidFill(c.BorderColor, c.Transparent)
+		if fillErr != nil {
+			return usage("--border-color must be a #RRGGBB or #RGB hex color")
+		}
+		properties.TableBorderFill = &slides.TableBorderFill{SolidFill: fill}
+		fields = append(fields, "tableBorderFill.solidFill.color", "tableBorderFill.solidFill.alpha")
+	}
+	if c.Weight != nil {
+		properties.Weight = slidesElementDimension(*c.Weight, "PT")
+		fields = append(fields, "weight")
+	}
+	if c.Dash != nil {
+		dash := normalizeSlidesEnum(*c.Dash)
+		if !slidesTableBorderDashes[dash] {
+			return usage("invalid --dash")
+		}
+		properties.DashStyle = dash
+		fields = append(fields, "dashStyle")
+	}
+	if len(fields) == 0 {
+		return usage("provide at least one border style option")
+	}
+
+	request := &slides.Request{UpdateTableBorderProperties: &slides.UpdateTableBorderPropertiesRequest{
+		ObjectId:              tableID,
+		TableRange:            slidesTableRange(c.Row, c.Col, c.RowSpan, c.ColSpan),
+		BorderPosition:        position,
+		TableBorderProperties: properties,
+		Fields:                strings.Join(fields, ","),
+	}}
+	return runSlidesTableMutation(ctx, flags, slidesTableMutation{
+		Op:             "slides.table.border.style",
+		Action:         "style table borders",
+		PresentationID: presentationID,
+		TableObjectID:  tableID,
+		Request:        request,
+		Payload:        map[string]any{"row": c.Row, "col": c.Col, "row_span": c.RowSpan, "col_span": c.ColSpan, "position": position, "fields": fields},
+		Output:         map[string]any{"presentationId": presentationID, "tableObjectId": tableID, "row": c.Row, "col": c.Col, "rowSpan": c.RowSpan, "colSpan": c.ColSpan, "position": position, "fields": fields},
+		Text:           fmt.Sprintf("Styled %s borders in table %s", position, tableID),
+		Validate: func(table *slides.Table) error {
+			return validateSlidesTableRange(table, c.Row, c.Col, c.RowSpan, c.ColSpan)
+		},
+	})
+}
+
+func slidesTableRange(row, col, rowSpan, colSpan int64) *slides.TableRange {
+	return &slides.TableRange{
+		Location:   slidesTableCellLocation(row, col),
+		RowSpan:    rowSpan,
+		ColumnSpan: colSpan,
+	}
+}
+
+func slidesTextStyleOptionsProvided(options slidesStyleTextOptions) bool {
+	return options.Bold || options.NoBold || options.Italic || options.NoItalic || options.Underline || options.NoUnderline ||
+		options.Color != "" || options.Size != 0 || strings.TrimSpace(options.Font) != ""
+}
+
+var slidesTableContentAlignments = map[string]bool{
+	"TOP":    true,
+	"MIDDLE": true,
+	"BOTTOM": true,
+}
+
+var slidesTableBorderPositions = map[string]bool{
+	slidesTableAll:     true,
+	"BOTTOM":           true,
+	"INNER":            true,
+	"INNER_HORIZONTAL": true,
+	"INNER_VERTICAL":   true,
+	"LEFT":             true,
+	"OUTER":            true,
+	"RIGHT":            true,
+	"TOP":              true,
+}
+
+var slidesTableBorderDashes = map[string]bool{
+	"SOLID":         true,
+	"DOT":           true,
+	"DASH":          true,
+	"DASH_DOT":      true,
+	"LONG_DASH":     true,
+	"LONG_DASH_DOT": true,
+}

--- a/internal/cmd/slides_table_style_test.go
+++ b/internal/cmd/slides_table_style_test.go
@@ -1,0 +1,251 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/slides/v1"
+)
+
+func TestSlidesTableStyle_DryRunRequests(t *testing.T) {
+	middle := "MIDDLE"
+	dash := "DASH"
+	weight := 2.5
+	tests := []struct {
+		name string
+		op   string
+		run  func(context.Context, *RootFlags) error
+		want func(*testing.T, []*slides.Request)
+	}{
+		{
+			name: "row size",
+			op:   "slides.table.row.size",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableRowSizeCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 2, Height: 48}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, requests []*slides.Request) {
+				t.Helper()
+				if len(requests) != 1 || requests[0].UpdateTableRowProperties == nil {
+					t.Fatalf("unexpected requests: %+v", requests)
+				}
+				got := requests[0].UpdateTableRowProperties
+				if got.ObjectId != "table1" || len(got.RowIndices) != 1 || got.RowIndices[0] != 2 || got.Fields != "minRowHeight" {
+					t.Fatalf("unexpected row size request: %+v", got)
+				}
+				if got.TableRowProperties.MinRowHeight.Magnitude != 48 || got.TableRowProperties.MinRowHeight.Unit != "PT" {
+					t.Fatalf("unexpected row height: %+v", got.TableRowProperties.MinRowHeight)
+				}
+			},
+		},
+		{
+			name: "column size",
+			op:   "slides.table.column.size",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableColumnSizeCmd{PresentationID: "pres1", TableObjectID: "table1", Col: 1, Width: 120}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, requests []*slides.Request) {
+				t.Helper()
+				if len(requests) != 1 || requests[0].UpdateTableColumnProperties == nil {
+					t.Fatalf("unexpected requests: %+v", requests)
+				}
+				got := requests[0].UpdateTableColumnProperties
+				if got.ObjectId != "table1" || len(got.ColumnIndices) != 1 || got.ColumnIndices[0] != 1 || got.Fields != "columnWidth" {
+					t.Fatalf("unexpected column size request: %+v", got)
+				}
+				if got.TableColumnProperties.ColumnWidth.Magnitude != 120 || got.TableColumnProperties.ColumnWidth.Unit != "PT" {
+					t.Fatalf("unexpected column width: %+v", got.TableColumnProperties.ColumnWidth)
+				}
+			},
+		},
+		{
+			name: "cell and text style",
+			op:   "slides.table.cell.style",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableCellStyleCmd{
+					PresentationID: "pres1",
+					TableObjectID:  "table1",
+					Row:            1,
+					Col:            2,
+					FillColor:      "#3367D6",
+					ContentAlign:   &middle,
+					Bold:           true,
+					TextColor:      "#FFFFFF",
+					Size:           18,
+					Font:           "Cambria",
+				}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, requests []*slides.Request) {
+				t.Helper()
+				if len(requests) != 2 {
+					t.Fatalf("requests = %d, want 2", len(requests))
+				}
+				cell := requests[0].UpdateTableCellProperties
+				if cell == nil || cell.ObjectId != "table1" || cell.TableRange.Location.RowIndex != 1 || cell.TableRange.Location.ColumnIndex != 2 {
+					t.Fatalf("unexpected cell style request: %+v", cell)
+				}
+				if cell.TableCellProperties.ContentAlignment != "MIDDLE" || cell.TableCellProperties.TableCellBackgroundFill.PropertyState != "RENDERED" {
+					t.Fatalf("unexpected cell properties: %+v", cell.TableCellProperties)
+				}
+				text := requests[1].UpdateTextStyle
+				if text == nil || text.CellLocation.RowIndex != 1 || text.CellLocation.ColumnIndex != 2 || text.TextRange.Type != slidesTableAll {
+					t.Fatalf("unexpected text style request: %+v", text)
+				}
+				if !text.Style.Bold || text.Style.FontFamily != "Cambria" || text.Style.FontSize.Magnitude != 18 {
+					t.Fatalf("unexpected text properties: %+v", text.Style)
+				}
+			},
+		},
+		{
+			name: "border style",
+			op:   "slides.table.border.style",
+			run: func(ctx context.Context, flags *RootFlags) error {
+				return (&SlidesTableBorderStyleCmd{
+					PresentationID: "pres1",
+					TableObjectID:  "table1",
+					Row:            0,
+					Col:            1,
+					RowSpan:        2,
+					ColSpan:        3,
+					Position:       "OUTER",
+					BorderColor:    "#EA4335",
+					Weight:         &weight,
+					Dash:           &dash,
+				}).Run(ctx, flags)
+			},
+			want: func(t *testing.T, requests []*slides.Request) {
+				t.Helper()
+				if len(requests) != 1 || requests[0].UpdateTableBorderProperties == nil {
+					t.Fatalf("unexpected requests: %+v", requests)
+				}
+				got := requests[0].UpdateTableBorderProperties
+				if got.ObjectId != "table1" || got.BorderPosition != "OUTER" || got.TableRange.RowSpan != 2 || got.TableRange.ColumnSpan != 3 {
+					t.Fatalf("unexpected border request: %+v", got)
+				}
+				if got.TableBorderProperties.Weight.Magnitude != weight || got.TableBorderProperties.DashStyle != dash {
+					t.Fatalf("unexpected border properties: %+v", got.TableBorderProperties)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runSlidesTableStyleDryRun(t, tt.run)
+			if got.Op != tt.op {
+				t.Fatalf("op = %q, want %q", got.Op, tt.op)
+			}
+			tt.want(t, got.Request.BatchUpdate.Requests)
+		})
+	}
+}
+
+func TestSlidesTableCellStyle_UsesRevisionForAtomicBatch(t *testing.T) {
+	var captured slides.BatchUpdatePresentationRequest
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(slidesTableTestPresentation())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&captured); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"presentationId": "pres1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	ctx := withSlidesTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), newSlidesServiceFromServer(t, srv))
+	cmd := &SlidesTableCellStyleCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Col: 0, FillColor: "#000000", Bold: true}
+	if err := cmd.Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(captured.Requests) != 2 || captured.Requests[0].UpdateTableCellProperties == nil || captured.Requests[1].UpdateTextStyle == nil {
+		t.Fatalf("unexpected atomic batch: %+v", captured.Requests)
+	}
+	if captured.WriteControl == nil || captured.WriteControl.RequiredRevisionId != "rev1" {
+		t.Fatalf("write control = %+v, want rev1", captured.WriteControl)
+	}
+}
+
+func TestSlidesTableStyle_LocalValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(context.Context, *RootFlags) error
+		want string
+	}{
+		{name: "negative row height", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableRowSizeCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Height: -1}).Run(ctx, flags)
+		}, want: "--height must be >= 0"},
+		{name: "column below provider minimum", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableColumnSizeCmd{PresentationID: "pres1", TableObjectID: "table1", Col: 0, Width: 31.99}).Run(ctx, flags)
+		}, want: "--width must be >= 32 points"},
+		{name: "cell style missing options", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableCellStyleCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Col: 0}).Run(ctx, flags)
+		}, want: "provide at least one cell or text style option"},
+		{name: "cell fill conflict", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableCellStyleCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Col: 0, FillColor: "#fff", FillTransparent: true}).Run(ctx, flags)
+		}, want: "mutually exclusive"},
+		{name: "text style conflict", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableCellStyleCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Col: 0, Bold: true, NoBold: true}).Run(ctx, flags)
+		}, want: "--bold and --no-bold are mutually exclusive"},
+		{name: "border missing options", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableBorderStyleCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Col: 0, RowSpan: 1, ColSpan: 1, Position: slidesTableAll}).Run(ctx, flags)
+		}, want: "provide at least one border style option"},
+		{name: "border color conflict", run: func(ctx context.Context, flags *RootFlags) error {
+			return (&SlidesTableBorderStyleCmd{PresentationID: "pres1", TableObjectID: "table1", Row: 0, Col: 0, RowSpan: 1, ColSpan: 1, Position: slidesTableAll, BorderColor: "#fff", Transparent: true}).Run(ctx, flags)
+		}, want: "mutually exclusive"},
+	}
+
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("invalid command must not create a Slides service")
+			return nil, context.Canceled
+		},
+	)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run(ctx, &RootFlags{Account: "a@b.com", Force: true})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
+type slidesTableStyleDryRun struct {
+	Op      string `json:"op"`
+	Request struct {
+		BatchUpdate slides.BatchUpdatePresentationRequest `json:"batch_update"`
+	} `json:"request"`
+}
+
+func runSlidesTableStyleDryRun(t *testing.T, run func(context.Context, *RootFlags) error) slidesTableStyleDryRun {
+	t.Helper()
+	var stdout bytes.Buffer
+	ctx := withSlidesTestServiceFactory(
+		newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard),
+		func(context.Context, string) (*slides.Service, error) {
+			t.Fatal("dry-run must not create a Slides service")
+			return nil, context.Canceled
+		},
+	)
+	err := run(ctx, &RootFlags{Account: "a@b.com", DryRun: true})
+	if err != nil && ExitCode(err) != 0 {
+		t.Fatalf("Run: %v", err)
+	}
+	var got slidesTableStyleDryRun
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode dry-run: %v\n%s", err, stdout.String())
+	}
+	return got
+}

--- a/scripts/live-tests/slides.sh
+++ b/scripts/live-tests/slides.sh
@@ -27,13 +27,72 @@ run_slides_tests() {
   read_json=$(gog slides read-slide "$slides_id" "$slide_id" --json)
   "$PY" -c 'import json,sys; assert len(json.load(sys.stdin).get("images", [])) >= 2' <<<"$read_json"
 
-  local native_json native_slide_id native_read native_after_delete table_read table_after_delete
+  local native_json native_slide_id native_read native_after_delete table_read table_after_delete table_style_read
   native_json=$(gog slides new-slide "$slides_id" --json)
   native_slide_id=$(extract_field "$native_json" slideObjectId)
   [ -n "$native_slide_id" ] || { echo "Failed to parse native slide object id" >&2; exit 1; }
 
   run_required "slides" "slides create table" gog slides table create \
     "$slides_id" "$native_slide_id" --rows 3 --cols 3 --object-id gogTableStruct >/dev/null
+  run_required "slides" "slides size table row" gog slides table row size \
+    "$slides_id" gogTableStruct --row 0 --height 48 >/dev/null
+  run_required "slides" "slides size table column" gog slides table column size \
+    "$slides_id" gogTableStruct --col 0 --width 120 >/dev/null
+  run_required "slides" "slides write styled table cell" gog slides insert-text \
+    "$slides_id" gogTableStruct "Header" --row 0 --col 0 --replace >/dev/null
+  run_required "slides" "slides style table cell" gog slides table cell style \
+    "$slides_id" gogTableStruct --row 0 --col 0 --fill-color '#3367d6' \
+    --content-align MIDDLE --bold --text-color '#ffffff' --size 18 --font Cambria >/dev/null
+  run_required "slides" "slides style table borders" gog slides table border style \
+    "$slides_id" gogTableStruct --row 0 --col 0 --row-span 2 --col-span 2 \
+    --position OUTER --border-color '#ea4335' --weight 2 --dash DASH >/dev/null
+  table_style_read=$(gog slides raw "$slides_id")
+  "$PY" -c '
+import json,sys
+
+def points(dimension):
+    magnitude = dimension["magnitude"]
+    return magnitude / 12700 if dimension["unit"] == "EMU" else magnitude
+
+def rgb(fill):
+    color = fill["solidFill"]["color"]["rgbColor"]
+    return tuple(round(color.get(component, 0) * 255) for component in ("red", "green", "blue"))
+
+presentation = json.load(sys.stdin)
+element = next(
+    element
+    for slide in presentation["slides"]
+    for element in slide.get("pageElements", [])
+    if element.get("objectId") == "gogTableStruct"
+)
+table = element["table"]
+assert abs(points(table["tableColumns"][0]["columnWidth"]) - 120) < 0.01
+assert abs(points(table["tableRows"][0]["tableRowProperties"]["minRowHeight"]) - 48) < 0.01
+cell = table["tableRows"][0]["tableCells"][0]
+properties = cell["tableCellProperties"]
+assert properties["contentAlignment"] == "MIDDLE"
+assert properties["tableCellBackgroundFill"].get("propertyState", "RENDERED") == "RENDERED"
+assert rgb(properties["tableCellBackgroundFill"]) == (51, 103, 214)
+run = next(item["textRun"] for item in cell["text"]["textElements"] if "textRun" in item)
+assert run["content"].rstrip("\n") == "Header"
+assert run["style"]["bold"] is True
+assert run["style"]["fontFamily"] == "Cambria"
+assert abs(points(run["style"]["fontSize"]) - 18) < 0.01
+foreground = run["style"]["foregroundColor"]["opaqueColor"]["rgbColor"]
+assert tuple(round(foreground.get(component, 0) * 255) for component in ("red", "green", "blue")) == (255, 255, 255)
+borders = [
+    border["tableBorderProperties"]
+    for rows in (table["horizontalBorderRows"], table["verticalBorderRows"])
+    for row in rows
+    for border in row.get("tableBorderCells", [])
+]
+assert any(
+    border.get("dashStyle") == "DASH"
+    and abs(points(border["weight"]) - 2) < 0.01
+    and rgb(border["tableBorderFill"]) == (234, 67, 53)
+    for border in borders
+)
+' <<<"$table_style_read"
   run_required "slides" "slides insert table row" gog slides table row insert \
     "$slides_id" gogTableStruct --row 0 --below >/dev/null
   run_required "slides" "slides insert table column" gog slides table column insert \


### PR DESCRIPTION
## Summary

- add revision-locked table row minimum-height and column-width commands
- add atomic table cell fill, vertical alignment, and text styling
- add range-scoped table border styling with generated command docs

Fixes #824.

## Verification

- `make ci`
- focused table request, validation, and revision-lock tests
- Codex autoreview: clean, no accepted/actionable findings
- live Slides create/style/read/delete lifecycle under the project test account
- raw provider readback verified dimensions, fill, alignment, text style, and borders
- cleanup query verified zero temporary Slides decks remained
