### PR TITLE
feat(docs): add structural and segment editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Added
 
+- Docs: add first-class footnote, section-break, horizontal-rule, and section-column commands with shared index, anchor, tab, dry-run, and batch behavior where supported. (#856) — thanks @sebsnyk.
+- Docs: add header/footer lifecycle commands plus segment-aware plain-text insert, update, delete, format, and range lookup across headers, footers, and footnotes. (#857) — thanks @sebsnyk.
 - Docs: add table cell borders, padding, and vertical content alignment to `docs cell-style`. (#855) — thanks @sebsnyk.
 - Docs: add minimum height and page-overflow controls to `docs table-row style`. (#855) — thanks @sebsnyk.
 - Docs: add `docs table-row pin-header --rows N` for pinning or unpinning repeated table header rows. (#855) — thanks @sebsnyk.

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -246,7 +246,15 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) export (download,dl) <docId> [flags]`](commands/gog-docs-export.md) - Export a Google Doc (pdf|docx|txt|md|html)
     - [`gog docs (doc) find-range <docId> <text> [flags]`](commands/gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
     - [`gog docs (doc) find-replace <docId> <find> [<replace>] [flags]`](commands/gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
+    - [`gog docs (doc) footer (footers) <command>`](commands/gog-docs-footer.md) - List, create, or delete document footers
+      - [`gog docs (doc) footer (footers) create (add,new) <docId> [flags]`](commands/gog-docs-footer-create.md) - Create and optionally populate a footer
+      - [`gog docs (doc) footer (footers) delete (rm,remove,del) <docId> <footerId> [flags]`](commands/gog-docs-footer-delete.md) - Delete a footer
+      - [`gog docs (doc) footer (footers) list (ls) <docId> [flags]`](commands/gog-docs-footer-list.md) - List footers and their segment IDs
     - [`gog docs (doc) format <docId> [flags]`](commands/gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+    - [`gog docs (doc) header (headers) <command>`](commands/gog-docs-header.md) - List, create, or delete document headers
+      - [`gog docs (doc) header (headers) create (add,new) <docId> [flags]`](commands/gog-docs-header-create.md) - Create and optionally populate a header
+      - [`gog docs (doc) header (headers) delete (rm,remove,del) <docId> <headerId> [flags]`](commands/gog-docs-header-delete.md) - Delete a header
+      - [`gog docs (doc) header (headers) list (ls) <docId> [flags]`](commands/gog-docs-header-list.md) - List headers and their segment IDs
     - [`gog docs (doc) headings <command>`](commands/gog-docs-headings.md) - List document headings
       - [`gog docs (doc) headings list (ls) <docId> [flags]`](commands/gog-docs-headings-list.md) - List heading paragraphs
     - [`gog docs (doc) images <command>`](commands/gog-docs-images.md) - List document images
@@ -255,9 +263,12 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) insert <docId> [<content>] [flags]`](commands/gog-docs-insert.md) - Insert text at a specific position
     - [`gog docs (doc) insert-date-chip --date=STRING <docId> [flags]`](commands/gog-docs-insert-date-chip.md) - Insert a native date smart chip
     - [`gog docs (doc) insert-file-chip (insert-rich-link) --file-id=STRING <docId> [flags]`](commands/gog-docs-insert-file-chip.md) - Insert a native Drive file smart chip
+    - [`gog docs (doc) insert-footnote <docId> [flags]`](commands/gog-docs-insert-footnote.md) - Insert and populate a footnote
+    - [`gog docs (doc) insert-horizontal-rule (insert-hr,hr) <docId> [flags]`](commands/gog-docs-insert-horizontal-rule.md) - Insert a paragraph-border horizontal rule
     - [`gog docs (doc) insert-image <docId> [flags]`](commands/gog-docs-insert-image.md) - Insert a public image URL or upload a local image into a Google Doc
     - [`gog docs (doc) insert-page-break (page-break,pb) <docId> [flags]`](commands/gog-docs-insert-page-break.md) - Insert a page break at a specific position (or end-of-doc with --at-end)
     - [`gog docs (doc) insert-person --email=STRING <docId> [flags]`](commands/gog-docs-insert-person.md) - Insert a native person smart chip
+    - [`gog docs (doc) insert-section-break <docId> [flags]`](commands/gog-docs-insert-section-break.md) - Insert a continuous or next-page section break
     - [`gog docs (doc) insert-table --rows=INT --cols=INT <docId> [flags]`](commands/gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [`gog docs (doc) list-tabs <docId>`](commands/gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [`gog docs (doc) named-range (named-ranges,namedranges,nr) <command>`](commands/gog-docs-named-range.md) - Manage named ranges
@@ -271,6 +282,7 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) raw <docId> [flags]`](commands/gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [`gog docs (doc) rename-tab <docId> [flags]`](commands/gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [`gog docs (doc) replace-image <docId> [flags]`](commands/gog-docs-replace-image.md) - Replace an existing image without changing its position or bounds
+    - [`gog docs (doc) section-columns --count=INT <docId> [flags]`](commands/gog-docs-section-columns.md) - Set the column count for a document section
     - [`gog docs (doc) sed <docId> [<expression>] [flags]`](commands/gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [`gog docs (doc) structure (struct) <docId> [flags]`](commands/gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [`gog docs (doc) table-column <command>`](commands/gog-docs-table-column.md) - Insert or delete native table columns

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 682.
+Generated pages: 694.
 
 ## Top-level Commands
 
@@ -297,7 +297,15 @@ Generated pages: 682.
     - [gog docs export](gog-docs-export.md) - Export a Google Doc (pdf|docx|txt|md|html)
     - [gog docs find-range](gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
     - [gog docs find-replace](gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
+    - [gog docs footer](gog-docs-footer.md) - List, create, or delete document footers
+      - [gog docs footer create](gog-docs-footer-create.md) - Create and optionally populate a footer
+      - [gog docs footer delete](gog-docs-footer-delete.md) - Delete a footer
+      - [gog docs footer list](gog-docs-footer-list.md) - List footers and their segment IDs
     - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+    - [gog docs header](gog-docs-header.md) - List, create, or delete document headers
+      - [gog docs header create](gog-docs-header-create.md) - Create and optionally populate a header
+      - [gog docs header delete](gog-docs-header-delete.md) - Delete a header
+      - [gog docs header list](gog-docs-header-list.md) - List headers and their segment IDs
     - [gog docs headings](gog-docs-headings.md) - List document headings
       - [gog docs headings list](gog-docs-headings-list.md) - List heading paragraphs
     - [gog docs images](gog-docs-images.md) - List document images
@@ -306,9 +314,12 @@ Generated pages: 682.
     - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
     - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
     - [gog docs insert-file-chip](gog-docs-insert-file-chip.md) - Insert a native Drive file smart chip
+    - [gog docs insert-footnote](gog-docs-insert-footnote.md) - Insert and populate a footnote
+    - [gog docs insert-horizontal-rule](gog-docs-insert-horizontal-rule.md) - Insert a paragraph-border horizontal rule
     - [gog docs insert-image](gog-docs-insert-image.md) - Insert a public image URL or upload a local image into a Google Doc
     - [gog docs insert-page-break](gog-docs-insert-page-break.md) - Insert a page break at a specific position (or end-of-doc with --at-end)
     - [gog docs insert-person](gog-docs-insert-person.md) - Insert a native person smart chip
+    - [gog docs insert-section-break](gog-docs-insert-section-break.md) - Insert a continuous or next-page section break
     - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
     - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
     - [gog docs named-range](gog-docs-named-range.md) - Manage named ranges
@@ -322,6 +333,7 @@ Generated pages: 682.
     - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
     - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
     - [gog docs replace-image](gog-docs-replace-image.md) - Replace an existing image without changing its position or bounds
+    - [gog docs section-columns](gog-docs-section-columns.md) - Set the column count for a document section
     - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
     - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns

--- a/docs/commands/gog-docs-delete.md
+++ b/docs/commands/gog-docs-delete.md
@@ -39,6 +39,7 @@ gog docs (doc) delete <docId> [flags]
 | `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--start` | `*int64` |  | Start index (>= 1; required unless --at is set) |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |

--- a/docs/commands/gog-docs-footer-create.md
+++ b/docs/commands/gog-docs-footer-create.md
@@ -1,18 +1,18 @@
-# `gog docs find-range`
+# `gog docs footer create`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Create and optionally populate a footer
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) footer (footers) create (add,new) <docId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog docs footer](gog-docs-footer.md)
 
 ## Flags
 
@@ -20,33 +20,34 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
+| `--at` | `string` |  | Anchor by literal text and use the start of the matched range |
+| `--at-end` | `bool` |  | Target end-of-doc/tab (mutually exclusive with --index and --at) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
+| `--file` | `string` |  | Read initial footer text from a file ('-' for stdin) |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index (1 = beginning); omit for end-of-doc |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--text` | `string` |  | Initial footer text |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs footer](gog-docs-footer.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-footer-delete.md
+++ b/docs/commands/gog-docs-footer-delete.md
@@ -1,18 +1,18 @@
-# `gog docs find-range`
+# `gog docs footer delete`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Delete a footer
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) footer (footers) delete (rm,remove,del) <docId> <footerId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog docs footer](gog-docs-footer.md)
 
 ## Flags
 
@@ -20,33 +20,27 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--tab` | `string` |  | Tab title or ID containing the footer |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs footer](gog-docs-footer.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-footer-list.md
+++ b/docs/commands/gog-docs-footer-list.md
@@ -1,18 +1,18 @@
-# `gog docs find-range`
+# `gog docs footer list`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+List footers and their segment IDs
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) footer (footers) list (ls) <docId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog docs footer](gog-docs-footer.md)
 
 ## Flags
 
@@ -20,33 +20,27 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--tab` | `string` |  | Limit results to a tab title or ID |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs footer](gog-docs-footer.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-footer.md
+++ b/docs/commands/gog-docs-footer.md
@@ -1,18 +1,24 @@
-# `gog docs find-range`
+# `gog docs footer`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+List, create, or delete document footers
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) footer (footers) <command>
 ```
 
 ## Parent
 
 - [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs footer create](gog-docs-footer-create.md) - Create and optionally populate a footer
+- [gog docs footer delete](gog-docs-footer-delete.md) - Delete a footer
+- [gog docs footer list](gog-docs-footer-list.md) - List footers and their segment IDs
 
 ## Flags
 
@@ -20,28 +26,21 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-docs-format.md
+++ b/docs/commands/gog-docs-format.md
@@ -63,6 +63,7 @@ gog docs (doc) format <docId> [flags]
 | `--ordered` | `bool` |  | Create a numbered list with the default decimal preset |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--space-above` | `*float64` |  | Space above the paragraph in points |
 | `--space-below` | `*float64` |  | Space below the paragraph in points |

--- a/docs/commands/gog-docs-header-create.md
+++ b/docs/commands/gog-docs-header-create.md
@@ -1,18 +1,18 @@
-# `gog docs find-range`
+# `gog docs header create`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Create and optionally populate a header
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) header (headers) create (add,new) <docId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog docs header](gog-docs-header.md)
 
 ## Flags
 
@@ -20,33 +20,34 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
+| `--at` | `string` |  | Anchor by literal text and use the start of the matched range |
+| `--at-end` | `bool` |  | Target end-of-doc/tab (mutually exclusive with --index and --at) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
+| `--file` | `string` |  | Read initial header text from a file ('-' for stdin) |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index (1 = beginning); omit for end-of-doc |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--text` | `string` |  | Initial header text |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs header](gog-docs-header.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-header-delete.md
+++ b/docs/commands/gog-docs-header-delete.md
@@ -1,18 +1,18 @@
-# `gog docs find-range`
+# `gog docs header delete`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Delete a header
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) header (headers) delete (rm,remove,del) <docId> <headerId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog docs header](gog-docs-header.md)
 
 ## Flags
 
@@ -20,33 +20,27 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--tab` | `string` |  | Tab title or ID containing the header |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs header](gog-docs-header.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-header-list.md
+++ b/docs/commands/gog-docs-header-list.md
@@ -1,18 +1,18 @@
-# `gog docs find-range`
+# `gog docs header list`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+List headers and their segment IDs
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) header (headers) list (ls) <docId> [flags]
 ```
 
 ## Parent
 
-- [gog docs](gog-docs.md)
+- [gog docs header](gog-docs-header.md)
 
 ## Flags
 
@@ -20,33 +20,27 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--tab` | `string` |  | Limit results to a tab title or ID |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog docs](gog-docs.md)
+- [gog docs header](gog-docs-header.md)
 - [Command index](README.md)

--- a/docs/commands/gog-docs-header.md
+++ b/docs/commands/gog-docs-header.md
@@ -1,18 +1,24 @@
-# `gog docs find-range`
+# `gog docs header`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+List, create, or delete document headers
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) header (headers) <command>
 ```
 
 ## Parent
 
 - [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs header create](gog-docs-header-create.md) - Create and optionally populate a header
+- [gog docs header delete](gog-docs-header-delete.md) - Delete a header
+- [gog docs header list](gog-docs-header-list.md) - List headers and their segment IDs
 
 ## Flags
 
@@ -20,28 +26,21 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
-| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-docs-insert-footnote.md
+++ b/docs/commands/gog-docs-insert-footnote.md
@@ -1,13 +1,13 @@
-# `gog docs find-range`
+# `gog docs insert-footnote`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Insert and populate a footnote
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) insert-footnote <docId> [flags]
 ```
 
 ## Parent
@@ -20,28 +20,29 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
+| `--at` | `string` |  | Anchor by literal text and use the start of the matched range |
+| `--at-end` | `bool` |  | Target end-of-doc/tab (mutually exclusive with --index and --at) |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
+| `--file` | `string` |  | Read footnote text from a file ('-' for stdin) |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index (1 = beginning); omit for end-of-doc |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--text` | `string` |  | Footnote text |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-docs-insert-horizontal-rule.md
+++ b/docs/commands/gog-docs-insert-horizontal-rule.md
@@ -1,13 +1,13 @@
-# `gog docs find-range`
+# `gog docs insert-horizontal-rule`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Insert a paragraph-border horizontal rule
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) insert-horizontal-rule (insert-hr,hr) <docId> [flags]
 ```
 
 ## Parent
@@ -20,26 +20,26 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
+| `--at` | `string` |  | Anchor by literal text and use the start of the matched range |
+| `--at-end` | `bool` |  | Target end-of-doc/tab (mutually exclusive with --index and --at) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index (1 = beginning); omit for end-of-doc |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/commands/gog-docs-insert-section-break.md
+++ b/docs/commands/gog-docs-insert-section-break.md
@@ -1,13 +1,13 @@
-# `gog docs find-range`
+# `gog docs insert-section-break`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Insert a continuous or next-page section break
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) insert-section-break <docId> [flags]
 ```
 
 ## Parent
@@ -20,28 +20,29 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
+| `--at` | `string` |  | Anchor by literal text and use the start of the matched range |
+| `--at-end` | `bool` |  | Target end-of-doc/tab (mutually exclusive with --index and --at) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index (1 = beginning); omit for end-of-doc |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
+| `--type` | `string` | next-page | Section type: next-page or continuous |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-docs-insert.md
+++ b/docs/commands/gog-docs-insert.md
@@ -41,6 +41,7 @@ gog docs (doc) insert <docId> [<content>] [flags]
 | `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |

