### PR TITLE
feat(docs): add paragraph list formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Docs: add paragraph bullet and numbering creation/removal plus indentation, spacing, and keep controls to `docs format` and plain-text `docs write`. (#852) — thanks @sebsnyk.
 - Docs: add `replace-image` with exact object-ID, alt-text, single-image, tab, public-URL, and local-file targeting while preserving the original image position and bounds. (#853) — thanks @sebsnyk.
 - Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851, #854) — thanks @sebsnyk.
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Docs: [Google Docs editing](docs/docs-editing.md),
 gog docs write <docId> --append --markdown --text '## Status'
 gog docs format <docId> --match Status --bold --font-size 18
 gog docs format <docId> --match "Project site" --link https://example.com
+gog docs format <docId> --match "Action item" --bullets --space-below 6
 gog docs find-range <docId> "Release status" --json
 gog docs insert-page-break <docId> --at-end
 gog docs insert-table <docId> --rows 3 --cols 2 --at-end

--- a/docs/commands/gog-docs-format.md
+++ b/docs/commands/gog-docs-format.md
@@ -24,6 +24,8 @@ gog docs (doc) format <docId> [flags]
 | `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
+| `--bullet-preset` | `string` |  | Create a list with a Google Docs bullet glyph preset |
+| `--bullets` | `bool` |  | Create a bulleted list with the default disc preset |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--code` | `bool` |  | Apply code style (Courier New + grey background) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
@@ -38,8 +40,13 @@ gog docs (doc) format <docId> [flags]
 | `--heading-level` | `*int` |  | Set paragraph named style to HEADING_1..HEADING_6 (shortcut for --named-style=HEADING_N) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--indent-end` | `*float64` |  | Paragraph end indentation in points |
+| `--indent-first-line` | `*float64` |  | Paragraph first-line indentation in points |
+| `--indent-start` | `*float64` |  | Paragraph start indentation in points |
 | `--italic` | `bool` |  | Set italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--keep-lines-together` | `*bool` |  | Keep all paragraph lines on one page or column when possible; use --no-keep-lines-together to clear |
+| `--keep-with-next` | `*bool` |  | Keep the paragraph with the next paragraph when possible; use --no-keep-with-next to clear |
 | `--line-spacing` | `float64` |  | Paragraph line spacing percentage, for example 100 or 150 |
 | `--link` | `string` |  | Set hyperlink target (http://, https://, mailto:, #bookmarkId, or #heading-slug) |
 | `--match` | `string` |  | Only format the first text match |
@@ -47,14 +54,18 @@ gog docs (doc) format <docId> [flags]
 | `--match-case` | `bool` |  | Use case-sensitive matching with --match |
 | `--named-style` | `string` |  | Set paragraph named style: NORMAL_TEXT, TITLE, SUBTITLE, HEADING_1..HEADING_6 |
 | `--no-bold` | `bool` |  | Clear bold |
+| `--no-bullets` | `bool` |  | Remove bullets or numbering |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `--no-italic` | `bool` |  | Clear italic |
 | `--no-link` | `bool` |  | Clear hyperlink |
 | `--no-strikethrough`<br>`--no-strike` | `bool` |  | Clear strikethrough |
 | `--no-underline` | `bool` |  | Clear underline |
+| `--ordered` | `bool` |  | Create a numbered list with the default decimal preset |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--space-above` | `*float64` |  | Space above the paragraph in points |
+| `--space-below` | `*float64` |  | Space below the paragraph in points |
 | `--strikethrough`<br>`--strike` | `bool` |  | Set strikethrough |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `--text-color` | `string` |  | Text color as #RRGGBB or #RGB |

--- a/docs/commands/gog-docs-write.md
+++ b/docs/commands/gog-docs-write.md
@@ -25,6 +25,8 @@ gog docs (doc) write <docId> [flags]
 | `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--bg-color` | `string` |  | Text background color as #RRGGBB or #RGB |
 | `--bold` | `bool` |  | Set bold |
+| `--bullet-preset` | `string` |  | Create a list with a Google Docs bullet glyph preset |
+| `--bullets` | `bool` |  | Create a bulleted list with the default disc preset |
 | `--check-orphans` | `bool` |  | Block markdown replacement when open comment quotes would disappear |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--code` | `bool` |  | Apply code style (Courier New + grey background) |
@@ -41,8 +43,13 @@ gog docs (doc) write <docId> [flags]
 | `--heading-level` | `*int` |  | Set paragraph named style to HEADING_1..HEADING_6 (shortcut for --named-style=HEADING_N) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--indent-end` | `*float64` |  | Paragraph end indentation in points |
+| `--indent-first-line` | `*float64` |  | Paragraph first-line indentation in points |
+| `--indent-start` | `*float64` |  | Paragraph start indentation in points |
 | `--italic` | `bool` |  | Set italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--keep-lines-together` | `*bool` |  | Keep all paragraph lines on one page or column when possible; use --no-keep-lines-together to clear |
+| `--keep-with-next` | `*bool` |  | Keep the paragraph with the next paragraph when possible; use --no-keep-with-next to clear |
 | `--line-spacing` | `float64` |  | Paragraph line spacing percentage, for example 100 or 150 |
 | `--margin-bottom` | `string` |  | Set bottom page margin (points by default; supports pt, in, cm, mm) |
 | `--margin-left` | `string` |  | Set left page margin (points by default; supports pt, in, cm, mm) |
@@ -51,10 +58,12 @@ gog docs (doc) write <docId> [flags]
 | `--markdown` | `bool` |  | Convert markdown to Google Docs formatting (requires --replace or --append) |
 | `--named-style` | `string` |  | Set paragraph named style: NORMAL_TEXT, TITLE, SUBTITLE, HEADING_1..HEADING_6 |
 | `--no-bold` | `bool` |  | Clear bold |
+| `--no-bullets` | `bool` |  | Remove bullets or numbering |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `--no-italic` | `bool` |  | Clear italic |
 | `--no-strikethrough`<br>`--no-strike` | `bool` |  | Clear strikethrough |
 | `--no-underline` | `bool` |  | Clear underline |
+| `--ordered` | `bool` |  | Create a numbered list with the default decimal preset |
 | `--page-height` | `string` |  | Set page height (points by default; supports pt, in, cm, mm) |
 | `--page-size` | `string` |  | Named page size: A4, A5, Letter, Legal, Tabloid |
 | `--page-width` | `string` |  | Set page width (points by default; supports pt, in, cm, mm) |
@@ -63,6 +72,8 @@ gog docs (doc) write <docId> [flags]
 | `--replace` | `bool` |  | Replace all content explicitly (required with --markdown unless --append is set) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--space-above` | `*float64` |  | Space above the paragraph in points |
+| `--space-below` | `*float64` |  | Space below the paragraph in points |
 | `--strikethrough`<br>`--strike` | `bool` |  | Set strikethrough |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `--text` | `string` |  | Text to write |

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -67,6 +67,28 @@ gog docs format <docId> --match "Status" --heading-level 2
 gog docs format <docId> --match "Overview" --named-style title --alignment center
 ```
 
+Create or remove native lists, optionally choosing an exact Docs glyph preset:
+
+```bash
+gog docs format <docId> --match "Action item" --bullets
+gog docs format <docId> --match "Step one" --ordered
+gog docs format <docId> --match "Task" --bullet-preset BULLET_CHECKBOX
+gog docs format <docId> --match "Action item" --no-bullets
+```
+
+Paragraph layout controls use points and accept explicit zero values. Boolean
+keep controls have matching `--no-...` forms:
+
+```bash
+gog docs format <docId> --match "Summary" --indent-start 24 --indent-first-line 12
+gog docs format <docId> --match "Summary" --space-above 6 --space-below 12 --keep-with-next
+gog docs format <docId> --match "Summary" --no-keep-with-next --keep-lines-together
+```
+
+Plain-text `docs write` accepts the same list and paragraph flags while
+replacing content. For `--append`, create the list and apply paragraph layout
+in a following `docs format` call so Docs can resolve post-insertion indexes.
+
 Use `--match-all` when every occurrence should be formatted.
 
 Command page:

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -120,6 +120,9 @@ func (c *DocsWriteCmd) resolveWriteText(ctx context.Context, kctx *kong.Context)
 }
 
 func (c *DocsWriteCmd) writePlainText(ctx context.Context, flags *RootFlags, docID, text string) error {
+	if c.Append && c.Format.createsBullets() && c.Format.hasParagraphStyle() {
+		return usage("docs write --append cannot combine bullet creation with paragraph formatting; append first, then use docs format")
+	}
 	if c.Format.any() {
 		if _, err := c.Format.buildRequests(1, 1+utf16Len(text), c.Tab); err != nil {
 			return err

--- a/internal/cmd/docs_format.go
+++ b/internal/cmd/docs_format.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/steipete/gogcli/internal/docsedit"
 	"github.com/steipete/gogcli/internal/docsformat"
+	"github.com/steipete/gogcli/internal/docssed"
 	"github.com/steipete/gogcli/internal/outfmt"
 	"github.com/steipete/gogcli/internal/ui"
 )
@@ -27,23 +28,34 @@ type DocsFormatCmd struct {
 }
 
 type DocsFormatFlags struct {
-	FontFamily    string  `name:"font-family" help:"Font family, for example Arial or Georgia"`
-	FontSize      float64 `name:"font-size" help:"Font size in points"`
-	TextColor     string  `name:"text-color" help:"Text color as #RRGGBB or #RGB"`
-	BgColor       string  `name:"bg-color" help:"Text background color as #RRGGBB or #RGB"`
-	Code          bool    `name:"code" help:"Apply code style (Courier New + grey background)"`
-	Bold          bool    `name:"bold" help:"Set bold"`
-	NoBold        bool    `name:"no-bold" help:"Clear bold"`
-	Italic        bool    `name:"italic" help:"Set italic"`
-	NoItalic      bool    `name:"no-italic" help:"Clear italic"`
-	Underline     bool    `name:"underline" help:"Set underline"`
-	NoUnderline   bool    `name:"no-underline" help:"Clear underline"`
-	Strikethrough bool    `name:"strikethrough" aliases:"strike" help:"Set strikethrough"`
-	NoStrike      bool    `name:"no-strikethrough" aliases:"no-strike" help:"Clear strikethrough"`
-	Alignment     string  `name:"alignment" help:"Paragraph alignment: left, center, right, justify, start, end, justified"`
-	LineSpacing   float64 `name:"line-spacing" help:"Paragraph line spacing percentage, for example 100 or 150"`
-	HeadingLevel  *int    `name:"heading-level" help:"Set paragraph named style to HEADING_1..HEADING_6 (shortcut for --named-style=HEADING_N)"`
-	NamedStyle    string  `name:"named-style" help:"Set paragraph named style: NORMAL_TEXT, TITLE, SUBTITLE, HEADING_1..HEADING_6"`
+	FontFamily        string   `name:"font-family" help:"Font family, for example Arial or Georgia"`
+	FontSize          float64  `name:"font-size" help:"Font size in points"`
+	TextColor         string   `name:"text-color" help:"Text color as #RRGGBB or #RGB"`
+	BgColor           string   `name:"bg-color" help:"Text background color as #RRGGBB or #RGB"`
+	Code              bool     `name:"code" help:"Apply code style (Courier New + grey background)"`
+	Bold              bool     `name:"bold" help:"Set bold"`
+	NoBold            bool     `name:"no-bold" help:"Clear bold"`
+	Italic            bool     `name:"italic" help:"Set italic"`
+	NoItalic          bool     `name:"no-italic" help:"Clear italic"`
+	Underline         bool     `name:"underline" help:"Set underline"`
+	NoUnderline       bool     `name:"no-underline" help:"Clear underline"`
+	Strikethrough     bool     `name:"strikethrough" aliases:"strike" help:"Set strikethrough"`
+	NoStrike          bool     `name:"no-strikethrough" aliases:"no-strike" help:"Clear strikethrough"`
+	Alignment         string   `name:"alignment" help:"Paragraph alignment: left, center, right, justify, start, end, justified"`
+	LineSpacing       float64  `name:"line-spacing" help:"Paragraph line spacing percentage, for example 100 or 150"`
+	HeadingLevel      *int     `name:"heading-level" help:"Set paragraph named style to HEADING_1..HEADING_6 (shortcut for --named-style=HEADING_N)"`
+	NamedStyle        string   `name:"named-style" help:"Set paragraph named style: NORMAL_TEXT, TITLE, SUBTITLE, HEADING_1..HEADING_6"`
+	Bullets           bool     `name:"bullets" help:"Create a bulleted list with the default disc preset"`
+	Ordered           bool     `name:"ordered" help:"Create a numbered list with the default decimal preset"`
+	BulletPreset      string   `name:"bullet-preset" placeholder:"PRESET" help:"Create a list with a Google Docs bullet glyph preset"`
+	NoBullets         bool     `name:"no-bullets" help:"Remove bullets or numbering"`
+	IndentStart       *float64 `name:"indent-start" placeholder:"PT" help:"Paragraph start indentation in points"`
+	IndentFirstLine   *float64 `name:"indent-first-line" placeholder:"PT" help:"Paragraph first-line indentation in points"`
+	IndentEnd         *float64 `name:"indent-end" placeholder:"PT" help:"Paragraph end indentation in points"`
+	SpaceAbove        *float64 `name:"space-above" placeholder:"PT" help:"Space above the paragraph in points"`
+	SpaceBelow        *float64 `name:"space-below" placeholder:"PT" help:"Space below the paragraph in points"`
+	KeepWithNext      *bool    `name:"keep-with-next" negatable:"" help:"Keep the paragraph with the next paragraph when possible; use --no-keep-with-next to clear"`
+	KeepLinesTogether *bool    `name:"keep-lines-together" negatable:"" help:"Keep all paragraph lines on one page or column when possible; use --no-keep-lines-together to clear"`
 
 	link         string
 	noLink       bool
@@ -92,25 +104,36 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"tab":         c.Tab,
 		"batch":       c.Batch,
 		"format": map[string]any{
-			"font_family":   c.Format.FontFamily,
-			"font_size":     c.Format.FontSize,
-			"text_color":    c.Format.TextColor,
-			"bg_color":      c.Format.BgColor,
-			"link":          c.Link,
-			"no_link":       c.NoLink,
-			"code":          c.Format.Code,
-			"bold":          c.Format.Bold,
-			"no_bold":       c.Format.NoBold,
-			"italic":        c.Format.Italic,
-			"no_italic":     c.Format.NoItalic,
-			"underline":     c.Format.Underline,
-			"no_underline":  c.Format.NoUnderline,
-			"strikethrough": c.Format.Strikethrough,
-			"no_strike":     c.Format.NoStrike,
-			"alignment":     c.Format.Alignment,
-			"line_spacing":  c.Format.LineSpacing,
-			"heading_level": c.Format.HeadingLevel,
-			"named_style":   c.Format.NamedStyle,
+			"font_family":         c.Format.FontFamily,
+			"font_size":           c.Format.FontSize,
+			"text_color":          c.Format.TextColor,
+			"bg_color":            c.Format.BgColor,
+			"link":                c.Link,
+			"no_link":             c.NoLink,
+			"code":                c.Format.Code,
+			"bold":                c.Format.Bold,
+			"no_bold":             c.Format.NoBold,
+			"italic":              c.Format.Italic,
+			"no_italic":           c.Format.NoItalic,
+			"underline":           c.Format.Underline,
+			"no_underline":        c.Format.NoUnderline,
+			"strikethrough":       c.Format.Strikethrough,
+			"no_strike":           c.Format.NoStrike,
+			"alignment":           c.Format.Alignment,
+			"line_spacing":        c.Format.LineSpacing,
+			"heading_level":       c.Format.HeadingLevel,
+			"named_style":         c.Format.NamedStyle,
+			"bullets":             c.Format.Bullets,
+			"ordered":             c.Format.Ordered,
+			"bullet_preset":       c.Format.BulletPreset,
+			"no_bullets":          c.Format.NoBullets,
+			"indent_start":        c.Format.IndentStart,
+			"indent_first_line":   c.Format.IndentFirstLine,
+			"indent_end":          c.Format.IndentEnd,
+			"space_above":         c.Format.SpaceAbove,
+			"space_below":         c.Format.SpaceBelow,
+			"keep_with_next":      c.Format.KeepWithNext,
+			"keep_lines_together": c.Format.KeepLinesTogether,
 		},
 	}); err != nil {
 		return err
@@ -140,14 +163,39 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	if len(ranges) == 0 {
 		return usage("no matching text found")
 	}
-
 	reqs := make([]*docs.Request, 0, len(ranges)*2)
-	for _, r := range ranges {
-		formatReqs, buildErr := format.buildRequests(r.StartIndex, r.EndIndex, tabID)
-		if buildErr != nil {
-			return buildErr
+	if format.createsBullets() {
+		// Apply exact-range text styles before bullet creation can remove nesting
+		// tabs, then group selected adjacent paragraphs into native list runs.
+		textFormat := format.textOnly()
+		if textFormat.any() {
+			for _, r := range ranges {
+				formatReqs, buildErr := textFormat.buildRequests(r.StartIndex, r.EndIndex, tabID)
+				if buildErr != nil {
+					return buildErr
+				}
+				reqs = append(reqs, formatReqs...)
+			}
 		}
-		reqs = append(reqs, formatReqs...)
+
+		paragraphFormat := format.paragraphOnly()
+		bulletTargets := groupDocsFormatBulletTargets(ranges)
+		adjustDocsFormatBulletTargets(bulletTargets, paragraphFormat.hasParagraphStyle())
+		for _, r := range bulletTargets {
+			formatReqs, buildErr := paragraphFormat.buildTargetRequests(r, tabID)
+			if buildErr != nil {
+				return buildErr
+			}
+			reqs = append(reqs, formatReqs...)
+		}
+	} else {
+		for _, r := range ranges {
+			formatReqs, buildErr := format.buildTargetRequests(r, tabID)
+			if buildErr != nil {
+				return buildErr
+			}
+			reqs = append(reqs, formatReqs...)
+		}
 	}
 	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, id, "docs.format", batchRevision, reqs, false); queued || queueErr != nil {
 		return queueErr
@@ -164,19 +212,7 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 	return c.writeResult(ctx, resp, len(reqs), len(ranges), tabID)
 }
 
-func (c *DocsFormatCmd) targetRanges(ctx context.Context, svc *docs.Service, docID string) ([]docsedit.TextRange, string, error) {
-	if strings.TrimSpace(c.Match) == "" {
-		endIndex, tabID, err := docsTargetEndIndexAndTabID(ctx, svc, docID, c.Tab)
-		if err != nil {
-			return nil, "", err
-		}
-		end := endIndex - 1
-		if end <= 1 {
-			return nil, tabID, nil
-		}
-		return []docsedit.TextRange{{StartIndex: 1, EndIndex: end}}, tabID, nil
-	}
-
+func (c *DocsFormatCmd) targetRanges(ctx context.Context, svc *docs.Service, docID string) ([]docsFormatTargetRange, string, error) {
 	getCall := svc.Documents.Get(docID).Context(ctx)
 	if c.Tab != "" {
 		getCall = getCall.IncludeTabsContent(true)
@@ -205,15 +241,128 @@ func (c *DocsFormatCmd) targetRanges(ctx context.Context, svc *docs.Service, doc
 		}
 	}
 
-	matches := docsedit.FindTextRanges(targetDoc, c.Match, docsedit.SearchOptions{
-		MatchCase:            c.MatchCase,
-		PreserveHTMLEntities: true,
-		RequireTextSegment:   true,
-	})
-	if !c.MatchAll && len(matches) > 1 {
-		matches = matches[:1]
+	var ranges []docsedit.TextRange
+	if strings.TrimSpace(c.Match) == "" {
+		end := docsDocumentEndIndex(targetDoc) - 1
+		if end > 1 {
+			ranges = []docsedit.TextRange{{StartIndex: 1, EndIndex: end}}
+		}
+	} else {
+		ranges = docsedit.FindTextRanges(targetDoc, c.Match, docsedit.SearchOptions{
+			MatchCase:            c.MatchCase,
+			PreserveHTMLEntities: true,
+			RequireTextSegment:   true,
+		})
+		if !c.MatchAll && len(ranges) > 1 {
+			ranges = ranges[:1]
+		}
 	}
-	return matches, tabID, nil
+
+	paragraphs := []docssed.DocumentParagraph(nil)
+	if projection := docssed.ProjectDocument(targetDoc); projection.Legacy != nil {
+		paragraphs = projection.Legacy.Paragraphs
+	}
+	targets := make([]docsFormatTargetRange, 0, len(ranges))
+	for _, r := range ranges {
+		target := docsFormatTargetRange{TextRange: r}
+		if c.Format.createsBullets() {
+			target.BulletParagraphs = docsFormatBulletParagraphs(paragraphs, r.StartIndex, r.EndIndex)
+		}
+		targets = append(targets, target)
+	}
+	return targets, tabID, nil
+}
+
+type docsFormatTargetRange struct {
+	docsedit.TextRange
+	PostBulletStart  int64
+	PostBulletEnd    int64
+	BulletParagraphs []docsFormatBulletParagraph
+}
+
+type docsFormatBulletParagraph struct {
+	StartIndex  int64
+	EndIndex    int64
+	LeadingTabs int64
+}
+
+func docsFormatBulletParagraphs(paragraphs []docssed.DocumentParagraph, start, end int64) []docsFormatBulletParagraph {
+	var affected []docsFormatBulletParagraph
+	for _, paragraph := range paragraphs {
+		if paragraph.StartIndex >= end || paragraph.EndIndex <= start {
+			continue
+		}
+		item := docsFormatBulletParagraph{StartIndex: paragraph.StartIndex, EndIndex: paragraph.EndIndex}
+		for _, r := range paragraph.Text {
+			if r != '\t' {
+				break
+			}
+			item.LeadingTabs++
+		}
+		affected = append(affected, item)
+	}
+	return affected
+}
+
+func adjustDocsFormatBulletTargets(targets []docsFormatTargetRange, withParagraphStyle bool) {
+	seenParagraphs := make(map[int64]bool)
+	var removedTabIndexes []int64
+	shiftedIndex := func(index int64) int64 {
+		shift := int64(0)
+		for _, removed := range removedTabIndexes {
+			if removed < index {
+				shift++
+			}
+		}
+		return index - shift
+	}
+
+	for i := range targets {
+		target := &targets[i]
+		target.StartIndex = shiftedIndex(target.StartIndex)
+		target.EndIndex = shiftedIndex(target.EndIndex)
+
+		for _, paragraph := range target.BulletParagraphs {
+			if seenParagraphs[paragraph.StartIndex] {
+				continue
+			}
+			seenParagraphs[paragraph.StartIndex] = true
+			for offset := int64(0); offset < paragraph.LeadingTabs; offset++ {
+				removedTabIndexes = append(removedTabIndexes, paragraph.StartIndex+offset)
+			}
+		}
+		if !withParagraphStyle || len(target.BulletParagraphs) == 0 {
+			continue
+		}
+
+		target.PostBulletStart = shiftedIndex(target.BulletParagraphs[0].StartIndex)
+		target.PostBulletEnd = shiftedIndex(target.BulletParagraphs[len(target.BulletParagraphs)-1].EndIndex)
+	}
+}
+
+func groupDocsFormatBulletTargets(targets []docsFormatTargetRange) []docsFormatTargetRange {
+	seen := make(map[int64]bool)
+	var groups []docsFormatTargetRange
+	for _, target := range targets {
+		for _, paragraph := range target.BulletParagraphs {
+			if seen[paragraph.StartIndex] {
+				continue
+			}
+			seen[paragraph.StartIndex] = true
+
+			last := len(groups) - 1
+			if last >= 0 && groups[last].BulletParagraphs[len(groups[last].BulletParagraphs)-1].EndIndex == paragraph.StartIndex {
+				groups[last].EndIndex = paragraph.EndIndex
+				groups[last].BulletParagraphs = append(groups[last].BulletParagraphs, paragraph)
+				continue
+			}
+			groups = append(groups, docsFormatTargetRange{
+				TextRange:        docsedit.TextRange{StartIndex: paragraph.StartIndex, EndIndex: paragraph.EndIndex},
+				BulletParagraphs: []docsFormatBulletParagraph{paragraph},
+			})
+		}
+	}
+	return groups
 }
 
 func (c *DocsFormatCmd) writeResult(ctx context.Context, resp *docs.BatchUpdateDocumentResponse, requestCount, rangeCount int, tabID string) error {
@@ -249,6 +398,57 @@ func (f DocsFormatFlags) any() bool {
 	return f.options().Any()
 }
 
+func (f DocsFormatFlags) createsBullets() bool {
+	return f.Bullets || f.Ordered || strings.TrimSpace(f.BulletPreset) != ""
+}
+
+func (f DocsFormatFlags) hasParagraphStyle() bool {
+	return strings.TrimSpace(f.Alignment) != "" || f.LineSpacing != 0 || f.HeadingLevel != nil ||
+		strings.TrimSpace(f.NamedStyle) != "" || f.IndentStart != nil || f.IndentFirstLine != nil ||
+		f.IndentEnd != nil || f.SpaceAbove != nil || f.SpaceBelow != nil ||
+		f.KeepWithNext != nil || f.KeepLinesTogether != nil
+}
+
+func (f DocsFormatFlags) textOnly() DocsFormatFlags {
+	return DocsFormatFlags{
+		FontFamily:    f.FontFamily,
+		FontSize:      f.FontSize,
+		TextColor:     f.TextColor,
+		BgColor:       f.BgColor,
+		Code:          f.Code,
+		Bold:          f.Bold,
+		NoBold:        f.NoBold,
+		Italic:        f.Italic,
+		NoItalic:      f.NoItalic,
+		Underline:     f.Underline,
+		NoUnderline:   f.NoUnderline,
+		Strikethrough: f.Strikethrough,
+		NoStrike:      f.NoStrike,
+		link:          f.link,
+		noLink:        f.noLink,
+		resolvedLink:  f.resolvedLink,
+	}
+}
+
+func (f DocsFormatFlags) paragraphOnly() DocsFormatFlags {
+	return DocsFormatFlags{
+		Alignment:         f.Alignment,
+		LineSpacing:       f.LineSpacing,
+		HeadingLevel:      f.HeadingLevel,
+		NamedStyle:        f.NamedStyle,
+		Bullets:           f.Bullets,
+		Ordered:           f.Ordered,
+		BulletPreset:      f.BulletPreset,
+		IndentStart:       f.IndentStart,
+		IndentFirstLine:   f.IndentFirstLine,
+		IndentEnd:         f.IndentEnd,
+		SpaceAbove:        f.SpaceAbove,
+		SpaceBelow:        f.SpaceBelow,
+		KeepWithNext:      f.KeepWithNext,
+		KeepLinesTogether: f.KeepLinesTogether,
+	}
+}
+
 func (f DocsFormatFlags) buildRequests(start, end int64, tabID string) ([]*docs.Request, error) {
 	requests, err := docsformat.BuildRequests(f.options(), start, end, tabID)
 	if err != nil {
@@ -257,28 +457,50 @@ func (f DocsFormatFlags) buildRequests(start, end int64, tabID string) ([]*docs.
 	return requests, nil
 }
 
+func (f DocsFormatFlags) buildTargetRequests(target docsFormatTargetRange, tabID string) ([]*docs.Request, error) {
+	options := f.options()
+	options.PostBulletParagraphStart = target.PostBulletStart
+	options.PostBulletParagraphEnd = target.PostBulletEnd
+	requests, err := docsformat.BuildRequests(options, target.StartIndex, target.EndIndex, tabID)
+	if err != nil {
+		return nil, usage(err.Error())
+	}
+	return requests, nil
+}
+
 func (f DocsFormatFlags) options() docsformat.Options {
 	return docsformat.Options{
-		FontFamily:     f.FontFamily,
-		FontSize:       f.FontSize,
-		TextColor:      f.TextColor,
-		Background:     f.BgColor,
-		Link:           f.link,
-		ClearLink:      f.noLink,
-		ResolvedLink:   f.resolvedLink,
-		Code:           f.Code,
-		Bold:           f.Bold,
-		ClearBold:      f.NoBold,
-		Italic:         f.Italic,
-		ClearItalic:    f.NoItalic,
-		Underline:      f.Underline,
-		ClearUnderline: f.NoUnderline,
-		Strikethrough:  f.Strikethrough,
-		ClearStrike:    f.NoStrike,
-		Alignment:      f.Alignment,
-		LineSpacing:    f.LineSpacing,
-		HeadingLevel:   f.HeadingLevel,
-		NamedStyle:     f.NamedStyle,
+		FontFamily:        f.FontFamily,
+		FontSize:          f.FontSize,
+		TextColor:         f.TextColor,
+		Background:        f.BgColor,
+		Link:              f.link,
+		ClearLink:         f.noLink,
+		ResolvedLink:      f.resolvedLink,
+		Code:              f.Code,
+		Bold:              f.Bold,
+		ClearBold:         f.NoBold,
+		Italic:            f.Italic,
+		ClearItalic:       f.NoItalic,
+		Underline:         f.Underline,
+		ClearUnderline:    f.NoUnderline,
+		Strikethrough:     f.Strikethrough,
+		ClearStrike:       f.NoStrike,
+		Alignment:         f.Alignment,
+		LineSpacing:       f.LineSpacing,
+		HeadingLevel:      f.HeadingLevel,
+		NamedStyle:        f.NamedStyle,
+		Bullets:           f.Bullets,
+		Ordered:           f.Ordered,
+		BulletPreset:      f.BulletPreset,
+		ClearBullets:      f.NoBullets,
+		IndentStart:       f.IndentStart,
+		IndentFirstLine:   f.IndentFirstLine,
+		IndentEnd:         f.IndentEnd,
+		SpaceAbove:        f.SpaceAbove,
+		SpaceBelow:        f.SpaceBelow,
+		KeepWithNext:      f.KeepWithNext,
+		KeepLinesTogether: f.KeepLinesTogether,
 	}
 }
 

--- a/internal/cmd/docs_format_test.go
+++ b/internal/cmd/docs_format_test.go
@@ -8,6 +8,10 @@ import (
 	"testing"
 
 	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/docsedit"
+	"github.com/steipete/gogcli/internal/docsformat"
+	"github.com/steipete/gogcli/internal/docssed"
 )
 
 func TestDocsFormatFlagsBuildRequests(t *testing.T) {
@@ -330,6 +334,102 @@ func TestDocsFormatCmdMatchAll(t *testing.T) {
 	}
 	if got := reqs[1].UpdateTextStyle.Range; got.StartIndex != 12 || got.EndIndex != 17 {
 		t.Fatalf("unexpected second match range: %#v", got)
+	}
+}
+
+func TestDocsFormatCmdParagraphControls(t *testing.T) {
+	t.Parallel()
+
+	var batchRequests [][]*docs.Request
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			batchRequests = append(batchRequests, req.Requests)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		case r.Method == http.MethodGet && strings.HasPrefix(r.URL.Path, "/v1/documents/"):
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(docBodyWithText("Alpha Beta Alpha\n"))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	ctx := withDocsTestService(newCmdRuntimeJSONOutputContext(t, io.Discard, io.Discard), docSvc)
+	flags := &RootFlags{Account: "a@b.com"}
+	err := runKong(t, &DocsFormatCmd{}, []string{
+		"doc1", "--match", "Alpha", "--match-all", "--bold", "--ordered",
+		"--indent-start", "24", "--space-below", "6",
+		"--keep-with-next", "--no-keep-lines-together",
+	}, ctx, flags)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if len(batchRequests) != 1 || len(batchRequests[0]) != 4 {
+		t.Fatalf("unexpected requests: %#v", batchRequests)
+	}
+
+	if first, second := batchRequests[0][0].UpdateTextStyle, batchRequests[0][1].UpdateTextStyle; first == nil || second == nil || first.Range.StartIndex != 1 || first.Range.EndIndex != 6 ||
+		second.Range.StartIndex != 12 || second.Range.EndIndex != 17 {
+		t.Fatalf("exact text requests must precede bullets: %#v", batchRequests[0][:2])
+	}
+	bullets := batchRequests[0][2].CreateParagraphBullets
+	paragraph := batchRequests[0][3].UpdateParagraphStyle
+	if paragraph == nil || bullets == nil || paragraph.Range.StartIndex != 1 || paragraph.Range.EndIndex != 18 ||
+		bullets.Range.StartIndex != 1 || bullets.Range.EndIndex != 18 {
+		t.Fatalf("grouped paragraph requests: %#v", batchRequests[0])
+	}
+	if paragraph.ParagraphStyle.IndentStart.Magnitude != 24 || paragraph.ParagraphStyle.SpaceBelow.Magnitude != 6 ||
+		!paragraph.ParagraphStyle.KeepWithNext || paragraph.ParagraphStyle.KeepLinesTogether {
+		t.Fatalf("unexpected paragraph style: %#v", paragraph.ParagraphStyle)
+	}
+	if bullets.BulletPreset != docsformat.BulletPresetNumbered {
+		t.Fatalf("preset = %q", bullets.BulletPreset)
+	}
+}
+
+func TestDocsFormatBulletTargetsAdjustLeadingTabsInForwardOrder(t *testing.T) {
+	t.Parallel()
+
+	paragraphs := []docssed.DocumentParagraph{
+		{Text: "\tFirst\n", StartIndex: 1, EndIndex: 8},
+		{Text: "\t\tSecond\n", StartIndex: 8, EndIndex: 17},
+		{Text: "Third\n", StartIndex: 17, EndIndex: 23},
+	}
+	targets := []docsFormatTargetRange{
+		{TextRange: docsedit.TextRange{StartIndex: 2, EndIndex: 7}, BulletParagraphs: docsFormatBulletParagraphs(paragraphs, 2, 7)},
+		{TextRange: docsedit.TextRange{StartIndex: 10, EndIndex: 16}, BulletParagraphs: docsFormatBulletParagraphs(paragraphs, 10, 16)},
+	}
+	adjustDocsFormatBulletTargets(targets, true)
+	if got := targets[0]; got.StartIndex != 2 || got.EndIndex != 7 || got.PostBulletStart != 1 || got.PostBulletEnd != 7 {
+		t.Fatalf("first adjusted target: %#v", got)
+	}
+	if got := targets[1]; got.StartIndex != 9 || got.EndIndex != 15 || got.PostBulletStart != 7 || got.PostBulletEnd != 14 {
+		t.Fatalf("second adjusted target: %#v", got)
+	}
+}
+
+func TestGroupDocsFormatBulletTargets(t *testing.T) {
+	t.Parallel()
+
+	p1 := docsFormatBulletParagraph{StartIndex: 1, EndIndex: 8}
+	p2 := docsFormatBulletParagraph{StartIndex: 8, EndIndex: 17}
+	p3 := docsFormatBulletParagraph{StartIndex: 20, EndIndex: 27}
+	targets := []docsFormatTargetRange{
+		{BulletParagraphs: []docsFormatBulletParagraph{p1}},
+		{BulletParagraphs: []docsFormatBulletParagraph{p1}},
+		{BulletParagraphs: []docsFormatBulletParagraph{p2}},
+		{BulletParagraphs: []docsFormatBulletParagraph{p3}},
+	}
+	groups := groupDocsFormatBulletTargets(targets)
+	if len(groups) != 2 || groups[0].StartIndex != 1 || groups[0].EndIndex != 17 ||
+		len(groups[0].BulletParagraphs) != 2 || groups[1].StartIndex != 20 || groups[1].EndIndex != 27 {
+		t.Fatalf("groups = %#v", groups)
 	}
 }
 

--- a/internal/docsedit/planner.go
+++ b/internal/docsedit/planner.go
@@ -43,8 +43,14 @@ func BuildWriteRequests(options WriteOptions) ([]*docs.Request, error) {
 
 	requests = append(requests, BuildInsertRequest(options.Text, options.InsertIndex, options.TabID))
 	if options.Format.Any() {
+		format := options.Format
+		if !options.Append && createsParagraphBullets(format) && hasParagraphStyle(format) {
+			format.PostBulletParagraphStart = options.InsertIndex
+			format.PostBulletParagraphEnd = options.InsertIndex + utf16Length(options.Text) - leadingParagraphTabs(options.Text)
+		}
+
 		formatRequests, err := docsformat.BuildRequests(
-			options.Format,
+			format,
 			options.InsertIndex,
 			options.InsertIndex+utf16Length(options.Text),
 			options.TabID,
@@ -57,6 +63,37 @@ func BuildWriteRequests(options WriteOptions) ([]*docs.Request, error) {
 	}
 
 	return requests, nil
+}
+
+func createsParagraphBullets(options docsformat.Options) bool {
+	return options.Bullets || options.Ordered || strings.TrimSpace(options.BulletPreset) != ""
+}
+
+func hasParagraphStyle(options docsformat.Options) bool {
+	return strings.TrimSpace(options.Alignment) != "" || options.LineSpacing != 0 || options.HeadingLevel != nil ||
+		strings.TrimSpace(options.NamedStyle) != "" || options.IndentStart != nil || options.IndentFirstLine != nil ||
+		options.IndentEnd != nil || options.SpaceAbove != nil || options.SpaceBelow != nil ||
+		options.KeepWithNext != nil || options.KeepLinesTogether != nil
+}
+
+func leadingParagraphTabs(text string) int64 {
+	atParagraphStart := true
+	count := int64(0)
+
+	for _, r := range text {
+		if r == '\n' {
+			atParagraphStart = true
+			continue
+		}
+
+		if atParagraphStart && r == '\t' {
+			count++
+			continue
+		}
+		atParagraphStart = false
+	}
+
+	return count
 }
 
 func BuildUpdateRequests(text string, insertIndex int64, tabID string, replace *Range) []*docs.Request {

--- a/internal/docsedit/planner_test.go
+++ b/internal/docsedit/planner_test.go
@@ -63,6 +63,31 @@ func TestBuildWriteRequestsAppendSkipsDelete(t *testing.T) {
 	}
 }
 
+func TestBuildWriteRequestsBulletsAdjustParagraphRangeAfterTabs(t *testing.T) {
+	indent := 54.0
+
+	requests, err := BuildWriteRequests(WriteOptions{
+		EndIndex:    1,
+		InsertIndex: 1,
+		Text:        "\tFirst\n\t\tSecond\n",
+		Format: docsformat.Options{
+			Ordered:     true,
+			IndentStart: &indent,
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildWriteRequests: %v", err)
+	}
+
+	if len(requests) != 3 || requests[0].InsertText == nil || requests[1].CreateParagraphBullets == nil || requests[2].UpdateParagraphStyle == nil {
+		t.Fatalf("requests = %#v", requests)
+	}
+
+	if got := requests[2].UpdateParagraphStyle.Range; got.StartIndex != 1 || got.EndIndex != 14 {
+		t.Fatalf("post-bullet paragraph range = %#v, want 1..14", got)
+	}
+}
+
 func TestBuildWriteRequestsEmptyBodySkipsDelete(t *testing.T) {
 	requests, err := BuildWriteRequests(WriteOptions{
 		EndIndex:    1,

--- a/internal/docsformat/format.go
+++ b/internal/docsformat/format.go
@@ -11,6 +11,11 @@ import (
 const codeBackgroundGrey = 0.95
 
 const (
+	BulletPresetDisc     = "BULLET_DISC_CIRCLE_SQUARE"
+	BulletPresetNumbered = "NUMBERED_DECIMAL_ALPHA_ROMAN"
+)
+
+const (
 	namedStyleNormalText = "NORMAL_TEXT"
 	namedStyleTitle      = "TITLE"
 	namedStyleSubtitle   = "SUBTITLE"
@@ -29,26 +34,41 @@ func (e ValidationError) Error() string {
 }
 
 type Options struct {
-	FontFamily     string
-	FontSize       float64
-	TextColor      string
-	Background     string
-	Link           string
-	ClearLink      bool
-	ResolvedLink   *docs.Link
-	Code           bool
-	Bold           bool
-	ClearBold      bool
-	Italic         bool
-	ClearItalic    bool
-	Underline      bool
-	ClearUnderline bool
-	Strikethrough  bool
-	ClearStrike    bool
-	Alignment      string
-	LineSpacing    float64
-	HeadingLevel   *int
-	NamedStyle     string
+	FontFamily        string
+	FontSize          float64
+	TextColor         string
+	Background        string
+	Link              string
+	ClearLink         bool
+	ResolvedLink      *docs.Link
+	Code              bool
+	Bold              bool
+	ClearBold         bool
+	Italic            bool
+	ClearItalic       bool
+	Underline         bool
+	ClearUnderline    bool
+	Strikethrough     bool
+	ClearStrike       bool
+	Alignment         string
+	LineSpacing       float64
+	HeadingLevel      *int
+	NamedStyle        string
+	Bullets           bool
+	Ordered           bool
+	BulletPreset      string
+	ClearBullets      bool
+	IndentStart       *float64
+	IndentFirstLine   *float64
+	IndentEnd         *float64
+	SpaceAbove        *float64
+	SpaceBelow        *float64
+	KeepWithNext      *bool
+	KeepLinesTogether *bool
+	// PostBulletParagraphStart/End identify the same affected paragraphs after
+	// CreateParagraphBullets removes any leading nesting tabs.
+	PostBulletParagraphStart int64
+	PostBulletParagraphEnd   int64
 }
 
 func (o Options) Any() bool {
@@ -66,7 +86,11 @@ func (o Options) Any() bool {
 		strings.TrimSpace(o.Alignment) != "" ||
 		o.LineSpacing != 0 ||
 		o.HeadingLevel != nil ||
-		strings.TrimSpace(o.NamedStyle) != ""
+		strings.TrimSpace(o.NamedStyle) != "" ||
+		o.Bullets || o.Ordered || strings.TrimSpace(o.BulletPreset) != "" || o.ClearBullets ||
+		o.IndentStart != nil || o.IndentFirstLine != nil || o.IndentEnd != nil ||
+		o.SpaceAbove != nil || o.SpaceBelow != nil ||
+		o.KeepWithNext != nil || o.KeepLinesTogether != nil
 }
 
 func BuildRequests(options Options, start, end int64, tabID string) ([]*docs.Request, error) {
@@ -79,18 +103,41 @@ func BuildRequests(options Options, start, end int64, tabID string) ([]*docs.Req
 		return nil, err
 	}
 
-	paragraphReq, hasParagraph, err := buildParagraphStyleRequest(options, start, end, tabID)
+	paragraphStart, paragraphEnd := start, end
+
+	hasPostBulletRange := options.PostBulletParagraphStart > 0 && options.PostBulletParagraphEnd > options.PostBulletParagraphStart
+	if hasPostBulletRange {
+		paragraphStart = options.PostBulletParagraphStart
+		paragraphEnd = options.PostBulletParagraphEnd
+	}
+
+	paragraphReq, hasParagraph, err := buildParagraphStyleRequest(options, paragraphStart, paragraphEnd, tabID)
 	if err != nil {
 		return nil, err
 	}
 
-	requests := make([]*docs.Request, 0, 2)
+	bulletReq, hasBullets, err := buildParagraphBulletsRequest(options, start, end, tabID)
+	if err != nil {
+		return nil, err
+	}
+
+	requests := make([]*docs.Request, 0, 3)
 	if hasText {
 		requests = append(requests, textReq)
 	}
 
+	// Removing bullets preserves list nesting by adding paragraph indentation.
+	// Apply explicit paragraph controls afterward so the caller's values win.
+	if hasBullets && (options.ClearBullets || hasPostBulletRange) {
+		requests = append(requests, bulletReq)
+	}
+
 	if hasParagraph {
 		requests = append(requests, paragraphReq)
+	}
+
+	if hasBullets && !options.ClearBullets && !hasPostBulletRange {
+		requests = append(requests, bulletReq)
 	}
 
 	if len(requests) == 0 {
@@ -256,6 +303,61 @@ func buildParagraphStyleRequest(options Options, start, end int64, tabID string)
 		fields = append(fields, "namedStyleType")
 	}
 
+	addDimension := func(value *float64, flag, field string, apply func(*docs.Dimension)) error {
+		if value == nil {
+			return nil
+		}
+
+		if *value < 0 {
+			return invalidf("--%s must be non-negative", flag)
+		}
+
+		dimension := &docs.Dimension{Magnitude: *value, Unit: "PT"}
+		if *value == 0 {
+			dimension.ForceSendFields = append(dimension.ForceSendFields, "Magnitude")
+		}
+
+		apply(dimension)
+
+		fields = append(fields, field)
+
+		return nil
+	}
+	if err := addDimension(options.IndentStart, "indent-start", "indentStart", func(v *docs.Dimension) { style.IndentStart = v }); err != nil {
+		return nil, false, err
+	}
+
+	if err := addDimension(options.IndentFirstLine, "indent-first-line", "indentFirstLine", func(v *docs.Dimension) { style.IndentFirstLine = v }); err != nil {
+		return nil, false, err
+	}
+
+	if err := addDimension(options.IndentEnd, "indent-end", "indentEnd", func(v *docs.Dimension) { style.IndentEnd = v }); err != nil {
+		return nil, false, err
+	}
+
+	if err := addDimension(options.SpaceAbove, "space-above", "spaceAbove", func(v *docs.Dimension) { style.SpaceAbove = v }); err != nil {
+		return nil, false, err
+	}
+
+	if err := addDimension(options.SpaceBelow, "space-below", "spaceBelow", func(v *docs.Dimension) { style.SpaceBelow = v }); err != nil {
+		return nil, false, err
+	}
+
+	addBool := func(value *bool, field, forceField string, apply func(bool)) {
+		if value == nil {
+			return
+		}
+
+		apply(*value)
+
+		fields = append(fields, field)
+		if !*value {
+			style.ForceSendFields = append(style.ForceSendFields, forceField)
+		}
+	}
+	addBool(options.KeepWithNext, "keepWithNext", "KeepWithNext", func(v bool) { style.KeepWithNext = v })
+	addBool(options.KeepLinesTogether, "keepLinesTogether", "KeepLinesTogether", func(v bool) { style.KeepLinesTogether = v })
+
 	if len(fields) == 0 {
 		return nil, false, nil
 	}
@@ -265,6 +367,79 @@ func buildParagraphStyleRequest(options Options, start, end int64, tabID string)
 		ParagraphStyle: style,
 		Fields:         strings.Join(fields, ","),
 	}}, true, nil
+}
+
+func buildParagraphBulletsRequest(options Options, start, end int64, tabID string) (*docs.Request, bool, error) {
+	presetFlags := 0
+	if options.Bullets {
+		presetFlags++
+	}
+
+	if options.Ordered {
+		presetFlags++
+	}
+
+	if strings.TrimSpace(options.BulletPreset) != "" {
+		presetFlags++
+	}
+
+	if presetFlags > 1 {
+		return nil, false, ValidationError("--bullets, --ordered, and --bullet-preset are mutually exclusive")
+	}
+
+	if options.ClearBullets && presetFlags > 0 {
+		return nil, false, ValidationError("--no-bullets cannot be combined with --bullets, --ordered, or --bullet-preset")
+	}
+
+	range_ := &docs.Range{StartIndex: start, EndIndex: end, TabId: tabID}
+	if options.ClearBullets {
+		return &docs.Request{DeleteParagraphBullets: &docs.DeleteParagraphBulletsRequest{Range: range_}}, true, nil
+	}
+
+	if presetFlags == 0 {
+		return nil, false, nil
+	}
+
+	preset := BulletPresetDisc
+	if options.Ordered {
+		preset = BulletPresetNumbered
+	}
+
+	if custom := strings.ToUpper(strings.TrimSpace(options.BulletPreset)); custom != "" {
+		preset = custom
+	}
+
+	if !validBulletPreset(preset) {
+		return nil, false, ValidationError("--bullet-preset must be a supported Google Docs bullet glyph preset")
+	}
+
+	return &docs.Request{CreateParagraphBullets: &docs.CreateParagraphBulletsRequest{
+		Range:        range_,
+		BulletPreset: preset,
+	}}, true, nil
+}
+
+func validBulletPreset(value string) bool {
+	switch value {
+	case "BULLET_DISC_CIRCLE_SQUARE",
+		"BULLET_DIAMONDX_ARROW3D_SQUARE",
+		"BULLET_CHECKBOX",
+		"BULLET_ARROW_DIAMOND_DISC",
+		"BULLET_STAR_CIRCLE_SQUARE",
+		"BULLET_ARROW3D_CIRCLE_SQUARE",
+		"BULLET_LEFTTRIANGLE_DIAMOND_DISC",
+		"BULLET_DIAMONDX_HOLLOWDIAMOND_SQUARE",
+		"BULLET_DIAMOND_CIRCLE_SQUARE",
+		"NUMBERED_DECIMAL_ALPHA_ROMAN",
+		"NUMBERED_DECIMAL_ALPHA_ROMAN_PARENS",
+		"NUMBERED_DECIMAL_NESTED",
+		"NUMBERED_UPPERALPHA_ALPHA_ROMAN",
+		"NUMBERED_UPPERROMAN_UPPERALPHA_DECIMAL",
+		"NUMBERED_ZERODECIMAL_ALPHA_ROMAN":
+		return true
+	default:
+		return false
+	}
 }
 
 func formatLink(value string) (*docs.Link, error) {

--- a/internal/docsformat/format_test.go
+++ b/internal/docsformat/format_test.go
@@ -77,8 +77,160 @@ func TestOptionsAny(t *testing.T) {
 	if !(Options{NamedStyle: "TITLE"}).Any() {
 		t.Fatal("named style should count as formatting")
 	}
+
+	if !(Options{SpaceBelow: floatPointer(0)}).Any() {
+		t.Fatal("explicit zero dimension should count as formatting")
+	}
+}
+
+func TestBuildRequestsParagraphControlsAndBullets(t *testing.T) {
+	requests, err := BuildRequests(Options{
+		Ordered:           true,
+		IndentStart:       floatPointer(36),
+		IndentFirstLine:   floatPointer(18),
+		IndentEnd:         floatPointer(0),
+		SpaceAbove:        floatPointer(6),
+		SpaceBelow:        floatPointer(12),
+		KeepWithNext:      boolPointer(true),
+		KeepLinesTogether: boolPointer(false),
+	}, 3, 20, "t.second")
+	if err != nil {
+		t.Fatalf("BuildRequests: %v", err)
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("requests = %d, want paragraph style and bullets", len(requests))
+	}
+
+	paragraph := requests[0].UpdateParagraphStyle
+	if paragraph == nil {
+		t.Fatalf("missing paragraph request: %#v", requests[0])
+	}
+
+	if paragraph.Fields != "indentStart,indentFirstLine,indentEnd,spaceAbove,spaceBelow,keepWithNext,keepLinesTogether" {
+		t.Fatalf("fields = %q", paragraph.Fields)
+	}
+
+	style := paragraph.ParagraphStyle
+	if style.IndentStart.Magnitude != 36 || style.IndentFirstLine.Magnitude != 18 || style.IndentEnd.Magnitude != 0 ||
+		style.SpaceAbove.Magnitude != 6 || style.SpaceBelow.Magnitude != 12 || !style.KeepWithNext || style.KeepLinesTogether {
+		t.Fatalf("unexpected paragraph style: %#v", style)
+	}
+
+	encoded, err := json.Marshal(style)
+	if err != nil {
+		t.Fatalf("marshal paragraph style: %v", err)
+	}
+
+	if !strings.Contains(string(encoded), `"keepLinesTogether":false`) {
+		t.Fatalf("clearing keep-lines-together must force-send false: %s", encoded)
+	}
+
+	if !strings.Contains(string(encoded), `"indentEnd":{"magnitude":0,"unit":"PT"}`) {
+		t.Fatalf("explicit zero dimension must force-send zero: %s", encoded)
+	}
+
+	bullets := requests[1].CreateParagraphBullets
+	if bullets == nil || bullets.BulletPreset != BulletPresetNumbered || bullets.Range.TabId != "t.second" {
+		t.Fatalf("unexpected bullets request: %#v", requests[1])
+	}
+}
+
+func TestBuildRequestsBulletOperations(t *testing.T) {
+	tests := []struct {
+		name       string
+		options    Options
+		wantPreset string
+		wantDelete bool
+	}{
+		{name: "bullets", options: Options{Bullets: true}, wantPreset: BulletPresetDisc},
+		{name: "custom case insensitive", options: Options{BulletPreset: "bullet_checkbox"}, wantPreset: "BULLET_CHECKBOX"},
+		{name: "remove", options: Options{ClearBullets: true}, wantDelete: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			requests, err := BuildRequests(tt.options, 1, 5, "")
+			if err != nil {
+				t.Fatalf("BuildRequests: %v", err)
+			}
+
+			if len(requests) != 1 {
+				t.Fatalf("requests = %#v", requests)
+			}
+
+			if tt.wantDelete {
+				if requests[0].DeleteParagraphBullets == nil {
+					t.Fatalf("missing delete request: %#v", requests[0])
+				}
+
+				return
+			}
+
+			if got := requests[0].CreateParagraphBullets; got == nil || got.BulletPreset != tt.wantPreset {
+				t.Fatalf("unexpected create request: %#v", requests[0])
+			}
+		})
+	}
+}
+
+func TestBuildRequestsBulletRemovalPrecedesParagraphControls(t *testing.T) {
+	requests, err := BuildRequests(Options{
+		ClearBullets:    true,
+		IndentStart:     floatPointer(0),
+		IndentFirstLine: floatPointer(0),
+	}, 1, 5, "")
+	if err != nil {
+		t.Fatalf("BuildRequests: %v", err)
+	}
+
+	if len(requests) != 2 || requests[0].DeleteParagraphBullets == nil || requests[1].UpdateParagraphStyle == nil {
+		t.Fatalf("bullet removal must precede paragraph controls: %#v", requests)
+	}
+}
+
+func TestBuildRequestsBulletCreationUsesPostBulletParagraphRange(t *testing.T) {
+	requests, err := BuildRequests(Options{
+		Bullets:                  true,
+		IndentStart:              floatPointer(54),
+		PostBulletParagraphStart: 1,
+		PostBulletParagraphEnd:   8,
+	}, 3, 9, "")
+	if err != nil {
+		t.Fatalf("BuildRequests: %v", err)
+	}
+
+	if len(requests) != 2 || requests[0].CreateParagraphBullets == nil || requests[1].UpdateParagraphStyle == nil {
+		t.Fatalf("bullet creation must precede paragraph controls: %#v", requests)
+	}
+
+	if got := requests[1].UpdateParagraphStyle.Range; got.StartIndex != 1 || got.EndIndex != 8 {
+		t.Fatalf("post-bullet paragraph range = %#v", got)
+	}
+}
+
+func TestBuildRequestsParagraphControlValidation(t *testing.T) {
+	tests := []Options{
+		{IndentStart: floatPointer(-1)},
+		{SpaceBelow: floatPointer(-1)},
+		{Bullets: true, Ordered: true},
+		{Bullets: true, ClearBullets: true},
+		{BulletPreset: "not_a_preset"},
+	}
+	for _, options := range tests {
+		if _, err := BuildRequests(options, 1, 2, ""); err == nil {
+			t.Fatalf("BuildRequests(%#v) expected error", options)
+		}
+	}
 }
 
 func intPointer(value int) *int {
+	return &value
+}
+
+func floatPointer(value float64) *float64 {
+	return &value
+}
+
+func boolPointer(value bool) *bool {
 	return &value
 }


### PR DESCRIPTION
Closes #852.

## Summary

- add native bullet, numbered-list, custom preset, and bullet-removal controls to `docs format`
- add paragraph indentation, spacing, keep-with-next, and keep-lines-together controls with explicit zero/false support
- preserve exact match text styling, contiguous list identity, and nested-list levels while accounting for Docs API index shifts
- expose the same controls for plain-text `docs write`, with a guarded append workflow

## Testing

- `make ci`
- structured autoreview: clean
- live Google Docs proof: contiguous numbered paragraphs shared one list ID; leading-tab paragraphs retained nesting levels 0/1; exact-match bold styling and paragraph spacing persisted; custom indentation/keep values survived list creation; bullet removal plus zero indentation reset succeeded
