### PR TITLE
feat(docs): add table row style controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Docs: add table cell borders, padding, and vertical content alignment to `docs cell-style`. (#855) — thanks @sebsnyk.
+- Docs: add minimum height and page-overflow controls to `docs table-row style`. (#855) — thanks @sebsnyk.
 - Docs: add paragraph bullet and numbering creation/removal plus indentation, spacing, and keep controls to `docs format` and plain-text `docs write`. (#852) — thanks @sebsnyk.
 - Docs: add `replace-image` with exact object-ID, alt-text, single-image, tab, public-URL, and local-file targeting while preserving the original image position and bounds. (#853) — thanks @sebsnyk.
 - Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851, #854) — thanks @sebsnyk.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -278,9 +278,10 @@ Generated from `gog schema --json`.
       - [`gog docs (doc) table-column insert (add,append) <docId> [flags]`](commands/gog-docs-table-column-insert.md) - Insert a native table column
     - [`gog docs (doc) table-column-width (table-width,column-width) <docId> [flags]`](commands/gog-docs-table-column-width.md) - Set or reset native table column widths
     - [`gog docs (doc) table-merge --range=STRING <docId> [flags]`](commands/gog-docs-table-merge.md) - Merge a native table cell range
-    - [`gog docs (doc) table-row <command>`](commands/gog-docs-table-row.md) - Insert or delete native table rows
+    - [`gog docs (doc) table-row <command>`](commands/gog-docs-table-row.md) - Insert, delete, or style native table rows
       - [`gog docs (doc) table-row delete (rm,remove,del) --row=INT <docId> [flags]`](commands/gog-docs-table-row-delete.md) - Delete a native table row
       - [`gog docs (doc) table-row insert (add,append) <docId> [flags]`](commands/gog-docs-table-row-insert.md) - Insert a native table row
+      - [`gog docs (doc) table-row style <docId> [flags]`](commands/gog-docs-table-row-style.md) - Set native table row height and overflow styles
     - [`gog docs (doc) table-unmerge (table-split) --cell=STRING <docId> [flags]`](commands/gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
     - [`gog docs (doc) tables <command>`](commands/gog-docs-tables.md) - List native tables
       - [`gog docs (doc) tables list (ls) <docId> [flags]`](commands/gog-docs-tables-list.md) - List native tables in document order

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 680.
+Generated pages: 681.
 
 ## Top-level Commands
 
@@ -329,9 +329,10 @@ Generated pages: 680.
       - [gog docs table-column insert](gog-docs-table-column-insert.md) - Insert a native table column
     - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
     - [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range
-    - [gog docs table-row](gog-docs-table-row.md) - Insert or delete native table rows
+    - [gog docs table-row](gog-docs-table-row.md) - Insert, delete, or style native table rows
       - [gog docs table-row delete](gog-docs-table-row-delete.md) - Delete a native table row
       - [gog docs table-row insert](gog-docs-table-row-insert.md) - Insert a native table row
+      - [gog docs table-row style](gog-docs-table-row-style.md) - Set native table row height and overflow styles
     - [gog docs table-unmerge](gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
     - [gog docs tables](gog-docs-tables.md) - List native tables
       - [gog docs tables list](gog-docs-tables-list.md) - List native tables in document order

--- a/docs/commands/gog-docs-table-row-style.md
+++ b/docs/commands/gog-docs-table-row-style.md
@@ -1,24 +1,18 @@
-# `gog docs table-row`
+# `gog docs table-row style`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, or style native table rows
+Set native table row height and overflow styles
 
 ## Usage
 
 ```bash
-gog docs (doc) table-row <command>
+gog docs (doc) table-row style <docId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
-
-## Subcommands
-
-- [gog docs table-row delete](gog-docs-table-row-delete.md) - Delete a native table row
-- [gog docs table-row insert](gog-docs-table-row-insert.md) - Insert a native table row
-- [gog docs table-row style](gog-docs-table-row-style.md) - Set native table row height and overflow styles
+- [gog docs table-row](gog-docs-table-row.md)
 
 ## Flags
 
@@ -37,15 +31,20 @@ gog docs (doc) table-row <command>
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--min-height` | `string` |  | Minimum row height (points by default; supports pt, in, cm, mm) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--prevent-overflow` | `*bool` |  | Keep the row within one page or column; use --no-prevent-overflow to clear |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--row` | `*int` |  | 1-based row number; negative indexes count from the end; omit to style all rows |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs table-row](gog-docs-table-row.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -53,7 +53,7 @@ gog docs (doc) <command> [flags]
 - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns
 - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
 - [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range
-- [gog docs table-row](gog-docs-table-row.md) - Insert or delete native table rows
+- [gog docs table-row](gog-docs-table-row.md) - Insert, delete, or style native table rows
 - [gog docs table-unmerge](gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
 - [gog docs tables](gog-docs-tables.md) - List native tables
 - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -32,7 +32,7 @@ type DocsCmd struct {
 	InsertTable      DocsInsertTableCmd      `cmd:"" name:"insert-table" help:"Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json"`
 	CellUpdate       DocsCellUpdateCmd       `cmd:"" name:"cell-update" aliases:"update-cell" help:"Replace or append content inside a specific table cell"`
 	CellStyle        DocsCellStyleCmd        `cmd:"" name:"cell-style" help:"Apply table cell, border, padding, alignment, and text styling"`
-	TableRow         DocsTableRowCmd         `cmd:"" name:"table-row" help:"Insert or delete native table rows"`
+	TableRow         DocsTableRowCmd         `cmd:"" name:"table-row" help:"Insert, delete, or style native table rows"`
 	TableColumn      DocsTableColumnCmd      `cmd:"" name:"table-column" help:"Insert or delete native table columns"`
 	TableMerge       DocsTableMergeCmd       `cmd:"" name:"table-merge" help:"Merge a native table cell range"`
 	TableUnmerge     DocsTableUnmergeCmd     `cmd:"" name:"table-unmerge" aliases:"table-split" help:"Unmerge the region containing a native table cell"`

--- a/internal/cmd/docs_table_ops.go
+++ b/internal/cmd/docs_table_ops.go
@@ -18,6 +18,7 @@ import (
 type DocsTableRowCmd struct {
 	Insert DocsTableRowInsertCmd `cmd:"" name:"insert" aliases:"add,append" help:"Insert a native table row"`
 	Delete DocsTableRowDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a native table row"`
+	Style  DocsTableRowStyleCmd  `cmd:"" name:"style" help:"Set native table row height and overflow styles"`
 }
 
 type DocsTableColumnCmd struct {

--- a/internal/cmd/docs_table_row_style.go
+++ b/internal/cmd/docs_table_row_style.go
@@ -1,0 +1,158 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsTableRowStyleCmd struct {
+	DocID           string `arg:"" name:"docId" help:"Doc ID"`
+	Table           string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	Row             *int   `name:"row" help:"1-based row number; negative indexes count from the end; omit to style all rows"`
+	MinHeight       string `name:"min-height" help:"Minimum row height (points by default; supports pt, in, cm, mm)"`
+	PreventOverflow *bool  `name:"prevent-overflow" negatable:"" help:"Keep the row within one page or column; use --no-prevent-overflow to clear"`
+	Tab             string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type docsTableRowStyleResult struct {
+	TableIndex int `json:"tableIndex"`
+	Row        any `json:"row"`
+}
+
+func (c *DocsTableRowStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
+	docID, err := validateDocsTableMutationArgs(c.DocID, c.Table)
+	if err != nil {
+		return err
+	}
+	style, fields, err := c.buildStyle()
+	if err != nil {
+		return err
+	}
+	if c.Row != nil && *c.Row == 0 {
+		return usage("--row cannot be 0")
+	}
+	row := any(literalAll)
+	if c.Row != nil {
+		row = *c.Row
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.table-row.style", map[string]any{
+		"documentId":      docID,
+		"table":           c.Table,
+		"row":             row,
+		"minHeight":       c.MinHeight,
+		"preventOverflow": c.PreventOverflow,
+		"tab":             c.Tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, loaded, selected, err := loadDocsSelectedTables(ctx, flags, docID, c.Tab, c.Table)
+	if err != nil {
+		return err
+	}
+	requests := make([]*docs.Request, 0, len(selected))
+	results := make([]docsTableRowStyleResult, 0, len(selected))
+	for _, target := range selected {
+		rowIndices, resolvedRow, resolveErr := resolveDocsTableStyleRow(target.table, c.Row)
+		if resolveErr != nil {
+			return resolveErr
+		}
+		requests = append(requests, &docs.Request{UpdateTableRowStyle: &docs.UpdateTableRowStyleRequest{
+			TableStartLocation: &docs.Location{Index: target.startIdx, TabId: loaded.tabID},
+			RowIndices:         rowIndices,
+			TableRowStyle:      style,
+			Fields:             strings.Join(fields, ","),
+		}})
+		results = append(results, docsTableRowStyleResult{TableIndex: target.index, Row: resolvedRow})
+	}
+	if _, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests); err != nil {
+		return fmt.Errorf("style table row: %w", err)
+	}
+	return writeDocsTableRowStyleResult(ctx, docID, loaded.tabID, results)
+}
+
+func (c *DocsTableRowStyleCmd) buildStyle() (*docs.TableRowStyle, []string, error) {
+	style := &docs.TableRowStyle{}
+	fields := []string{}
+	if raw := strings.TrimSpace(c.MinHeight); raw != "" {
+		dimension, _, err := parseDocsDimension("min-height", raw, true)
+		if err != nil {
+			return nil, nil, err
+		}
+		style.MinRowHeight = dimension
+		fields = append(fields, "minRowHeight")
+	}
+	if c.PreventOverflow != nil {
+		style.PreventOverflow = *c.PreventOverflow
+		style.ForceSendFields = append(style.ForceSendFields, "PreventOverflow")
+		fields = append(fields, "preventOverflow")
+	}
+	if len(fields) == 0 {
+		return nil, nil, usage("no row style flags provided")
+	}
+	return style, fields, nil
+}
+
+func resolveDocsTableStyleRow(table *docs.Table, requested *int) ([]int64, any, error) {
+	if table == nil || len(table.TableRows) == 0 {
+		return nil, nil, usage("target table has no rows")
+	}
+	if requested == nil {
+		return nil, literalAll, nil
+	}
+	resolved := *requested
+	if resolved < 0 {
+		resolved = len(table.TableRows) + resolved + 1
+	}
+	if resolved < 1 || resolved > len(table.TableRows) {
+		return nil, nil, usagef("row %d out of range (table has %d rows)", *requested, len(table.TableRows))
+	}
+	return []int64{int64(resolved - 1)}, resolved, nil
+}
+
+func writeDocsTableRowStyleResult(
+	ctx context.Context,
+	docID, tabID string,
+	results []docsTableRowStyleResult,
+) error {
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].TableIndex < results[j].TableIndex
+	})
+	if outfmt.IsJSON(ctx) {
+		payload := map[string]any{
+			"documentId": docID,
+			"action":     "style",
+			"target":     "row",
+			"updated":    true,
+			"tables":     results,
+		}
+		if len(results) == 1 {
+			payload["tableIndex"] = results[0].TableIndex
+			payload["row"] = results[0].Row
+		}
+		if tabID != "" {
+			payload["tabId"] = tabID
+		}
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+	}
+
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", docID)
+	u.Out().Linef("action\tstyle")
+	u.Out().Linef("target\trow")
+	for _, result := range results {
+		u.Out().Linef("table\t%d\trow\t%v", result.TableIndex, result.Row)
+	}
+	u.Out().Linef("updated\ttrue")
+	if tabID != "" {
+		u.Out().Linef("tabId\t%s", tabID)
+	}
+	return nil
+}

--- a/internal/cmd/docs_table_row_style_test.go
+++ b/internal/cmd/docs_table_row_style_test.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsTableRowStyleBuildsExplicitFalseValues(t *testing.T) {
+	falseValue := false
+	cmd := &DocsTableRowStyleCmd{
+		MinHeight:       "0",
+		PreventOverflow: &falseValue,
+	}
+	style, fields, err := cmd.buildStyle()
+	if err != nil {
+		t.Fatalf("buildStyle: %v", err)
+	}
+	if got := strings.Join(fields, ","); got != "minRowHeight,preventOverflow" {
+		t.Fatalf("fields = %q", got)
+	}
+	encoded, err := json.Marshal(style)
+	if err != nil {
+		t.Fatalf("marshal style: %v", err)
+	}
+	if got := string(encoded); !strings.Contains(got, `"preventOverflow":false`) {
+		t.Fatalf("style JSON = %s", got)
+	}
+	if style.MinRowHeight == nil || style.MinRowHeight.Magnitude != 0 || style.MinRowHeight.Unit != "PT" {
+		t.Fatalf("min row height = %#v", style.MinRowHeight)
+	}
+}
+
+func TestResolveDocsTableStyleRow(t *testing.T) {
+	table := docsTableOpsTestElement(5, "Header", 3).Table
+	rows, resolved, err := resolveDocsTableStyleRow(table, nil)
+	if err != nil || rows != nil || resolved != "all" {
+		t.Fatalf("all rows = %#v, %#v, %v", rows, resolved, err)
+	}
+	last := -1
+	rows, resolved, err = resolveDocsTableStyleRow(table, &last)
+	if err != nil || len(rows) != 1 || rows[0] != 2 || resolved != 3 {
+		t.Fatalf("last row = %#v, %#v, %v", rows, resolved, err)
+	}
+	outOfRange := 4
+	if _, _, err := resolveDocsTableStyleRow(table, &outOfRange); err == nil || !strings.Contains(err.Error(), "out of range") {
+		t.Fatalf("expected out-of-range error, got %v", err)
+	}
+}
+
+func TestDocsTableRowStyleRunUsesRevisionAndResolvedRow(t *testing.T) {
+	doc := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 2))
+	var got docs.BatchUpdateDocumentRequest
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(&docs.BatchUpdateDocumentResponse{DocumentId: "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	cmd := &DocsTableRowStyleCmd{}
+	err := runKong(t, cmd, []string{
+		"doc1", "--row=-1", "--min-height", "24pt", "--prevent-overflow",
+	}, newDocsTableOpsTestContext(t, docSvc), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got.WriteControl == nil || got.WriteControl.RequiredRevisionId != "rev-1" {
+		t.Fatalf("write control = %#v", got.WriteControl)
+	}
+	if len(got.Requests) != 1 || got.Requests[0].UpdateTableRowStyle == nil {
+		t.Fatalf("requests = %#v", got.Requests)
+	}
+	request := got.Requests[0].UpdateTableRowStyle
+	if request.TableStartLocation.Index != 5 || len(request.RowIndices) != 1 || request.RowIndices[0] != 1 {
+		t.Fatalf("target = %#v rows=%#v", request.TableStartLocation, request.RowIndices)
+	}
+	if request.Fields != "minRowHeight,preventOverflow" {
+		t.Fatalf("fields = %q", request.Fields)
+	}
+	if request.TableRowStyle.MinRowHeight.Magnitude != 24 || !request.TableRowStyle.PreventOverflow {
+		t.Fatalf("style = %#v", request.TableRowStyle)
+	}
+}
+
+func TestDocsTableRowStyleRequiresStyleFlag(t *testing.T) {
+	cmd := &DocsTableRowStyleCmd{DocID: "doc1", Table: "1"}
+	err := cmd.Run(newCmdRuntimeOutputContext(t, nil, nil), &RootFlags{Account: "a@b.com", DryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "no row style flags") {
+		t.Fatalf("expected style error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add `docs table-row style` with one-based and negative row selection, plus all-row updates when `--row` is omitted
- expose writable minimum-height and page-overflow styles, including explicit `--no-prevent-overflow` clears
- retain table selectors, tab targeting, revision-controlled updates, JSON/plain output, and dry-run behavior
- regenerate command docs and add the changelog entry

Part of #855.

`TableRowStyle.tableHeader` is deliberately not exposed: the current schema lists it, but live `updateTableRowStyle` calls reject it as an unallowed field. Header repetition is handled by the dedicated `pinTableHeaderRows` request in the next slice.

## Validation

- `make ci`
- autoreview: clean, no actionable findings
- live E2E with `clawdbot@gmail.com`: created disposable native Docs tables; validated dry-run; applied and read back 36pt minimum height plus overflow prevention on one row; applied and read back 18pt minimum height on all rows; cleared overflow prevention with the negated flag while preserving minimum height; permanently deleted every fixture