--- a/docs/commands/gog-docs-section-columns.md
+++ b/docs/commands/gog-docs-section-columns.md
@@ -1,13 +1,13 @@
-# `gog docs find-range`
+# `gog docs section-columns`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Find text and print Docs API UTF-16 index ranges
+Set the column count for a document section
 
 ## Usage
 
 ```bash
-gog docs (doc) find-range <docId> <text> [flags]
+gog docs (doc) section-columns --count=INT <docId> [flags]
 ```
 
 ## Parent
@@ -20,27 +20,29 @@ gog docs (doc) find-range <docId> <text> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--all` | `bool` |  | Return all matches |
+| `--at` | `string` |  | Anchor by literal text and use the start of the matched range |
+| `--at-end` | `bool` |  | Target end-of-doc/tab (mutually exclusive with --index and --at) |
+| `--batch` | `string` |  | Append requests to a persisted Docs batch instead of submitting |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--count` | `int` |  | Number of columns (1-3; 1 resets to one column) |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
-| `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no matches |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `--index` | `*int64` |  | Character index (1 = beginning); omit for end-of-doc |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
-| `--match-case` | `bool` |  | Use case-sensitive matching |
+| `--match-case` | `bool` |  | Use case-sensitive --at matching |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
-| `--normalize-whitespace` | `bool` | true | Collapse whitespace while matching |
-| `--occurrence` | `*int` |  | Return the Nth occurrence (1-based; default first) |
+| `--occurrence` | `*int` |  | Use the Nth --at match (1-based; required when --at is ambiguous) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
-| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--separator` | `string` | none | Column separator: none or between |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |

--- a/docs/commands/gog-docs-update.md
+++ b/docs/commands/gog-docs-update.md
@@ -43,6 +43,7 @@ gog docs (doc) update <docId> [flags]
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--replace-range` | `string` |  | Replace UTF-16 Docs API range START:END instead of inserting |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--segment` | `string` |  | Target an exact header, footer, or footnote segment ID |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs) |
 | `--text` | `string` |  | Text to insert |

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -30,16 +30,21 @@ gog docs (doc) <command> [flags]
 - [gog docs export](gog-docs-export.md) - Export a Google Doc (pdf|docx|txt|md|html)
 - [gog docs find-range](gog-docs-find-range.md) - Find text and print Docs API UTF-16 index ranges
 - [gog docs find-replace](gog-docs-find-replace.md) - Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence.
+- [gog docs footer](gog-docs-footer.md) - List, create, or delete document footers
 - [gog docs format](gog-docs-format.md) - Apply text or paragraph formatting to a Google Doc
+- [gog docs header](gog-docs-header.md) - List, create, or delete document headers
 - [gog docs headings](gog-docs-headings.md) - List document headings
 - [gog docs images](gog-docs-images.md) - List document images
 - [gog docs info](gog-docs-info.md) - Get Google Doc metadata
 - [gog docs insert](gog-docs-insert.md) - Insert text at a specific position
 - [gog docs insert-date-chip](gog-docs-insert-date-chip.md) - Insert a native date smart chip
 - [gog docs insert-file-chip](gog-docs-insert-file-chip.md) - Insert a native Drive file smart chip
+- [gog docs insert-footnote](gog-docs-insert-footnote.md) - Insert and populate a footnote
+- [gog docs insert-horizontal-rule](gog-docs-insert-horizontal-rule.md) - Insert a paragraph-border horizontal rule
 - [gog docs insert-image](gog-docs-insert-image.md) - Insert a public image URL or upload a local image into a Google Doc
 - [gog docs insert-page-break](gog-docs-insert-page-break.md) - Insert a page break at a specific position (or end-of-doc with --at-end)
 - [gog docs insert-person](gog-docs-insert-person.md) - Insert a native person smart chip
+- [gog docs insert-section-break](gog-docs-insert-section-break.md) - Insert a continuous or next-page section break
 - [gog docs insert-table](gog-docs-insert-table.md) - Insert a native table at a specific position (or end-of-doc with --at-end), optionally populated via --values-json
 - [gog docs list-tabs](gog-docs-list-tabs.md) - List all tabs in a Google Doc
 - [gog docs named-range](gog-docs-named-range.md) - Manage named ranges
@@ -48,6 +53,7 @@ gog docs (doc) <command> [flags]
 - [gog docs raw](gog-docs-raw.md) - Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)
 - [gog docs rename-tab](gog-docs-rename-tab.md) - Rename a tab in a Google Doc
 - [gog docs replace-image](gog-docs-replace-image.md) - Replace an existing image without changing its position or bounds
+- [gog docs section-columns](gog-docs-section-columns.md) - Set the column count for a document section
 - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
 - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
 - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -247,6 +247,79 @@ Command page:
 
 - [`gog docs insert-page-break`](commands/gog-docs-insert-page-break.md)
 
+## Structural Inserts And Sections
+
+Insert footnotes, section breaks, and paragraph-border horizontal rules with
+the same placement selectors as `insert-page-break`:
+
+```bash
+gog docs insert-footnote <docId> --at "Claim" --text "Source note"
+gog docs insert-section-break <docId> --at "Appendix" --type next-page
+gog docs insert-horizontal-rule <docId> --at "Summary"
+```
+
+All three accept `--index`, `--at`, `--occurrence`, `--match-case`,
+`--at-end`, and `--tab`. Footnote creation is a two-step operation because the
+Docs API returns the new footnote segment ID before its text can be populated;
+it therefore does not support persisted `--batch` mode.
+
+Set the columns on the section containing a selected position:
+
+```bash
+gog docs section-columns <docId> --at "Newsletter" --count 2
+gog docs section-columns <docId> --at-end --count 3 --separator between
+gog docs section-columns <docId> --at "Appendix" --count 1
+```
+
+Google Docs supports one to three section columns. `--count 1` resets the
+selected section to one column. Horizontal rules are implemented as a newline
+with a bottom paragraph border because the Docs API has no native horizontal
+rule insertion request.
+
+Command pages:
+
+- [`gog docs insert-footnote`](commands/gog-docs-insert-footnote.md)
+- [`gog docs insert-section-break`](commands/gog-docs-insert-section-break.md)
+- [`gog docs insert-horizontal-rule`](commands/gog-docs-insert-horizontal-rule.md)
+- [`gog docs section-columns`](commands/gog-docs-section-columns.md)
+
+## Headers, Footers, And Segments
+
+Create, discover, populate, and delete default headers and footers:
+
+```bash
+header_id=$(gog docs header create <docId> --text "Quarterly report" --json | jq -r .segmentId)
+gog docs header list <docId> --json
+gog docs footer create <docId> --file footer.txt
+gog --force docs header delete <docId> "$header_id"
+```
+
+Creation accepts the standard placement flags to select a section. Without a
+placement selector, the header or footer applies to the document's default
+section. The current Docs API only creates `DEFAULT` headers and footers; the
+first-page and even-page IDs exposed by raw output are read-only.
+
+Use an exact segment ID with the plain-text targeting commands:
+
+```bash
+gog docs find-range <docId> "Quarterly" --segment "$header_id" --json
+gog docs insert <docId> "FY26 " --segment "$header_id" --index 0
+gog docs update <docId> --segment "$header_id" --at "Quarterly" --text "Annual"
+gog docs format <docId> --segment "$header_id" --match "Annual" --bold
+gog docs delete <docId> --segment "$header_id" --at "FY26 "
+```
+
+`--segment` accepts the opaque ID returned by create/list/raw; do not prefix it
+with `header:` or `footer:`. It can be combined with `--tab` to scope lookup in
+a multi-tab document. Segment inserts and updates are plain-text-only because
+Markdown can contain tables, images, and other structures that are invalid in
+headers, footers, or footnotes.
+
+Command pages:
+
+- [`gog docs header`](commands/gog-docs-header.md)
+- [`gog docs footer`](commands/gog-docs-footer.md)
+
 ## Page Layout
 
 Set an existing document to pageless or paged mode:

