### PR TITLE
feat(docs): add table header row pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Docs: add table cell borders, padding, and vertical content alignment to `docs cell-style`. (#855) — thanks @sebsnyk.
 - Docs: add minimum height and page-overflow controls to `docs table-row style`. (#855) — thanks @sebsnyk.
+- Docs: add `docs table-row pin-header --rows N` for pinning or unpinning repeated table header rows. (#855) — thanks @sebsnyk.
 - Docs: add paragraph bullet and numbering creation/removal plus indentation, spacing, and keep controls to `docs format` and plain-text `docs write`. (#852) — thanks @sebsnyk.
 - Docs: add `replace-image` with exact object-ID, alt-text, single-image, tab, public-URL, and local-file targeting while preserving the original image position and bounds. (#853) — thanks @sebsnyk.
 - Docs: add `insert --markdown` to convert markdown to Google Docs formatting and place the converted block at a position resolved by `--index`/`--at`/`--occurrence`, giving `insert` parity with the existing `update --markdown` and `write --markdown` paths. (#851, #854) — thanks @sebsnyk.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -278,9 +278,10 @@ Generated from `gog schema --json`.
       - [`gog docs (doc) table-column insert (add,append) <docId> [flags]`](commands/gog-docs-table-column-insert.md) - Insert a native table column
     - [`gog docs (doc) table-column-width (table-width,column-width) <docId> [flags]`](commands/gog-docs-table-column-width.md) - Set or reset native table column widths
     - [`gog docs (doc) table-merge --range=STRING <docId> [flags]`](commands/gog-docs-table-merge.md) - Merge a native table cell range
-    - [`gog docs (doc) table-row <command>`](commands/gog-docs-table-row.md) - Insert, delete, or style native table rows
+    - [`gog docs (doc) table-row <command>`](commands/gog-docs-table-row.md) - Insert, delete, style, or pin native table rows
       - [`gog docs (doc) table-row delete (rm,remove,del) --row=INT <docId> [flags]`](commands/gog-docs-table-row-delete.md) - Delete a native table row
       - [`gog docs (doc) table-row insert (add,append) <docId> [flags]`](commands/gog-docs-table-row-insert.md) - Insert a native table row
+      - [`gog docs (doc) table-row pin-header --rows=INT-64 <docId> [flags]`](commands/gog-docs-table-row-pin-header.md) - Pin or unpin leading table header rows
       - [`gog docs (doc) table-row style <docId> [flags]`](commands/gog-docs-table-row-style.md) - Set native table row height and overflow styles
     - [`gog docs (doc) table-unmerge (table-split) --cell=STRING <docId> [flags]`](commands/gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
     - [`gog docs (doc) tables <command>`](commands/gog-docs-tables.md) - List native tables

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 681.
+Generated pages: 682.
 
 ## Top-level Commands
 
@@ -329,9 +329,10 @@ Generated pages: 681.
       - [gog docs table-column insert](gog-docs-table-column-insert.md) - Insert a native table column
     - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
     - [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range
-    - [gog docs table-row](gog-docs-table-row.md) - Insert, delete, or style native table rows
+    - [gog docs table-row](gog-docs-table-row.md) - Insert, delete, style, or pin native table rows
       - [gog docs table-row delete](gog-docs-table-row-delete.md) - Delete a native table row
       - [gog docs table-row insert](gog-docs-table-row-insert.md) - Insert a native table row
+      - [gog docs table-row pin-header](gog-docs-table-row-pin-header.md) - Pin or unpin leading table header rows
       - [gog docs table-row style](gog-docs-table-row-style.md) - Set native table row height and overflow styles
     - [gog docs table-unmerge](gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
     - [gog docs tables](gog-docs-tables.md) - List native tables

--- a/docs/commands/gog-docs-table-row-pin-header.md
+++ b/docs/commands/gog-docs-table-row-pin-header.md
@@ -1,25 +1,18 @@
-# `gog docs table-row`
+# `gog docs table-row pin-header`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Insert, delete, style, or pin native table rows
+Pin or unpin leading table header rows
 
 ## Usage
 
 ```bash
-gog docs (doc) table-row <command>
+gog docs (doc) table-row pin-header --rows=INT-64 <docId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
-
-## Subcommands
-
-- [gog docs table-row delete](gog-docs-table-row-delete.md) - Delete a native table row
-- [gog docs table-row insert](gog-docs-table-row-insert.md) - Insert a native table row
-- [gog docs table-row pin-header](gog-docs-table-row-pin-header.md) - Pin or unpin leading table header rows
-- [gog docs table-row style](gog-docs-table-row-style.md) - Set native table row height and overflow styles
+- [gog docs table-row](gog-docs-table-row.md)
 
 ## Flags
 
@@ -41,12 +34,15 @@ gog docs (doc) table-row <command>
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--rows` | `int64` |  | Number of leading rows to pin; 0 unpins all header rows |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--table` | `string` | 1 | Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs table-row](gog-docs-table-row.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -53,7 +53,7 @@ gog docs (doc) <command> [flags]
 - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns
 - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
 - [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range
-- [gog docs table-row](gog-docs-table-row.md) - Insert, delete, or style native table rows
+- [gog docs table-row](gog-docs-table-row.md) - Insert, delete, style, or pin native table rows
 - [gog docs table-unmerge](gog-docs-table-unmerge.md) - Unmerge the region containing a native table cell
 - [gog docs tables](gog-docs-tables.md) - List native tables
 - [gog docs tabs](gog-docs-tabs.md) - Manage Google Doc tabs

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -32,7 +32,7 @@ type DocsCmd struct {
 	InsertTable      DocsInsertTableCmd      `cmd:"" name:"insert-table" help:"Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json"`
 	CellUpdate       DocsCellUpdateCmd       `cmd:"" name:"cell-update" aliases:"update-cell" help:"Replace or append content inside a specific table cell"`
 	CellStyle        DocsCellStyleCmd        `cmd:"" name:"cell-style" help:"Apply table cell, border, padding, alignment, and text styling"`
-	TableRow         DocsTableRowCmd         `cmd:"" name:"table-row" help:"Insert, delete, or style native table rows"`
+	TableRow         DocsTableRowCmd         `cmd:"" name:"table-row" help:"Insert, delete, style, or pin native table rows"`
 	TableColumn      DocsTableColumnCmd      `cmd:"" name:"table-column" help:"Insert or delete native table columns"`
 	TableMerge       DocsTableMergeCmd       `cmd:"" name:"table-merge" help:"Merge a native table cell range"`
 	TableUnmerge     DocsTableUnmergeCmd     `cmd:"" name:"table-unmerge" aliases:"table-split" help:"Unmerge the region containing a native table cell"`

--- a/internal/cmd/docs_table_ops.go
+++ b/internal/cmd/docs_table_ops.go
@@ -16,9 +16,10 @@ import (
 )
 
 type DocsTableRowCmd struct {
-	Insert DocsTableRowInsertCmd `cmd:"" name:"insert" aliases:"add,append" help:"Insert a native table row"`
-	Delete DocsTableRowDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a native table row"`
-	Style  DocsTableRowStyleCmd  `cmd:"" name:"style" help:"Set native table row height and overflow styles"`
+	Insert    DocsTableRowInsertCmd `cmd:"" name:"insert" aliases:"add,append" help:"Insert a native table row"`
+	Delete    DocsTableRowDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a native table row"`
+	Style     DocsTableRowStyleCmd  `cmd:"" name:"style" help:"Set native table row height and overflow styles"`
+	PinHeader DocsTablePinHeaderCmd `cmd:"" name:"pin-header" help:"Pin or unpin leading table header rows"`
 }
 
 type DocsTableColumnCmd struct {

--- a/internal/cmd/docs_table_pin_header.go
+++ b/internal/cmd/docs_table_pin_header.go
@@ -1,0 +1,56 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/docs/v1"
+)
+
+type DocsTablePinHeaderCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Table string `name:"table" help:"Table selector: index, exact first-cell text, *, or text:VALUE for numeric/syntax-looking text" default:"1"`
+	Rows  int64  `name:"rows" required:"" help:"Number of leading rows to pin; 0 unpins all header rows"`
+	Tab   string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+func (c *DocsTablePinHeaderCmd) Run(ctx context.Context, flags *RootFlags) error {
+	docID, err := validateDocsTableMutationArgs(c.DocID, c.Table)
+	if err != nil {
+		return err
+	}
+	if c.Rows < 0 {
+		return usage("--rows must be >= 0")
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "docs.table-row.pin-header", map[string]any{
+		"documentId": docID,
+		"table":      c.Table,
+		"rows":       c.Rows,
+		"tab":        c.Tab,
+	}); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, loaded, selected, err := loadDocsSelectedTables(ctx, flags, docID, c.Tab, c.Table)
+	if err != nil {
+		return err
+	}
+	requests := make([]*docs.Request, 0, len(selected))
+	results := make([]docsTableRowActionResult, 0, len(selected))
+	for _, target := range selected {
+		rowCount := int64(len(target.table.TableRows))
+		if c.Rows > rowCount {
+			return usagef("cannot pin %d header rows in table %d (table has %d rows)", c.Rows, target.index, rowCount)
+		}
+		requests = append(requests, &docs.Request{PinTableHeaderRows: &docs.PinTableHeaderRowsRequest{
+			TableStartLocation:    &docs.Location{Index: target.startIdx, TabId: loaded.tabID},
+			PinnedHeaderRowsCount: c.Rows,
+			ForceSendFields:       []string{"PinnedHeaderRowsCount"},
+		}})
+		results = append(results, docsTableRowActionResult{TableIndex: target.index, Value: c.Rows})
+	}
+	if _, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests); err != nil {
+		return fmt.Errorf("pin table header rows: %w", err)
+	}
+	return writeDocsTableRowActionResult(ctx, docID, loaded.tabID, "pin-header", "rows", results)
+}

--- a/internal/cmd/docs_table_pin_header_test.go
+++ b/internal/cmd/docs_table_pin_header_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsTablePinHeaderZeroIsSerializedForAllTables(t *testing.T) {
+	doc := docsTableOpsTestDocument(
+		docsTableOpsTestElement(5, "First", 2),
+		docsTableOpsTestElement(40, "Second", 3),
+	)
+	var got map[string]any
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+				t.Fatalf("decode batch: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(&docs.BatchUpdateDocumentResponse{DocumentId: "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	defer cleanup()
+
+	cmd := &DocsTablePinHeaderCmd{}
+	err := runKong(t, cmd, []string{"doc1", "--table", "*", "--rows", "0"}, newDocsTableOpsTestContext(t, docSvc), &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	writeControl, ok := got["writeControl"].(map[string]any)
+	if !ok || writeControl["requiredRevisionId"] != "rev-1" {
+		t.Fatalf("write control = %#v", got["writeControl"])
+	}
+	requests, ok := got["requests"].([]any)
+	if !ok || len(requests) != 2 {
+		t.Fatalf("requests = %#v", got["requests"])
+	}
+	wantStarts := []float64{40, 5}
+	for i, rawRequest := range requests {
+		request, ok := rawRequest.(map[string]any)
+		if !ok {
+			t.Fatalf("request %d = %#v", i, rawRequest)
+		}
+		pin, ok := request["pinTableHeaderRows"].(map[string]any)
+		if !ok {
+			t.Fatalf("pin request %d = %#v", i, request)
+		}
+		count, exists := pin["pinnedHeaderRowsCount"]
+		if !exists || count != float64(0) {
+			t.Fatalf("pinned count %d = %#v, exists=%v", i, count, exists)
+		}
+		location := pin["tableStartLocation"].(map[string]any)
+		if location["index"] != wantStarts[i] {
+			t.Fatalf("table start %d = %#v, want %v", i, location["index"], wantStarts[i])
+		}
+	}
+}
+
+func TestDocsTablePinHeaderRejectsTooManyRows(t *testing.T) {
+	doc := docsTableOpsTestDocument(docsTableOpsTestElement(5, "Header", 2))
+	postCount := 0
+	docSvc, cleanup := newDocsServiceForTest(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode(doc)
+			return
+		}
+		if r.Method == http.MethodPost {
+			postCount++
+		}
+		http.NotFound(w, r)
+	})
+	defer cleanup()
+
+	cmd := &DocsTablePinHeaderCmd{}
+	err := runKong(t, cmd, []string{"doc1", "--rows", "3"}, newDocsTableOpsTestContext(t, docSvc), &RootFlags{Account: "a@b.com"})
+	if err == nil || !strings.Contains(err.Error(), "table has 2 rows") {
+		t.Fatalf("expected row-count error, got %v", err)
+	}
+	if postCount != 0 {
+		t.Fatalf("post count = %d, want 0", postCount)
+	}
+}
+
+func TestDocsTablePinHeaderRejectsNegativeRows(t *testing.T) {
+	cmd := &DocsTablePinHeaderCmd{DocID: "doc1", Table: "1", Rows: -1}
+	err := cmd.Run(newCmdRuntimeOutputContext(t, nil, nil), &RootFlags{Account: "a@b.com", DryRun: true})
+	if err == nil || !strings.Contains(err.Error(), "--rows must be >= 0") {
+		t.Fatalf("expected rows error, got %v", err)
+	}
+}

--- a/internal/cmd/docs_table_row_style.go
+++ b/internal/cmd/docs_table_row_style.go
@@ -21,9 +21,9 @@ type DocsTableRowStyleCmd struct {
 	Tab             string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
 }
 
-type docsTableRowStyleResult struct {
-	TableIndex int `json:"tableIndex"`
-	Row        any `json:"row"`
+type docsTableRowActionResult struct {
+	TableIndex int
+	Value      any
 }
 
 func (c *DocsTableRowStyleCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -58,7 +58,7 @@ func (c *DocsTableRowStyleCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 	requests := make([]*docs.Request, 0, len(selected))
-	results := make([]docsTableRowStyleResult, 0, len(selected))
+	results := make([]docsTableRowActionResult, 0, len(selected))
 	for _, target := range selected {
 		rowIndices, resolvedRow, resolveErr := resolveDocsTableStyleRow(target.table, c.Row)
 		if resolveErr != nil {
@@ -70,12 +70,12 @@ func (c *DocsTableRowStyleCmd) Run(ctx context.Context, flags *RootFlags) error 
 			TableRowStyle:      style,
 			Fields:             strings.Join(fields, ","),
 		}})
-		results = append(results, docsTableRowStyleResult{TableIndex: target.index, Row: resolvedRow})
+		results = append(results, docsTableRowActionResult{TableIndex: target.index, Value: resolvedRow})
 	}
 	if _, err := executeDocsTableRequests(ctx, svc, docID, loaded.full.RevisionId, requests); err != nil {
 		return fmt.Errorf("style table row: %w", err)
 	}
-	return writeDocsTableRowStyleResult(ctx, docID, loaded.tabID, results)
+	return writeDocsTableRowActionResult(ctx, docID, loaded.tabID, "style", "row", results)
 }
 
 func (c *DocsTableRowStyleCmd) buildStyle() (*docs.TableRowStyle, []string, error) {
@@ -117,25 +117,29 @@ func resolveDocsTableStyleRow(table *docs.Table, requested *int) ([]int64, any, 
 	return []int64{int64(resolved - 1)}, resolved, nil
 }
 
-func writeDocsTableRowStyleResult(
+func writeDocsTableRowActionResult(
 	ctx context.Context,
-	docID, tabID string,
-	results []docsTableRowStyleResult,
+	docID, tabID, action, valueName string,
+	results []docsTableRowActionResult,
 ) error {
 	sort.Slice(results, func(i, j int) bool {
 		return results[i].TableIndex < results[j].TableIndex
 	})
+	tables := make([]map[string]any, 0, len(results))
+	for _, result := range results {
+		tables = append(tables, map[string]any{"tableIndex": result.TableIndex, valueName: result.Value})
+	}
 	if outfmt.IsJSON(ctx) {
 		payload := map[string]any{
 			"documentId": docID,
-			"action":     "style",
+			"action":     action,
 			"target":     "row",
 			"updated":    true,
-			"tables":     results,
+			"tables":     tables,
 		}
 		if len(results) == 1 {
 			payload["tableIndex"] = results[0].TableIndex
-			payload["row"] = results[0].Row
+			payload[valueName] = results[0].Value
 		}
 		if tabID != "" {
 			payload["tabId"] = tabID
@@ -145,10 +149,10 @@ func writeDocsTableRowStyleResult(
 
 	u := ui.FromContext(ctx)
 	u.Out().Linef("documentId\t%s", docID)
-	u.Out().Linef("action\tstyle")
+	u.Out().Linef("action\t%s", action)
 	u.Out().Linef("target\trow")
 	for _, result := range results {
-		u.Out().Linef("table\t%d\trow\t%v", result.TableIndex, result.Row)
+		u.Out().Linef("table\t%d\t%s\t%v", result.TableIndex, valueName, result.Value)
 	}
 	u.Out().Linef("updated\ttrue")
 	if tabID != "" {


### PR DESCRIPTION
## Summary

- add `docs table-row pin-header --rows N` for pinning the first N table rows or unpinning with `--rows 0`
- validate counts against every selected table, preserve tab targeting and table selectors, and submit revision-controlled requests
- force-serialize zero so unpin requests are not dropped by the generated API client
- share row-action result formatting with `docs table-row style`, removing duplicate output code
- regenerate command docs and add the changelog entry

Closes #855.

## Validation

- `make ci`
- autoreview: clean, no actionable findings
- live API E2E with `clawdbot@gmail.com`: created disposable native Docs tables; validated dry-run; pinned one and two leading rows; confirmed `tableHeader` state through `docs raw`; unpinned with zero and confirmed all header state cleared
- live render E2E: exported a 70-row table to two PDFs; the 5-page pinned export repeated the header marker 5 times, while the unpinned export contained it once; permanently deleted all Drive fixtures
