### PR TITLE
feat(auth): add guided Google setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Evals: add reproducible structural and live Codex/OpenClaw gog/gws comparisons with correctness assertions, token/tool/latency metrics, cache-counterbalanced repetitions, methodology, and CI coverage.
 - CLI: add `GOG_HELP=agent` compact root help with common read-only recipes and targeted schema guidance so agents can execute Gmail, Calendar, and Drive tasks without traversing multiple help levels.
+- Auth: add `auth setup` for guided Google Cloud project/API preparation, OAuth client installation, and optional browser authorization.
 
 ## 0.30.0 - 2026-06-21
 

--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ Docs: [Auth clients](docs/auth-clients.md),
 Store a Desktop OAuth client once:
 
 ```bash
+gog auth setup you@gmail.com --gcloud-project my-gog-project --enable-apis --open-console
 gog auth credentials ~/Downloads/client_secret_....json
 gog auth add you@gmail.com --services gmail,calendar,drive
 ```

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -52,6 +52,7 @@ Generated from `gog schema --json`.
       - [`gog auth service-account status <email>`](commands/gog-auth-service-account-status.md) - Show stored service account key status
       - [`gog auth service-account unset <email>`](commands/gog-auth-service-account-unset.md) - Remove stored service account key
     - [`gog auth services [flags]`](commands/gog-auth-services.md) - List supported auth services and scopes
+    - [`gog auth setup [<email>] [flags]`](commands/gog-auth-setup.md) - Guide Google Cloud, OAuth client, and account setup
     - [`gog auth status`](commands/gog-auth-status.md) - Show auth configuration and keyring backend
     - [`gog auth tokens <command>`](commands/gog-auth-tokens.md) - Manage stored refresh tokens
       - [`gog auth tokens delete <email>`](commands/gog-auth-tokens-delete.md) - Delete a stored refresh token

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 694.
+Generated pages: 695.
 
 ## Top-level Commands
 
@@ -103,6 +103,7 @@ Generated pages: 694.
       - [gog auth service-account status](gog-auth-service-account-status.md) - Show stored service account key status
       - [gog auth service-account unset](gog-auth-service-account-unset.md) - Remove stored service account key
     - [gog auth services](gog-auth-services.md) - List supported auth services and scopes
+    - [gog auth setup](gog-auth-setup.md) - Guide Google Cloud, OAuth client, and account setup
     - [gog auth status](gog-auth-status.md) - Show auth configuration and keyring backend
     - [gog auth tokens](gog-auth-tokens.md) - Manage stored refresh tokens
       - [gog auth tokens delete](gog-auth-tokens-delete.md) - Delete a stored refresh token

--- a/docs/commands/gog-auth-setup.md
+++ b/docs/commands/gog-auth-setup.md
@@ -1,36 +1,18 @@
-# `gog auth`
+# `gog auth setup`
 
 > Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
 
-Auth and credentials
+Guide Google Cloud, OAuth client, and account setup
 
 ## Usage
 
 ```bash
-gog auth <command> [flags]
+gog auth setup [<email>] [flags]
 ```
 
 ## Parent
 
-- [gog](gog.md)
-
-## Subcommands
-
-- [gog auth add](gog-auth-add.md) - Authorize and store a refresh token
-- [gog auth alias](gog-auth-alias.md) - Manage account aliases
-- [gog auth credentials](gog-auth-credentials.md) - Manage OAuth client credentials
-- [gog auth doctor](gog-auth-doctor.md) - Diagnose auth, keyring, and refresh-token issues
-- [gog auth import](gog-auth-import.md) - Import a required refresh token and optional current access token non-interactively
-- [gog auth keep](gog-auth-keep.md) - Configure service account for Google Keep (Workspace only)
-- [gog auth keyring](gog-auth-keyring.md) - Configure keyring backend
-- [gog auth list](gog-auth-list.md) - List stored accounts
-- [gog auth manage](gog-auth-manage.md) - Open interactive accounts manager in browser
-- [gog auth remove](gog-auth-remove.md) - Remove a stored refresh token
-- [gog auth service-account](gog-auth-service-account.md) - Configure service account (Workspace only; domain-wide delegation)
-- [gog auth services](gog-auth-services.md) - List supported auth services and scopes
-- [gog auth setup](gog-auth-setup.md) - Guide Google Cloud, OAuth client, and account setup
-- [gog auth status](gog-auth-status.md) - Show auth configuration and keyring backend
-- [gog auth tokens](gog-auth-tokens.md) - Manage stored refresh tokens
+- [gog auth](gog-auth.md)
 
 ## Flags
 