--- a/internal/cmd/calendar_focus_time.go
+++ b/internal/cmd/calendar_focus_time.go
@@ -79,7 +79,7 @@ func (c *CalendarFocusTimeCmd) Run(ctx context.Context, flags *RootFlags) error 
 func validateAutoDeclineMode(s string) (string, error) {
 	s = strings.TrimSpace(strings.ToLower(s))
 	switch s {
-	case "", "none":
+	case "", sendUpdatesNone:
 		return "declineNone", nil
 	case defaultFocusAutoDecline:
 		return "declineAllConflictingInvitations", nil

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -23,6 +23,8 @@ type DocsCmd struct {
 	Cat              DocsCatCmd              `cmd:"" name:"cat" aliases:"text,read" help:"Print a Google Doc as plain text"`
 	Comments         DocsCommentsCmd         `cmd:"" name:"comments" help:"Manage comments on files"`
 	Tabs             DocsTabsCmd             `cmd:"" name:"tabs" help:"Manage Google Doc tabs"`
+	Header           DocsHeaderCmd           `cmd:"" name:"header" aliases:"headers" help:"List, create, or delete document headers"`
+	Footer           DocsFooterCmd           `cmd:"" name:"footer" aliases:"footers" help:"List, create, or delete document footers"`
 	AddTab           DocsAddTabCmd           `cmd:"" name:"add-tab" help:"Add a tab to a Google Doc"`
 	RenameTab        DocsRenameTabCmd        `cmd:"" name:"rename-tab" help:"Rename a tab in a Google Doc"`
 	DeleteTab        DocsDeleteTabCmd        `cmd:"" name:"delete-tab" help:"Delete a tab from a Google Doc"`
@@ -43,6 +45,10 @@ type DocsCmd struct {
 	InsertFileChip   DocsInsertFileChipCmd   `cmd:"" name:"insert-file-chip" aliases:"insert-rich-link" help:"Insert a native Drive file smart chip"`
 	InsertDateChip   DocsInsertDateChipCmd   `cmd:"" name:"insert-date-chip" help:"Insert a native date smart chip"`
 	InsertPageBreak  DocsInsertPageBreakCmd  `cmd:"" name:"insert-page-break" aliases:"page-break,pb" help:"Insert a page break at a specific position (or end-of-doc with --at-end)"`
+	Footnote         DocsFootnoteCmd         `cmd:"" name:"insert-footnote" help:"Insert and populate a footnote"`
+	SectionBreak     DocsSectionBreakCmd     `cmd:"" name:"insert-section-break" help:"Insert a continuous or next-page section break"`
+	HorizontalRule   DocsHorizontalRuleCmd   `cmd:"" name:"insert-horizontal-rule" aliases:"insert-hr,hr" help:"Insert a paragraph-border horizontal rule"`
+	SectionColumns   DocsSectionColumnsCmd   `cmd:"" name:"section-columns" help:"Set the column count for a document section"`
 	Delete           DocsDeleteCmd           `cmd:"" name:"delete" help:"Delete text range from document"`
 	FindRange        DocsFindRangeCmd        `cmd:"" name:"find-range" help:"Find text and print Docs API UTF-16 index ranges"`
 	FindReplace      DocsFindReplaceCmd      `cmd:"" name:"find-replace" help:"Find and replace text. Supports plain text or markdown with images; use --first for a single occurrence."`

--- a/internal/cmd/docs_at_anchor.go
+++ b/internal/cmd/docs_at_anchor.go
@@ -16,12 +16,15 @@ type docsAtAnchorFlags struct {
 	Occurrence *int
 	MatchCase  bool
 	Tab        string
+	Segment    string
 }
 
 type docsResolvedAtAnchor struct {
-	Match      docsedit.TextRange
-	RevisionID string
-	Document   *docs.Document
+	Match       docsedit.TextRange
+	RevisionID  string
+	Document    *docs.Document
+	SegmentID   string
+	SegmentKind string
 }
 
 const docsAtIndexAnchorStart = "at:start"
@@ -43,7 +46,7 @@ func resolveDocsAtAnchor(ctx context.Context, svc *docs.Service, docID string, a
 		return docsResolvedAtAnchor{}, usage(err.Error())
 	}
 
-	loaded, err := loadDocsTargetDocument(ctx, svc, docID, anchor.Tab)
+	loaded, err := loadDocsTargetSegment(ctx, svc, docID, anchor.Tab, anchor.Segment)
 	if err != nil {
 		return docsResolvedAtAnchor{}, err
 	}
@@ -58,7 +61,10 @@ func resolveDocsAtAnchor(ctx context.Context, svc *docs.Service, docID string, a
 	if err != nil {
 		return docsResolvedAtAnchor{}, err
 	}
-	return docsResolvedAtAnchor{Match: match, RevisionID: loaded.full.RevisionId, Document: loaded.full}, nil
+	return docsResolvedAtAnchor{
+		Match: match, RevisionID: loaded.full.RevisionId, Document: loaded.full,
+		SegmentID: loaded.segmentID, SegmentKind: loaded.segmentKind,
+	}, nil
 }
 
 func selectDocsAtAnchorMatch(at string, matches []docsedit.TextRange, occurrence *int) (docsedit.TextRange, error) {

--- a/internal/cmd/docs_comments_locate.go
+++ b/internal/cmd/docs_comments_locate.go
@@ -75,11 +75,11 @@ func (c *DocsCommentsLocateCmd) Run(ctx context.Context, flags *RootFlags) error
 func (c *DocsCommentsLocateCmd) findQuoteMatches(ctx context.Context, svc *docs.Service, docID string, quote string) ([]docsedit.TextRange, error) {
 	if c.Tab != "" {
 		findCmd := DocsFindRangeCmd{Tab: c.Tab}
-		doc, tabID, err := findCmd.loadTargetDoc(ctx, svc, docID)
+		doc, target, err := findCmd.loadTargetDoc(ctx, svc, docID)
 		if err != nil {
 			return nil, err
 		}
-		return c.findQuoteMatchesInDoc(doc, quote, tabID), nil
+		return c.findQuoteMatchesInDoc(doc, quote, target.TabID), nil
 	}
 
 	doc, err := svc.Documents.Get(docID).Context(ctx).IncludeTabsContent(true).Do()

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -106,7 +106,7 @@ func (c *DocsWriteCmd) validateDocumentStyle() error {
 }
 
 func (c *DocsWriteCmd) resolveWriteText(ctx context.Context, kctx *kong.Context) (string, error) {
-	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx, "text", "file")
+	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx)
 	if err != nil {
 		return "", err
 	}
@@ -652,6 +652,7 @@ type DocsUpdateCmd struct {
 	Markdown     bool   `name:"markdown" help:"Convert markdown to Google Docs formatting"`
 	Pageless     bool   `name:"pageless" help:"Set document to pageless mode"`
 	Tab          string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Segment      string `name:"segment" help:"Target an exact header, footer, or footnote segment ID"`
 	TabID        string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 	Batch        string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
@@ -663,7 +664,7 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return usage("empty docId")
 	}
 
-	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx, "text", "file")
+	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx)
 	if err != nil {
 		return err
 	}
@@ -676,6 +677,7 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	placement, err := docsedit.PlanUpdatePlacement(docsedit.UpdatePlacementOptions{
 		Index:         c.Index,
 		IndexProvided: flagProvided(kctx, "index"),
+		AllowZero:     strings.TrimSpace(c.Segment) != "",
 		ReplaceRange:  c.ReplaceRange,
 		Anchor: docsedit.AnchorOptions{
 			Text:       c.At,
@@ -697,6 +699,9 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return tabErr
 	}
 	c.Tab = tab
+	if strings.TrimSpace(c.Segment) != "" && c.Markdown {
+		return usage("--segment supports plain-text updates only; markdown can contain structures that are invalid in segments")
+	}
 	if c.Batch != "" && (c.Markdown || c.Pageless) {
 		return usage("--batch supports plain text updates without --pageless")
 	}
@@ -716,12 +721,13 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return err
 	}
 
-	resolvedPlacement, err := resolveDocsPlacement(ctx, svc, id, c.Tab, placement)
+	resolvedPlacement, err := resolveDocsPlacementTarget(ctx, svc, id, c.Tab, c.Segment, placement)
 	if err != nil {
 		return err
 	}
 	insertIndex := resolvedPlacement.Index
 	c.Tab = resolvedPlacement.TabID
+	c.Segment = resolvedPlacement.SegmentID
 	if resolvedPlacement.Range != nil {
 		replaceStart = resolvedPlacement.Range.Start
 		replaceEnd = resolvedPlacement.Range.End
@@ -794,6 +800,7 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 			targetRange = &docsedit.Range{Start: replaceStart, End: replaceEnd}
 		}
 		reqs := docsedit.BuildUpdateRequests(text, insertIndex, c.Tab, targetRange)
+		applyDocsRequestTarget(reqs, docsTargetFromPlacement(resolvedPlacement.ResolvedPlacement))
 		requestCount = len(reqs)
 		batchReq := &docs.BatchUpdateDocumentRequest{Requests: reqs}
 		batchReq.WriteControl = docsRequiredRevisionWriteControl(resolvedPlacement.RequiredRevisionID)
@@ -831,6 +838,10 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		if c.Tab != "" {
 			payload["tabId"] = c.Tab
 		}
+		if c.Segment != "" {
+			payload["segmentId"] = c.Segment
+			payload["segmentType"] = resolvedPlacement.SegmentKind
+		}
 		if resp.WriteControl != nil {
 			payload["writeControl"] = resp.WriteControl
 		}
@@ -850,6 +861,10 @@ func (c *DocsUpdateCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	}
 	if c.Tab != "" {
 		u.Out().Linef("tabId\t%s", c.Tab)
+	}
+	if c.Segment != "" {
+		u.Out().Linef("segmentId\t%s", c.Segment)
+		u.Out().Linef("segmentType\t%s", resolvedPlacement.SegmentKind)
 	}
 	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
 		u.Out().Linef("revision\t%s", resp.WriteControl.RequiredRevisionId)
@@ -874,6 +889,7 @@ func (c *DocsUpdateCmd) dryRunPayload(docID string, written int, replacing bool,
 		"markdown":    c.Markdown,
 		"pageless":    c.Pageless,
 		"tab":         c.Tab,
+		"segment":     c.Segment,
 		"batch":       c.Batch,
 	}
 	if replacing {
@@ -893,6 +909,7 @@ type DocsInsertCmd struct {
 	File       string `name:"file" short:"f" help:"Read content from file (use - for stdin)"`
 	Markdown   bool   `name:"markdown" help:"Convert markdown to Google Docs formatting before inserting"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Segment    string `name:"segment" help:"Target an exact header, footer, or footnote segment ID"`
 	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
@@ -911,7 +928,8 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return usage("no content provided (use argument, --file, or stdin)")
 	}
 	placement, err := docsedit.PlanInsertPlacement(docsedit.InsertPlacementOptions{
-		Index: c.Index,
+		Index:     c.Index,
+		AllowZero: strings.TrimSpace(c.Segment) != "",
 		Anchor: docsedit.AnchorOptions{
 			Text:       c.At,
 			Provided:   flagProvided(kctx, "at"),
@@ -929,6 +947,9 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return tabErr
 	}
 	c.Tab = tab
+	if strings.TrimSpace(c.Segment) != "" && c.Markdown {
+		return usage("--segment supports plain-text inserts only; markdown can contain structures that are invalid in segments")
+	}
 	if c.Markdown && c.Batch != "" {
 		return usage("--markdown cannot be combined with --batch")
 	}
@@ -937,6 +958,7 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		"inserted":   len(content),
 		"markdown":   c.Markdown,
 		"tab":        c.Tab,
+		"segment":    c.Segment,
 		"batch":      c.Batch,
 	}
 	switch placement.Kind {
@@ -964,12 +986,13 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return err
 	}
 
-	resolvedPlacement, err := resolveDocsPlacement(ctx, svc, docID, c.Tab, placement)
+	resolvedPlacement, err := resolveDocsPlacementTarget(ctx, svc, docID, c.Tab, c.Segment, placement)
 	if err != nil {
 		return err
 	}
 	insertIndex := resolvedPlacement.Index
 	c.Tab = resolvedPlacement.TabID
+	c.Segment = resolvedPlacement.SegmentID
 
 	if c.Markdown {
 		return c.runMarkdown(ctx, svc, docID, insertIndex, resolvedPlacement.RequiredRevisionID, content)
@@ -978,6 +1001,7 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	batchReq := &docs.BatchUpdateDocumentRequest{
 		Requests: []*docs.Request{docsedit.BuildInsertRequest(content, insertIndex, c.Tab)},
 	}
+	applyDocsRequestTarget(batchReq.Requests, docsTargetFromPlacement(resolvedPlacement.ResolvedPlacement))
 	batchReq.WriteControl = docsRequiredRevisionWriteControl(resolvedPlacement.RequiredRevisionID)
 	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.insert", batchRevision, batchReq.Requests, false); queued || queueErr != nil {
 		return queueErr
@@ -992,6 +1016,10 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		if c.Tab != "" {
 			payload["tabId"] = c.Tab
 		}
+		if c.Segment != "" {
+			payload["segmentId"] = c.Segment
+			payload["segmentType"] = resolvedPlacement.SegmentKind
+		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
 
@@ -1000,6 +1028,10 @@ func (c *DocsInsertCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	u.Out().Linef("atIndex\t%d", insertIndex)
 	if c.Tab != "" {
 		u.Out().Linef("tabId\t%s", c.Tab)
+	}
+	if c.Segment != "" {
+		u.Out().Linef("segmentId\t%s", c.Segment)
+		u.Out().Linef("segmentType\t%s", resolvedPlacement.SegmentKind)
 	}
 	return nil
 }
@@ -1086,6 +1118,7 @@ type DocsDeleteCmd struct {
 	Occurrence *int   `name:"occurrence" help:"Use the Nth --at match (1-based; required when --at is ambiguous)"`
 	MatchCase  bool   `name:"match-case" help:"Use case-sensitive --at matching"`
 	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Segment    string `name:"segment" help:"Target an exact header, footer, or footnote segment ID"`
 	TabID      string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 	Batch      string `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
 }
@@ -1097,8 +1130,9 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		return usage("empty docId")
 	}
 	placement, err := docsedit.PlanRangePlacement(docsedit.RangePlacementOptions{
-		Start: c.Start,
-		End:   c.End,
+		Start:     c.Start,
+		End:       c.End,
+		AllowZero: strings.TrimSpace(c.Segment) != "",
 		Anchor: docsedit.AnchorOptions{
 			Text:       c.At,
 			Provided:   flagProvided(kctx, "at"),
@@ -1122,6 +1156,7 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		"end_index":   docsDeleteDryRunEnd(c.End),
 		"deleted":     docsDeleteDryRunDeleted(c.Start, c.End, at),
 		"tab":         c.Tab,
+		"segment":     c.Segment,
 		"batch":       c.Batch,
 	}
 	addDocsAtAnchorDryRunPayload(dryRunPayload, docsAtAnchorFlags{At: at, Occurrence: c.Occurrence, MatchCase: c.MatchCase})
@@ -1140,17 +1175,19 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	if err != nil {
 		return err
 	}
-	resolvedPlacement, err := resolveDocsPlacement(ctx, svc, docID, c.Tab, placement)
+	resolvedPlacement, err := resolveDocsPlacementTarget(ctx, svc, docID, c.Tab, c.Segment, placement)
 	if err != nil {
 		return err
 	}
 	start := resolvedPlacement.Range.Start
 	end := resolvedPlacement.Range.End
 	c.Tab = resolvedPlacement.TabID
+	c.Segment = resolvedPlacement.SegmentID
 
 	batchReq := &docs.BatchUpdateDocumentRequest{
 		Requests: []*docs.Request{docsedit.BuildDeleteRequest(docsedit.Range{Start: start, End: end}, c.Tab)},
 	}
+	applyDocsRequestTarget(batchReq.Requests, docsTargetFromPlacement(resolvedPlacement.ResolvedPlacement))
 	batchReq.WriteControl = docsRequiredRevisionWriteControl(resolvedPlacement.RequiredRevisionID)
 	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, docID, "docs.delete", batchRevision, batchReq.Requests, false); queued || queueErr != nil {
 		return queueErr
@@ -1170,6 +1207,10 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 		if c.Tab != "" {
 			payload["tabId"] = c.Tab
 		}
+		if c.Segment != "" {
+			payload["segmentId"] = c.Segment
+			payload["segmentType"] = resolvedPlacement.SegmentKind
+		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
 	}
 
@@ -1178,6 +1219,10 @@ func (c *DocsDeleteCmd) Run(ctx context.Context, kctx *kong.Context, flags *Root
 	u.Out().Linef("range\t%d-%d", start, end)
 	if c.Tab != "" {
 		u.Out().Linef("tabId\t%s", c.Tab)
+	}
+	if c.Segment != "" {
+		u.Out().Linef("segmentId\t%s", c.Segment)
+		u.Out().Linef("segmentType\t%s", resolvedPlacement.SegmentKind)
 	}
 	return nil
 }

--- a/internal/cmd/docs_find_range.go
+++ b/internal/cmd/docs_find_range.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	"google.golang.org/api/docs/v1"
@@ -21,11 +20,15 @@ type DocsFindRangeCmd struct {
 	NormalizeWhitespace bool   `name:"normalize-whitespace" help:"Collapse whitespace while matching" default:"true" negatable:""`
 	FailEmpty           bool   `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no matches"`
 	Tab                 string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Segment             string `name:"segment" help:"Target an exact header, footer, or footnote segment ID"`
 	TabID               string `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 type docsFindRangeResult struct {
-	Matches []docsedit.TextRange `json:"matches"`
+	Matches     []docsedit.TextRange `json:"matches"`
+	TabID       string               `json:"tabId,omitempty"`
+	SegmentID   string               `json:"segmentId,omitempty"`
+	SegmentType string               `json:"segmentType,omitempty"`
 }
 
 func (c *DocsFindRangeCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -54,53 +57,28 @@ func (c *DocsFindRangeCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	doc, tabID, err := c.loadTargetDoc(ctx, svc, id)
+	doc, target, err := c.loadTargetDoc(ctx, svc, id)
 	if err != nil {
 		return err
 	}
 	matches := docsedit.FindTextRanges(doc, c.Text, docsedit.SearchOptions{
 		MatchCase:           c.MatchCase,
 		NormalizeWhitespace: c.NormalizeWhitespace,
-		TabID:               tabID,
+		TabID:               target.TabID,
 	})
 	matches = c.selectMatches(matches)
 
-	return c.writeResult(ctx, matches)
+	return c.writeResult(ctx, matches, target)
 }
 
-func (c *DocsFindRangeCmd) loadTargetDoc(ctx context.Context, svc *docs.Service, docID string) (*docs.Document, string, error) {
-	getCall := svc.Documents.Get(docID).Context(ctx)
-	if c.Tab != "" {
-		getCall = getCall.IncludeTabsContent(true)
-	}
-	doc, err := getCall.Do()
+func (c *DocsFindRangeCmd) loadTargetDoc(ctx context.Context, svc *docs.Service, docID string) (*docs.Document, docsRequestTarget, error) {
+	loaded, err := loadDocsTargetSegment(ctx, svc, docID, c.Tab, c.Segment)
 	if err != nil {
-		if isDocsNotFound(err) {
-			return nil, "", fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
-		}
-		return nil, "", err
+		return nil, docsRequestTarget{}, err
 	}
-	doc, err = requireRawResponse(doc, "doc not found")
-	if err != nil {
-		return nil, "", err
-	}
-
-	if c.Tab == "" {
-		return doc, "", nil
-	}
-	tab, tabErr := findTab(flattenTabs(doc.Tabs), c.Tab)
-	if tabErr != nil {
-		return nil, "", tabErr
-	}
-	tabID := ""
-	if tab.TabProperties != nil {
-		tabID = tab.TabProperties.TabId
-	}
-	targetDoc := &docs.Document{}
-	if tab.DocumentTab != nil {
-		targetDoc.Body = tab.DocumentTab.Body
-	}
-	return targetDoc, tabID, nil
+	return loaded.target, docsRequestTarget{
+		TabID: loaded.tabID, SegmentID: loaded.segmentID, SegmentKind: loaded.segmentKind,
+	}, nil
 }
 
 func (c *DocsFindRangeCmd) selectMatches(matches []docsedit.TextRange) []docsedit.TextRange {
@@ -117,12 +95,14 @@ func (c *DocsFindRangeCmd) selectMatches(matches []docsedit.TextRange) []docsedi
 	return matches[occurrence-1 : occurrence]
 }
 
-func (c *DocsFindRangeCmd) writeResult(ctx context.Context, matches []docsedit.TextRange) error {
+func (c *DocsFindRangeCmd) writeResult(ctx context.Context, matches []docsedit.TextRange, target docsRequestTarget) error {
 	if matches == nil {
 		matches = []docsedit.TextRange{}
 	}
 	if outfmt.IsJSON(ctx) {
-		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), docsFindRangeResult{Matches: matches}); err != nil {
+		if err := outfmt.WriteJSON(ctx, stdoutWriter(ctx), docsFindRangeResult{
+			Matches: matches, TabID: target.TabID, SegmentID: target.SegmentID, SegmentType: target.SegmentKind,
+		}); err != nil {
 			return err
 		}
 		return failEmptyIfNoDocsRange(c.FailEmpty, matches)

--- a/internal/cmd/docs_format.go
+++ b/internal/cmd/docs_format.go
@@ -20,6 +20,7 @@ type DocsFormatCmd struct {
 	MatchAll  bool            `name:"match-all" help:"Format all matches instead of only the first"`
 	MatchCase bool            `name:"match-case" help:"Use case-sensitive matching with --match"`
 	Tab       string          `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+	Segment   string          `name:"segment" help:"Target an exact header, footer, or footnote segment ID"`
 	TabID     string          `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 	Link      string          `name:"link" help:"Set hyperlink target (http://, https://, mailto:, #bookmarkId, or #heading-slug)"`
 	NoLink    bool            `name:"no-link" help:"Clear hyperlink"`
@@ -102,6 +103,7 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		"match_all":   c.MatchAll,
 		"match_case":  c.MatchCase,
 		"tab":         c.Tab,
+		"segment":     c.Segment,
 		"batch":       c.Batch,
 		"format": map[string]any{
 			"font_family":         c.Format.FontFamily,
@@ -151,12 +153,13 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	format, err = format.withResolvedLink(ctx, svc, id, c.Tab)
+	ranges, target, err := c.targetRanges(ctx, svc, id)
 	if err != nil {
 		return err
 	}
-
-	ranges, tabID, err := c.targetRanges(ctx, svc, id)
+	c.Tab = target.TabID
+	c.Segment = target.SegmentID
+	format, err = format.withResolvedLink(ctx, svc, id, c.Tab)
 	if err != nil {
 		return err
 	}
@@ -170,7 +173,7 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		textFormat := format.textOnly()
 		if textFormat.any() {
 			for _, r := range ranges {
-				formatReqs, buildErr := textFormat.buildRequests(r.StartIndex, r.EndIndex, tabID)
+				formatReqs, buildErr := textFormat.buildRequests(r.StartIndex, r.EndIndex, target.TabID)
 				if buildErr != nil {
 					return buildErr
 				}
@@ -182,7 +185,7 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		bulletTargets := groupDocsFormatBulletTargets(ranges)
 		adjustDocsFormatBulletTargets(bulletTargets, paragraphFormat.hasParagraphStyle())
 		for _, r := range bulletTargets {
-			formatReqs, buildErr := paragraphFormat.buildTargetRequests(r, tabID)
+			formatReqs, buildErr := paragraphFormat.buildTargetRequests(r, target.TabID)
 			if buildErr != nil {
 				return buildErr
 			}
@@ -190,13 +193,14 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	} else {
 		for _, r := range ranges {
-			formatReqs, buildErr := format.buildTargetRequests(r, tabID)
+			formatReqs, buildErr := format.buildTargetRequests(r, target.TabID)
 			if buildErr != nil {
 				return buildErr
 			}
 			reqs = append(reqs, formatReqs...)
 		}
 	}
+	applyDocsRequestTarget(reqs, target)
 	if queued, queueErr := queueDocsBatchRequests(ctx, flags, c.Batch, id, "docs.format", batchRevision, reqs, false); queued || queueErr != nil {
 		return queueErr
 	}
@@ -209,43 +213,26 @@ func (c *DocsFormatCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
-	return c.writeResult(ctx, resp, len(reqs), len(ranges), tabID)
+	return c.writeResult(ctx, resp, len(reqs), len(ranges), target)
 }
 
-func (c *DocsFormatCmd) targetRanges(ctx context.Context, svc *docs.Service, docID string) ([]docsFormatTargetRange, string, error) {
-	getCall := svc.Documents.Get(docID).Context(ctx)
-	if c.Tab != "" {
-		getCall = getCall.IncludeTabsContent(true)
-	}
-	doc, err := getCall.Do()
+func (c *DocsFormatCmd) targetRanges(ctx context.Context, svc *docs.Service, docID string) ([]docsFormatTargetRange, docsRequestTarget, error) {
+	loaded, err := loadDocsTargetSegment(ctx, svc, docID, c.Tab, c.Segment)
 	if err != nil {
-		if isDocsNotFound(err) {
-			return nil, "", fmt.Errorf("doc not found or not a Google Doc (id=%s)", docID)
-		}
-		return nil, "", err
+		return nil, docsRequestTarget{}, err
 	}
-
-	tabID := ""
-	targetDoc := doc
-	if c.Tab != "" {
-		tab, tabErr := findTab(flattenTabs(doc.Tabs), c.Tab)
-		if tabErr != nil {
-			return nil, "", tabErr
-		}
-		if tab.TabProperties != nil {
-			tabID = tab.TabProperties.TabId
-		}
-		targetDoc = &docs.Document{}
-		if tab.DocumentTab != nil {
-			targetDoc.Body = tab.DocumentTab.Body
-		}
-	}
+	targetDoc := loaded.target
+	target := docsRequestTarget{TabID: loaded.tabID, SegmentID: loaded.segmentID, SegmentKind: loaded.segmentKind}
 
 	var ranges []docsedit.TextRange
 	if strings.TrimSpace(c.Match) == "" {
+		start := int64(1)
+		if target.SegmentID != "" {
+			start = 0
+		}
 		end := docsDocumentEndIndex(targetDoc) - 1
-		if end > 1 {
-			ranges = []docsedit.TextRange{{StartIndex: 1, EndIndex: end}}
+		if end > start {
+			ranges = []docsedit.TextRange{{StartIndex: start, EndIndex: end}}
 		}
 	} else {
 		ranges = docsedit.FindTextRanges(targetDoc, c.Match, docsedit.SearchOptions{
@@ -270,7 +257,7 @@ func (c *DocsFormatCmd) targetRanges(ctx context.Context, svc *docs.Service, doc
 		}
 		targets = append(targets, target)
 	}
-	return targets, tabID, nil
+	return targets, target, nil
 }
 
 type docsFormatTargetRange struct {
@@ -365,7 +352,7 @@ func groupDocsFormatBulletTargets(targets []docsFormatTargetRange) []docsFormatT
 	return groups
 }
 
-func (c *DocsFormatCmd) writeResult(ctx context.Context, resp *docs.BatchUpdateDocumentResponse, requestCount, rangeCount int, tabID string) error {
+func (c *DocsFormatCmd) writeResult(ctx context.Context, resp *docs.BatchUpdateDocumentResponse, requestCount, rangeCount int, target docsRequestTarget) error {
 	u := ui.FromContext(ctx)
 	if outfmt.IsJSON(ctx) {
 		payload := map[string]any{
@@ -373,8 +360,12 @@ func (c *DocsFormatCmd) writeResult(ctx context.Context, resp *docs.BatchUpdateD
 			"requests":   requestCount,
 			"ranges":     rangeCount,
 		}
-		if tabID != "" {
-			payload["tabId"] = tabID
+		if target.TabID != "" {
+			payload["tabId"] = target.TabID
+		}
+		if target.SegmentID != "" {
+			payload["segmentId"] = target.SegmentID
+			payload["segmentType"] = target.SegmentKind
 		}
 		if resp.WriteControl != nil {
 			payload["writeControl"] = resp.WriteControl
@@ -385,8 +376,12 @@ func (c *DocsFormatCmd) writeResult(ctx context.Context, resp *docs.BatchUpdateD
 	u.Out().Linef("id\t%s", resp.DocumentId)
 	u.Out().Linef("requests\t%d", requestCount)
 	u.Out().Linef("ranges\t%d", rangeCount)
-	if tabID != "" {
-		u.Out().Linef("tabId\t%s", tabID)
+	if target.TabID != "" {
+		u.Out().Linef("tabId\t%s", target.TabID)
+	}
+	if target.SegmentID != "" {
+		u.Out().Linef("segmentId\t%s", target.SegmentID)
+		u.Out().Linef("segmentType\t%s", target.SegmentKind)
 	}
 	if resp.WriteControl != nil && resp.WriteControl.RequiredRevisionId != "" {
 		u.Out().Linef("revision\t%s", resp.WriteControl.RequiredRevisionId)

--- a/internal/cmd/docs_header_footer.go
+++ b/internal/cmd/docs_header_footer.go
@@ -1,0 +1,398 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsHeaderCmd struct {
+	List   DocsHeaderListCmd   `cmd:"" name:"list" aliases:"ls" help:"List headers and their segment IDs"`
+	Create DocsHeaderCreateCmd `cmd:"" name:"create" aliases:"add,new" help:"Create and optionally populate a header"`
+	Delete DocsHeaderDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a header"`
+}
+
+type DocsFooterCmd struct {
+	List   DocsFooterListCmd   `cmd:"" name:"list" aliases:"ls" help:"List footers and their segment IDs"`
+	Create DocsFooterCreateCmd `cmd:"" name:"create" aliases:"add,new" help:"Create and optionally populate a footer"`
+	Delete DocsFooterDeleteCmd `cmd:"" name:"delete" aliases:"rm,remove,del" help:"Delete a footer"`
+}
+
+type DocsHeaderListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Limit results to a tab title or ID"`
+}
+
+type DocsFooterListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Limit results to a tab title or ID"`
+}
+
+type DocsHeaderCreateCmd struct {
+	DocID     string                 `arg:"" name:"docId" help:"Doc ID"`
+	Text      string                 `name:"text" help:"Initial header text"`
+	File      string                 `name:"file" help:"Read initial header text from a file ('-' for stdin)"`
+	Placement DocsBodyPlacementFlags `embed:""`
+}
+
+type DocsFooterCreateCmd struct {
+	DocID     string                 `arg:"" name:"docId" help:"Doc ID"`
+	Text      string                 `name:"text" help:"Initial footer text"`
+	File      string                 `name:"file" help:"Read initial footer text from a file ('-' for stdin)"`
+	Placement DocsBodyPlacementFlags `embed:""`
+}
+
+type DocsHeaderDeleteCmd struct {
+	DocID     string `arg:"" name:"docId" help:"Doc ID"`
+	SegmentID string `arg:"" name:"headerId" help:"Exact header segment ID"`
+	Tab       string `name:"tab" help:"Tab title or ID containing the header"`
+}
+
+type DocsFooterDeleteCmd struct {
+	DocID     string `arg:"" name:"docId" help:"Doc ID"`
+	SegmentID string `arg:"" name:"footerId" help:"Exact footer segment ID"`
+	Tab       string `name:"tab" help:"Tab title or ID containing the footer"`
+}
+
+type docsSegmentListItem struct {
+	ID     string `json:"id"`
+	Type   string `json:"type"`
+	TabID  string `json:"tabId,omitempty"`
+	Length int64  `json:"length"`
+}
+
+func (c *DocsHeaderListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runDocsSegmentList(ctx, flags, c.DocID, c.Tab, docsSegmentKindHeader)
+}
+
+func (c *DocsFooterListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runDocsSegmentList(ctx, flags, c.DocID, c.Tab, docsSegmentKindFooter)
+}
+
+func runDocsSegmentList(ctx context.Context, flags *RootFlags, rawDocID, tabQuery, kind string) error {
+	docID := normalizeGoogleID(strings.TrimSpace(rawDocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	doc, err := svc.Documents.Get(docID).IncludeTabsContent(true).Context(ctx).Do()
+	if err != nil {
+		return err
+	}
+	items, err := collectDocsSegments(doc, tabQuery, kind)
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		key := kind + "s"
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"documentId": docID, key: items})
+	}
+	u := ui.FromContext(ctx)
+	for _, item := range items {
+		u.Out().Linef("%s\t%s\t%s\t%d", item.ID, item.Type, item.TabID, item.Length)
+	}
+	return nil
+}
+
+func collectDocsSegments(doc *docs.Document, tabQuery, kind string) ([]docsSegmentListItem, error) {
+	items := make([]docsSegmentListItem, 0)
+	add := func(tabID string, content map[string][]*docs.StructuralElement) {
+		for id, elements := range content {
+			items = append(items, docsSegmentListItem{ID: id, Type: kind, TabID: tabID, Length: docsStructuralContentEnd(elements)})
+		}
+	}
+	collectTab := func(tab *docs.Tab) {
+		if tab == nil || tab.DocumentTab == nil {
+			return
+		}
+		tabID := ""
+		if tab.TabProperties != nil {
+			tabID = tab.TabProperties.TabId
+		}
+		add(tabID, docsSegmentElements(tab.DocumentTab, kind))
+	}
+	if strings.TrimSpace(tabQuery) != "" {
+		tab, err := findTab(flattenTabs(doc.Tabs), tabQuery)
+		if err != nil {
+			return nil, err
+		}
+		collectTab(tab)
+	} else {
+		for _, tab := range flattenTabs(doc.Tabs) {
+			collectTab(tab)
+		}
+		add("", docsLegacySegmentElements(doc, kind))
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].TabID != items[j].TabID {
+			return items[i].TabID < items[j].TabID
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items, nil
+}
+
+func docsSegmentElements(tab *docs.DocumentTab, kind string) map[string][]*docs.StructuralElement {
+	result := make(map[string][]*docs.StructuralElement)
+	switch kind {
+	case docsSegmentKindHeader:
+		for id, segment := range tab.Headers {
+			result[id] = segment.Content
+		}
+	case docsSegmentKindFooter:
+		for id, segment := range tab.Footers {
+			result[id] = segment.Content
+		}
+	}
+	return result
+}
+
+func docsLegacySegmentElements(doc *docs.Document, kind string) map[string][]*docs.StructuralElement {
+	return docsSegmentElements(&docs.DocumentTab{Headers: doc.Headers, Footers: doc.Footers}, kind)
+}
+
+func docsStructuralContentEnd(content []*docs.StructuralElement) int64 {
+	var end int64
+	for _, element := range content {
+		if element != nil && element.EndIndex > end {
+			end = element.EndIndex
+		}
+	}
+	return end
+}
+
+func (c *DocsHeaderCreateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	return runDocsSegmentCreate(ctx, kctx, flags, c.DocID, c.Text, c.File, c.Placement, docsSegmentKindHeader)
+}
+
+func (c *DocsFooterCreateCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	return runDocsSegmentCreate(ctx, kctx, flags, c.DocID, c.Text, c.File, c.Placement, docsSegmentKindFooter)
+}
+
+func runDocsSegmentCreate(ctx context.Context, kctx *kong.Context, flags *RootFlags, rawDocID, textFlag, fileFlag string, placementFlags DocsBodyPlacementFlags, kind string) error {
+	docID := normalizeGoogleID(strings.TrimSpace(rawDocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	text, provided, err := resolveTextInput(ctx, textFlag, fileFlag, kctx)
+	if err != nil {
+		return err
+	}
+	hasPlacement := placementFlags.Index != nil || placementFlags.AtEnd || flagProvided(kctx, "at")
+	var placementPayload map[string]any
+	if hasPlacement {
+		placement, planErr := placementFlags.plan(kctx)
+		if planErr != nil {
+			return planErr
+		}
+		placementPayload = placementFlags.dryRunPayload(placement)
+	} else {
+		placementPayload = map[string]any{"tab": placementFlags.Tab, "section": "document-default"}
+	}
+	placementPayload["documentId"] = docID
+	placementPayload["segmentType"] = kind
+	placementPayload["textBytes"] = len(text)
+	if dryRunErr := dryRunExit(ctx, flags, "docs."+kind+".create", placementPayload); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	tabID, sectionLocation, err := resolveDocsCreateSegmentLocation(ctx, kctx, svc, docID, placementFlags, hasPlacement)
+	if err != nil {
+		return err
+	}
+	request := &docs.Request{}
+	if kind == docsSegmentKindHeader {
+		request.CreateHeader = &docs.CreateHeaderRequest{Type: "DEFAULT", SectionBreakLocation: sectionLocation}
+	} else {
+		request.CreateFooter = &docs.CreateFooterRequest{Type: "DEFAULT", SectionBreakLocation: sectionLocation}
+	}
+	response, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: []*docs.Request{request}}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("create %s: %w", kind, err)
+	}
+	segmentID := docsCreatedSegmentID(response, kind)
+	if segmentID == "" {
+		return fmt.Errorf("create %s response missing segment ID", kind)
+	}
+	requestCount := 1
+	if provided && text != "" {
+		_, err = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: []*docs.Request{{
+			InsertText: &docs.InsertTextRequest{
+				EndOfSegmentLocation: &docs.EndOfSegmentLocation{SegmentId: segmentID, TabId: tabID},
+				Text:                 text,
+			},
+		}}}).Context(ctx).Do()
+		if err != nil {
+			return fmt.Errorf("%s %s was created but could not be populated: %w", kind, segmentID, err)
+		}
+		requestCount++
+	}
+	return writeDocsSegmentMutationResult(ctx, docID, tabID, segmentID, kind, requestCount, false)
+}
+
+func resolveDocsCreateSegmentLocation(ctx context.Context, kctx *kong.Context, svc *docs.Service, docID string, flags DocsBodyPlacementFlags, hasPlacement bool) (string, *docs.Location, error) {
+	if !hasPlacement {
+		if strings.TrimSpace(flags.Tab) == "" {
+			return "", nil, nil
+		}
+		loaded, err := loadDocsTargetDocument(ctx, svc, docID, flags.Tab)
+		if err != nil {
+			return "", nil, err
+		}
+		return loaded.tabID, docsDefaultSectionLocation(loaded.tabID), nil
+	}
+	placement, err := flags.plan(kctx)
+	if err != nil {
+		return "", nil, err
+	}
+	resolved, err := resolveDocsPlacement(ctx, svc, docID, flags.Tab, placement)
+	if err != nil {
+		return "", nil, err
+	}
+	if resolved.InTable {
+		return "", nil, usage("header/footer sections cannot be selected from inside a table")
+	}
+	loaded, err := loadDocsTargetDocument(ctx, svc, docID, resolved.TabID)
+	if err != nil {
+		return "", nil, err
+	}
+	location := docsSectionBreakLocation(loaded.target, loaded.tabID, resolved.Index)
+	if location == nil {
+		location = docsDefaultSectionLocation(loaded.tabID)
+	}
+	return loaded.tabID, location, nil
+}
+
+func docsDefaultSectionLocation(tabID string) *docs.Location {
+	if tabID == "" {
+		return nil
+	}
+	location := &docs.Location{Index: 0, TabId: tabID}
+	forceZeroLocationIndex(location)
+	return location
+}
+
+func docsSectionBreakLocation(doc *docs.Document, tabID string, index int64) *docs.Location {
+	var selected *docs.StructuralElement
+	if doc != nil && doc.Body != nil {
+		for _, element := range doc.Body.Content {
+			if element == nil || element.SectionBreak == nil || element.StartIndex > index {
+				continue
+			}
+			if selected == nil || element.StartIndex > selected.StartIndex {
+				selected = element
+			}
+		}
+	}
+	if selected == nil {
+		return nil
+	}
+	location := &docs.Location{Index: selected.StartIndex, TabId: tabID}
+	forceZeroLocationIndex(location)
+	return location
+}
+
+func docsCreatedSegmentID(response *docs.BatchUpdateDocumentResponse, kind string) string {
+	if response == nil {
+		return ""
+	}
+	for _, reply := range response.Replies {
+		if reply == nil {
+			continue
+		}
+		if kind == docsSegmentKindHeader && reply.CreateHeader != nil {
+			return reply.CreateHeader.HeaderId
+		}
+		if kind == docsSegmentKindFooter && reply.CreateFooter != nil {
+			return reply.CreateFooter.FooterId
+		}
+	}
+	return ""
+}
+
+func (c *DocsHeaderDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runDocsSegmentDelete(ctx, flags, c.DocID, c.Tab, c.SegmentID, docsSegmentKindHeader)
+}
+
+func (c *DocsFooterDeleteCmd) Run(ctx context.Context, flags *RootFlags) error {
+	return runDocsSegmentDelete(ctx, flags, c.DocID, c.Tab, c.SegmentID, docsSegmentKindFooter)
+}
+
+func runDocsSegmentDelete(ctx context.Context, flags *RootFlags, rawDocID, tabQuery, rawSegmentID, kind string) error {
+	docID := normalizeGoogleID(strings.TrimSpace(rawDocID))
+	segmentID := strings.TrimSpace(rawSegmentID)
+	if docID == "" {
+		return usage("empty docId")
+	}
+	if segmentID == "" {
+		return usage("empty segment ID")
+	}
+	if err := dryRunAndConfirmDestructive(ctx, flags, "docs."+kind+".delete", map[string]any{
+		"documentId": docID, "segmentId": segmentID, "segmentType": kind, "tab": tabQuery,
+	}, fmt.Sprintf("delete %s %s from doc %s", kind, segmentID, docID)); err != nil {
+		return err
+	}
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	loaded, err := loadDocsTargetSegment(ctx, svc, docID, tabQuery, segmentID)
+	if err != nil {
+		return err
+	}
+	if loaded.segmentKind != kind {
+		return usagef("segment %s is a %s, not a %s", segmentID, loaded.segmentKind, kind)
+	}
+	request := &docs.Request{}
+	if kind == docsSegmentKindHeader {
+		request.DeleteHeader = &docs.DeleteHeaderRequest{HeaderId: segmentID, TabId: loaded.tabID}
+	} else {
+		request.DeleteFooter = &docs.DeleteFooterRequest{FooterId: segmentID, TabId: loaded.tabID}
+	}
+	_, err = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: []*docs.Request{request}}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("delete %s: %w", kind, err)
+	}
+	return writeDocsSegmentMutationResult(ctx, docID, loaded.tabID, segmentID, kind, 1, true)
+}
+
+func writeDocsSegmentMutationResult(ctx context.Context, docID, tabID, segmentID, kind string, requests int, deleted bool) error {
+	payload := map[string]any{
+		"documentId": docID, "segmentId": segmentID, "segmentType": kind, "requests": requests,
+	}
+	if tabID != "" {
+		payload["tabId"] = tabID
+	}
+	if deleted {
+		payload["deleted"] = true
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), payload)
+	}
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", docID)
+	u.Out().Linef("segmentId\t%s", segmentID)
+	u.Out().Linef("segmentType\t%s", kind)
+	u.Out().Linef("requests\t%d", requests)
+	if tabID != "" {
+		u.Out().Linef("tabId\t%s", tabID)
+	}
+	if deleted {
+		u.Out().Linef("deleted\ttrue")
+	}
+	return nil
+}

