### PR TITLE
feat(sheets): verify formula errors structurally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Sheets: add structured formula-error verification to `sheets update --fail-on-formula-error`, using exact updated-range grid data and canonical `--values-json @file` input. (#849) — thanks @alexknowshtml.
 - Docs: add first-class footnote, section-break, horizontal-rule, and section-column commands with shared index, anchor, tab, dry-run, and batch behavior where supported. (#856) — thanks @sebsnyk.
 - Docs: add header/footer lifecycle commands plus segment-aware plain-text insert, update, delete, format, and range lookup across headers, footers, and footnotes. (#857) — thanks @sebsnyk.
 - Docs: add table cell borders, padding, and vertical content alignment to `docs cell-style`. (#855) — thanks @sebsnyk.

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Docs: [Sheets batch updates](docs/sheets-batch-update.md),
 
 ```bash
 gog sheets get <spreadsheetId> 'Sheet1!A1:D20' --json
+gog sheets update <spreadsheetId> 'Sheet1!B13' --values-json @formula.json --fail-on-formula-error --json
 gog sheets batch-update <spreadsheetId> --data-json @updates.json --json
 gog sheets table list <spreadsheetId>
 gog sheets table append <spreadsheetId> Tasks 'Ship README|done'

--- a/docs/commands/gog-sheets-update.md
+++ b/docs/commands/gog-sheets-update.md
@@ -27,6 +27,7 @@ gog sheets (sheet) update (edit,set) <spreadsheetId> <range> [<values> ...] [fla
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--fail-on-formula-error` | `bool` |  | Read back the updated range and fail if any cell has a Sheets formula error |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
@@ -37,7 +38,7 @@ gog sheets (sheet) update (edit,set) <spreadsheetId> <range> [<values> ...] [fla
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--values-json` | `string` |  | Values as JSON 2D array |
+| `--values-json` | `string` |  | Values as a JSON 2D array, @file, or @- for stdin |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/sheets-batch-update.md
+++ b/docs/sheets-batch-update.md
@@ -52,3 +52,24 @@ Related command reference:
 
 - [`gog sheets batch-update`](commands/gog-sheets-batch-update.md)
 - [`gog sheets update`](commands/gog-sheets-update.md)
+
+## Single-range formula verification
+
+For a single updated range, `--values-json` accepts inline JSON, `@file`, or
+`@-` for stdin. File or stdin input avoids shell history expansion and quoting
+problems for formulas containing `!`:
+
+```bash
+printf '%s\n' '[["=Sheet2!C9"]]' >formula.json
+gog sheets update "$spreadsheet_id" 'Sheet1!B13' \
+  --values-json @formula.json \
+  --fail-on-formula-error \
+  --json
+```
+
+With `--fail-on-formula-error`, the command reads the exact updated range back
+as structured grid data. It exits nonzero when Sheets reports an effective
+cell error and returns `formulaErrors` entries with the cell, error type, and
+message. Literal strings stored with `--input RAW`, such as `#REF!`, remain
+valid because verification uses the API's typed error value instead of matching
+displayed text.

--- a/internal/cmd/sheets.go
+++ b/internal/cmd/sheets.go
@@ -10,6 +10,7 @@ import (
 	"google.golang.org/api/sheets/v4"
 
 	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/sheetsa1"
 	"github.com/steipete/gogcli/internal/sheetsvalues"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -174,8 +175,9 @@ type SheetsUpdateCmd struct {
 	Range              string   `arg:"" name:"range" help:"Range (A1 notation or named range name; e.g. Sheet1!A1:B2 or MyNamedRange)"`
 	Values             []string `arg:"" optional:"" name:"values" help:"Values (comma-separated rows, pipe-separated cells)"`
 	ValueInput         string   `name:"input" help:"Value input option: RAW or USER_ENTERED" default:"USER_ENTERED"`
-	ValuesJSON         string   `name:"values-json" help:"Values as JSON 2D array"`
+	ValuesJSON         string   `name:"values-json" help:"Values as a JSON 2D array, @file, or @- for stdin"`
 	CopyValidationFrom string   `name:"copy-validation-from" help:"Copy data validation from an A1 range or named range (e.g. 'Sheet1!A2:D2' or MyNamedRange) to the updated cells"`
+	FailOnFormulaError bool     `name:"fail-on-formula-error" help:"Read back the updated range and fail if any cell has a Sheets formula error"`
 }
 
 func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -191,7 +193,6 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	var values [][]interface{}
-
 	switch {
 	case strings.TrimSpace(c.ValuesJSON) != "":
 		b, err := resolveInlineOrFileBytes(c.ValuesJSON, stdinReader(ctx))
@@ -221,6 +222,7 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"value_input_option":      valueInputOption,
 		"copy_validation_from":    strings.TrimSpace(c.CopyValidationFrom),
 		"copy_validation_to_hint": "updatedRange",
+		"fail_on_formula_error":   c.FailOnFormulaError,
 	}); err != nil {
 		return err
 	}
@@ -251,22 +253,111 @@ func (c *SheetsUpdateCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if strings.TrimSpace(resp.UpdatedRange) == "" {
 			return fmt.Errorf("update response missing updated range for validation copy")
 		}
-		if err := copyDataValidation(ctx, svc, spreadsheetID, c.CopyValidationFrom, resp.UpdatedRange); err != nil {
-			return err
+		if copyErr := copyDataValidation(ctx, svc, spreadsheetID, c.CopyValidationFrom, resp.UpdatedRange); copyErr != nil {
+			return copyErr
 		}
 	}
 
+	formulaErrors := make([]sheetsFormulaError, 0)
+	if c.FailOnFormulaError {
+		if strings.TrimSpace(resp.UpdatedRange) == "" {
+			return fmt.Errorf("update response missing updated range for formula verification")
+		}
+		formulaErrors, err = readSheetsFormulaErrors(ctx, svc, spreadsheetID, resp.UpdatedRange)
+		if err != nil {
+			return fmt.Errorf("verify updated formulas: %w", err)
+		}
+	}
+
+	result := map[string]any{
+		"updatedRange":   resp.UpdatedRange,
+		"updatedRows":    resp.UpdatedRows,
+		"updatedColumns": resp.UpdatedColumns,
+		"updatedCells":   resp.UpdatedCells,
+	}
+	if c.FailOnFormulaError {
+		result["formulaErrors"] = formulaErrors
+	}
+
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
-			"updatedRange":   resp.UpdatedRange,
-			"updatedRows":    resp.UpdatedRows,
-			"updatedColumns": resp.UpdatedColumns,
-			"updatedCells":   resp.UpdatedCells,
-		})
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), result); err != nil {
+			return err
+		}
+		if len(formulaErrors) > 0 {
+			return sheetsFormulaVerificationError(formulaErrors)
+		}
+		return nil
 	}
 
 	u.Out().Linef("Updated %d cells in %s", resp.UpdatedCells, resp.UpdatedRange)
+	if len(formulaErrors) > 0 {
+		return sheetsFormulaVerificationError(formulaErrors)
+	}
 	return nil
+}
+
+type sheetsFormulaError struct {
+	Cell    string `json:"cell"`
+	Type    string `json:"type"`
+	Message string `json:"message,omitempty"`
+}
+
+func readSheetsFormulaErrors(ctx context.Context, svc *sheets.Service, spreadsheetID, updatedRange string) ([]sheetsFormulaError, error) {
+	spreadsheet, err := svc.Spreadsheets.Get(spreadsheetID).
+		Ranges(updatedRange).
+		IncludeGridData(true).
+		Fields("sheets(properties(title),data(startRow,startColumn,rowData(values(effectiveValue(errorValue)))))").
+		Context(ctx).
+		Do()
+	if err != nil {
+		return nil, err
+	}
+
+	formulaErrors := make([]sheetsFormulaError, 0)
+	for _, sheet := range spreadsheet.Sheets {
+		if sheet == nil {
+			continue
+		}
+		title := ""
+		if sheet.Properties != nil {
+			title = sheet.Properties.Title
+		}
+		for _, grid := range sheet.Data {
+			if grid == nil {
+				continue
+			}
+			for rowOffset, row := range grid.RowData {
+				if row == nil {
+					continue
+				}
+				for columnOffset, cell := range row.Values {
+					if cell == nil || cell.EffectiveValue == nil || cell.EffectiveValue.ErrorValue == nil {
+						continue
+					}
+					formulaErrors = append(formulaErrors, sheetsFormulaError{
+						Cell: sheetsa1.FormatCell(
+							title,
+							int(grid.StartRow)+rowOffset+1,
+							int(grid.StartColumn)+columnOffset+1,
+						),
+						Type:    cell.EffectiveValue.ErrorValue.Type,
+						Message: cell.EffectiveValue.ErrorValue.Message,
+					})
+				}
+			}
+		}
+	}
+
+	return formulaErrors, nil
+}
+
+func sheetsFormulaVerificationError(formulaErrors []sheetsFormulaError) error {
+	parts := make([]string, 0, len(formulaErrors))
+	for _, formulaError := range formulaErrors {
+		parts = append(parts, fmt.Sprintf("%s (%s): %s", formulaError.Cell, formulaError.Type, formulaError.Message))
+	}
+
+	return fmt.Errorf("formula verification failed: %s", strings.Join(parts, "; "))
 }
 
 type SheetsBatchUpdateCmd struct {

--- a/internal/cmd/sheets_formula_verification_test.go
+++ b/internal/cmd/sheets_formula_verification_test.go
@@ -1,0 +1,155 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/sheets/v4"
+)
+
+func TestSheetsUpdateFormulaVerificationReportsStructuredErrors(t *testing.T) {
+	t.Parallel()
+
+	valuesPath := filepath.Join(t.TempDir(), "values.json")
+	if err := os.WriteFile(valuesPath, []byte(`[["=1+1","#REF!","=1/0"]]`), 0o600); err != nil {
+		t.Fatalf("write values: %v", err)
+	}
+
+	var updatedValues [][]any
+	var verifyQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPut && strings.Contains(r.URL.Path, "/spreadsheets/s1/values/"):
+			var request sheets.ValueRange
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode update: %v", err)
+			}
+			updatedValues = request.Values
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"updatedRange":   "Sheet1!A1:C1",
+				"updatedRows":    1,
+				"updatedColumns": 3,
+				"updatedCells":   3,
+			})
+		case r.Method == http.MethodGet && strings.Contains(r.URL.Path, "/spreadsheets/s1"):
+			verifyQuery = r.URL.RawQuery
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"spreadsheetId": "s1",
+				"sheets": []any{map[string]any{
+					"properties": map[string]any{"title": "Sheet1"},
+					"data": []any{map[string]any{
+						"startRow":    0,
+						"startColumn": 0,
+						"rowData": []any{map[string]any{"values": []any{
+							map[string]any{"effectiveValue": map[string]any{"numberValue": 2}},
+							map[string]any{"effectiveValue": map[string]any{"stringValue": "#REF!"}},
+							map[string]any{"effectiveValue": map[string]any{"errorValue": map[string]any{
+								"type": "DIVIDE_BY_ZERO", "message": "Function DIVIDE parameter 2 cannot be zero.",
+							}}},
+						}}},
+					}},
+				}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var output bytes.Buffer
+	svc := newSheetsServiceFromServer(t, srv)
+	ctx := withSheetsTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), svc)
+	err := runKong(t, &SheetsUpdateCmd{}, []string{
+		"s1", "Sheet1!A1:C1",
+		"--values-json", "@" + valuesPath,
+		"--fail-on-formula-error",
+	}, ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "Sheet1!C1 (DIVIDE_BY_ZERO)") {
+		t.Fatalf("verification error = %v", err)
+	}
+	if len(updatedValues) != 1 || len(updatedValues[0]) != 3 || updatedValues[0][0] != "=1+1" {
+		t.Fatalf("updated values = %#v", updatedValues)
+	}
+	if !strings.Contains(verifyQuery, "includeGridData=true") || !strings.Contains(verifyQuery, "ranges=Sheet1%21A1%3AC1") {
+		t.Fatalf("verification query = %q", verifyQuery)
+	}
+
+	var result struct {
+		FormulaErrors []sheetsFormulaError `json:"formulaErrors"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatalf("decode output: %v", err)
+	}
+	if len(result.FormulaErrors) != 1 || result.FormulaErrors[0].Cell != "Sheet1!C1" || result.FormulaErrors[0].Type != "DIVIDE_BY_ZERO" {
+		t.Fatalf("formula errors = %#v", result.FormulaErrors)
+	}
+}
+
+func TestSheetsUpdateFormulaVerificationIgnoresLiteralErrorText(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.Method {
+		case http.MethodPut:
+			_ = json.NewEncoder(w).Encode(map[string]any{"updatedRange": "Sheet1!A1", "updatedCells": 1})
+		case http.MethodGet:
+			_ = json.NewEncoder(w).Encode(map[string]any{"sheets": []any{map[string]any{
+				"properties": map[string]any{"title": "Sheet1"},
+				"data": []any{map[string]any{"rowData": []any{map[string]any{"values": []any{
+					map[string]any{"effectiveValue": map[string]any{"stringValue": "#REF!"}},
+				}}}}},
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var output bytes.Buffer
+	ctx := withSheetsTestService(
+		newCmdRuntimeJSONOutputContext(t, &output, io.Discard),
+		newSheetsServiceFromServer(t, srv),
+	)
+	if err := runKong(t, &SheetsUpdateCmd{}, []string{
+		"s1", "Sheet1!A1", "--values-json", `[["#REF!"]]`, "--input", "RAW", "--fail-on-formula-error",
+	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("literal error text: %v", err)
+	}
+	if !strings.Contains(output.String(), `"formulaErrors": []`) {
+		t.Fatalf("output = %s", output.String())
+	}
+}
+
+func TestSheetsUpdateFormulaVerificationReadbackFailureIsFatal(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"updatedRange": "Sheet1!A1", "updatedCells": 1})
+			return
+		}
+		http.Error(w, "readback failed", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	ctx := withSheetsTestService(
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		newSheetsServiceFromServer(t, srv),
+	)
+	err := runKong(t, &SheetsUpdateCmd{}, []string{
+		"s1", "Sheet1!A1", "--values-json", `[["=1+1"]]`, "--fail-on-formula-error",
+	}, ctx, &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "verify updated formulas") {
+		t.Fatalf("readback error = %v", err)
+	}
+}

--- a/scripts/live-tests/sheets.sh
+++ b/scripts/live-tests/sheets.sh
@@ -8,7 +8,7 @@ run_sheets_tests() {
     return 0
   fi
 
-  local sheet_json sheet_id copy_json copy_id export_path
+  local sheet_json sheet_id copy_json copy_id export_path formula_values_path
   sheet_json=$(gog sheets create "gogcli-smoke-sheet-$TS" --json)
   sheet_id=$(extract_id "$sheet_json")
   [ -n "$sheet_id" ] || { echo "Failed to parse sheet id" >&2; exit 1; }
@@ -16,6 +16,30 @@ run_sheets_tests() {
 
   run_required "sheets" "sheets metadata" gog sheets metadata "$sheet_id" --json >/dev/null
   run_required "sheets" "sheets update" gog sheets update "$sheet_id" "Sheet1!A1:B2" --values-json '[["A1","B1"],["A2","B2"]]' --json >/dev/null
+
+  formula_values_path="$LIVE_TMP/sheets-formula-$TS.json"
+  printf '[["=Sheet1!A1"]]\n' >"$formula_values_path"
+  run_required "sheets" "sheets formula file update" gog sheets update "$sheet_id" \
+    "Sheet1!F1" --values-json "@$formula_values_path" --fail-on-formula-error --json >/dev/null
+  run_required "sheets" "sheets literal error text" gog sheets update "$sheet_id" \
+    "Sheet1!F2" --values-json '[["#REF!"]]' --input RAW --fail-on-formula-error --json >/dev/null
+
+  local formula_error_json formula_error_rc
+  if formula_error_json=$(gog sheets update "$sheet_id" "Sheet1!F3" \
+    --values-json '[["=1/0"]]' --fail-on-formula-error --json \
+    2>"$LIVE_TMP/sheets-formula-error-$TS.err"); then
+    echo "Expected formula verification to fail" >&2
+    exit 1
+  else
+    formula_error_rc=$?
+  fi
+  [ "$formula_error_rc" -ne 0 ] || { echo "Unexpected formula verification exit: $formula_error_rc" >&2; exit 1; }
+  "$PY" -c 'import json,sys
+errors=json.load(sys.stdin).get("formulaErrors", [])
+assert len(errors) == 1
+assert errors[0]["cell"] == "Sheet1!F3"
+assert errors[0]["type"] == "DIVIDE_BY_ZERO"' <<<"$formula_error_json"
+
   run_required "sheets" "sheets batch-update" gog sheets batch-update "$sheet_id" --data-json '[{"range":"Sheet1!C1:D1","values":[["C1","D1"]]},{"range":"Sheet1!C2:D2","values":[["C2","D2"]]}]' --json >/dev/null
   run_required "sheets" "sheets get" gog sheets get "$sheet_id" "Sheet1!A1:B2" --json >/dev/null
   run_required "sheets" "sheets append" gog sheets append "$sheet_id" "Sheet1!A3:B3" --values-json '[["A3","B3"]]' --json >/dev/null


### PR DESCRIPTION
## Summary

- use the existing `--values-json @file` / `@-` path for shell-safe formula input
- add `--fail-on-formula-error` to read back the exact updated range as typed grid data
- fail on real Sheets formula errors while preserving RAW literal strings such as `#REF!`
- return structured `formulaErrors` entries with cell, type, and message
- document the workflow and extend disposable live coverage

This replaces the proposed `--safe-formula` input path with the command's canonical file/stdin input and replaces displayed-text matching with `effectiveValue.errorValue` inspection.

## Verification

- `make ci`
- autoreview: clean against `main`
- focused tests for file input, typed errors, RAW literals, and readback failures
- disposable live Google Sheets run covering a valid file formula, RAW literal error text, and a failing divide-by-zero formula
