### PR TITLE
feat(docs): add layout-preserving image replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Docs: add `replace-image` with exact object-ID, alt-text, single-image, tab, public-URL, and local-file targeting while preserving the original image position and bounds. (#853) — thanks @sebsnyk.
 - Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851, #854) — thanks @sebsnyk.
 
 ## 0.29.0 - 2026-06-19

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -270,6 +270,7 @@ Generated from `gog schema --json`.
       - [`gog docs (doc) paragraphs list (ls) <docId> [flags]`](commands/gog-docs-paragraphs-list.md) - List paragraphs
     - [`gog docs (doc) raw <docId> [flags]`](commands/gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [`gog docs (doc) rename-tab <docId> [flags]`](commands/gog-docs-rename-tab.md) - Rename a tab in a Google Doc
+    - [`gog docs (doc) replace-image <docId> [flags]`](commands/gog-docs-replace-image.md) - Replace an existing image without changing its position or bounds
     - [`gog docs (doc) sed <docId> [<expression>] [flags]`](commands/gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [`gog docs (doc) structure (struct) <docId> [flags]`](commands/gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [`gog docs (doc) table-column <command>`](commands/gog-docs-table-column.md) - Insert or delete native table columns

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 679.
+Generated pages: 680.
 
 ## Top-level Commands
 
@@ -321,6 +321,7 @@ Generated pages: 679.
       - [gog docs paragraphs list](gog-docs-paragraphs-list.md) - List paragraphs
     - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
+    - [gog docs replace-image](gog-docs-replace-image.md) - Replace an existing image without changing its position or bounds
     - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns

--- a/docs/commands/gog-docs-replace-image.md
+++ b/docs/commands/gog-docs-replace-image.md
@@ -1,0 +1,52 @@
+# `gog docs replace-image`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Replace an existing image without changing its position or bounds
+
+## Usage
+
+```bash
+gog docs (doc) replace-image <docId> [flags]
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--file` | `string` |  | Local PNG, JPEG, or GIF image to upload and use |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--match-alt` | `string` |  | Select the image whose alt text contains this value (case-insensitive) |
+| `--name` | `string` |  | Override the uploaded Drive filename |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--object-id` | `string` |  | Exact image object ID from docs images list |
+| `--parent` | `string` |  | Drive folder ID for an uploaded local image |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--url` | `string` |  | Public HTTPS image URL to use directly |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -47,6 +47,7 @@ gog docs (doc) <command> [flags]
 - [gog docs paragraphs](gog-docs-paragraphs.md) - List document paragraphs
 - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
 - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
+- [gog docs replace-image](gog-docs-replace-image.md) - Replace an existing image without changing its position or bounds
 - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
 - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
 - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -191,9 +191,21 @@ Both modes accept `--tab`, `--width`, and `--height`. Omit anchor flags or use
 `--at end` to append. `--at <text>` deletes and replaces the first literal text
 match; use `--before <text>` or `--after <text>` to preserve the anchor text.
 
-Command page:
+Replace an existing image without changing its position or rendered bounds:
+
+```bash
+gog docs replace-image <docId> --object-id <imageObjectId> --url https://example.com/chart.png
+gog docs replace-image <docId> --match-alt "Quarterly chart" --file chart.png
+```
+
+Get image object IDs and alt text from `docs images list`. When the selected tab
+contains exactly one image, omit both selector flags. Local replacement files
+use the same temporary Drive sharing and permission cleanup as `insert-image`.
+
+Command pages:
 
 - [`gog docs insert-image`](commands/gog-docs-insert-image.md)
+- [`gog docs replace-image`](commands/gog-docs-replace-image.md)
 
 ## Page Breaks
 

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -38,6 +38,7 @@ type DocsCmd struct {
 	TableUnmerge     DocsTableUnmergeCmd     `cmd:"" name:"table-unmerge" aliases:"table-split" help:"Unmerge the region containing a native table cell"`
 	TableColumnWidth DocsTableColumnWidthCmd `cmd:"" name:"table-column-width" aliases:"table-width,column-width" help:"Set or reset native table column widths"`
 	InsertImage      DocsInsertImageCmd      `cmd:"" name:"insert-image" help:"Insert a public image URL or upload a local image into a Google Doc"`
+	ReplaceImage     DocsReplaceImageCmd     `cmd:"" name:"replace-image" help:"Replace an existing image without changing its position or bounds"`
 	InsertPerson     DocsInsertPersonCmd     `cmd:"" name:"insert-person" help:"Insert a native person smart chip"`
 	InsertFileChip   DocsInsertFileChipCmd   `cmd:"" name:"insert-file-chip" aliases:"insert-rich-link" help:"Insert a native Drive file smart chip"`
 	InsertDateChip   DocsInsertDateChipCmd   `cmd:"" name:"insert-date-chip" help:"Insert a native date smart chip"`

--- a/internal/cmd/docs_enumerators.go
+++ b/internal/cmd/docs_enumerators.go
@@ -271,6 +271,19 @@ func loadDocsEnumeratorDocument(
 	if err != nil {
 		return nil, "", err
 	}
+	return loadDocsEnumeratorDocumentWithService(ctx, svc, id, tabQuery)
+}
+
+func loadDocsEnumeratorDocumentWithService(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	tabQuery string,
+) (*docs.Document, string, error) {
+	id := normalizeGoogleID(strings.TrimSpace(docID))
+	if id == "" {
+		return nil, "", usage("empty docId")
+	}
 	tabQuery = strings.TrimSpace(tabQuery)
 	call := svc.Documents.Get(id).Context(ctx)
 	if tabQuery != "" {

--- a/internal/cmd/docs_insert_image.go
+++ b/internal/cmd/docs_insert_image.go
@@ -254,11 +254,7 @@ func (c *DocsInsertImageCmd) runFile(ctx context.Context, docsSvc *docs.Service,
 	result.uploadedFileID = uploaded.Id
 	result.uploadedFileName = uploaded.Name
 
-	perm, err := driveSvc.Permissions.Create(uploaded.Id, &drive.Permission{Type: "anyone", Role: drivePermRoleReader}).
-		SupportsAllDrives(true).
-		Fields("id,type,role").
-		Context(ctx).
-		Do()
+	perm, err := shareDocsImagePublicly(ctx, driveSvc, uploaded.Id)
 	if err != nil {
 		if strings.EqualFold(c.OnRestricted, "link") && isDrivePublicSharingRestricted(err) {
 			return c.insertRestrictedImageFallback(ctx, docsSvc, docID, uploaded, target, result)
@@ -271,18 +267,7 @@ func (c *DocsInsertImageCmd) runFile(ctx context.Context, docsSvc *docs.Service,
 		if perm.Id == "" {
 			return
 		}
-		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
-		defer cancel()
-		revokeErr := driveSvc.Permissions.Delete(uploaded.Id, perm.Id).SupportsAllDrives(true).Context(cleanupCtx).Do()
-		if revokeErr == nil {
-			result.revoked = true
-			return
-		}
-		if err != nil {
-			err = fmt.Errorf("%w; additionally failed to revoke temporary public permission %s on %s: %w", err, perm.Id, uploaded.Id, revokeErr)
-			return
-		}
-		err = fmt.Errorf("revoke temporary public permission %s on %s: %w", perm.Id, uploaded.Id, revokeErr)
+		result.revoked, err = finishDocsImagePublicShare(ctx, driveSvc, uploaded.Id, perm.Id, err)
 	}()
 
 	imageURL := driveImageDownloadURL(uploaded.Id)
@@ -346,6 +331,36 @@ func uploadDocsInlineImage(ctx context.Context, svc *drive.Service, localPath, n
 		return nil, fmt.Errorf("upload image: %w", err)
 	}
 	return created, nil
+}
+
+func shareDocsImagePublicly(ctx context.Context, svc *drive.Service, fileID string) (*drive.Permission, error) {
+	return svc.Permissions.Create(fileID, &drive.Permission{Type: "anyone", Role: drivePermRoleReader}).
+		SupportsAllDrives(true).
+		Fields("id,type,role").
+		Context(ctx).
+		Do()
+}
+
+func finishDocsImagePublicShare(
+	ctx context.Context,
+	svc *drive.Service,
+	fileID string,
+	permissionID string,
+	operationErr error,
+) (bool, error) {
+	if permissionID == "" {
+		return false, operationErr
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 30*time.Second)
+	defer cancel()
+	revokeErr := svc.Permissions.Delete(fileID, permissionID).SupportsAllDrives(true).Context(cleanupCtx).Do()
+	if revokeErr == nil {
+		return true, operationErr
+	}
+	if operationErr != nil {
+		return false, fmt.Errorf("%w; additionally failed to revoke temporary public permission %s on %s: %w", operationErr, permissionID, fileID, revokeErr)
+	}
+	return false, fmt.Errorf("revoke temporary public permission %s on %s: %w", permissionID, fileID, revokeErr)
 }
 
 func (c *DocsInsertImageCmd) buildInsertRequests(ctx context.Context, svc *docs.Service, docID string, target docsImageTarget, imageURL string) ([]*docs.Request, int64, string, error) {

--- a/internal/cmd/docs_replace_image.go
+++ b/internal/cmd/docs_replace_image.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+const docsImageReplaceMethodCenterCrop = "CENTER_CROP"
+
+type DocsReplaceImageCmd struct {
+	DocID    string `arg:"" name:"docId" help:"Doc ID"`
+	File     string `name:"file" help:"Local PNG, JPEG, or GIF image to upload and use" type:"existingfile"`
+	URL      string `name:"url" help:"Public HTTPS image URL to use directly"`
+	ObjectID string `name:"object-id" help:"Exact image object ID from docs images list"`
+	MatchAlt string `name:"match-alt" help:"Select the image whose alt text contains this value (case-insensitive)"`
+	Parent   string `name:"parent" help:"Drive folder ID for an uploaded local image"`
+	Name     string `name:"name" help:"Override the uploaded Drive filename"`
+	Tab      string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type docsReplaceImageTarget struct {
+	image      docsImageListItem
+	tabID      string
+	revisionID string
+}
+
+type docsReplaceImageResult struct {
+	documentID       string
+	image            docsImageListItem
+	tabID            string
+	sourceURL        string
+	uploadedFileID   string
+	uploadedFileName string
+	permissionID     string
+	revoked          bool
+}
+
+func (c *DocsReplaceImageCmd) Run(ctx context.Context, flags *RootFlags) error {
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if strings.TrimSpace(c.ObjectID) != "" && strings.TrimSpace(c.MatchAlt) != "" {
+		return usage("--object-id and --match-alt are mutually exclusive")
+	}
+	source, err := (&DocsInsertImageCmd{
+		File:   c.File,
+		URL:    c.URL,
+		Parent: c.Parent,
+		Name:   c.Name,
+	}).resolveSource()
+	if err != nil {
+		return err
+	}
+
+	dryRunPayload := map[string]any{
+		"documentId": docID,
+		"objectId":   strings.TrimSpace(c.ObjectID),
+		"matchAlt":   strings.TrimSpace(c.MatchAlt),
+		"tab":        strings.TrimSpace(c.Tab),
+		"method":     docsImageReplaceMethodCenterCrop,
+	}
+	if source.imageURL != "" {
+		dryRunPayload["url"] = source.imageURL
+	} else {
+		dryRunPayload["file"] = source.localPath
+		dryRunPayload["name"] = source.name
+		dryRunPayload["mimeType"] = source.mimeType
+		dryRunPayload["parent"] = strings.TrimSpace(c.Parent)
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.replace-image", dryRunPayload); dryRunErr != nil {
+		return dryRunErr
+	}
+	if source.imageURL == "" {
+		if confirmErr := confirmDestructiveChecked(ctx, flagsWithoutDryRun(flags), fmt.Sprintf("temporarily share uploaded image %s with anyone (public) so Google Docs can fetch it", source.name)); confirmErr != nil {
+			return confirmErr
+		}
+	}
+
+	account, err := requireAccount(flags)
+	if err != nil {
+		return err
+	}
+	docsSvc, err := docsService(ctx, account)
+	if err != nil {
+		return err
+	}
+	target, err := c.resolveTarget(ctx, docsSvc, docID)
+	if err != nil {
+		return err
+	}
+
+	var result docsReplaceImageResult
+	if source.imageURL != "" {
+		result, err = c.replaceImageURL(ctx, docsSvc, docID, target, source.imageURL)
+	} else {
+		driveSvc, driveErr := driveService(ctx, account)
+		if driveErr != nil {
+			return driveErr
+		}
+		result, err = c.replaceImageFile(ctx, docsSvc, driveSvc, docID, target, source)
+	}
+	if err != nil {
+		return err
+	}
+	return writeDocsReplaceImageResult(ctx, result)
+}
+
+func (c *DocsReplaceImageCmd) resolveTarget(ctx context.Context, svc *docs.Service, docID string) (docsReplaceImageTarget, error) {
+	doc, tabID, err := loadDocsEnumeratorDocumentWithService(ctx, svc, docID, c.Tab)
+	if err != nil {
+		return docsReplaceImageTarget{}, err
+	}
+	image, err := selectDocsReplaceImage(enumerateDocsImages(doc), c.ObjectID, c.MatchAlt)
+	if err != nil {
+		return docsReplaceImageTarget{}, err
+	}
+	return docsReplaceImageTarget{image: image, tabID: tabID, revisionID: doc.RevisionId}, nil
+}
+
+func selectDocsReplaceImage(items []docsImageListItem, objectID, matchAlt string) (docsImageListItem, error) {
+	objectID = strings.TrimSpace(objectID)
+	matchAlt = strings.TrimSpace(matchAlt)
+	if objectID != "" {
+		for _, item := range items {
+			if item.ObjectID == objectID {
+				return item, nil
+			}
+		}
+		return docsImageListItem{}, &ExitError{Code: emptyResultsExitCode, Err: fmt.Errorf("image object not found: %s", objectID)}
+	}
+
+	matches := items
+	if matchAlt != "" {
+		matches = nil
+		needle := strings.ToLower(matchAlt)
+		for _, item := range items {
+			if strings.Contains(strings.ToLower(item.Alt), needle) {
+				matches = append(matches, item)
+			}
+		}
+	}
+	if len(matches) == 0 {
+		if matchAlt != "" {
+			return docsImageListItem{}, &ExitError{Code: emptyResultsExitCode, Err: fmt.Errorf("no image alt text contains %q", matchAlt)}
+		}
+		return docsImageListItem{}, &ExitError{Code: emptyResultsExitCode, Err: fmt.Errorf("no images found in document")}
+	}
+	if len(matches) > 1 {
+		ids := make([]string, 0, len(matches))
+		for _, item := range matches {
+			ids = append(ids, item.ObjectID)
+		}
+		if matchAlt != "" {
+			return docsImageListItem{}, usagef("ambiguous --match-alt %q matched %d images (%s); use --object-id", matchAlt, len(matches), strings.Join(ids, ", "))
+		}
+		return docsImageListItem{}, usagef("document contains %d images (%s); use --object-id or --match-alt", len(matches), strings.Join(ids, ", "))
+	}
+	return matches[0], nil
+}
+
+func (c *DocsReplaceImageCmd) replaceImageFile(
+	ctx context.Context,
+	docsSvc *docs.Service,
+	driveSvc *drive.Service,
+	docID string,
+	target docsReplaceImageTarget,
+	source docsInsertImageSource,
+) (result docsReplaceImageResult, err error) {
+	uploaded, err := uploadDocsInlineImage(ctx, driveSvc, source.localPath, source.name, source.mimeType, strings.TrimSpace(c.Parent))
+	if err != nil {
+		return result, err
+	}
+	result.uploadedFileID = uploaded.Id
+	result.uploadedFileName = uploaded.Name
+
+	permission, err := shareDocsImagePublicly(ctx, driveSvc, uploaded.Id)
+	if err != nil {
+		return result, fmt.Errorf("share uploaded image publicly: %w", err)
+	}
+	result.permissionID = permission.Id
+	defer func() {
+		result.revoked, err = finishDocsImagePublicShare(ctx, driveSvc, uploaded.Id, permission.Id, err)
+	}()
+
+	result, err = c.replaceImageURL(ctx, docsSvc, docID, target, driveImageDownloadURL(uploaded.Id))
+	result.uploadedFileID = uploaded.Id
+	result.uploadedFileName = uploaded.Name
+	result.permissionID = permission.Id
+	return result, err
+}
+
+func (c *DocsReplaceImageCmd) replaceImageURL(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	target docsReplaceImageTarget,
+	imageURL string,
+) (docsReplaceImageResult, error) {
+	request := &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{ReplaceImage: &docs.ReplaceImageRequest{
+			ImageObjectId:      target.image.ObjectID,
+			Uri:                imageURL,
+			ImageReplaceMethod: docsImageReplaceMethodCenterCrop,
+			TabId:              target.tabID,
+		}}},
+		WriteControl: docsRequiredRevisionWriteControl(target.revisionID),
+	}
+	if _, err := svc.Documents.BatchUpdate(docID, request).Context(ctx).Do(); err != nil {
+		if isDocsNotFound(err) {
+			return docsReplaceImageResult{}, fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
+		}
+		return docsReplaceImageResult{}, fmt.Errorf("replace image: %w", err)
+	}
+	return docsReplaceImageResult{
+		documentID: docID,
+		image:      target.image,
+		tabID:      target.tabID,
+		sourceURL:  imageURL,
+	}, nil
+}
+
+func writeDocsReplaceImageResult(ctx context.Context, result docsReplaceImageResult) error {
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": result.documentID,
+			"objectId":   result.image.ObjectID,
+			"positioned": result.image.Positioned,
+			"width":      result.image.Width,
+			"height":     result.image.Height,
+			"sizeUnit":   result.image.SizeUnit,
+			"method":     docsImageReplaceMethodCenterCrop,
+			"replaced":   true,
+		}
+		if result.tabID != "" {
+			payload["tabId"] = result.tabID
+		}
+		if result.uploadedFileID != "" {
+			payload["uploadedFileId"] = result.uploadedFileID
+			payload["uploadedFileName"] = result.uploadedFileName
+			payload["permissionId"] = result.permissionID
+			payload["revoked"] = result.revoked
+		} else {
+			payload["url"] = result.sourceURL
+		}
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", result.documentID)
+	u.Out().Linef("objectId\t%s", result.image.ObjectID)
+	u.Out().Linef("positioned\t%t", result.image.Positioned)
+	u.Out().Linef("width\t%s", formatOptionalFloat(result.image.Width))
+	u.Out().Linef("height\t%s", formatOptionalFloat(result.image.Height))
+	u.Out().Linef("sizeUnit\t%s", result.image.SizeUnit)
+	u.Out().Linef("method\t%s", docsImageReplaceMethodCenterCrop)
+	u.Out().Linef("replaced\ttrue")
+	if result.tabID != "" {
+		u.Out().Linef("tabId\t%s", result.tabID)
+	}
+	if result.uploadedFileID != "" {
+		u.Out().Linef("uploadedFileId\t%s", result.uploadedFileID)
+		u.Out().Linef("revoked\t%t", result.revoked)
+	}
+	return nil
+}

--- a/internal/cmd/docs_replace_image_test.go
+++ b/internal/cmd/docs_replace_image_test.go
@@ -1,0 +1,292 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+	"google.golang.org/api/drive/v3"
+)
+
+func TestSelectDocsReplaceImage(t *testing.T) {
+	t.Parallel()
+
+	items := []docsImageListItem{
+		{ObjectID: "img-a", Alt: "Quarterly chart"},
+		{ObjectID: "img-b", Alt: "Quarterly chart detail", Positioned: true},
+	}
+	tests := []struct {
+		name      string
+		objectID  string
+		matchAlt  string
+		wantID    string
+		wantError string
+		wantExit  int
+	}{
+		{name: "object id", objectID: "img-b", wantID: "img-b"},
+		{name: "case insensitive alt", matchAlt: "DETAIL", wantID: "img-b"},
+		{name: "ambiguous alt", matchAlt: "quarterly", wantError: "ambiguous --match-alt", wantExit: 2},
+		{name: "ambiguous default", wantError: "document contains 2 images", wantExit: 2},
+		{name: "missing object", objectID: "missing", wantError: "image object not found", wantExit: emptyResultsExitCode},
+		{name: "missing alt", matchAlt: "missing", wantError: "no image alt text contains", wantExit: emptyResultsExitCode},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := selectDocsReplaceImage(items, tt.objectID, tt.matchAlt)
+			if tt.wantError != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantError) || ExitCode(err) != tt.wantExit {
+					t.Fatalf("error = %v, exit = %d; want %q, exit %d", err, ExitCode(err), tt.wantError, tt.wantExit)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("select: %v", err)
+			}
+			if got.ObjectID != tt.wantID {
+				t.Fatalf("object ID = %q, want %q", got.ObjectID, tt.wantID)
+			}
+		})
+	}
+
+	if _, err := selectDocsReplaceImage(nil, "", ""); err == nil || ExitCode(err) != emptyResultsExitCode {
+		t.Fatalf("empty images error = %v, exit = %d", err, ExitCode(err))
+	}
+}
+
+func TestDocsReplaceImageURLRun(t *testing.T) {
+	t.Parallel()
+
+	doc := docsReplaceImageTestDocument()
+	var got docs.BatchUpdateDocumentRequest
+	docsSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	driveFactory := func(context.Context, string) (*drive.Service, error) {
+		t.Fatal("URL replacement must not create a Drive service")
+		return nil, errors.New("unexpected Drive service call")
+	}
+	var stdout, stderr bytes.Buffer
+	ctx := withDriveTestServiceFactory(newCmdRuntimeJSONOutputContext(t, &stdout, &stderr), driveFactory)
+	ctx = withDocsTestService(ctx, docsSvc)
+	err := runKong(t, &DocsReplaceImageCmd{}, []string{
+		"doc1",
+		"--url", "https://example.com/replacement.png?sig=abc",
+		"--object-id", "img-positioned",
+	}, ctx, &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("replace-image: %v", err)
+	}
+	if len(got.Requests) != 1 || got.Requests[0].ReplaceImage == nil {
+		t.Fatalf("requests = %#v", got.Requests)
+	}
+	replace := got.Requests[0].ReplaceImage
+	if replace.ImageObjectId != "img-positioned" || replace.Uri != "https://example.com/replacement.png?sig=abc" ||
+		replace.ImageReplaceMethod != docsImageReplaceMethodCenterCrop {
+		t.Fatalf("replace request = %#v", replace)
+	}
+	if got.WriteControl == nil || got.WriteControl.RequiredRevisionId != "rev-images" {
+		t.Fatalf("write control = %#v", got.WriteControl)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if payload["objectId"] != "img-positioned" || payload["positioned"] != true || payload["replaced"] != true {
+		t.Fatalf("output = %#v", payload)
+	}
+	if payload["width"] != 320.0 || payload["height"] != 180.0 || payload["url"] != "https://example.com/replacement.png?sig=abc" {
+		t.Fatalf("output metadata = %#v", payload)
+	}
+}
+
+func TestDocsReplaceImageFileUploadAndCleanup(t *testing.T) {
+	t.Parallel()
+
+	imagePath := filepath.Join(t.TempDir(), "replacement.png")
+	if err := os.WriteFile(imagePath, []byte("test-png"), 0o600); err != nil {
+		t.Fatalf("write image: %v", err)
+	}
+
+	var got docs.BatchUpdateDocumentRequest
+	docsSvc, docsCleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			_ = json.NewEncoder(w).Encode(docsReplaceImageSingleInlineDocument())
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer docsCleanup()
+
+	var uploads, shares, revokes int
+	driveSvc, driveCleanup := newDriveTestService(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/upload/drive/v3/files"):
+			uploads++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "uploaded-1", "name": "replacement.png"})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/files/uploaded-1/permissions"):
+			shares++
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "permission-1", "type": "anyone", "role": "reader"})
+		case r.Method == http.MethodDelete && strings.HasSuffix(r.URL.Path, "/files/uploaded-1/permissions/permission-1"):
+			revokes++
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer driveCleanup()
+
+	var stdout, stderr bytes.Buffer
+	ctx := withDriveTestService(newCmdRuntimeJSONOutputContext(t, &stdout, &stderr), driveSvc)
+	ctx = withDocsTestService(ctx, docsSvc)
+	err := runKong(t, &DocsReplaceImageCmd{}, []string{"doc1", "--file", imagePath}, ctx, &RootFlags{
+		Account: "a@b.com",
+		Force:   true,
+		NoInput: true,
+	})
+	if err != nil {
+		t.Fatalf("replace-image --file: %v", err)
+	}
+	if uploads != 1 || shares != 1 || revokes != 1 {
+		t.Fatalf("drive calls: uploads=%d shares=%d revokes=%d", uploads, shares, revokes)
+	}
+	if len(got.Requests) != 1 || got.Requests[0].ReplaceImage == nil ||
+		!strings.Contains(got.Requests[0].ReplaceImage.Uri, "uploaded-1") {
+		t.Fatalf("replace request = %#v", got.Requests)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if payload["uploadedFileId"] != "uploaded-1" || payload["permissionId"] != "permission-1" || payload["revoked"] != true {
+		t.Fatalf("output = %#v", payload)
+	}
+}
+
+func TestDocsReplaceImageDryRunSkipsServices(t *testing.T) {
+	t.Parallel()
+
+	docsFactory := func(context.Context, string) (*docs.Service, error) {
+		t.Fatal("dry-run must not create a Docs service")
+		return nil, errors.New("unexpected Docs service call")
+	}
+	driveFactory := func(context.Context, string) (*drive.Service, error) {
+		t.Fatal("dry-run must not create a Drive service")
+		return nil, errors.New("unexpected Drive service call")
+	}
+	var stdout, stderr bytes.Buffer
+	ctx := withDriveTestServiceFactory(newCmdRuntimeJSONOutputContext(t, &stdout, &stderr), driveFactory)
+	ctx = withDocsTestServiceFactory(ctx, docsFactory)
+	err := runKong(t, &DocsReplaceImageCmd{}, []string{
+		"doc1",
+		"--url", "https://example.com/replacement.png",
+		"--match-alt", "chart",
+	}, ctx, &RootFlags{Account: "a@b.com", DryRun: true, NoInput: true})
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 0 {
+		t.Fatalf("dry-run error = %v", err)
+	}
+	var payload struct {
+		Op      string `json:"op"`
+		Request struct {
+			MatchAlt string `json:"matchAlt"`
+			Method   string `json:"method"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, stdout.String())
+	}
+	if payload.Op != "docs.replace-image" || payload.Request.MatchAlt != "chart" || payload.Request.Method != docsImageReplaceMethodCenterCrop {
+		t.Fatalf("output = %#v", payload)
+	}
+}
+
+func TestDocsReplaceImageSelectorConflict(t *testing.T) {
+	t.Parallel()
+
+	err := runKong(t, &DocsReplaceImageCmd{}, []string{
+		"doc1", "--url", "https://example.com/replacement.png", "--object-id", "img-1", "--match-alt", "chart",
+	}, newCmdRuntimeOutputContext(t, nil, nil), &RootFlags{Account: "a@b.com", DryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func docsReplaceImageSingleInlineDocument() *docs.Document {
+	doc := docsReplaceImageTestDocument()
+	doc.Body.Content[0].Paragraph.PositionedObjectIds = nil
+	doc.PositionedObjects = nil
+	return doc
+}
+
+func docsReplaceImageTestDocument() *docs.Document {
+	return &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev-images",
+		Body: &docs.Body{Content: []*docs.StructuralElement{{
+			StartIndex: 1,
+			EndIndex:   2,
+			Paragraph: &docs.Paragraph{
+				Elements: []*docs.ParagraphElement{{
+					StartIndex: 1,
+					EndIndex:   2,
+					InlineObjectElement: &docs.InlineObjectElement{
+						InlineObjectId: "img-inline",
+					},
+				}},
+				PositionedObjectIds: []string{"img-positioned"},
+			},
+		}}},
+		InlineObjects: map[string]docs.InlineObject{
+			"img-inline": {
+				InlineObjectProperties: &docs.InlineObjectProperties{EmbeddedObject: docsReplaceEmbeddedObject("Inline chart", 200, 100)},
+			},
+		},
+		PositionedObjects: map[string]docs.PositionedObject{
+			"img-positioned": {
+				PositionedObjectProperties: &docs.PositionedObjectProperties{EmbeddedObject: docsReplaceEmbeddedObject("Positioned diagram", 320, 180)},
+			},
+		},
+	}
+}
+
+func docsReplaceEmbeddedObject(title string, width, height float64) *docs.EmbeddedObject {
+	return &docs.EmbeddedObject{
+		Title:           title,
+		ImageProperties: &docs.ImageProperties{},
+		Size: &docs.Size{
+			Width:  &docs.Dimension{Magnitude: width, Unit: "PT"},
+			Height: &docs.Dimension{Magnitude: height, Unit: "PT"},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- add `docs replace-image` with exact object-ID, case-insensitive alt substring, or implicit single-image selection
- support public HTTPS URLs and local PNG/JPEG/GIF uploads with temporary Drive sharing cleanup
- preserve object position and rendered bounds through `ReplaceImageRequest` with `CENTER_CROP`
- retain tab targeting and document revision control
- document the command and add changelog credit for @sebsnyk

Closes #853.

## Verification

- `go test ./internal/cmd -run 'Docs.*Image|DocsImages|DocsSed'`
- `go test ./internal/docssed ./internal/docsedit`
- `make ci`
- Codex autoreview: clean, no actionable findings
- live Google Docs proof on exact branch head: inserted a public Docs logo, replaced it by exact object ID with a Sheets logo, verified the same object ID and 72×72 PT bounds plus the changed source URI, then replaced it again through implicit single-image selection; disposable document moved to trash

The local-file path has full mocked Drive upload, public-share, Docs replacement, and permission-revoke coverage. No additional external image upload was performed during live proof.