--- a/internal/cmd/docs_header_footer_test.go
+++ b/internal/cmd/docs_header_footer_test.go
@@ -1,0 +1,225 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsHeaderCreatePopulatesReturnedSegment(t *testing.T) {
+	t.Parallel()
+	svc, calls, cleanup := newDocsCreateAndPopulateService(t, map[string]any{
+		"createHeader": map[string]any{"headerId": "header-1"},
+	})
+	defer cleanup()
+
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	if err := runKong(t, &DocsHeaderCreateCmd{}, []string{"doc1", "--text", "Header text"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("create header: %v", err)
+	}
+	if len(*calls) != 2 || (*calls)[0][0].CreateHeader == nil || (*calls)[0][0].CreateHeader.Type != "DEFAULT" {
+		t.Fatalf("create requests = %#v", *calls)
+	}
+	insert := (*calls)[1][0].InsertText
+	if insert == nil || insert.EndOfSegmentLocation == nil || insert.EndOfSegmentLocation.SegmentId != "header-1" || insert.Text != "Header text" {
+		t.Fatalf("populate request = %#v", (*calls)[1])
+	}
+}
+
+func newDocsCreateAndPopulateService(t *testing.T, createReply map[string]any) (*docs.Service, *[][]*docs.Request, func()) {
+	t.Helper()
+
+	var calls [][]*docs.Request
+	svc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method != http.MethodPost || !strings.HasSuffix(r.URL.Path, ":batchUpdate") {
+			http.NotFound(w, r)
+			return
+		}
+		var body docs.BatchUpdateDocumentRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+		calls = append(calls, body.Requests)
+		response := map[string]any{"documentId": "doc1"}
+		if len(calls) == 1 {
+			response["replies"] = []any{createReply}
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	return svc, &calls, cleanup
+}
+
+func TestDocsHeaderCreateTargetsFirstSectionOfSelectedTab(t *testing.T) {
+	t.Parallel()
+	doc := &docs.Document{DocumentId: "doc1", Tabs: []*docs.Tab{
+		{
+			TabProperties: &docs.TabProperties{TabId: "tab-1", Title: "First"},
+			DocumentTab:   &docs.DocumentTab{Body: &docs.Body{}},
+		},
+		{
+			TabProperties: &docs.TabProperties{TabId: "tab-2", Title: "Second"},
+			DocumentTab: &docs.DocumentTab{Body: &docs.Body{Content: []*docs.StructuralElement{{
+				StartIndex:   10,
+				SectionBreak: &docs.SectionBreak{},
+			}}}},
+		},
+	}}
+	var wireBody []byte
+	svc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			var err error
+			wireBody, err = io.ReadAll(r.Body)
+			if err != nil {
+				t.Fatalf("read request: %v", err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"replies":    []any{map[string]any{"createHeader": map[string]any{"headerId": "header-2"}}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	if err := runKong(t, &DocsHeaderCreateCmd{}, []string{"doc1", "--tab", "Second"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("create header: %v", err)
+	}
+	encoded := string(wireBody)
+	if !strings.Contains(encoded, `"sectionBreakLocation":{"index":0,"tabId":"tab-2"}`) {
+		t.Fatalf("selected tab first-section location missing from wire request: %s", encoded)
+	}
+}
+
+func TestDocsSegmentTextCommandsPropagateSegmentID(t *testing.T) {
+	t.Parallel()
+	segmentDoc := &docs.Document{
+		DocumentId: "doc1",
+		RevisionId: "rev1",
+		Headers: map[string]docs.Header{
+			"header-1": {
+				HeaderId: "header-1",
+				Content: []*docs.StructuralElement{{
+					StartIndex: 0,
+					EndIndex:   7,
+					Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{{
+						StartIndex: 0, EndIndex: 7, TextRun: &docs.TextRun{Content: "Header\n"},
+					}}},
+				}},
+			},
+		},
+	}
+	var batches [][]*docs.Request
+	svc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(segmentDoc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			var body docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			batches = append(batches, body.Requests)
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	flags := &RootFlags{Account: "a@b.com"}
+
+	commands := []struct {
+		cmd  any
+		args []string
+	}{
+		{&DocsInsertCmd{}, []string{"doc1", "X", "--segment", "header-1", "--index", "0"}},
+		{&DocsUpdateCmd{}, []string{"doc1", "--text", "Y", "--segment", "header-1", "--replace-range", "0:1"}},
+		{&DocsDeleteCmd{}, []string{"doc1", "--segment", "header-1", "--start", "0", "--end", "1"}},
+		{&DocsFormatCmd{}, []string{"doc1", "--segment", "header-1", "--match", "Header", "--bold"}},
+	}
+	for _, command := range commands {
+		if err := runKong(t, command.cmd, command.args, ctx, flags); err != nil {
+			t.Fatalf("run %T: %v", command.cmd, err)
+		}
+	}
+	if len(batches) != len(commands) {
+		t.Fatalf("batch count = %d, want %d", len(batches), len(commands))
+	}
+	for batchIndex, requests := range batches {
+		found := false
+		for _, request := range requests {
+			if request.InsertText != nil && request.InsertText.Location != nil && request.InsertText.Location.SegmentId == "header-1" {
+				found = true
+			}
+			for _, targetRange := range docsRequestRanges(request) {
+				if targetRange.SegmentId == "header-1" {
+					found = true
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("batch %d lost segment target: %#v", batchIndex, requests)
+		}
+	}
+}
+
+func TestDocsHeaderListAndDelete(t *testing.T) {
+	t.Parallel()
+	doc := &docs.Document{DocumentId: "doc1", Headers: map[string]docs.Header{
+		"header-1": {HeaderId: "header-1", Content: []*docs.StructuralElement{{EndIndex: 4}}},
+	}}
+	var deleted *docs.DeleteHeaderRequest
+	svc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet:
+			_ = json.NewEncoder(w).Encode(doc)
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+			var body docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode request: %v", err)
+			}
+			deleted = body.Requests[0].DeleteHeader
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	var output bytes.Buffer
+	jsonCtx := withDocsTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), svc)
+	if err := runKong(t, &DocsHeaderListCmd{}, []string{"doc1"}, jsonCtx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("list headers: %v", err)
+	}
+	var listed struct {
+		Headers []docsSegmentListItem `json:"headers"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &listed); err != nil {
+		t.Fatalf("decode list output: %v", err)
+	}
+	if len(listed.Headers) != 1 || listed.Headers[0].ID != "header-1" {
+		t.Fatalf("unexpected list output: %s", output.String())
+	}
+
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	if err := runKong(t, &DocsHeaderDeleteCmd{}, []string{"doc1", "header-1"}, ctx, &RootFlags{Account: "a@b.com", Force: true}); err != nil {
+		t.Fatalf("delete header: %v", err)
+	}
+	if deleted == nil || deleted.HeaderId != "header-1" {
+		t.Fatalf("delete request = %#v", deleted)
+	}
+}

--- a/internal/cmd/docs_helpers.go
+++ b/internal/cmd/docs_helpers.go
@@ -59,12 +59,12 @@ const (
 	docsDocumentModePageless = "PAGELESS"
 )
 
-func resolveTextInput(ctx context.Context, text, file string, kctx *kong.Context, textFlag, fileFlag string) (string, bool, error) {
+func resolveTextInput(ctx context.Context, text, file string, kctx *kong.Context) (string, bool, error) {
 	file = strings.TrimSpace(file)
-	textProvided := text != "" || flagProvided(kctx, textFlag)
-	fileProvided := file != "" || flagProvided(kctx, fileFlag)
+	textProvided := text != "" || flagProvided(kctx, "text")
+	fileProvided := file != "" || flagProvided(kctx, "file")
 	if textProvided && fileProvided {
-		return "", true, usage(fmt.Sprintf("use only one of --%s or --%s", textFlag, fileFlag))
+		return "", true, usage("use only one of --text or --file")
 	}
 	if fileProvided {
 		b, err := readTextInput(ctx, file)

--- a/internal/cmd/docs_mutation.go
+++ b/internal/cmd/docs_mutation.go
@@ -24,14 +24,21 @@ const (
 )
 
 type docsLoadedTarget struct {
-	full   *docs.Document
-	target *docs.Document
-	tabID  string
+	full        *docs.Document
+	target      *docs.Document
+	tabID       string
+	segmentID   string
+	segmentKind string
 }
 
 func loadDocsTargetDocument(ctx context.Context, svc *docs.Service, docID, tabID string) (*docsLoadedTarget, error) {
+	return loadDocsTargetSegment(ctx, svc, docID, tabID, "")
+}
+
+func loadDocsTargetSegment(ctx context.Context, svc *docs.Service, docID, tabQuery, segmentID string) (*docsLoadedTarget, error) {
+	segmentID = strings.TrimSpace(segmentID)
 	getCall := svc.Documents.Get(docID).Context(ctx)
-	if tabID != "" {
+	if tabQuery != "" || segmentID != "" {
 		getCall = getCall.IncludeTabsContent(true)
 	}
 
@@ -45,11 +52,15 @@ func loadDocsTargetDocument(ctx context.Context, svc *docs.Service, docID, tabID
 	if doc == nil {
 		return nil, errors.New("doc not found")
 	}
-	if tabID == "" {
+	if tabQuery == "" && segmentID == "" {
 		return &docsLoadedTarget{full: doc, target: doc}, nil
 	}
 
-	tab, tabErr := findTab(flattenTabs(doc.Tabs), tabID)
+	if segmentID != "" {
+		return selectDocsSegmentTarget(doc, tabQuery, segmentID)
+	}
+
+	tab, tabErr := findTab(flattenTabs(doc.Tabs), tabQuery)
 	if tabErr != nil {
 		return nil, tabErr
 	}
@@ -58,10 +69,10 @@ func loadDocsTargetDocument(ctx context.Context, svc *docs.Service, docID, tabID
 		resolvedTabID = strings.TrimSpace(tab.TabProperties.TabId)
 	}
 	if resolvedTabID == "" {
-		return nil, fmt.Errorf("tab has no ID: %s", tabID)
+		return nil, fmt.Errorf("tab has no ID: %s", tabQuery)
 	}
 	if tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
-		return nil, fmt.Errorf("tab has no document body: %s", tabID)
+		return nil, fmt.Errorf("tab has no document body: %s", tabQuery)
 	}
 
 	return &docsLoadedTarget{

--- a/internal/cmd/docs_named_ranges.go
+++ b/internal/cmd/docs_named_ranges.go
@@ -307,7 +307,7 @@ func (c *DocsNamedRangesReplaceCmd) Run(ctx context.Context, kctx *kong.Context,
 	if in == "" {
 		return usage("empty nameOrId")
 	}
-	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx, "text", "file")
+	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/docs_placement.go
+++ b/internal/cmd/docs_placement.go
@@ -22,6 +22,17 @@ func resolveDocsPlacement(
 	tab string,
 	placement docsedit.Placement,
 ) (docsResolvedPlacement, error) {
+	return resolveDocsPlacementTarget(ctx, svc, docID, tab, "", placement)
+}
+
+func resolveDocsPlacementTarget(
+	ctx context.Context,
+	svc *docs.Service,
+	docID string,
+	tab string,
+	segment string,
+	placement docsedit.Placement,
+) (docsResolvedPlacement, error) {
 	var facts docsedit.PlacementFacts
 	var document *docs.Document
 
@@ -32,27 +43,36 @@ func resolveDocsPlacement(
 			Occurrence: placement.Anchor.Occurrence,
 			MatchCase:  placement.Anchor.MatchCase,
 			Tab:        tab,
+			Segment:    segment,
 		})
 		if err != nil {
 			return docsResolvedPlacement{}, err
 		}
 		facts.Anchor = &anchor.Match
 		facts.RequiredRevisionID = anchor.RevisionID
+		facts.SegmentID = anchor.SegmentID
+		facts.SegmentKind = anchor.SegmentKind
 		document = anchor.Document
 	case docsedit.PlacementEnd:
-		endIndex, tabID, err := docsTargetEndIndexAndTabID(ctx, svc, docID, tab)
+		loaded, err := loadDocsTargetSegment(ctx, svc, docID, tab, segment)
 		if err != nil {
 			return docsResolvedPlacement{}, err
 		}
-		facts.EndIndex = endIndex
-		facts.TabID = tabID
+		facts.EndIndex = docsDocumentEndIndex(loaded.target)
+		facts.TabID = loaded.tabID
+		facts.SegmentID = loaded.segmentID
+		facts.SegmentKind = loaded.segmentKind
+		document = loaded.full
 	case docsedit.PlacementIndex, docsedit.PlacementRange:
-		if strings.TrimSpace(tab) != "" {
-			tabID, err := resolveDocsTabID(ctx, svc, docID, tab)
+		if strings.TrimSpace(tab) != "" || strings.TrimSpace(segment) != "" {
+			loaded, err := loadDocsTargetSegment(ctx, svc, docID, tab, segment)
 			if err != nil {
 				return docsResolvedPlacement{}, err
 			}
-			facts.TabID = tabID
+			facts.TabID = loaded.tabID
+			facts.SegmentID = loaded.segmentID
+			facts.SegmentKind = loaded.segmentKind
+			document = loaded.full
 		}
 	default:
 		return docsResolvedPlacement{}, fmt.Errorf("resolve Docs placement: unsupported kind %d", placement.Kind)

--- a/internal/cmd/docs_structural.go
+++ b/internal/cmd/docs_structural.go
@@ -1,0 +1,340 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/docsedit"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type DocsBodyPlacementFlags struct {
+	Index      *int64 `name:"index" help:"Character index (1 = beginning); omit for end-of-doc"`
+	At         string `name:"at" help:"Anchor by literal text and use the start of the matched range"`
+	Occurrence *int   `name:"occurrence" help:"Use the Nth --at match (1-based; required when --at is ambiguous)"`
+	MatchCase  bool   `name:"match-case" help:"Use case-sensitive --at matching"`
+	AtEnd      bool   `name:"at-end" help:"Target end-of-doc/tab (mutually exclusive with --index and --at)"`
+	Tab        string `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs)"`
+}
+
+type DocsFootnoteCmd struct {
+	DocID     string                 `arg:"" name:"docId" help:"Doc ID"`
+	Text      string                 `name:"text" help:"Footnote text"`
+	File      string                 `name:"file" help:"Read footnote text from a file ('-' for stdin)"`
+	Placement DocsBodyPlacementFlags `embed:""`
+}
+
+type DocsSectionBreakCmd struct {
+	DocID     string                 `arg:"" name:"docId" help:"Doc ID"`
+	Type      string                 `name:"type" help:"Section type: next-page or continuous" default:"next-page"`
+	Batch     string                 `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
+	Placement DocsBodyPlacementFlags `embed:""`
+}
+
+type DocsHorizontalRuleCmd struct {
+	DocID     string                 `arg:"" name:"docId" help:"Doc ID"`
+	Batch     string                 `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
+	Placement DocsBodyPlacementFlags `embed:""`
+}
+
+type DocsSectionColumnsCmd struct {
+	DocID     string                 `arg:"" name:"docId" help:"Doc ID"`
+	Count     int                    `name:"count" required:"" help:"Number of columns (1-3; 1 resets to one column)"`
+	Separator string                 `name:"separator" help:"Column separator: none or between" default:"none"`
+	Batch     string                 `name:"batch" help:"Append requests to a persisted Docs batch instead of submitting"`
+	Placement DocsBodyPlacementFlags `embed:""`
+}
+
+type docsBodyMutation struct {
+	action    string
+	docID     string
+	batch     string
+	placement DocsBodyPlacementFlags
+	payload   map[string]any
+	build     func(docsResolvedPlacement) ([]*docs.Request, error)
+}
+
+func (p DocsBodyPlacementFlags) plan(kctx *kong.Context) (docsedit.Placement, error) {
+	placement, err := docsedit.PlanEndInsertPlacement(docsedit.EndInsertPlacementOptions{
+		Index: p.Index,
+		AtEnd: p.AtEnd,
+		Anchor: docsedit.AnchorOptions{
+			Text:       p.At,
+			Provided:   flagProvided(kctx, "at"),
+			Occurrence: p.Occurrence,
+			MatchCase:  p.MatchCase,
+		},
+	})
+	if err != nil {
+		return docsedit.Placement{}, usage(err.Error())
+	}
+	return placement, nil
+}
+
+func (p DocsBodyPlacementFlags) dryRunPayload(placement docsedit.Placement) map[string]any {
+	payload := map[string]any{"tab": p.Tab}
+	switch placement.Kind {
+	case docsedit.PlacementAnchor:
+		payload["atIndex"] = docsAtIndexAnchorStart
+		addDocsAtAnchorDryRunPayload(payload, docsAtAnchorFlags{
+			At: p.At, Occurrence: p.Occurrence, MatchCase: p.MatchCase,
+		})
+	case docsedit.PlacementIndex:
+		payload["atIndex"] = placement.Index
+	default:
+		payload["atIndex"] = docsAtIndexEnd
+	}
+	return payload
+}
+
+func runDocsBodyMutation(ctx context.Context, kctx *kong.Context, flags *RootFlags, mutation docsBodyMutation) error {
+	docID := normalizeGoogleID(strings.TrimSpace(mutation.docID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	placement, err := mutation.placement.plan(kctx)
+	if err != nil {
+		return err
+	}
+	payload := mutation.placement.dryRunPayload(placement)
+	payload["documentId"] = docID
+	payload["batch"] = mutation.batch
+	for key, value := range mutation.payload {
+		payload[key] = value
+	}
+	if dryRunErr := dryRunExit(ctx, flags, mutation.action, payload); dryRunErr != nil {
+		return dryRunErr
+	}
+	if batchErr := validateDocsBatchTarget(ctx, flags, mutation.batch, docID); batchErr != nil {
+		return batchErr
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	batchRevision, err := captureDocsBatchRevision(ctx, svc, mutation.batch, docID)
+	if err != nil {
+		return err
+	}
+	resolved, err := resolveDocsPlacement(ctx, svc, docID, mutation.placement.Tab, placement)
+	if err != nil {
+		return err
+	}
+	if resolved.InTable {
+		return usage(fmt.Sprintf("%s cannot target text inside a table", mutation.action))
+	}
+	requests, err := mutation.build(resolved)
+	if err != nil {
+		return err
+	}
+	applyDocsRequestTarget(requests, docsTargetFromPlacement(resolved.ResolvedPlacement))
+	if queued, queueErr := queueDocsBatchRequests(ctx, flags, mutation.batch, docID, mutation.action, batchRevision, requests, false); queued || queueErr != nil {
+		return queueErr
+	}
+	response, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests:     requests,
+		WriteControl: docsRequiredRevisionWriteControl(resolved.RequiredRevisionID),
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("%s: %w", mutation.action, err)
+	}
+	return writeDocsBodyMutationResult(ctx, response, resolved, len(requests), mutation.payload)
+}
+
+func writeDocsBodyMutationResult(ctx context.Context, response *docs.BatchUpdateDocumentResponse, resolved docsResolvedPlacement, requestCount int, payload map[string]any) error {
+	documentID := ""
+	if response != nil {
+		documentID = response.DocumentId
+	}
+	result := map[string]any{
+		"documentId": documentID,
+		"atIndex":    resolved.Index,
+		"requests":   requestCount,
+	}
+	if resolved.TabID != "" {
+		result["tabId"] = resolved.TabID
+	}
+	for key, value := range payload {
+		result[key] = value
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), result)
+	}
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", documentID)
+	u.Out().Linef("atIndex\t%d", resolved.Index)
+	u.Out().Linef("requests\t%d", requestCount)
+	if resolved.TabID != "" {
+		u.Out().Linef("tabId\t%s", resolved.TabID)
+	}
+	return nil
+}
+
+func (c *DocsSectionBreakCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	sectionType, err := normalizeDocsSectionType(c.Type)
+	if err != nil {
+		return err
+	}
+	return runDocsBodyMutation(ctx, kctx, flags, docsBodyMutation{
+		action: "docs.insert-section-break", docID: c.DocID, batch: c.Batch, placement: c.Placement,
+		payload: map[string]any{"sectionType": sectionType},
+		build: func(resolved docsResolvedPlacement) ([]*docs.Request, error) {
+			return []*docs.Request{{InsertSectionBreak: &docs.InsertSectionBreakRequest{
+				Location: &docs.Location{Index: resolved.Index}, SectionType: sectionType,
+			}}}, nil
+		},
+	})
+}
+
+func normalizeDocsSectionType(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "next-page", "next_page", "nextpage":
+		return "NEXT_PAGE", nil
+	case "continuous":
+		return "CONTINUOUS", nil
+	default:
+		return "", usage("--type must be next-page or continuous")
+	}
+}
+
+func (c *DocsHorizontalRuleCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	return runDocsBodyMutation(ctx, kctx, flags, docsBodyMutation{
+		action: "docs.insert-horizontal-rule", docID: c.DocID, batch: c.Batch, placement: c.Placement,
+		payload: map[string]any{"kind": "paragraph-border"},
+		build: func(resolved docsResolvedPlacement) ([]*docs.Request, error) {
+			return []*docs.Request{
+				{InsertText: &docs.InsertTextRequest{Location: &docs.Location{Index: resolved.Index}, Text: "\n"}},
+				buildHruleBorderRequest(resolved.Index, resolved.Index+1),
+			}, nil
+		},
+	})
+}
+
+func (c *DocsSectionColumnsCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	if c.Count < 1 || c.Count > 3 {
+		return usage("--count must be between 1 and 3")
+	}
+	separator, err := normalizeDocsColumnSeparator(c.Separator)
+	if err != nil {
+		return err
+	}
+	return runDocsBodyMutation(ctx, kctx, flags, docsBodyMutation{
+		action: "docs.section-columns", docID: c.DocID, batch: c.Batch, placement: c.Placement,
+		payload: map[string]any{"count": c.Count, "separator": separator},
+		build: func(resolved docsResolvedPlacement) ([]*docs.Request, error) {
+			columns := make([]*docs.SectionColumnProperties, c.Count)
+			for index := range columns {
+				columns[index] = &docs.SectionColumnProperties{PaddingEnd: &docs.Dimension{Magnitude: 36, Unit: "PT"}}
+			}
+			return []*docs.Request{{UpdateSectionStyle: &docs.UpdateSectionStyleRequest{
+				Range:        &docs.Range{StartIndex: resolved.Index, EndIndex: resolved.Index + 1},
+				SectionStyle: &docs.SectionStyle{ColumnProperties: columns, ColumnSeparatorStyle: separator},
+				Fields:       "columnProperties,columnSeparatorStyle",
+			}}}, nil
+		},
+	})
+}
+
+func normalizeDocsColumnSeparator(value string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "none", "":
+		return "NONE", nil
+	case "between", "between-each-column", "between_each_column":
+		return "BETWEEN_EACH_COLUMN", nil
+	default:
+		return "", usage("--separator must be none or between")
+	}
+}
+
+func (c *DocsFootnoteCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
+	docID := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if docID == "" {
+		return usage("empty docId")
+	}
+	text, provided, err := resolveTextInput(ctx, c.Text, c.File, kctx)
+	if err != nil {
+		return err
+	}
+	if !provided || text == "" {
+		return usage("required: non-empty --text or --file")
+	}
+	placement, err := c.Placement.plan(kctx)
+	if err != nil {
+		return err
+	}
+	payload := c.Placement.dryRunPayload(placement)
+	payload["documentId"] = docID
+	payload["textBytes"] = len(text)
+	if dryRunErr := dryRunExit(ctx, flags, "docs.insert-footnote", payload); dryRunErr != nil {
+		return dryRunErr
+	}
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+	resolved, err := resolveDocsPlacement(ctx, svc, docID, c.Placement.Tab, placement)
+	if err != nil {
+		return err
+	}
+	if resolved.InTable {
+		return usage("docs.insert-footnote cannot target text inside a table")
+	}
+	createResponse, err := svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{
+		Requests: []*docs.Request{{CreateFootnote: &docs.CreateFootnoteRequest{
+			Location: &docs.Location{Index: resolved.Index, TabId: resolved.TabID},
+		}}},
+		WriteControl: docsRequiredRevisionWriteControl(resolved.RequiredRevisionID),
+	}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("create footnote: %w", err)
+	}
+	footnoteID := docsCreatedFootnoteID(createResponse)
+	if footnoteID == "" {
+		return fmt.Errorf("create footnote response missing footnote ID")
+	}
+	_, err = svc.Documents.BatchUpdate(docID, &docs.BatchUpdateDocumentRequest{Requests: []*docs.Request{{
+		InsertText: &docs.InsertTextRequest{
+			EndOfSegmentLocation: &docs.EndOfSegmentLocation{SegmentId: footnoteID, TabId: resolved.TabID},
+			Text:                 text,
+		},
+	}}}).Context(ctx).Do()
+	if err != nil {
+		return fmt.Errorf("footnote %s was created but could not be populated: %w", footnoteID, err)
+	}
+	result := map[string]any{
+		"documentId": docID, "footnoteId": footnoteID, "segmentId": footnoteID,
+		"segmentType": docsSegmentKindFootnote, "atIndex": resolved.Index, "requests": 2,
+	}
+	if resolved.TabID != "" {
+		result["tabId"] = resolved.TabID
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), result)
+	}
+	u := ui.FromContext(ctx)
+	u.Out().Linef("documentId\t%s", docID)
+	u.Out().Linef("footnoteId\t%s", footnoteID)
+	u.Out().Linef("atIndex\t%d", resolved.Index)
+	if resolved.TabID != "" {
+		u.Out().Linef("tabId\t%s", resolved.TabID)
+	}
+	return nil
+}
+
+func docsCreatedFootnoteID(response *docs.BatchUpdateDocumentResponse) string {
+	if response == nil {
+		return ""
+	}
+	for _, reply := range response.Replies {
+		if reply != nil && reply.CreateFootnote != nil && reply.CreateFootnote.FootnoteId != "" {
+			return reply.CreateFootnote.FootnoteId
+		}
+	}
+	return ""
+}