@@ -40,24 +22,34 @@ gog auth <command> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--create-project` | `bool` |  | Create --gcloud-project with gcloud (requires confirmation) |
+| `--credentials` | `string` |  | Downloaded Desktop OAuth client JSON to store |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-apis` | `bool` |  | Enable selected Google APIs with gcloud |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--force-consent` | `bool` |  | Force OAuth consent when --login runs |
+| `--gcloud-project`<br>`--project-id` | `string` |  | Google Cloud project ID (default: active gcloud project) |
 | `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
 | `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
 | `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
 | `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--login` | `bool` |  | Run browser OAuth after project/client setup |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `--open-console` | `bool` |  | Open the OAuth client page for the selected project |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--project-name` | `string` | gog CLI | Display name when creating a project |
+| `--readonly` | `bool` |  | Use read-only OAuth scopes when --login runs |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--services` | `string` | gmail,calendar,drive,docs,sheets,contacts | Services to configure: comma-separated gmail,calendar,chat,classroom,drive,driveactivity,drivelabels,docs,slides,contacts,tasks,sheets,people,forms,sites,meet,appscript,analytics,searchconsole,ads,youtube,photos |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
 
 ## See Also
 
-- [gog](gog.md)
+- [gog auth](gog-auth.md)
 - [Command index](README.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -21,6 +21,23 @@ Other options (Docker, Windows ZIPs, source builds) are documented on
 
 ## 2. Get an OAuth client
 
+For guided setup, inspect or execute the common `gcloud` path:
+
+```bash
+gog auth setup you@gmail.com --gcloud-project my-gog-project --enable-apis --open-console
+```
+
+Add `--create-project` to create that project after confirmation. After downloading the
+Desktop OAuth client JSON, one command can store it and start authorization:
+
+```bash
+gog auth setup you@gmail.com --gcloud-project my-gog-project \
+  --credentials ~/Downloads/client_secret_*.json --login
+```
+
+Use `--dry-run --json --no-input` to inspect the complete plan without creating a project,
+enabling APIs, storing credentials, opening a browser, or starting OAuth.
+
 `gog` talks to Google APIs as you, using your own Cloud project. The one-time
 setup is:
 

--- a/internal/cmd/auth.go
+++ b/internal/cmd/auth.go
@@ -90,6 +90,7 @@ const (
 )
 
 type AuthCmd struct {
+	Setup       AuthSetupCmd          `cmd:"" name:"setup" help:"Guide Google Cloud, OAuth client, and account setup"`
 	Credentials AuthCredentialsCmd    `cmd:"" name:"credentials" help:"Manage OAuth client credentials"`
 	Add         AuthAddCmd            `cmd:"" name:"add" help:"Authorize and store a refresh token"`
 	Import      AuthImportCmd         `cmd:"" name:"import" help:"Import a required refresh token and optional current access token non-interactively"`

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -152,7 +152,7 @@ func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
 		}
 	}
 
