### PR TITLE
feat(docs): add table cell border and padding styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Docs: add table cell borders, padding, and vertical content alignment to `docs cell-style`. (#855) — thanks @sebsnyk.
 - Docs: add paragraph bullet and numbering creation/removal plus indentation, spacing, and keep controls to `docs format` and plain-text `docs write`. (#852) — thanks @sebsnyk.
 - Docs: add `replace-image` with exact object-ID, alt-text, single-image, tab, public-URL, and local-file targeting while preserving the original image position and bounds. (#853) — thanks @sebsnyk.
 - Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851, #854) — thanks @sebsnyk.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -225,7 +225,7 @@ Generated from `gog schema --json`.
   - [`gog docs (doc) <command> [flags]`](commands/gog-docs.md) - Google Docs (export via Drive)
     - [`gog docs (doc) add-tab <docId> [flags]`](commands/gog-docs-add-tab.md) - Add a tab to a Google Doc
     - [`gog docs (doc) cat (text,read) <docId> [flags]`](commands/gog-docs-cat.md) - Print a Google Doc as plain text
-    - [`gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]`](commands/gog-docs-cell-style.md) - Apply table cell background and text styling
+    - [`gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]`](commands/gog-docs-cell-style.md) - Apply table cell, border, padding, alignment, and text styling
     - [`gog docs (doc) cell-update (update-cell) --row=INT --col=INT <docId> [flags]`](commands/gog-docs-cell-update.md) - Replace or append content inside a specific table cell
     - [`gog docs (doc) clear <docId>`](commands/gog-docs-clear.md) - Clear all content from a Google Doc
     - [`gog docs (doc) comments <command>`](commands/gog-docs-comments.md) - Manage comments on files

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -276,7 +276,7 @@ Generated pages: 680.
   - [gog docs](gog-docs.md) - Google Docs (export via Drive)
     - [gog docs add-tab](gog-docs-add-tab.md) - Add a tab to a Google Doc
     - [gog docs cat](gog-docs-cat.md) - Print a Google Doc as plain text
-    - [gog docs cell-style](gog-docs-cell-style.md) - Apply table cell background and text styling
+    - [gog docs cell-style](gog-docs-cell-style.md) - Apply table cell, border, padding, alignment, and text styling
     - [gog docs cell-update](gog-docs-cell-update.md) - Replace or append content inside a specific table cell
     - [gog docs clear](gog-docs-clear.md) - Clear all content from a Google Doc
     - [gog docs comments](gog-docs-comments.md) - Manage comments on files

--- a/docs/commands/gog-docs-cell-style.md
+++ b/docs/commands/gog-docs-cell-style.md
@@ -2,7 +2,7 @@
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Apply table cell background and text styling
+Apply table cell, border, padding, alignment, and text styling
 
 ## Usage
 
@@ -23,10 +23,16 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--background-color`<br>`--bg-color` | `string` |  | Cell background color as #RRGGBB or #RGB |
 | `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--bold` | `bool` |  | Set cell text bold |
+| `--border-all` | `string` |  | All borders as WIDTH[,COLOR[,SOLID\|DOT\|DASH]] (e.g. 1pt,#000,DASH) |
+| `--border-bottom` | `string` |  | Bottom border; overrides --border-all |
+| `--border-left` | `string` |  | Left border; overrides --border-all |
+| `--border-right` | `string` |  | Right border; overrides --border-all |
+| `--border-top` | `string` |  | Top border; overrides --border-all |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--col` | `int` |  | 1-based column number |
 | `--col-span` | `int64` | 1 | Number of columns to style |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--content-align` | `string` |  | Vertical content alignment: top, middle, or bottom |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
@@ -38,6 +44,11 @@ gog docs (doc) cell-style --row=INT --col=INT <docId> [flags]
 | `--italic` | `bool` |  | Set cell text italic |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--padding-all` | `string` |  | All cell padding (points by default; supports pt, in, cm, mm) |
+| `--padding-bottom` | `string` |  | Bottom cell padding; overrides --padding-all |
+| `--padding-left` | `string` |  | Left cell padding; overrides --padding-all |
+| `--padding-right` | `string` |  | Right cell padding; overrides --padding-all |
+| `--padding-top` | `string` |  | Top cell padding; overrides --padding-all |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--row` | `int` |  | 1-based row number |

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -18,7 +18,7 @@ gog docs (doc) <command> [flags]
 
 - [gog docs add-tab](gog-docs-add-tab.md) - Add a tab to a Google Doc
 - [gog docs cat](gog-docs-cat.md) - Print a Google Doc as plain text
-- [gog docs cell-style](gog-docs-cell-style.md) - Apply table cell background and text styling
+- [gog docs cell-style](gog-docs-cell-style.md) - Apply table cell, border, padding, alignment, and text styling
 - [gog docs cell-update](gog-docs-cell-update.md) - Replace or append content inside a specific table cell
 - [gog docs clear](gog-docs-clear.md) - Clear all content from a Google Doc
 - [gog docs comments](gog-docs-comments.md) - Manage comments on files

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -31,7 +31,7 @@ type DocsCmd struct {
 	Insert           DocsInsertCmd           `cmd:"" name:"insert" help:"Insert text at a specific position"`
 	InsertTable      DocsInsertTableCmd      `cmd:"" name:"insert-table" help:"Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json"`
 	CellUpdate       DocsCellUpdateCmd       `cmd:"" name:"cell-update" aliases:"update-cell" help:"Replace or append content inside a specific table cell"`
-	CellStyle        DocsCellStyleCmd        `cmd:"" name:"cell-style" help:"Apply table cell background and text styling"`
+	CellStyle        DocsCellStyleCmd        `cmd:"" name:"cell-style" help:"Apply table cell, border, padding, alignment, and text styling"`
 	TableRow         DocsTableRowCmd         `cmd:"" name:"table-row" help:"Insert or delete native table rows"`
 	TableColumn      DocsTableColumnCmd      `cmd:"" name:"table-column" help:"Insert or delete native table columns"`
 	TableMerge       DocsTableMergeCmd       `cmd:"" name:"table-merge" help:"Merge a native table cell range"`

--- a/internal/cmd/docs_cell_style.go
+++ b/internal/cmd/docs_cell_style.go
@@ -11,6 +11,15 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
+const (
+	docsTableContentAlignTop    = "TOP"
+	docsTableContentAlignMiddle = "MIDDLE"
+	docsTableContentAlignBottom = "BOTTOM"
+	docsTableBorderDashSolid    = "SOLID"
+	docsTableBorderDashDot      = "DOT"
+	docsTableBorderDashDash     = "DASH"
+)
+
 type DocsCellStyleCmd struct {
 	DocID           string `arg:"" name:"docId" help:"Doc ID"`
 	TableIndex      int    `name:"table-index" help:"1-based table index in document order; negative indexes count from the end" default:"1"`
@@ -19,6 +28,17 @@ type DocsCellStyleCmd struct {
 	RowSpan         int64  `name:"row-span" help:"Number of rows to style" default:"1"`
 	ColSpan         int64  `name:"col-span" help:"Number of columns to style" default:"1"`
 	BackgroundColor string `name:"background-color" aliases:"bg-color" help:"Cell background color as #RRGGBB or #RGB"`
+	BorderAll       string `name:"border-all" help:"All borders as WIDTH[,COLOR[,SOLID|DOT|DASH]] (e.g. 1pt,#000,DASH)"`
+	BorderTop       string `name:"border-top" help:"Top border; overrides --border-all"`
+	BorderBottom    string `name:"border-bottom" help:"Bottom border; overrides --border-all"`
+	BorderLeft      string `name:"border-left" help:"Left border; overrides --border-all"`
+	BorderRight     string `name:"border-right" help:"Right border; overrides --border-all"`
+	PaddingAll      string `name:"padding-all" help:"All cell padding (points by default; supports pt, in, cm, mm)"`
+	PaddingTop      string `name:"padding-top" help:"Top cell padding; overrides --padding-all"`
+	PaddingBottom   string `name:"padding-bottom" help:"Bottom cell padding; overrides --padding-all"`
+	PaddingLeft     string `name:"padding-left" help:"Left cell padding; overrides --padding-all"`
+	PaddingRight    string `name:"padding-right" help:"Right cell padding; overrides --padding-all"`
+	ContentAlign    string `name:"content-align" help:"Vertical content alignment: top, middle, or bottom"`
 	TextColor       string `name:"text-color" help:"Text color as #RRGGBB or #RGB"`
 	Bold            bool   `name:"bold" help:"Set cell text bold"`
 	Italic          bool   `name:"italic" help:"Set cell text italic"`
@@ -49,7 +69,7 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("no style flags provided")
 	}
 	if c.hasTextStyle() && (c.RowSpan != 1 || c.ColSpan != 1) {
-		return usage("--row-span/--col-span can only be combined with --background-color; text style flags target one cell")
+		return usage("text style flags target one cell; use cell style flags with --row-span/--col-span")
 	}
 	if err := dryRunExit(ctx, flags, "docs.cell-style", map[string]any{
 		"documentId":      docID,
@@ -59,6 +79,17 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"rowSpan":         c.RowSpan,
 		"colSpan":         c.ColSpan,
 		"backgroundColor": c.BackgroundColor,
+		"borderAll":       c.BorderAll,
+		"borderTop":       c.BorderTop,
+		"borderBottom":    c.BorderBottom,
+		"borderLeft":      c.BorderLeft,
+		"borderRight":     c.BorderRight,
+		"paddingAll":      c.PaddingAll,
+		"paddingTop":      c.PaddingTop,
+		"paddingBottom":   c.PaddingBottom,
+		"paddingLeft":     c.PaddingLeft,
+		"paddingRight":    c.PaddingRight,
+		"contentAlign":    c.ContentAlign,
 		"textColor":       c.TextColor,
 		"bold":            c.Bold,
 		"italic":          c.Italic,
@@ -140,6 +171,17 @@ func (c *DocsCellStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 func (c *DocsCellStyleCmd) anyStyle() bool {
 	return strings.TrimSpace(c.BackgroundColor) != "" ||
+		strings.TrimSpace(c.BorderAll) != "" ||
+		strings.TrimSpace(c.BorderTop) != "" ||
+		strings.TrimSpace(c.BorderBottom) != "" ||
+		strings.TrimSpace(c.BorderLeft) != "" ||
+		strings.TrimSpace(c.BorderRight) != "" ||
+		strings.TrimSpace(c.PaddingAll) != "" ||
+		strings.TrimSpace(c.PaddingTop) != "" ||
+		strings.TrimSpace(c.PaddingBottom) != "" ||
+		strings.TrimSpace(c.PaddingLeft) != "" ||
+		strings.TrimSpace(c.PaddingRight) != "" ||
+		strings.TrimSpace(c.ContentAlign) != "" ||
 		strings.TrimSpace(c.TextColor) != "" ||
 		c.Bold || c.Italic || c.Underline
 }
@@ -150,14 +192,14 @@ func (c *DocsCellStyleCmd) hasTextStyle() bool {
 
 func (c *DocsCellStyleCmd) buildRequests(tableStart int64, cell *docs.TableCell, tabID string) ([]*docs.Request, error) {
 	reqs := make([]*docs.Request, 0, 2)
-	if bg := strings.TrimSpace(c.BackgroundColor); bg != "" {
-		color, err := docsFormatColor(bg, "--background-color")
-		if err != nil {
-			return nil, err
-		}
+	cellStyle, fields, err := c.buildCellStyle()
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) > 0 {
 		reqs = append(reqs, &docs.Request{UpdateTableCellStyle: &docs.UpdateTableCellStyleRequest{
-			TableCellStyle: &docs.TableCellStyle{BackgroundColor: color},
-			Fields:         "backgroundColor",
+			TableCellStyle: cellStyle,
+			Fields:         strings.Join(fields, ","),
 			TableRange: &docs.TableRange{
 				RowSpan:    c.RowSpan,
 				ColumnSpan: c.ColSpan,
@@ -185,6 +227,115 @@ func (c *DocsCellStyleCmd) buildRequests(tableStart int64, cell *docs.TableCell,
 		return nil, usage("no style flags provided")
 	}
 	return reqs, nil
+}
+
+func (c *DocsCellStyleCmd) buildCellStyle() (*docs.TableCellStyle, []string, error) {
+	style := &docs.TableCellStyle{}
+	fields := []string{}
+	if bg := strings.TrimSpace(c.BackgroundColor); bg != "" {
+		color, err := docsFormatColor(bg, "--background-color")
+		if err != nil {
+			return nil, nil, err
+		}
+		style.BackgroundColor = color
+		fields = append(fields, "backgroundColor")
+	}
+
+	// Docs resolves shared-border conflicts in this order. Match it so the field
+	// mask and request payload make the final edge precedence explicit.
+	borderSides := []struct {
+		field string
+		flag  string
+		value string
+		set   func(*docs.TableCellBorder)
+	}{
+		{field: "borderRight", flag: "border-right", value: c.BorderRight, set: func(v *docs.TableCellBorder) { style.BorderRight = v }},
+		{field: "borderLeft", flag: "border-left", value: c.BorderLeft, set: func(v *docs.TableCellBorder) { style.BorderLeft = v }},
+		{field: "borderBottom", flag: "border-bottom", value: c.BorderBottom, set: func(v *docs.TableCellBorder) { style.BorderBottom = v }},
+		{field: "borderTop", flag: "border-top", value: c.BorderTop, set: func(v *docs.TableCellBorder) { style.BorderTop = v }},
+	}
+	for _, side := range borderSides {
+		raw, flag := strings.TrimSpace(side.value), side.flag
+		if raw == "" {
+			raw, flag = strings.TrimSpace(c.BorderAll), "border-all"
+		}
+		if raw == "" {
+			continue
+		}
+		border, err := parseDocsTableCellBorder(flag, raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		side.set(border)
+		fields = append(fields, side.field)
+	}
+
+	paddingSides := []struct {
+		field string
+		flag  string
+		value string
+		set   func(*docs.Dimension)
+	}{
+		{field: "paddingTop", flag: "padding-top", value: c.PaddingTop, set: func(v *docs.Dimension) { style.PaddingTop = v }},
+		{field: "paddingBottom", flag: "padding-bottom", value: c.PaddingBottom, set: func(v *docs.Dimension) { style.PaddingBottom = v }},
+		{field: "paddingLeft", flag: "padding-left", value: c.PaddingLeft, set: func(v *docs.Dimension) { style.PaddingLeft = v }},
+		{field: "paddingRight", flag: "padding-right", value: c.PaddingRight, set: func(v *docs.Dimension) { style.PaddingRight = v }},
+	}
+	for _, side := range paddingSides {
+		raw, flag := strings.TrimSpace(side.value), side.flag
+		if raw == "" {
+			raw, flag = strings.TrimSpace(c.PaddingAll), "padding-all"
+		}
+		if raw == "" {
+			continue
+		}
+		dimension, _, err := parseDocsDimension(flag, raw, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		side.set(dimension)
+		fields = append(fields, side.field)
+	}
+
+	if align := strings.ToUpper(strings.TrimSpace(c.ContentAlign)); align != "" {
+		switch align {
+		case docsTableContentAlignTop, docsTableContentAlignMiddle, docsTableContentAlignBottom:
+			style.ContentAlignment = align
+			fields = append(fields, "contentAlignment")
+		default:
+			return nil, nil, usage("--content-align must be top, middle, or bottom")
+		}
+	}
+	return style, fields, nil
+}
+
+func parseDocsTableCellBorder(flag, raw string) (*docs.TableCellBorder, error) {
+	parts := strings.Split(raw, ",")
+	if len(parts) > 3 || strings.TrimSpace(parts[0]) == "" {
+		return nil, usagef("invalid --%s %q (expected WIDTH[,COLOR[,SOLID|DOT|DASH]])", flag, raw)
+	}
+	width, _, err := parseDocsDimension(flag, strings.TrimSpace(parts[0]), true)
+	if err != nil {
+		return nil, err
+	}
+	colorRaw := "#000000"
+	if len(parts) >= 2 && strings.TrimSpace(parts[1]) != "" {
+		colorRaw = strings.TrimSpace(parts[1])
+	}
+	color, err := docsFormatColor(colorRaw, "--"+flag)
+	if err != nil {
+		return nil, err
+	}
+	dash := docsTableBorderDashSolid
+	if len(parts) == 3 && strings.TrimSpace(parts[2]) != "" {
+		dash = strings.ToUpper(strings.TrimSpace(parts[2]))
+	}
+	switch dash {
+	case docsTableBorderDashSolid, docsTableBorderDashDot, docsTableBorderDashDash:
+	default:
+		return nil, usagef("invalid --%s dash style %q (expected SOLID, DOT, or DASH)", flag, strings.TrimSpace(parts[2]))
+	}
+	return &docs.TableCellBorder{Width: width, Color: color, DashStyle: dash}, nil
 }
 
 func (c *DocsCellStyleCmd) buildTextStyleRequest(cell *docs.TableCell, tabID string) (*docs.Request, bool, error) {

--- a/internal/cmd/docs_remaining_features_test.go
+++ b/internal/cmd/docs_remaining_features_test.go
@@ -79,6 +79,73 @@ func TestDocsCellStyleBuildsTableAndTextRequests(t *testing.T) {
 	}
 }
 
+func TestDocsCellStyleBuildsBordersPaddingAndAlignment(t *testing.T) {
+	cmd := &DocsCellStyleCmd{
+		Row:          2,
+		Col:          3,
+		RowSpan:      2,
+		ColSpan:      4,
+		BorderAll:    "1pt,#abc,DOT",
+		BorderTop:    "2pt,#123456,DASH",
+		PaddingAll:   "6pt",
+		PaddingRight: "0",
+		ContentAlign: "middle",
+	}
+	reqs, err := cmd.buildRequests(8, &docs.TableCell{}, "tab-2")
+	if err != nil {
+		t.Fatalf("buildRequests: %v", err)
+	}
+	if len(reqs) != 1 || reqs[0].UpdateTableCellStyle == nil {
+		t.Fatalf("unexpected requests: %#v", reqs)
+	}
+	got := reqs[0].UpdateTableCellStyle
+	wantFields := "borderRight,borderLeft,borderBottom,borderTop,paddingTop,paddingBottom,paddingLeft,paddingRight,contentAlignment"
+	if got.Fields != wantFields {
+		t.Fatalf("fields = %q, want %q", got.Fields, wantFields)
+	}
+	if got.TableRange.RowSpan != 2 || got.TableRange.ColumnSpan != 4 {
+		t.Fatalf("table range = %#v", got.TableRange)
+	}
+	style := got.TableCellStyle
+	if style.BorderRight.Width.Magnitude != 1 || style.BorderRight.DashStyle != "DOT" {
+		t.Fatalf("right border = %#v", style.BorderRight)
+	}
+	if style.BorderTop.Width.Magnitude != 2 || style.BorderTop.DashStyle != "DASH" {
+		t.Fatalf("top border = %#v", style.BorderTop)
+	}
+	if gotRed := style.BorderTop.Color.Color.RgbColor.Red; gotRed < 0.07 || gotRed > 0.08 {
+		t.Fatalf("top border color = %#v", style.BorderTop.Color)
+	}
+	if style.PaddingTop.Magnitude != 6 || style.PaddingRight.Magnitude != 0 {
+		t.Fatalf("padding = top %#v right %#v", style.PaddingTop, style.PaddingRight)
+	}
+	if style.ContentAlignment != "MIDDLE" {
+		t.Fatalf("content alignment = %q", style.ContentAlignment)
+	}
+}
+
+func TestDocsCellStyleRejectsInvalidTableStyles(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  DocsCellStyleCmd
+		want string
+	}{
+		{name: "border shape", cmd: DocsCellStyleCmd{BorderTop: "1pt,#fff,SOLID,extra"}, want: "expected WIDTH"},
+		{name: "border dash", cmd: DocsCellStyleCmd{BorderTop: "1pt,#fff,WAVE"}, want: "expected SOLID"},
+		{name: "border color", cmd: DocsCellStyleCmd{BorderTop: "1pt,nope"}, want: "must be #RRGGBB"},
+		{name: "padding", cmd: DocsCellStyleCmd{PaddingAll: "-1pt"}, want: "non-negative length"},
+		{name: "alignment", cmd: DocsCellStyleCmd{ContentAlign: "center"}, want: "top, middle, or bottom"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := tt.cmd.buildCellStyle()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("expected %q error, got %v", tt.want, err)
+			}
+		})
+	}
+}
+
 func TestDocsCellStyle_TableSelectionErrorsAreUsage(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add compact per-side table cell border flags with all-side defaults and explicit Docs shared-edge ordering
- add all-side and per-side cell padding plus vertical content alignment
- preserve range, tab, dry-run, persisted batch, and revision-control behavior
- regenerate command docs and add the changelog entry

Part of #855.

## Validation

- `make ci`
- autoreview: clean, no actionable findings
- live E2E with `clawdbot@gmail.com`: created a disposable 2x2 native Docs table; validated the dry-run request; applied a dashed 2pt top border, solid 1pt remaining borders, 9pt padding with a 0pt right override, and middle alignment across the table; confirmed all values through `docs raw`; permanently deleted the fixture