--- a/internal/cmd/docs_structural_test.go
+++ b/internal/cmd/docs_structural_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestDocsStructuralCommandsBuildExpectedRequests(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		cmd    any
+		args   []string
+		assert func(*testing.T, []*docs.Request)
+	}{
+		{
+			name: "section break",
+			cmd:  &DocsSectionBreakCmd{},
+			args: []string{"doc1", "--index", "7", "--type", "continuous"},
+			assert: func(t *testing.T, requests []*docs.Request) {
+				t.Helper()
+				req := requests[0].InsertSectionBreak
+				if req == nil || req.Location.Index != 7 || req.SectionType != "CONTINUOUS" {
+					t.Fatalf("unexpected section break: %#v", requests)
+				}
+			},
+		},
+		{
+			name: "horizontal rule",
+			cmd:  &DocsHorizontalRuleCmd{},
+			args: []string{"doc1", "--index", "8"},
+			assert: func(t *testing.T, requests []*docs.Request) {
+				t.Helper()
+				if len(requests) != 2 || requests[0].InsertText == nil || requests[0].InsertText.Text != "\n" || requests[1].UpdateParagraphStyle == nil {
+					t.Fatalf("unexpected horizontal rule: %#v", requests)
+				}
+				if requests[1].UpdateParagraphStyle.Fields != "borderBottom" {
+					t.Fatalf("unexpected border request: %#v", requests[1])
+				}
+			},
+		},
+		{
+			name: "section columns",
+			cmd:  &DocsSectionColumnsCmd{},
+			args: []string{"doc1", "--index", "9", "--count", "3", "--separator", "between"},
+			assert: func(t *testing.T, requests []*docs.Request) {
+				t.Helper()
+				req := requests[0].UpdateSectionStyle
+				if req == nil || req.Range.StartIndex != 9 || req.Range.EndIndex != 10 {
+					t.Fatalf("unexpected section columns range: %#v", requests)
+				}
+				if len(req.SectionStyle.ColumnProperties) != 3 || req.SectionStyle.ColumnSeparatorStyle != "BETWEEN_EACH_COLUMN" {
+					t.Fatalf("unexpected section style: %#v", req.SectionStyle)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var captured []*docs.Request
+			svc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, ":batchUpdate"):
+					var body docs.BatchUpdateDocumentRequest
+					if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+						t.Fatalf("decode request: %v", err)
+					}
+					captured = body.Requests
+					_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer cleanup()
+			ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+			if err := runKong(t, tt.cmd, tt.args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+				t.Fatalf("run: %v", err)
+			}
+			tt.assert(t, captured)
+		})
+	}
+}
+
+func TestDocsInsertFootnoteCreatesThenPopulatesSegment(t *testing.T) {
+	t.Parallel()
+	svc, calls, cleanup := newDocsCreateAndPopulateService(t, map[string]any{
+		"createFootnote": map[string]any{"footnoteId": "fn-1"},
+	})
+	defer cleanup()
+
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), svc)
+	err := runKong(t, &DocsFootnoteCmd{}, []string{"doc1", "--index", "5", "--text", "Footnote body"}, ctx, &RootFlags{Account: "a@b.com"})
+	if err != nil {
+		t.Fatalf("insert footnote: %v", err)
+	}
+	if len(*calls) != 2 || (*calls)[0][0].CreateFootnote == nil || (*calls)[0][0].CreateFootnote.Location.Index != 5 {
+		t.Fatalf("create requests = %#v", *calls)
+	}
+	insert := (*calls)[1][0].InsertText
+	if insert == nil || insert.Text != "Footnote body" || insert.EndOfSegmentLocation == nil || insert.EndOfSegmentLocation.SegmentId != "fn-1" {
+		t.Fatalf("populate request = %#v", (*calls)[1])
+	}
+}
+
+func TestDocsSectionColumnsRejectsUnsupportedCountBeforeAuth(t *testing.T) {
+	t.Parallel()
+	err := runKong(
+		t,
+		&DocsSectionColumnsCmd{},
+		[]string{"doc1", "--count", "4"},
+		newCmdRuntimeOutputContext(t, io.Discard, io.Discard),
+		&RootFlags{Account: "a@b.com"},
+	)
+	if err == nil || !strings.Contains(err.Error(), "between 1 and 3") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cmd/docs_target.go
+++ b/internal/cmd/docs_target.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/docsedit"
+)
+
+const (
+	docsSegmentKindBody     = "body"
+	docsSegmentKindHeader   = "header"
+	docsSegmentKindFooter   = "footer"
+	docsSegmentKindFootnote = "footnote"
+)
+
+type docsRequestTarget struct {
+	TabID       string
+	SegmentID   string
+	SegmentKind string
+}
+
+func docsTargetFromPlacement(resolved docsedit.ResolvedPlacement) docsRequestTarget {
+	kind := resolved.SegmentKind
+	if kind == "" {
+		kind = docsSegmentKindBody
+	}
+	return docsRequestTarget{TabID: resolved.TabID, SegmentID: resolved.SegmentID, SegmentKind: kind}
+}
+
+func applyDocsRequestTarget(requests []*docs.Request, target docsRequestTarget) {
+	for _, req := range requests {
+		if req == nil {
+			continue
+		}
+		if req.InsertText != nil {
+			if req.InsertText.Location != nil {
+				req.InsertText.Location.TabId = target.TabID
+				req.InsertText.Location.SegmentId = target.SegmentID
+				forceZeroLocationIndex(req.InsertText.Location)
+			}
+			if req.InsertText.EndOfSegmentLocation != nil {
+				req.InsertText.EndOfSegmentLocation.TabId = target.TabID
+				req.InsertText.EndOfSegmentLocation.SegmentId = target.SegmentID
+			}
+		}
+		for _, location := range docsRequestLocations(req) {
+			location.TabId = target.TabID
+			location.SegmentId = target.SegmentID
+			forceZeroLocationIndex(location)
+		}
+		for _, targetRange := range docsRequestRanges(req) {
+			targetRange.TabId = target.TabID
+			targetRange.SegmentId = target.SegmentID
+			forceZeroRangeStart(targetRange)
+		}
+	}
+}
+
+func forceZeroLocationIndex(location *docs.Location) {
+	if location != nil && location.Index == 0 && !docsContainsString(location.ForceSendFields, "Index") {
+		location.ForceSendFields = append(location.ForceSendFields, "Index")
+	}
+}
+
+func forceZeroRangeStart(targetRange *docs.Range) {
+	if targetRange != nil && targetRange.StartIndex == 0 && !docsContainsString(targetRange.ForceSendFields, "StartIndex") {
+		targetRange.ForceSendFields = append(targetRange.ForceSendFields, "StartIndex")
+	}
+}
+
+func docsContainsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func docsRequestLocations(req *docs.Request) []*docs.Location {
+	var locations []*docs.Location
+	if req.InsertPageBreak != nil && req.InsertPageBreak.Location != nil {
+		locations = append(locations, req.InsertPageBreak.Location)
+	}
+	if req.InsertSectionBreak != nil && req.InsertSectionBreak.Location != nil {
+		locations = append(locations, req.InsertSectionBreak.Location)
+	}
+	if req.CreateFootnote != nil && req.CreateFootnote.Location != nil {
+		locations = append(locations, req.CreateFootnote.Location)
+	}
+	return locations
+}
+
+func docsRequestRanges(req *docs.Request) []*docs.Range {
+	var ranges []*docs.Range
+	if req.DeleteContentRange != nil && req.DeleteContentRange.Range != nil {
+		ranges = append(ranges, req.DeleteContentRange.Range)
+	}
+	if req.UpdateTextStyle != nil && req.UpdateTextStyle.Range != nil {
+		ranges = append(ranges, req.UpdateTextStyle.Range)
+	}
+	if req.UpdateParagraphStyle != nil && req.UpdateParagraphStyle.Range != nil {
+		ranges = append(ranges, req.UpdateParagraphStyle.Range)
+	}
+	if req.CreateParagraphBullets != nil && req.CreateParagraphBullets.Range != nil {
+		ranges = append(ranges, req.CreateParagraphBullets.Range)
+	}
+	if req.DeleteParagraphBullets != nil && req.DeleteParagraphBullets.Range != nil {
+		ranges = append(ranges, req.DeleteParagraphBullets.Range)
+	}
+	if req.UpdateSectionStyle != nil && req.UpdateSectionStyle.Range != nil {
+		ranges = append(ranges, req.UpdateSectionStyle.Range)
+	}
+	return ranges
+}
+
+func selectDocsSegmentTarget(doc *docs.Document, tabQuery, segmentID string) (*docsLoadedTarget, error) {
+	tabQuery = strings.TrimSpace(tabQuery)
+	segmentID = strings.TrimSpace(segmentID)
+	if segmentID == "" {
+		return nil, usage("empty --segment")
+	}
+
+	if tabQuery != "" {
+		tab, err := findTab(flattenTabs(doc.Tabs), tabQuery)
+		if err != nil {
+			return nil, err
+		}
+		return docsSegmentInTab(doc, tab, segmentID)
+	}
+
+	var matches []*docsLoadedTarget
+	for _, tab := range flattenTabs(doc.Tabs) {
+		match, err := docsSegmentInTab(doc, tab, segmentID)
+		if err == nil {
+			matches = append(matches, match)
+		}
+	}
+	if match := docsLegacySegment(doc, segmentID); match != nil {
+		matches = append(matches, match)
+	}
+	if len(matches) == 0 {
+		return nil, usagef("segment not found: %s", segmentID)
+	}
+	if len(matches) > 1 {
+		return nil, usagef("segment %s exists in multiple tabs; pass --tab", segmentID)
+	}
+	return matches[0], nil
+}
+
+func docsSegmentInTab(doc *docs.Document, tab *docs.Tab, segmentID string) (*docsLoadedTarget, error) {
+	if tab == nil || tab.DocumentTab == nil {
+		return nil, usagef("segment not found: %s", segmentID)
+	}
+	tabID := ""
+	if tab.TabProperties != nil {
+		tabID = strings.TrimSpace(tab.TabProperties.TabId)
+	}
+	content, kind, ok := docsSegmentContent(tab.DocumentTab.Headers, tab.DocumentTab.Footers, tab.DocumentTab.Footnotes, segmentID)
+	if !ok {
+		return nil, usagef("segment not found in tab %s: %s", tabID, segmentID)
+	}
+	return newDocsSegmentTarget(doc, tabID, segmentID, kind, content), nil
+}
+
+func docsLegacySegment(doc *docs.Document, segmentID string) *docsLoadedTarget {
+	content, kind, ok := docsSegmentContent(doc.Headers, doc.Footers, doc.Footnotes, segmentID)
+	if !ok {
+		return nil
+	}
+	return newDocsSegmentTarget(doc, "", segmentID, kind, content)
+}
+
+func docsSegmentContent(headers map[string]docs.Header, footers map[string]docs.Footer, footnotes map[string]docs.Footnote, segmentID string) ([]*docs.StructuralElement, string, bool) {
+	if header, ok := headers[segmentID]; ok {
+		return header.Content, docsSegmentKindHeader, true
+	}
+	if footer, ok := footers[segmentID]; ok {
+		return footer.Content, docsSegmentKindFooter, true
+	}
+	if footnote, ok := footnotes[segmentID]; ok {
+		return footnote.Content, docsSegmentKindFootnote, true
+	}
+	return nil, "", false
+}
+
+func newDocsSegmentTarget(doc *docs.Document, tabID, segmentID, kind string, content []*docs.StructuralElement) *docsLoadedTarget {
+	return &docsLoadedTarget{
+		full: doc,
+		target: &docs.Document{
+			DocumentId: doc.DocumentId,
+			RevisionId: doc.RevisionId,
+			Body:       &docs.Body{Content: content},
+		},
+		tabID:       tabID,
+		segmentID:   segmentID,
+		segmentKind: kind,
+	}
+}