-	result.NextSteps = authSetupNextSteps(c, result, gcloudAvailable)
+	result.NextSteps = authSetupNextSteps(c, result, gcloudAvailable, authclient.ClientOverrideFromContext(ctx))
 	if c.Login {
 		return (&AuthAddCmd{
 			Email:        strings.TrimSpace(c.Email),
@@ -204,8 +204,12 @@ func authSetupClient(ctx context.Context, email string) (string, error) {
 	return normalizeClientForFlag(override)
 }
 
-func authSetupNextSteps(c *AuthSetupCmd, result authSetupResult, gcloudAvailable bool) []string {
+func authSetupNextSteps(c *AuthSetupCmd, result authSetupResult, gcloudAvailable bool, clientOverride string) []string {
 	steps := make([]string, 0, 6)
+	gogCommand := "gog"
+	if client := strings.TrimSpace(clientOverride); client != "" {
+		gogCommand += " --client " + client
+	}
 	if !gcloudAvailable {
 		steps = append(steps, "Install gcloud, or create/select a Google Cloud project manually")
 	} else if result.GcloudAccount == "" {
@@ -220,12 +224,12 @@ func authSetupNextSteps(c *AuthSetupCmd, result authSetupResult, gcloudAvailable
 		)
 	}
 	if !result.CredentialsSaved {
-		steps = append(steps, "Store the download with `gog auth credentials /path/to/client_secret.json`")
+		steps = append(steps, "Store the download with `"+gogCommand+" auth credentials /path/to/client_secret.json`")
 	}
 	if strings.TrimSpace(c.Email) != "" {
-		steps = append(steps, fmt.Sprintf("Authorize with `gog auth add %s --services %s`", strings.TrimSpace(c.Email), strings.Join(result.Services, ",")))
+		steps = append(steps, fmt.Sprintf("Authorize with `%s auth add %s --services %s`", gogCommand, strings.TrimSpace(c.Email), strings.Join(result.Services, ",")))
 	} else {
-		steps = append(steps, "Authorize with `gog auth add you@example.com --services "+strings.Join(result.Services, ",")+"`")
+		steps = append(steps, "Authorize with `"+gogCommand+" auth add you@example.com --services "+strings.Join(result.Services, ",")+"`")
 	}
 	steps = append(steps, "Verify with `gog auth doctor --check`")
 	return steps

--- a/internal/cmd/auth_setup.go
+++ b/internal/cmd/auth_setup.go
@@ -1,0 +1,311 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/authclient"
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/googleauth"
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+type AuthSetupCmd struct {
+	Email         string `arg:"" optional:"" name:"email" help:"Google account to authorize after setup"`
+	Project       string `name:"gcloud-project" aliases:"project-id" help:"Google Cloud project ID (default: active gcloud project)"`
+	ProjectName   string `name:"project-name" help:"Display name when creating a project" default:"gog CLI"`
+	ServicesCSV   string `name:"services" help:"Services to configure: comma-separated ${auth_services}" default:"gmail,calendar,drive,docs,sheets,contacts"`
+	Credentials   string `name:"credentials" type:"path" help:"Downloaded Desktop OAuth client JSON to store"`
+	CreateProject bool   `name:"create-project" help:"Create --gcloud-project with gcloud (requires confirmation)"`
+	EnableAPIs    bool   `name:"enable-apis" help:"Enable selected Google APIs with gcloud"`
+	Login         bool   `name:"login" help:"Run browser OAuth after project/client setup"`
+	Readonly      bool   `name:"readonly" help:"Use read-only OAuth scopes when --login runs"`
+	ForceConsent  bool   `name:"force-consent" help:"Force OAuth consent when --login runs"`
+	OpenConsole   bool   `name:"open-console" help:"Open the OAuth client page for the selected project"`
+}
+
+type authSetupResult struct {
+	Status           string   `json:"status"`
+	Project          string   `json:"project,omitempty"`
+	GcloudAccount    string   `json:"gcloud_account,omitempty"`
+	Services         []string `json:"services"`
+	APIs             []string `json:"apis"`
+	ProjectCreated   bool     `json:"project_created"`
+	APIsEnabled      bool     `json:"apis_enabled"`
+	CredentialsSaved bool     `json:"credentials_saved"`
+	NextSteps        []string `json:"next_steps"`
+}
+
+func (c *AuthSetupCmd) Run(ctx context.Context, flags *RootFlags) error {
+	services, err := parseAuthServices(c.ServicesCSV)
+	if err != nil {
+		return err
+	}
+	serviceNames := make([]string, 0, len(services))
+	for _, service := range services {
+		serviceNames = append(serviceNames, string(service))
+	}
+	apiIDs, err := googleauth.APIServiceIDsForServices(services)
+	if err != nil {
+		return usage(err.Error())
+	}
+
+	project := strings.TrimSpace(c.Project)
+	account := ""
+	gcloudAvailable := authSetupGcloudAvailable()
+	if gcloudAvailable {
+		account, _ = authSetupGcloudValue(ctx, "account")
+		if project == "" {
+			project, _ = authSetupGcloudValue(ctx, "project")
+		}
+	}
+	if project != "" && !validGoogleCloudProjectID(project) {
+		return usagef("invalid --gcloud-project %q (use 6-30 lowercase letters, digits, or hyphens; start with a letter)", project)
+	}
+	if c.CreateProject && project == "" {
+		return usage("--create-project requires --gcloud-project")
+	}
+	if c.EnableAPIs && project == "" {
+		return usage("--enable-apis requires --gcloud-project or an active gcloud project")
+	}
+	if c.OpenConsole && project == "" {
+		return usage("--open-console requires --gcloud-project or an active gcloud project")
+	}
+	if (c.CreateProject || c.EnableAPIs) && !gcloudAvailable && (flags == nil || !flags.DryRun) {
+		return usage("gcloud is required for --create-project or --enable-apis; install it or omit those flags for manual guidance")
+	}
+	if c.Login && strings.TrimSpace(c.Email) == "" {
+		return usage("--login requires an email argument")
+	}
+	if c.Login && flags != nil && flags.NoInput && !flags.DryRun {
+		return usage("--login requires interactive browser input; omit --no-input or run `gog auth import`")
+	}
+	if c.OpenConsole && flags != nil && flags.NoInput && !flags.DryRun {
+		return usage("--open-console is not available with --no-input")
+	}
+
+	plan := map[string]any{
+		"project":          project,
+		"project_name":     strings.TrimSpace(c.ProjectName),
+		"services":         serviceNames,
+		"apis":             apiIDs,
+		"create_project":   c.CreateProject,
+		"enable_apis":      c.EnableAPIs,
+		"credentials_file": strings.TrimSpace(c.Credentials),
+		"login_email":      strings.TrimSpace(c.Email),
+		"readonly":         c.Readonly,
+		"force_consent":    c.ForceConsent,
+		"open_console":     c.OpenConsole,
+	}
+	if dryRunErr := dryRunExit(ctx, flags, "auth.setup", plan); dryRunErr != nil {
+		return dryRunErr
+	}
+
+	result := authSetupResult{
+		Status:        "guided",
+		Project:       project,
+		GcloudAccount: account,
+		Services:      serviceNames,
+		APIs:          apiIDs,
+		NextSteps:     []string{},
+	}
+
+	if c.CreateProject {
+		if err := confirmDestructiveChecked(ctx, flags, "create Google Cloud project "+project); err != nil {
+			return err
+		}
+		args := []string{"projects", "create", project}
+		if name := strings.TrimSpace(c.ProjectName); name != "" {
+			args = append(args, "--name", name)
+		}
+		if _, err := authSetupRunGcloud(ctx, args...); err != nil {
+			return fmt.Errorf("create Google Cloud project: %w", err)
+		}
+		result.ProjectCreated = true
+	}
+
+	if c.EnableAPIs {
+		args := append([]string{"services", "enable"}, apiIDs...)
+		args = append(args, "--project", project)
+		if _, err := authSetupRunGcloud(ctx, args...); err != nil {
+			return fmt.Errorf("enable Google APIs: %w", err)
+		}
+		result.APIsEnabled = true
+	}
+
+	if credentials := strings.TrimSpace(c.Credentials); credentials != "" {
+		if err := runAuthSetupCredentials(ctx, flags, credentials, strings.TrimSpace(c.Email)); err != nil {
+			return err
+		}
+		result.CredentialsSaved = true
+	}
+
+	if c.OpenConsole {
+		if err := openURL(ctx, googleCloudOAuthClientsURL(project)); err != nil {
+			return fmt.Errorf("open OAuth client page: %w", err)
+		}
+	}
+
+	result.NextSteps = authSetupNextSteps(c, result, gcloudAvailable)
+	if c.Login {
+		return (&AuthAddCmd{
+			Email:        strings.TrimSpace(c.Email),
+			ServicesCSV:  c.ServicesCSV,
+			Readonly:     c.Readonly,
+			ForceConsent: c.ForceConsent,
+		}).Run(ctx, flags)
+	}
+
+	return writeAuthSetupResult(ctx, result)
+}
+
+func runAuthSetupCredentials(ctx context.Context, flags *RootFlags, path string, email string) error {
+	client, err := authSetupClient(ctx, email)
+	if err != nil {
+		return err
+	}
+	expanded, err := config.ExpandPath(path)
+	if err != nil {
+		return err
+	}
+	raw, err := os.ReadFile(expanded) //nolint:gosec // explicit user-provided credentials path
+	if err != nil {
+		return err
+	}
+	credentials, err := config.ParseGoogleOAuthClientJSON(raw)
+	if err != nil {
+		return err
+	}
+	if flags != nil && flags.DryRun {
+		return nil
+	}
+	store, err := commandOAuthCredentialsStore(ctx)
+	if err != nil {
+		return err
+	}
+	if err := store.Write(client, credentials, false); err != nil {
+		return fmt.Errorf("store OAuth client credentials: %w", err)
+	}
+	return nil
+}
+
+func authSetupClient(ctx context.Context, email string) (string, error) {
+	override := authclient.ClientOverrideFromContext(ctx)
+	if email != "" {
+		return authclient.ResolveClientWithOverride(ctx, email, override)
+	}
+
+	return normalizeClientForFlag(override)
+}
+
+func authSetupNextSteps(c *AuthSetupCmd, result authSetupResult, gcloudAvailable bool) []string {
+	steps := make([]string, 0, 6)
+	if !gcloudAvailable {
+		steps = append(steps, "Install gcloud, or create/select a Google Cloud project manually")
+	} else if result.GcloudAccount == "" {
+		steps = append(steps, "Run `gcloud auth login`")
+	}
+	if result.Project == "" {
+		steps = append(steps, "Choose a project with `--gcloud-project PROJECT_ID` or `gcloud config set project PROJECT_ID`")
+	} else {
+		steps = append(steps,
+			"Configure OAuth consent: "+googleCloudConsentURL(result.Project),
+			"Create a Desktop OAuth client and download its JSON: "+googleCloudOAuthClientsURL(result.Project),
+		)
+	}
+	if !result.CredentialsSaved {
+		steps = append(steps, "Store the download with `gog auth credentials /path/to/client_secret.json`")
+	}
+	if strings.TrimSpace(c.Email) != "" {
+		steps = append(steps, fmt.Sprintf("Authorize with `gog auth add %s --services %s`", strings.TrimSpace(c.Email), strings.Join(result.Services, ",")))
+	} else {
+		steps = append(steps, "Authorize with `gog auth add you@example.com --services "+strings.Join(result.Services, ",")+"`")
+	}
+	steps = append(steps, "Verify with `gog auth doctor --check`")
+	return steps
+}
+
+func writeAuthSetupResult(ctx context.Context, result authSetupResult) error {
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), result)
+	}
+	u := ui.FromContext(ctx)
+	u.Out().Linef("status\t%s", result.Status)
+	if result.GcloudAccount != "" {
+		u.Out().Linef("gcloud_account\t%s", result.GcloudAccount)
+	}
+	if result.Project != "" {
+		u.Out().Linef("project\t%s", result.Project)
+	}
+	u.Out().Linef("services\t%s", strings.Join(result.Services, ","))
+	u.Out().Linef("apis\t%s", strings.Join(result.APIs, ","))
+	for index, step := range result.NextSteps {
+		u.Out().Linef("next_%d\t%s", index+1, step)
+	}
+	return nil
+}
+
+func authSetupGcloudBinary() string {
+	if runtime.GOOS == "windows" {
+		return "gcloud.cmd"
+	}
+	return "gcloud"
+}
+
+func authSetupGcloudAvailable() bool {
+	_, err := exec.LookPath(authSetupGcloudBinary())
+	return err == nil
+}
+
+func authSetupGcloudValue(ctx context.Context, key string) (string, error) {
+	output, err := authSetupRunGcloud(ctx, "config", "get-value", key)
+	if err != nil {
+		return "", err
+	}
+	value := strings.TrimSpace(output)
+	if value == "(unset)" {
+		return "", nil
+	}
+	return value, nil
+}
+
+func authSetupRunGcloud(ctx context.Context, args ...string) (string, error) {
+	command := exec.CommandContext(ctx, authSetupGcloudBinary(), args...) //nolint:gosec // fixed gcloud binary; arguments are validated or generated
+	command.Env = append(os.Environ(), "CLOUDSDK_CORE_DISABLE_PROMPTS=1")
+	output, err := command.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			return "", err
+		}
+		return "", fmt.Errorf("%s: %w", detail, err)
+	}
+	return string(output), nil
+}
+
+func validGoogleCloudProjectID(value string) bool {
+	if len(value) < 6 || len(value) > 30 || value[0] < 'a' || value[0] > 'z' {
+		return false
+	}
+	for _, char := range value {
+		if (char >= 'a' && char <= 'z') || (char >= '0' && char <= '9') || char == '-' {
+			continue
+		}
+		return false
+	}
+	return !strings.HasSuffix(value, "-")
+}
+
+func googleCloudConsentURL(project string) string {
+	return "https://console.cloud.google.com/auth/branding?project=" + url.QueryEscape(project)
+}
+
+func googleCloudOAuthClientsURL(project string) string {
+	return "https://console.cloud.google.com/auth/clients?project=" + url.QueryEscape(project)
+}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -1,0 +1,119 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/steipete/gogcli/internal/authclient"
+	"github.com/steipete/gogcli/internal/googleauth"
+)
+
+func TestAuthSetupDryRun(t *testing.T) {
+	var stdout bytes.Buffer
+	ctx := newCmdRuntimeJSONOutputContext(t, &stdout, &bytes.Buffer{})
+	err := (&AuthSetupCmd{
+		Email:         "user@example.com",
+		Project:       "gog-test-project",
+		ServicesCSV:   "gmail,docs",
+		CreateProject: true,
+		EnableAPIs:    true,
+		Credentials:   "/tmp/client.json",
+		Login:         true,
+		Readonly:      true,
+	}).Run(ctx, &RootFlags{DryRun: true, NoInput: true})
+	if ExitCode(err) != 0 {
+		t.Fatalf("exit code = %d, want 0: %v", ExitCode(err), err)
+	}
+
+	var got struct {
+		DryRun  bool   `json:"dry_run"`
+		Op      string `json:"op"`
+		Request struct {
+			Project  string   `json:"project"`
+			APIs     []string `json:"apis"`
+			Readonly bool     `json:"readonly"`
+		} `json:"request"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v\n%s", err, stdout.String())
+	}
+	if !got.DryRun || got.Op != "auth.setup" || got.Request.Project != "gog-test-project" || !got.Request.Readonly {
+		t.Fatalf("unexpected dry-run: %#v", got)
+	}
+	wantAPIs := []string{"docs.googleapis.com", "drive.googleapis.com", "gmail.googleapis.com"}
+	if strings.Join(got.Request.APIs, ",") != strings.Join(wantAPIs, ",") {
+		t.Fatalf("apis = %#v, want %#v", got.Request.APIs, wantAPIs)
+	}
+}
+
+func TestAuthSetupGuidance(t *testing.T) {
+	result := authSetupResult{
+		Project:  "gog-test-project",
+		Services: []string{"gmail", "drive"},
+	}
+	steps := authSetupNextSteps(&AuthSetupCmd{Email: "user@example.com"}, result, true)
+	joined := strings.Join(steps, "\n")
+	for _, want := range []string{"auth/branding?project=gog-test-project", "auth/clients?project=gog-test-project", "gog auth credentials", "gog auth add user@example.com --services gmail,drive", "gog auth doctor --check"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("guidance missing %q:\n%s", want, joined)
+		}
+	}
+}
+
+func TestAuthSetupClientMatchesLoginResolution(t *testing.T) {
+	ctx := authclient.WithClientResolver(context.Background(), func(email string, override string) (string, error) {
+		if email != "user@example.com" || override != "" {
+			t.Fatalf("resolver args = %q, %q", email, override)
+		}
+
+		return "mapped-client", nil
+	})
+
+	client, err := authSetupClient(ctx, "user@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if client != "mapped-client" {
+		t.Fatalf("client = %q, want mapped-client", client)
+	}
+}
+
+func TestAuthSetupValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  AuthSetupCmd
+		want string
+	}{
+		{name: "invalid project", cmd: AuthSetupCmd{Project: "BAD"}, want: "invalid --gcloud-project"},
+		{name: "login email", cmd: AuthSetupCmd{Project: "valid-project", Login: true}, want: "--login requires an email"},
+		{name: "create project", cmd: AuthSetupCmd{CreateProject: true}, want: "--create-project requires --gcloud-project"},
+		{name: "open console", cmd: AuthSetupCmd{OpenConsole: true, Credentials: "/not/read.json"}, want: "--open-console requires --gcloud-project"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PATH", t.TempDir())
+			err := tt.cmd.Run(context.Background(), &RootFlags{})
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestAPIServiceIDsForServices(t *testing.T) {
+	got, err := googleauth.APIServiceIDsForServices([]googleauth.Service{
+		googleauth.ServiceSheets,
+		googleauth.ServiceDocs,
+		googleauth.ServiceDrive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"docs.googleapis.com", "drive.googleapis.com", "sheets.googleapis.com"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("got %#v, want %#v", got, want)
+	}
+}

--- a/internal/cmd/auth_setup_test.go
+++ b/internal/cmd/auth_setup_test.go
@@ -54,9 +54,9 @@ func TestAuthSetupGuidance(t *testing.T) {
 		Project:  "gog-test-project",
 		Services: []string{"gmail", "drive"},
 	}
-	steps := authSetupNextSteps(&AuthSetupCmd{Email: "user@example.com"}, result, true)
+	steps := authSetupNextSteps(&AuthSetupCmd{Email: "user@example.com"}, result, true, "work")
 	joined := strings.Join(steps, "\n")
-	for _, want := range []string{"auth/branding?project=gog-test-project", "auth/clients?project=gog-test-project", "gog auth credentials", "gog auth add user@example.com --services gmail,drive", "gog auth doctor --check"} {
+	for _, want := range []string{"auth/branding?project=gog-test-project", "auth/clients?project=gog-test-project", "gog --client work auth credentials", "gog --client work auth add user@example.com --services gmail,drive", "gog auth doctor --check"} {
 		if !strings.Contains(joined, want) {
 			t.Fatalf("guidance missing %q:\n%s", want, joined)
 		}

--- a/internal/googleauth/service.go
+++ b/internal/googleauth/service.go
@@ -312,6 +312,35 @@ var serviceInfoByService = map[Service]serviceInfo{
 	},
 }
 
+var apiServiceIDsByService = map[Service][]string{
+	ServiceGmail:         {"gmail.googleapis.com"},
+	ServiceCalendar:      {"calendar-json.googleapis.com"},
+	ServiceChat:          {"chat.googleapis.com"},
+	ServiceClassroom:     {"classroom.googleapis.com"},
+	ServiceDrive:         {"drive.googleapis.com"},
+	ServiceDriveActivity: {"driveactivity.googleapis.com"},
+	ServiceDriveLabels:   {"drivelabels.googleapis.com"},
+	ServiceDocs:          {"docs.googleapis.com", "drive.googleapis.com"},
+	ServiceSlides:        {"drive.googleapis.com", "slides.googleapis.com"},
+	ServiceContacts:      {"people.googleapis.com"},
+	ServiceTasks:         {"tasks.googleapis.com"},
+	ServiceSheets:        {"drive.googleapis.com", "sheets.googleapis.com"},
+	ServicePeople:        {"people.googleapis.com"},
+	ServiceForms:         {"forms.googleapis.com"},
+	ServiceSites:         {"drive.googleapis.com"},
+	ServiceMeet:          {"meet.googleapis.com"},
+	ServiceAppScript:     {"script.googleapis.com"},
+	ServiceAnalytics:     {"analyticsadmin.googleapis.com", "analyticsdata.googleapis.com"},
+	ServiceSearchConsole: {"searchconsole.googleapis.com"},
+	ServiceAds:           {"googleads.googleapis.com"},
+	ServiceGroups:        {"cloudidentity.googleapis.com"},
+	ServiceKeep:          {"keep.googleapis.com"},
+	ServiceAdmin:         {"admin.googleapis.com"},
+	ServiceYouTube:       {"youtube.googleapis.com"},
+	ServicePhotos:        {"photoslibrary.googleapis.com"},
+	ServicePhotosPicker:  {"photospicker.googleapis.com"},
+}
+
 func ParseService(s string) (Service, error) {
 	parsed := Service(strings.ToLower(strings.TrimSpace(s)))
 	if _, ok := serviceInfoByService[parsed]; ok {
@@ -388,6 +417,30 @@ func ServicesInfo() []ServiceInfo {
 	}
 
 	return out
+}
+
+func APIServiceIDsForServices(services []Service) ([]string, error) {
+	var ids []string
+
+	for _, service := range services {
+		serviceIDs, ok := apiServiceIDsByService[service]
+		if !ok {
+			return nil, fmt.Errorf("%w %q", errUnknownService, service)
+		}
+
+		ids = append(ids, serviceIDs...)
+	}
+
+	sort.Strings(ids)
+
+	out := ids[:0]
+	for _, id := range ids {
+		if len(out) == 0 || out[len(out)-1] != id {
+			out = append(out, id)
+		}
+	}
+
+	return out, nil
 }
 
 func ServicesMarkdown(infos []ServiceInfo) string {


### PR DESCRIPTION
## Summary

Adds `gog auth setup`, a guided path through the Google Cloud and OAuth prerequisites that currently require users to assemble several commands and Console pages themselves.

The command can:

- discover the active gcloud account and project;
- create a selected project after confirmation;
- enable the exact Google APIs needed by selected gog services;
- open the project-specific OAuth consent/client pages;
- install a downloaded Desktop OAuth client JSON;
- continue directly into `gog auth add` with matching account/client resolution;
- emit a complete non-mutating plan through `--dry-run --json --no-input`.

When gcloud is unavailable, the command remains useful: it emits ordered manual next steps and direct project-scoped Console URLs instead of failing unless a gcloud-only action was explicitly requested.

## Design details

- Uses argv-based `exec.CommandContext`; no shell interpolation.
- Sets `CLOUDSDK_CORE_DISABLE_PROMPTS=1` for deterministic automation.
- Validates every incompatible or incomplete flag combination before credentials, project, API, browser, or OAuth side effects.
- Resolves the credential client exactly as `auth add` does when an email is supplied, preventing a saved-client/login-client mismatch.
- Centralizes service-to-Google-API mappings, with sorting and deduplication for composite services such as Docs and Sheets.
- Avoids the root `--project` selector alias collision by naming the Cloud flag `--gcloud-project` (`--project-id` alias).

## User-visible examples

```bash
gog auth setup you@gmail.com --gcloud-project my-gog-project --enable-apis --open-console

gog auth setup you@gmail.com --gcloud-project my-gog-project \
  --credentials ~/Downloads/client_secret_*.json --login

gog auth setup --gcloud-project my-gog-project --services gmail,drive \
  --enable-apis --dry-run --json --no-input
```

## Validation

- `make ci`
- focused command and Google-auth unit tests
- generated 695 command-reference pages; docs coverage passed
- live E2E on `clawmac.local`: built the branch binary and ran `auth setup --services gmail,drive --json --no-input`; verified guided fallback status, two mapped APIs, and actionable next steps
- live gcloud probe: gcloud is not installed on that host, confirming the supported no-gcloud fallback without external mutations
- autoreview: clean after fixing two accepted findings (early `--open-console` validation and shared client resolution)

## Safety

The live proof was read-only. No Cloud project was created, no API was enabled, no credentials were stored, and no OAuth flow or browser was started.
