### PR TITLE
feat(docs insert): add --markdown for positional formatted-markdown insertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.29.1 - Unreleased
 
+### Added
+
+- Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851)
+
 ## 0.29.0 - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851)
+- Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851, #854) — thanks @sebsnyk.
 
 ## 0.29.0 - 2026-06-19
 

--- a/docs/commands/gog-docs-insert.md
+++ b/docs/commands/gog-docs-insert.md
@@ -35,6 +35,7 @@ gog docs (doc) insert <docId> [<content>] [flags]
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `--index` | `*int64` |  | Character index to insert at (1 = beginning). Defaults to end-of-doc when omitted. |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--markdown` | `bool` |  | Convert markdown to Google Docs formatting before inserting |
 | `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -111,6 +111,15 @@ Use `--occurrence N` when an anchor is ambiguous and `--match-case` when case
 must be exact. `docs comments locate` applies the same matching rules to a
 comment's quoted text and reports its tab plus UTF-16 range.
 
+`insert` and `update` both accept `--markdown` to convert the content (headings,
+fenced code blocks, lists, tables, images) before placing it at the resolved
+position. `insert --markdown` adds the block without deleting anything; `update
+--markdown` with `--at`/`--replace-range` replaces the matched range.
+
+```bash
+gog docs insert <docId> --markdown --at "## Section" --file block.md
+```
+
 Command pages:
 
 - [`gog docs find-range`](commands/gog-docs-find-range.md)

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -969,7 +969,7 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	c.Tab = resolvedPlacement.TabID
 
 	if c.Markdown {
-		return c.runMarkdown(ctx, svc, docID, insertIndex, content)
+		return c.runMarkdown(ctx, svc, docID, insertIndex, resolvedPlacement.RequiredRevisionID, content)
 	}
 
 	batchReq := &docs.BatchUpdateDocumentRequest{
@@ -1006,9 +1006,25 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 // insertion helper that backs `docs write --markdown` and the non-replacing
 // branch of `docs update --markdown`, so headings, fenced code blocks, lists,
 // tables and images render identically regardless of which command placed them.
-func (c *DocsInsertCmd) runMarkdown(ctx context.Context, svc *docs.Service, docID string, insertIndex int64, content string) error {
+func (c *DocsInsertCmd) runMarkdown(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	insertIndex int64,
+	requiredRevisionID string,
+	content string,
+) error {
 	markdown := prepareMarkdown(content)
-	insertResult, err := insertPreparedDocsMarkdownAt(ctx, svc, docID, insertIndex, markdown, c.Tab, true)
+	insertResult, err := insertPreparedDocsMarkdownAtWithWriteControl(
+		ctx,
+		svc,
+		docID,
+		insertIndex,
+		markdown,
+		c.Tab,
+		true,
+		docsRequiredRevisionWriteControl(requiredRevisionID),
+	)
 	if err != nil {
 		if isDocsNotFound(err) {
 			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -888,6 +888,7 @@ type DocsInsertCmd struct {
 	Occurrence *int   `name:"occurrence" help:"Use the Nth --at match (1-based; required when --at is ambiguous)"`
 	MatchCase  bool   `name:"match-case" help:"Use case-sensitive --at matching"`
 	File       string `name:"file" short:"f" help:"Read content from file (use - for stdin)"`
+	Markdown   bool   `name:"markdown" help:"Convert markdown to Google Docs formatting before inserting"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
@@ -925,9 +926,13 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return tabErr
 	}
 	c.Tab = tab
+	if c.Markdown && c.Batch != "" {
+		return usage("--markdown cannot be combined with --batch")
+	}
 	dryRunPayload := map[string]any{
 		"documentId": docID,
 		"inserted":   len(content),
+		"markdown":   c.Markdown,
 		"tab":        c.Tab,
 		"batch":      c.Batch,
 	}
@@ -963,6 +968,10 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	insertIndex := resolvedPlacement.Index
 	c.Tab = resolvedPlacement.TabID
 
+	if c.Markdown {
+		return c.runMarkdown(ctx, svc, docID, insertIndex, content)
+	}
+
 	batchReq := &docs.BatchUpdateDocumentRequest{
 		Requests: []*docs.Request{docsedit.BuildInsertRequest(content, insertIndex, c.Tab)},
 	}
@@ -986,6 +995,64 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	u.Out().Linef("documentId\t%s", result.DocumentId)
 	u.Out().Linef("inserted\t%d bytes", len(content))
 	u.Out().Linef("atIndex\t%d", insertIndex)
+	if c.Tab != "" {
+		u.Out().Linef("tabId\t%s", c.Tab)
+	}
+	return nil
+}
+
+// runMarkdown converts the supplied content from markdown to Google Docs
+// formatting and inserts it at insertIndex. It reuses the same converter +
+// insertion helper that backs `docs write --markdown` and the non-replacing
+// branch of `docs update --markdown`, so headings, fenced code blocks, lists,
+// tables and images render identically regardless of which command placed them.
+func (c *DocsInsertCmd) runMarkdown(ctx context.Context, svc *docs.Service, docID string, insertIndex int64, content string) error {
+	markdown := prepareMarkdown(content)
+	insertResult, err := insertPreparedDocsMarkdownAt(ctx, svc, docID, insertIndex, markdown, c.Tab, true)
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return err
+	}
+	requestCount := insertResult.RequestCount
+	if markdownMayContainHeadingLinks(markdown.cleaned) {
+		explicitHeadingAnchors := docsmarkdown.ExplicitHeadingAnchors(markdown.cleaned)
+		rewritten, rewriteErr := rewriteMarkdownHeadingLinksInRange(
+			ctx,
+			svc,
+			docID,
+			c.Tab,
+			explicitHeadingAnchors,
+			insertResult.ContentStart,
+			insertResult.ContentEnd,
+		)
+		if rewriteErr != nil {
+			return fmt.Errorf("rewrite heading links: %w", rewriteErr)
+		}
+		requestCount += rewritten
+	}
+
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": docID,
+			"inserted":   insertResult.Inserted,
+			"requests":   requestCount,
+			"atIndex":    insertIndex,
+			"markdown":   true,
+		}
+		if c.Tab != "" {
+			payload["tabId"] = c.Tab
+		}
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", docID)
+	u.Out().Linef("inserted\t%d", insertResult.Inserted)
+	u.Out().Linef("requests\t%d", requestCount)
+	u.Out().Linef("atIndex\t%d", insertIndex)
+	u.Out().Linef("markdown\ttrue")
 	if c.Tab != "" {
 		u.Out().Linef("tabId\t%s", c.Tab)
 	}

--- a/internal/cmd/docs_insert_markdown_test.go
+++ b/internal/cmd/docs_insert_markdown_test.go
@@ -43,7 +43,8 @@ func TestDocsInsertCmd_MarkdownAtIndex(t *testing.T) {
 	flags := &RootFlags{Account: "a@b.com"}
 	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), docSvc)
 
-	if err := runKong(t, &DocsInsertCmd{}, []string{"doc1", "## Heading", "--markdown", "--index", "7"}, ctx, flags); err != nil {
+	markdown := "## Heading\n\n```\ncode\n```"
+	if err := runKong(t, &DocsInsertCmd{}, []string{"doc1", markdown, "--markdown", "--index", "7"}, ctx, flags); err != nil {
 		t.Fatalf("insert --markdown: %v", err)
 	}
 
@@ -58,6 +59,7 @@ func TestDocsInsertCmd_MarkdownAtIndex(t *testing.T) {
 
 	var insertAtIndex *docs.InsertTextRequest
 	var sawHeadingStyle bool
+	var fencedCodeStyle *docs.UpdateTextStyleRequest
 	for _, req := range batchRequests[0] {
 		if req.InsertText != nil && req.InsertText.Location != nil && req.InsertText.Location.Index == 7 {
 			insertAtIndex = req.InsertText
@@ -66,6 +68,9 @@ func TestDocsInsertCmd_MarkdownAtIndex(t *testing.T) {
 			req.UpdateParagraphStyle.ParagraphStyle != nil &&
 			strings.HasPrefix(req.UpdateParagraphStyle.ParagraphStyle.NamedStyleType, "HEADING") {
 			sawHeadingStyle = true
+		}
+		if req.UpdateTextStyle != nil && strings.Contains(req.UpdateTextStyle.Fields, "weightedFontFamily") {
+			fencedCodeStyle = req.UpdateTextStyle
 		}
 	}
 	if insertAtIndex == nil {
@@ -77,6 +82,26 @@ func TestDocsInsertCmd_MarkdownAtIndex(t *testing.T) {
 	if !sawHeadingStyle {
 		t.Fatalf("expected a HEADING paragraph-style request from the markdown converter, requests: %#v", batchRequests[0])
 	}
+	assertFencedCodeTextStyle(t, fencedCodeStyle)
+}
+
+func TestDocsInsertCmd_MarkdownAtAnchorUsesRevisionControl(t *testing.T) {
+	t.Parallel()
+
+	rec := &docsAtAnchorRecorder{}
+	doc := docsFindRangeDoc(docsFindRangeParagraph(1, "Before anchor after\n"))
+	doc.RevisionId = "rev-markdown-anchor"
+	svc := setupDocsAtAnchorTestService(t, doc, rec)
+
+	flags := &RootFlags{Account: "a@b.com"}
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	if err := runKong(t, &DocsInsertCmd{}, []string{"doc1", "## Heading", "--markdown", "--at", "anchor"}, ctx, flags); err != nil {
+		t.Fatalf("insert --markdown --at: %v", err)
+	}
+	if len(rec.batchRequests) != 1 {
+		t.Fatalf("batch calls = %d, want 1", len(rec.batchRequests))
+	}
+	assertDocsAtAnchorWriteControl(t, rec, 0, "rev-markdown-anchor")
 }
 
 // TestDocsInsertCmd_MarkdownRejectsBatch verifies the --markdown/--batch combo

--- a/internal/cmd/docs_insert_markdown_test.go
+++ b/internal/cmd/docs_insert_markdown_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+// TestDocsInsertCmd_MarkdownAtIndex verifies that `docs insert --markdown
+// --index N` converts the markdown and places the converted block at the
+// resolved index: a body InsertText at N plus the converter's heading
+// paragraph-style request, rather than a single plain InsertText.
+func TestDocsInsertCmd_MarkdownAtIndex(t *testing.T) {
+	t.Parallel()
+
+	var batchRequests [][]*docs.Request
+	var getCalls int
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			getCalls++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(docBodyWithEndIndex(42))
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			batchRequests = append(batchRequests, req.Requests)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	flags := &RootFlags{Account: "a@b.com"}
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), docSvc)
+
+	if err := runKong(t, &DocsInsertCmd{}, []string{"doc1", "## Heading", "--markdown", "--index", "7"}, ctx, flags); err != nil {
+		t.Fatalf("insert --markdown: %v", err)
+	}
+
+	// Explicit --index means no GET is needed to resolve placement, and the
+	// markdown has no heading links so no rewrite GET is issued either.
+	if getCalls != 0 {
+		t.Fatalf("explicit --index with no heading links should not GET the doc, got %d", getCalls)
+	}
+	if len(batchRequests) != 1 {
+		t.Fatalf("expected one batchUpdate, got %d", len(batchRequests))
+	}
+
+	var insertAtIndex *docs.InsertTextRequest
+	var sawHeadingStyle bool
+	for _, req := range batchRequests[0] {
+		if req.InsertText != nil && req.InsertText.Location != nil && req.InsertText.Location.Index == 7 {
+			insertAtIndex = req.InsertText
+		}
+		if req.UpdateParagraphStyle != nil &&
+			req.UpdateParagraphStyle.ParagraphStyle != nil &&
+			strings.HasPrefix(req.UpdateParagraphStyle.ParagraphStyle.NamedStyleType, "HEADING") {
+			sawHeadingStyle = true
+		}
+	}
+	if insertAtIndex == nil {
+		t.Fatalf("expected an InsertText at index 7, requests: %#v", batchRequests[0])
+	}
+	if !strings.Contains(insertAtIndex.Text, "Heading") {
+		t.Fatalf("expected inserted text to contain the heading text, got %q", insertAtIndex.Text)
+	}
+	if !sawHeadingStyle {
+		t.Fatalf("expected a HEADING paragraph-style request from the markdown converter, requests: %#v", batchRequests[0])
+	}
+}
+
+// TestDocsInsertCmd_MarkdownRejectsBatch verifies the --markdown/--batch combo
+// is rejected up front (the markdown path issues its own batchUpdate calls and
+// cannot be queued into a persisted batch).
+func TestDocsInsertCmd_MarkdownRejectsBatch(t *testing.T) {
+	t.Parallel()
+
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer cleanup()
+
+	flags := &RootFlags{Account: "a@b.com"}
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), docSvc)
+
+	err := runKong(t, &DocsInsertCmd{}, []string{"doc1", "## H", "--markdown", "--batch", "b1"}, ctx, flags)
+	if err == nil || !strings.Contains(err.Error(), "--markdown cannot be combined with --batch") {
+		t.Fatalf("expected --markdown/--batch rejection, got %v", err)
+	}
+}

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -285,6 +285,19 @@ func insertPreparedDocsMarkdownAt(
 	tabID string,
 	stripHeadingAnchors bool,
 ) (docsMarkdownInsertResult, error) {
+	return insertPreparedDocsMarkdownAtWithWriteControl(ctx, svc, docID, insertIdx, markdown, tabID, stripHeadingAnchors, nil)
+}
+
+func insertPreparedDocsMarkdownAtWithWriteControl(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	insertIdx int64,
+	markdown preparedMarkdown,
+	tabID string,
+	stripHeadingAnchors bool,
+	writeControl *docs.WriteControl,
+) (docsMarkdownInsertResult, error) {
 	elements := docsmarkdown.ParseMarkdown(markdown.cleaned)
 	if stripHeadingAnchors {
 		docsmarkdown.StripElementHeadingAnchors(elements)
@@ -321,7 +334,7 @@ func insertPreparedDocsMarkdownAt(
 	})
 	requests = append(requests, formattingRequests...)
 
-	requestCount, err := submitBatchedDocsRequests(ctx, svc, docID, requests, nil)
+	requestCount, err := submitBatchedDocsRequests(ctx, svc, docID, requests, writeControl)
 	if err != nil {
 		return docsMarkdownInsertResult{}, fmt.Errorf("append (markdown): %w", err)
 	}


### PR DESCRIPTION
## What

Adds `--markdown` to `gog docs insert`, so a formatted markdown block (heading, fenced code block, list, table, image, inline styles) can be inserted at a position resolved by `--index` / `--at` / `--occurrence`, without deleting anything at the anchor.

Closes #851.

## Why

`docs insert` already places content at an arbitrary position, but only as plain text — a heading or fenced code block inserted this way landed as literal, unformatted characters. The converted-markdown path already exists in the codebase and is already exposed on `docs update --markdown` (its non-replacing branch). So `insert` was the only positional command missing a capability the tool already has, which is a discoverability cliff: users reach for `docs insert --markdown` first, hit an unknown-flag error, and then have to learn that the converted path lives on `update` instead.

## How

- New `--markdown` bool on `DocsInsertCmd`.
- When set, after the placement index is resolved, route through the existing `insertPreparedDocsMarkdownAt` helper and run the existing heading-link rewrite over the inserted range — mirroring the non-replacing branch of `docs update --markdown`. The shared converter (`docsmarkdown.MarkdownToDocsRequests`) is already parameterized on an arbitrary base index, so code-fence styling (Roboto Mono + grey shading) and everything else render identically to `write --markdown`.
- `--markdown` is rejected together with `--batch`, since the markdown path issues its own `documents.batchUpdate` calls and cannot be queued into a persisted batch.
- Plain (non-`--markdown`) behavior is unchanged.

The split between the two commands stays clean: `insert` = place at a position, never delete; `update --markdown --at` / `--replace-range` = delete-and-replace.

## Tests

- `TestDocsInsertCmd_MarkdownAtIndex` — asserts a converted heading inserts at the resolved index with the converter's HEADING paragraph-style request (and that an explicit `--index` with no heading links issues no extra GET).
- `TestDocsInsertCmd_MarkdownRejectsBatch` — asserts the `--markdown` + `--batch` guard.
- Existing plain-insert tests unchanged and passing.

`go build ./...`, `go vet ./internal/cmd/`, and `go test ./internal/cmd/` all pass. CHANGELOG and the generated `docs insert` command page + editing guide are updated.