--- a/internal/cmd/docs_target_test.go
+++ b/internal/cmd/docs_target_test.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestSelectDocsSegmentTargetFindsSegmentAcrossTabs(t *testing.T) {
+	t.Parallel()
+	doc := &docs.Document{DocumentId: "doc1", RevisionId: "rev1", Tabs: []*docs.Tab{
+		{
+			TabProperties: &docs.TabProperties{TabId: "tab-1", Title: "First"},
+			DocumentTab:   &docs.DocumentTab{Body: &docs.Body{}},
+		},
+		{
+			TabProperties: &docs.TabProperties{TabId: "tab-2", Title: "Second"},
+			DocumentTab: &docs.DocumentTab{
+				Body: &docs.Body{},
+				Headers: map[string]docs.Header{
+					"header-2": {HeaderId: "header-2", Content: []*docs.StructuralElement{{StartIndex: 0, EndIndex: 7}}},
+				},
+			},
+		},
+	}}
+
+	target, err := selectDocsSegmentTarget(doc, "", "header-2")
+	if err != nil {
+		t.Fatalf("select segment: %v", err)
+	}
+	if target.tabID != "tab-2" || target.segmentID != "header-2" || target.segmentKind != docsSegmentKindHeader {
+		t.Fatalf("unexpected target: %#v", target)
+	}
+	if got := docsDocumentEndIndex(target.target); got != 7 {
+		t.Fatalf("segment end = %d, want 7", got)
+	}
+}
+
+func TestApplyDocsRequestTargetPropagatesSegment(t *testing.T) {
+	t.Parallel()
+	requests := []*docs.Request{
+		{InsertText: &docs.InsertTextRequest{Location: &docs.Location{Index: 2}, Text: "x"}},
+		{DeleteContentRange: &docs.DeleteContentRangeRequest{Range: &docs.Range{StartIndex: 1, EndIndex: 2}}},
+		{UpdateTextStyle: &docs.UpdateTextStyleRequest{Range: &docs.Range{StartIndex: 1, EndIndex: 2}}},
+		{UpdateParagraphStyle: &docs.UpdateParagraphStyleRequest{Range: &docs.Range{StartIndex: 1, EndIndex: 2}}},
+	}
+	applyDocsRequestTarget(requests, docsRequestTarget{TabID: "tab-2", SegmentID: "header-2", SegmentKind: docsSegmentKindHeader})
+
+	if got := requests[0].InsertText.Location; got.TabId != "tab-2" || got.SegmentId != "header-2" {
+		t.Fatalf("insert location = %#v", got)
+	}
+	for index, request := range requests[1:] {
+		ranges := docsRequestRanges(request)
+		if len(ranges) != 1 || ranges[0].TabId != "tab-2" || ranges[0].SegmentId != "header-2" {
+			t.Fatalf("request %d ranges = %#v", index+1, ranges)
+		}
+	}
+	wire, err := json.Marshal(requests)
+	if err != nil {
+		t.Fatalf("marshal requests: %v", err)
+	}
+	encoded := string(wire)
+	if !strings.Contains(encoded, `"segmentId":"header-2"`) {
+		t.Fatalf("wire requests lost segment ID: %s", encoded)
+	}
+}
+
+func TestApplyDocsRequestTargetForcesZeroIndexesOntoWire(t *testing.T) {
+	t.Parallel()
+	requests := []*docs.Request{
+		{InsertText: &docs.InsertTextRequest{Location: &docs.Location{Index: 0}, Text: "x"}},
+		{DeleteContentRange: &docs.DeleteContentRangeRequest{Range: &docs.Range{StartIndex: 0, EndIndex: 1}}},
+	}
+	applyDocsRequestTarget(requests, docsRequestTarget{SegmentID: "header-1", SegmentKind: docsSegmentKindHeader})
+	wire, err := json.Marshal(requests)
+	if err != nil {
+		t.Fatalf("marshal requests: %v", err)
+	}
+	encoded := string(wire)
+	if !strings.Contains(encoded, `"index":0`) || !strings.Contains(encoded, `"startIndex":0`) {
+		t.Fatalf("zero indexes omitted from wire request: %s", encoded)
+	}
+}

--- a/internal/docsedit/placement.go
+++ b/internal/docsedit/placement.go
@@ -37,30 +37,36 @@ type Placement struct {
 type UpdatePlacementOptions struct {
 	Index         int64
 	IndexProvided bool
+	AllowZero     bool
 	ReplaceRange  string
 	Anchor        AnchorOptions
 }
 
 type InsertPlacementOptions struct {
-	Index  *int64
-	Anchor AnchorOptions
+	Index     *int64
+	AllowZero bool
+	Anchor    AnchorOptions
 }
 
 type EndInsertPlacementOptions struct {
-	Index  *int64
-	AtEnd  bool
-	Anchor AnchorOptions
+	Index     *int64
+	AllowZero bool
+	AtEnd     bool
+	Anchor    AnchorOptions
 }
 
 type RangePlacementOptions struct {
-	Start  *int64
-	End    *int64
-	Anchor AnchorOptions
+	Start     *int64
+	End       *int64
+	AllowZero bool
+	Anchor    AnchorOptions
 }
 
 type PlacementFacts struct {
 	EndIndex           int64
 	TabID              string
+	SegmentID          string
+	SegmentKind        string
 	Anchor             *TextRange
 	RequiredRevisionID string
 }
@@ -69,6 +75,8 @@ type ResolvedPlacement struct {
 	Index              int64
 	Range              *Range
 	TabID              string
+	SegmentID          string
+	SegmentKind        string
 	RequiredRevisionID string
 	Anchored           bool
 	InTable            bool
@@ -97,8 +105,14 @@ func ValidateAnchor(options AnchorOptions) error {
 
 func PlanUpdatePlacement(options UpdatePlacementOptions) (Placement, error) {
 	replaceRange := strings.TrimSpace(options.ReplaceRange)
-	if options.IndexProvided && options.Index <= 0 {
-		return Placement{}, invalid("invalid --index (must be >= 1)")
+
+	minimum := int64(1)
+	if options.AllowZero {
+		minimum = 0
+	}
+
+	if options.IndexProvided && options.Index < minimum {
+		return Placement{}, invalid(fmt.Sprintf("invalid --index (must be >= %d)", minimum))
 	}
 
 	if options.IndexProvided && replaceRange != "" {
@@ -113,7 +127,7 @@ func PlanUpdatePlacement(options UpdatePlacementOptions) (Placement, error) {
 		return Placement{}, invalid("--at cannot be combined with --index or --replace-range")
 	}
 
-	target, replacing, err := ParseRange(replaceRange)
+	target, replacing, err := parseRangeWithMinimum(replaceRange, minimum)
 	if err != nil {
 		return Placement{}, err
 	}
@@ -131,8 +145,13 @@ func PlanUpdatePlacement(options UpdatePlacementOptions) (Placement, error) {
 }
 
 func PlanInsertPlacement(options InsertPlacementOptions) (Placement, error) {
-	if options.Index != nil && *options.Index < 1 {
-		return Placement{}, invalid("--index must be >= 1 (index 0 is reserved)")
+	minimum := int64(1)
+	if options.AllowZero {
+		minimum = 0
+	}
+
+	if options.Index != nil && *options.Index < minimum {
+		return Placement{}, invalid(fmt.Sprintf("--index must be >= %d", minimum))
 	}
 
 	if err := ValidateAnchor(options.Anchor); err != nil {
@@ -151,8 +170,13 @@ func PlanEndInsertPlacement(options EndInsertPlacementOptions) (Placement, error
 		return Placement{}, invalid("--at-end and --index are mutually exclusive")
 	}
 
-	if options.Index != nil && *options.Index < 1 {
-		return Placement{}, invalid("--index must be >= 1 (index 0 is reserved)")
+	minimum := int64(1)
+	if options.AllowZero {
+		minimum = 0
+	}
+
+	if options.Index != nil && *options.Index < minimum {
+		return Placement{}, invalid(fmt.Sprintf("--index must be >= %d", minimum))
 	}
 
 	if err := ValidateAnchor(options.Anchor); err != nil {
@@ -184,8 +208,13 @@ func PlanRangePlacement(options RangePlacementOptions) (Placement, error) {
 		return Placement{Kind: PlacementAnchor, Anchor: options.Anchor}, nil
 	}
 
-	if *options.Start < 1 {
-		return Placement{}, invalid("--start must be >= 1")
+	minimum := int64(1)
+	if options.AllowZero {
+		minimum = 0
+	}
+
+	if *options.Start < minimum {
+		return Placement{}, invalid(fmt.Sprintf("--start must be >= %d", minimum))
 	}
 
 	if *options.End <= *options.Start {
@@ -202,21 +231,27 @@ func ResolvePlacement(placement Placement, facts PlacementFacts) (ResolvedPlacem
 	switch placement.Kind {
 	case PlacementEnd:
 		return ResolvedPlacement{
-			Index: AppendIndex(facts.EndIndex),
-			TabID: facts.TabID,
+			Index:       AppendIndexForTarget(facts.EndIndex, facts.SegmentID),
+			TabID:       facts.TabID,
+			SegmentID:   facts.SegmentID,
+			SegmentKind: facts.SegmentKind,
 		}, nil
 	case PlacementIndex:
 		return ResolvedPlacement{
-			Index: placement.Index,
-			TabID: facts.TabID,
+			Index:       placement.Index,
+			TabID:       facts.TabID,
+			SegmentID:   facts.SegmentID,
+			SegmentKind: facts.SegmentKind,
 		}, nil
 	case PlacementRange:
 		target := placement.Range
 
 		return ResolvedPlacement{
-			Index: target.Start,
-			Range: &target,
-			TabID: facts.TabID,
+			Index:       target.Start,
+			Range:       &target,
+			TabID:       facts.TabID,
+			SegmentID:   facts.SegmentID,
+			SegmentKind: facts.SegmentKind,
 		}, nil
 	case PlacementAnchor:
 		if facts.Anchor == nil {
@@ -232,6 +267,8 @@ func ResolvePlacement(placement Placement, facts PlacementFacts) (ResolvedPlacem
 			Index:              target.Start,
 			Range:              &target,
 			TabID:              facts.Anchor.TabID,
+			SegmentID:          facts.SegmentID,
+			SegmentKind:        facts.SegmentKind,
 			RequiredRevisionID: facts.RequiredRevisionID,
 			Anchored:           true,
 			InTable:            facts.Anchor.InTable,
@@ -251,6 +288,18 @@ func AppendIndex(endIndex int64) int64 {
 	}
 
 	return 1
+}
+
+func AppendIndexForTarget(endIndex int64, segmentID string) int64 {
+	if strings.TrimSpace(segmentID) == "" {
+		return AppendIndex(endIndex)
+	}
+
+	if endIndex > 0 {
+		return endIndex - 1
+	}
+
+	return 0
 }
 
 func insertPlacement(index *int64, atEnd bool, anchor AnchorOptions) Placement {

--- a/internal/docsedit/placement_test.go
+++ b/internal/docsedit/placement_test.go
@@ -155,6 +155,40 @@ func TestPlanInsertPlacement(t *testing.T) {
 	}
 }
 
+func TestSegmentPlacementAllowsZeroAndUsesSegmentEnd(t *testing.T) {
+	zero := int64(0)
+
+	placement, err := PlanInsertPlacement(InsertPlacementOptions{Index: &zero, AllowZero: true})
+	if err != nil {
+		t.Fatalf("plan segment index zero: %v", err)
+	}
+
+	resolved, err := ResolvePlacement(placement, PlacementFacts{
+		TabID: "tab-1", SegmentID: "header-1", SegmentKind: "header",
+	})
+	if err != nil {
+		t.Fatalf("resolve segment index zero: %v", err)
+	}
+
+	if resolved.Index != 0 || resolved.SegmentID != "header-1" || resolved.SegmentKind != "header" {
+		t.Fatalf("unexpected resolved placement: %#v", resolved)
+	}
+
+	endPlacement, err := PlanEndInsertPlacement(EndInsertPlacementOptions{})
+	if err != nil {
+		t.Fatalf("plan segment end: %v", err)
+	}
+
+	resolved, err = ResolvePlacement(endPlacement, PlacementFacts{EndIndex: 1, SegmentID: "header-1"})
+	if err != nil {
+		t.Fatalf("resolve segment end: %v", err)
+	}
+
+	if resolved.Index != 0 {
+		t.Fatalf("segment append index = %d, want 0", resolved.Index)
+	}
+}
+
 func TestPlanEndInsertPlacement(t *testing.T) {
 	t.Parallel()
 

--- a/internal/docsedit/planner.go
+++ b/internal/docsedit/planner.go
@@ -119,6 +119,10 @@ func BuildDeleteRequest(target Range, tabID string) *docs.Request {
 }
 
 func ParseRange(value string) (Range, bool, error) {
+	return parseRangeWithMinimum(value, 1)
+}
+
+func parseRangeWithMinimum(value string, minimum int64) (Range, bool, error) {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return Range{}, false, nil
@@ -130,8 +134,8 @@ func ParseRange(value string) (Range, bool, error) {
 	}
 
 	start, err := strconv.ParseInt(strings.TrimSpace(parts[0]), 10, 64)
-	if err != nil || start < 1 {
-		return Range{}, false, invalid("invalid --replace-range start (must be >= 1)")
+	if err != nil || start < minimum {
+		return Range{}, false, invalid(fmt.Sprintf("invalid --replace-range start (must be >= %d)", minimum))
 	}
 
 	end, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)

--- a/internal/docsformat/format.go
+++ b/internal/docsformat/format.go
@@ -94,7 +94,7 @@ func (o Options) Any() bool {
 }
 
 func BuildRequests(options Options, start, end int64, tabID string) ([]*docs.Request, error) {
-	if start <= 0 || end <= start {
+	if start < 0 || end <= start {
 		return nil, invalidf("invalid format range: %d..%d", start, end)
 	}
 

--- a/scripts/live-tests/docs.sh
+++ b/scripts/live-tests/docs.sh
@@ -125,6 +125,42 @@ assert not any("{#recent-tab}" in value for item in objects for value in item.va
   run_required "docs" "docs page break at anchor" gog docs insert-page-break "$doc_id" \
     --at BreakHere --json >/dev/null
 
+  local footnote_json header_json header_id footer_json footer_id segment_raw_json
+  footnote_json=$(gog docs insert-footnote "$doc_id" --at AnchorReplaced \
+    --text "gogcli live footnote $TS" --json)
+  "$PY" -c 'import json,sys; assert json.load(sys.stdin)["footnoteId"]' <<<"$footnote_json"
+  run_required "docs" "docs horizontal rule at anchor" gog docs insert-horizontal-rule "$doc_id" \
+    --at AnchorReplaced --json >/dev/null
+  run_required "docs" "docs continuous section break" gog docs insert-section-break "$doc_id" \
+    --at BatchAnchor --type continuous --json >/dev/null
+  run_required "docs" "docs section columns" gog docs section-columns "$doc_id" \
+    --at Heading --count 2 --separator between --json >/dev/null
+
+  header_json=$(gog docs header create "$doc_id" --text "Live Header $TS" --json)
+  header_id=$("$PY" -c 'import json,sys; print(json.load(sys.stdin)["segmentId"])' <<<"$header_json")
+  footer_json=$(gog docs footer create "$doc_id" --text "Live Footer $TS" --json)
+  footer_id=$("$PY" -c 'import json,sys; print(json.load(sys.stdin)["segmentId"])' <<<"$footer_json")
+  [ -n "$header_id" ] && [ -n "$footer_id" ] || { echo "Failed to create Docs header/footer" >&2; exit 1; }
+  run_required "docs" "docs header list" gog docs header list "$doc_id" --json >/dev/null
+  run_required "docs" "docs footer list" gog docs footer list "$doc_id" --json >/dev/null
+  run_required "docs" "docs segment insert" gog docs insert "$doc_id" "!" \
+    --segment "$header_id" --json >/dev/null
+  run_required "docs" "docs segment update" gog docs update "$doc_id" \
+    --segment "$header_id" --at Live --text Verified --json >/dev/null
+  run_required "docs" "docs segment format" gog docs format "$doc_id" \
+    --segment "$header_id" --match Verified --bold --json >/dev/null
+  run_required "docs" "docs segment delete" gog docs delete "$doc_id" \
+    --segment "$header_id" --at Header --json >/dev/null
+  segment_raw_json=$(gog docs raw "$doc_id" --json)
+  "$PY" -c 'import json,sys
+obj=json.load(sys.stdin)
+segment=sys.argv[1]
+content=json.dumps(obj["headers"][segment].get("content", []))
+assert "Verified" in content
+assert any(run.get("textRun", {}).get("textStyle", {}).get("bold") is True for element in obj["headers"][segment].get("content", []) for para in [element.get("paragraph", {})] for run in para.get("elements", []))' "$header_id" <<<"$segment_raw_json"
+  run_required "docs" "docs header delete" gog --force docs header delete "$doc_id" "$header_id" --json >/dev/null
+  run_required "docs" "docs footer delete" gog --force docs footer delete "$doc_id" "$footer_id" --json >/dev/null
+
   local batch_id batch_json
   batch_id=$("$BIN" --account "$ACCOUNT" batch begin --service docs --doc "$doc_id" --name "live-$TS")
   [ -n "$batch_id" ] || { echo "Failed to create Docs batch" >&2; exit 1; }


### PR DESCRIPTION
## Summary

- add footnote, section-break, horizontal-rule, and section-column commands
- add header/footer list, create, and delete lifecycle commands
- add exact segment targeting to plain-text insert, update, delete, format, and range lookup
- document the new workflows and extend disposable live coverage

Closes #856.
Closes #857.

## Verification

- `make ci`
- autoreview: clean
- disposable Google Docs end-to-end run with the OpenClaw bot-maintenance account
- multi-tab first-section header creation, lookup, and deletion against the live Docs API
