### PR TITLE
feat(evals): add live gog/gws agent comparison

### DIFF
--- a/.agents/skills/gog/SKILL.md
+++ b/.agents/skills/gog/SKILL.md
@@ -15,12 +15,14 @@ state before acting.
 gog --version
 gog auth list --check --json --no-input
 gog auth doctor --check --json --no-input
+GOG_HELP=agent gog --help
 gog schema --json
 ```
 
-`gog` has no separate agent mode. Its machine output, non-interactive behavior,
-stable exit codes, command guards, and untrusted-content wrapping apply across
-the CLI. Root help summarizes the human contract; `schema` exposes command
+`GOG_HELP=agent` makes root help emit a compact automation contract and common
+read-only recipes; commands and behavior stay unchanged. Machine output,
+non-interactive behavior, stable exit codes, command guards, and
+untrusted-content wrapping apply across the CLI. `schema` exposes command
 syntax, stable exit codes, and effective safety state for automation.
 
 For JSON output projection, `--fields` is accepted as an alias for `--select` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.30.1 - Unreleased
 
+- Evals: add a credential-free, reproducible gog/gws comparison harness with checked scenarios, timing/output metrics, methodology, and CI coverage.
+
 ## 0.30.0 - 2026-06-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 0.30.1 - Unreleased
 
-- Evals: add a credential-free, reproducible gog/gws comparison harness with checked scenarios, timing/output metrics, methodology, and CI coverage.
+- Evals: add reproducible structural and live Codex/OpenClaw gog/gws comparisons with correctness assertions, token/tool/latency metrics, cache-counterbalanced repetitions, methodology, and CI coverage.
+- CLI: add `GOG_HELP=agent` compact root help with common read-only recipes and targeted schema guidance so agents can execute Gmail, Calendar, and Drive tasks without traversing multiple help levels.
 
 ## 0.30.0 - 2026-06-21
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := build
 
 .PHONY: build build-safe gog gogcli gog-help gogcli-help help fmt fmt-check lint deadcode test ci tools pnpm-gate docs-commands docs-site docs-check
-.PHONY: worker-ci eval-gws eval-gws-test
+.PHONY: worker-ci eval-gws eval-gws-agents eval-gws-test
 
 BIN_DIR := $(CURDIR)/bin
 BIN := $(BIN_DIR)/gog
@@ -132,13 +132,16 @@ pnpm-gate:
 
 test:
 	@go test $(GO_TEST_FLAGS) $(TEST_FLAGS) $(TEST_PKGS)
-	@node --test scripts/eval-gws.test.mjs
+	@node --test scripts/eval-gws.test.mjs scripts/eval-gws-agents.test.mjs
 
 eval-gws: build
 	@node scripts/eval-gws.mjs --gog $(BIN) --gws $${GWS_BIN:-gws} --out $${OUT:-/tmp/gog-gws-eval.json}
 
+eval-gws-agents: build
+	@node scripts/eval-gws-agents.mjs --gog $(BIN) --gws $${GWS_BIN:-gws} --account "$${GOG_EVAL_ACCOUNT:?set GOG_EVAL_ACCOUNT}" $${GOG_EVAL_DRIVE_NAME:+--drive-name "$${GOG_EVAL_DRIVE_NAME}"} --out $${OUT:-/tmp/gog-gws-agent-eval.json}
+
 eval-gws-test:
-	@node --test scripts/eval-gws.test.mjs
+	@node --test scripts/eval-gws.test.mjs scripts/eval-gws-agents.test.mjs
 
 ci: pnpm-gate fmt-check lint deadcode test docs-check
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 .DEFAULT_GOAL := build
 
 .PHONY: build build-safe gog gogcli gog-help gogcli-help help fmt fmt-check lint deadcode test ci tools pnpm-gate docs-commands docs-site docs-check
-.PHONY: worker-ci
+.PHONY: worker-ci eval-gws eval-gws-test
 
 BIN_DIR := $(CURDIR)/bin
 BIN := $(BIN_DIR)/gog
@@ -132,6 +132,13 @@ pnpm-gate:
 
 test:
 	@go test $(GO_TEST_FLAGS) $(TEST_FLAGS) $(TEST_PKGS)
+	@node --test scripts/eval-gws.test.mjs
+
+eval-gws: build
+	@node scripts/eval-gws.mjs --gog $(BIN) --gws $${GWS_BIN:-gws} --out $${OUT:-/tmp/gog-gws-eval.json}
+
+eval-gws-test:
+	@node --test scripts/eval-gws.test.mjs
 
 ci: pnpm-gate fmt-check lint deadcode test docs-check
 

--- a/README.md
+++ b/README.md
@@ -503,13 +503,31 @@ gog schema --json
 gog schema --json | jq '.automation'
 ```
 
-There is no separate agent mode. The same CLI is designed for interactive use,
-scripts, CI, and agents: `--json`/`--plain` keep stdout parseable, `--no-input`
-prevents prompts, stable exit codes classify failures, `--wrap-untrusted`
-marks fetched free text, and runtime or baked command policies constrain
-available operations. Root `--help` summarizes that contract; `gog schema
---json` exposes the complete command schema, exit-code map, and effective
-safety state. See [Automation](docs/automation.md).
+There is no separate agent execution mode. The same CLI behavior serves
+interactive use, scripts, CI, and agents: `--json`/`--plain` keep stdout
+parseable, `--no-input` prevents prompts, stable exit codes classify failures,
+`--wrap-untrusted` marks fetched free text, and runtime or baked command
+policies constrain available operations. `GOG_HELP=agent gog --help` emits a
+compact root-help contract with common read-only recipes; it does not change
+commands or authorization. `gog schema --json` exposes the complete command
+schema, exit-code map, and effective safety state. See
+[Automation](docs/automation.md).
+
+### Agent evaluation
+
+The reproducible [gog/GWS comparison](docs/gws-comparison.md) runs identical
+Gmail, Calendar, and exact-name Drive tasks through Codex and OpenClaw. In the
+final two-repetition, cache-counterbalanced matrix against GWS 0.22.5, all 24
+task assertions passed:
+
+| Agent | gog median tokens | GWS median tokens | gog median latency | GWS median latency |
+| --- | ---: | ---: | ---: | ---: |
+| Codex | 94,078.5 | 97,546 | 13,735 ms | 13,676 ms |
+| OpenClaw | 38,350.5 | 45,727 | 41,124.5 ms | 45,597 ms |
+
+With correctness tied, gog used 3.6% fewer total tokens in Codex and 16.1%
+fewer in OpenClaw. The linked methodology documents fixtures, cache ordering,
+tool-call and uncached-token metrics, credential isolation, and reproduction.
 
 Useful global flags:
 

--- a/docs/gws-comparison.md
+++ b/docs/gws-comparison.md
@@ -1,0 +1,72 @@
+---
+title: gog and gws evaluation
+description: "Reproduce a safety-focused comparison between gog and Google's Discovery-driven Workspace CLI."
+---
+
+# gog and gws evaluation
+
+Google's `gws` (`@googleworkspace/cli`) and `gog` optimize for different jobs.
+`gws` derives a broad, regular command surface from Google Discovery documents.
+`gog` invests more heavily in curated workflows, multi-account operation,
+stable automation contracts, human-readable output, and layered runtime safety.
+
+This repository keeps the comparison executable instead of relying on a static
+feature table that drifts.
+
+## Reproduce
+
+```bash
+make build
+npm install --prefix /tmp/gws-eval @googleworkspace/cli@0.22.5
+GWS_BIN=/tmp/gws-eval/node_modules/.bin/gws make eval-gws
+```
+
+The default suite is credential-free and read-only. It compares root discovery,
+Gmail command discovery, method schema output, invalid-command exit behavior,
+latency, and output size. The harness removes access-token environment variables
+before spawning either CLI.
+
+Scenarios live in `evals/gws/scenarios.json`.
+The JSON report includes every argv, assertion, exit code, duration, and output
+size. Use a different binary or scenario file without editing the runner:
+
+```bash
+node scripts/eval-gws.mjs \
+  --gog ./bin/gog \
+  --gws /tmp/gws-eval/node_modules/.bin/gws \
+  --scenarios evals/gws/scenarios.json \
+  --out /tmp/gog-gws-eval.json
+```
+
+## What each project teaches us
+
+What gog should retain:
+
+- first-class workflows instead of exposing only raw API methods;
+- stable JSON/TSV, exit codes, dry-run plans, command guards, no-send policy,
+  untrusted-content wrapping, and baked safety profiles;
+- named OAuth clients, account aliases, service accounts, keyring choices, and
+  backup/restore workflows.
+
+What gog should learn from gws:
+
+- Discovery-backed coverage closes the long tail quickly;
+- a regular `service resource method` grammar is easy to predict;
+- schema lookup is an effective agent primitive;
+- generic pagination, upload, download, and output-format contracts reduce
+  per-command learning.
+
+The intended direction is additive: preserve gog's curated and safety-oriented
+surface while using Discovery as an explicit escape hatch, not as a replacement
+for high-quality first-class commands.
+
+## Interpretation limits
+
+The default suite measures structural behavior, not API correctness or product
+quality. Timing is a local observation affected by caches and network state.
+Do not rank tools by a single aggregate score. Inspect per-scenario output and
+add task-specific, non-mutating scenarios when evaluating a real workflow.
+
+Sources: [Google Workspace CLI repository](https://github.com/googleworkspace/cli),
+[npm package](https://www.npmjs.com/package/@googleworkspace/cli), and gog's
+[automation contract](automation.md).

--- a/docs/gws-comparison.md
+++ b/docs/gws-comparison.md
@@ -38,6 +38,41 @@ node scripts/eval-gws.mjs \
   --out /tmp/gog-gws-eval.json
 ```
 
+## Live agent evaluation
+
+The live suite gives Codex and OpenClaw the same tasks through a neutral
+`workspace-cli` executable. Each agent/CLI pair gets a fresh workspace and
+session. The suite records task assertions, input/output/cache tokens, tool
+calls, and elapsed time without retaining API responses, file IDs, or raw agent
+transcripts in the report. Local-only traces remain in the printed temporary
+artifact directories for diagnosis. CLI order alternates by repetition to
+counterbalance provider prompt-cache warming. The gog wrapper enables
+`GOG_HELP=agent`, the documented compact root-help mode intended for agent
+discovery; API commands and output remain unchanged.
+
+Authorize the same disposable account in both CLIs with read-only Gmail,
+Calendar, and Drive scopes. The live runner excludes secret-bearing environment
+variables from agent processes. A credential-free local proxy retains auth in
+the parent process and accepts only the suite's help, schema, Gmail-label,
+calendar-list, and Drive-search commands. Then run:
+
+```bash
+GOG_EVAL_ACCOUNT=test-account@example.com \
+GOG_EVAL_DRIVE_NAME='exact fixture file name' \
+GWS_BIN=/tmp/gws-eval/node_modules/.bin/gws \
+make eval-gws-agents
+```
+
+The Drive task is omitted when `GOG_EVAL_DRIVE_NAME` is unset. Before invoking
+an agent, the harness queries both CLIs directly and refuses to score the run if
+their normalized fixtures disagree or the requested Drive fixture is empty.
+Correctness is the first comparison
+criterion; ties use total tokens, tool calls, then latency. Results remain
+stratified by agent because Codex and OpenClaw have different fixed prompt and
+cache overhead. Two repetitions are the default so each CLI runs first once.
+Pin models with `GOG_EVAL_CODEX_MODEL` and `GOG_EVAL_OPENCLAW_MODEL` when a
+long-lived comparison must not follow the agents' configured defaults.
+
 ## What each project teaches us
 
 What gog should retain:
@@ -63,9 +98,10 @@ for high-quality first-class commands.
 ## Interpretation limits
 
 The default suite measures structural behavior, not API correctness or product
-quality. Timing is a local observation affected by caches and network state.
-Do not rank tools by a single aggregate score. Inspect per-scenario output and
-add task-specific, non-mutating scenarios when evaluating a real workflow.
+quality. The live suite covers real API reads, but its fixture and timing results
+still depend on the selected account, model, caches, and network state. Compare
+gog and gws within each agent, repeat runs before drawing conclusions, and keep
+task success ahead of efficiency metrics.
 
 Sources: [Google Workspace CLI repository](https://github.com/googleworkspace/cli),
 [npm package](https://www.npmjs.com/package/@googleworkspace/cli), and gog's

--- a/docs/index.md
+++ b/docs/index.md
@@ -59,6 +59,7 @@ gog slides create-from-markdown "Weekly update" --content-file slides.md
 - **Grouping Docs edits atomically.** [Google Docs request batches](docs-batch.md) covers persisted, revision-locked request queues and explicit recovery modes.
 - **Verifying real API behavior.** [Live testing](live-testing.md) covers the dedicated-account smoke suite, cleanup, retries, and optional infrastructure.
 - **Looking up a flag.** The [Command Index](commands/) has a generated page for every subcommand.
+- **Comparing Discovery-driven CLIs.** Reproduce the [gog and gws evaluation](gws-comparison.md) instead of relying on a stale feature table.
 
 ## Project
 

--- a/evals/gws/scenarios.json
+++ b/evals/gws/scenarios.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "scenarios": [
+    {
+      "id": "root-help",
+      "description": "Root command discovery without credentials",
+      "gog": {"args": ["--help"], "exit": [0], "contains": ["Usage", "Gmail", "Calendar"]},
+      "gws": {"args": ["--help"], "exit": [0], "contains": ["USAGE", "gmail", "calendar"]}
+    },
+    {
+      "id": "gmail-label-schema",
+      "description": "Machine-readable schema for the same Gmail labels-list task",
+      "gog": {"args": ["schema", "gmail", "labels", "list"], "exit": [0], "json": true},
+      "gws": {"args": ["schema", "gmail.users.labels.list"], "exit": [0], "json": true}
+    },
+    {
+      "id": "gmail-help",
+      "description": "Service-level command discoverability",
+      "gog": {"args": ["gmail", "--help"], "exit": [0], "contains": ["search", "send", "labels"]},
+      "gws": {"args": ["gmail", "--help"], "exit": [0], "contains": ["users"]}
+    },
+    {
+      "id": "invalid-command",
+      "description": "Failure classification for an unknown command",
+      "gog": {"args": ["not-a-command"], "exit": [2]},
+      "gws": {"args": ["not-a-command"], "exit": [3, 4]}
+    }
+  ]
+}

--- a/internal/cmd/help_printer.go
+++ b/internal/cmd/help_printer.go
@@ -14,7 +14,10 @@ import (
 	"github.com/steipete/gogcli/internal/termutil"
 )
 
-const helpModeFull = "full"
+const (
+	helpModeAgent = "agent"
+	helpModeFull  = "full"
+)
 
 func helpOptions() kong.HelpOptions {
 	mode := strings.ToLower(strings.TrimSpace(os.Getenv("GOG_HELP")))
@@ -65,9 +68,34 @@ func helpPrinter(options kong.HelpOptions, ctx *kong.Context) error {
 	out = removeEmptyCommandGroups(out)
 	out = injectBuildLine(out)
 	out = injectAutomationHelp(out, ctx.Selected())
+	if strings.EqualFold(strings.TrimSpace(os.Getenv("GOG_HELP")), helpModeAgent) {
+		owner := helpOwnerNode(ctx.Selected())
+		if ctx.Selected() == nil || (owner != nil && owner.Type == kong.ApplicationNode) {
+			out = compactAgentHelp(out)
+		}
+	}
 	out = colorizeHelp(out, helpProfile(origStdout, helpColorMode(ctx.Args)))
 	_, err = io.WriteString(origStdout, out)
 	return err
+}
+
+func compactAgentHelp(out string) string {
+	lines := strings.Split(out, "\n")
+	prefix := make([]string, 0, 2)
+	for _, line := range lines {
+		if strings.HasPrefix(line, "Usage:") || strings.HasPrefix(line, "Build:") {
+			prefix = append(prefix, line)
+		}
+	}
+	start := strings.Index(out, "Automation:\n")
+	if start < 0 {
+		return out
+	}
+	section := out[start:]
+	if end := strings.Index(section, "\nCommands:\n"); end >= 0 {
+		section = section[:end]
+	}
+	return strings.Join(prefix, "\n") + "\n\n" + strings.TrimSpace(section) + "\n"
 }
 
 func injectBuildLine(out string) string {
@@ -105,7 +133,13 @@ func injectAutomationHelp(out string, selected *kong.Node) string {
 
 	const section = `Automation:
   Use --json or --plain for stable output; --no-input disables prompts.
-  Use "gog help <command>" or "gog <command> --help" for command help.
+  Common read-only commands:
+    gog gmail labels list --json --results-only
+    gog calendar calendars --json --results-only
+    gog drive search <text> --json --results-only
+  For exact Drive API filters, add --raw-query to drive search.
+  Run "gog schema <command path>" for a targeted machine-readable contract.
+  Use "gog help <command>" or "gog <command> --help" for prose help.
   Exit codes: 0 success, 1 error, 2 usage, 3 empty, 4 auth, 5 not found,
     6 denied, 7 rate limited, 8 retryable, 10 config, 11 orphaned,
     130 interrupted.

--- a/internal/cmd/help_printer_test.go
+++ b/internal/cmd/help_printer_test.go
@@ -64,11 +64,25 @@ func TestInjectAutomationHelp(t *testing.T) {
 
 	in := "Usage: gog\nFlags:\n\nCommands:\n  foo\n"
 	out := injectAutomationHelp(in, parser.Model.Node)
-	if !strings.Contains(out, "\nAutomation:\n") || !strings.Contains(out, `gog schema --json`) {
+	if !strings.Contains(out, "\nAutomation:\n") ||
+		!strings.Contains(out, `gog schema --json`) ||
+		!strings.Contains(out, `gog gmail labels list --json --results-only`) ||
+		!strings.Contains(out, `add --raw-query to drive search`) {
 		t.Fatalf("automation help missing: %q", out)
 	}
 	if again := injectAutomationHelp(out, parser.Model.Node); again != out {
 		t.Fatalf("injectAutomationHelp should be idempotent")
+	}
+}
+
+func TestCompactAgentHelp(t *testing.T) {
+	in := "Usage: gog <command>\nBuild: dev\n\nFlags:\n  --help\n\nAutomation:\n  recipe\n\nCommands:\n  gmail\n"
+	out := compactAgentHelp(in)
+	if !strings.Contains(out, "Usage: gog <command>") || !strings.Contains(out, "Automation:\n  recipe") {
+		t.Fatalf("compact help missing contract: %q", out)
+	}
+	if strings.Contains(out, "Flags:") || strings.Contains(out, "Commands:") {
+		t.Fatalf("compact help retained verbose sections: %q", out)
 	}
 }
 

--- a/internal/cmd/help_snapshot_test.go
+++ b/internal/cmd/help_snapshot_test.go
@@ -108,3 +108,16 @@ func TestHelpSnapshot_RootAutomationContract(t *testing.T) {
 		t.Fatalf("removed discovery commands leaked into help: %q", out)
 	}
 }
+
+func TestHelpSnapshot_RootAgentMode(t *testing.T) {
+	t.Setenv("GOG_HELP", "agent")
+	out := captureHelpOutput(t, "--help")
+	requireHelpContains(t, out,
+		"Usage: gog <command>",
+		"\nAutomation:\n",
+		"gog gmail labels list --json --results-only",
+	)
+	if strings.Contains(out, "\nFlags:\n") || strings.Contains(out, "\nCommands:\n") {
+		t.Fatalf("agent help retained verbose sections: %q", out)
+	}
+}

--- a/scripts/eval-gws-agents.mjs
+++ b/scripts/eval-gws-agents.mjs
@@ -1,0 +1,720 @@
+#!/usr/bin/env node
+
+import { spawn } from "node:child_process";
+import { constants as fsConstants } from "node:fs";
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import net from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function parseArgs(argv, environment = process.env) {
+  const options = {
+    gog: path.join(root, "bin", "gog"),
+    gws: "gws",
+    account: environment.GOG_EVAL_ACCOUNT ?? "",
+    driveName: environment.GOG_EVAL_DRIVE_NAME ?? "",
+    codexModel: environment.GOG_EVAL_CODEX_MODEL ?? "",
+    openclawModel: environment.GOG_EVAL_OPENCLAW_MODEL ?? "",
+    agents: ["codex", "openclaw"],
+    repetitions: 2,
+    timeoutMs: 300_000,
+    out: "",
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    switch (key) {
+      case "--gog": options.gog = value; index += 1; break;
+      case "--gws": options.gws = value; index += 1; break;
+      case "--account": options.account = value; index += 1; break;
+      case "--drive-name": options.driveName = value; index += 1; break;
+      case "--codex-model": options.codexModel = value; index += 1; break;
+      case "--openclaw-model": options.openclawModel = value; index += 1; break;
+      case "--agents": options.agents = value.split(",").filter(Boolean); index += 1; break;
+      case "--repetitions": options.repetitions = Number(value); index += 1; break;
+      case "--timeout-ms": options.timeoutMs = Number(value); index += 1; break;
+      case "--out": options.out = value; index += 1; break;
+      default: throw new Error(`unknown argument: ${key}`);
+    }
+  }
+  if (!options.account) throw new Error("--account or GOG_EVAL_ACCOUNT is required");
+  if (!Number.isInteger(options.repetitions) || options.repetitions <= 0) {
+    throw new Error("--repetitions must be a positive integer");
+  }
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error("--timeout-ms must be positive");
+  }
+  const supported = new Set(["codex", "openclaw"]);
+  if (options.agents.length === 0 || options.agents.some((agent) => !supported.has(agent))) {
+    throw new Error("--agents must contain codex and/or openclaw");
+  }
+  return options;
+}
+
+function runProcess(command, args, { cwd, env, timeoutMs }) {
+  return new Promise((resolve) => {
+    const started = process.hrtime.bigint();
+    const child = spawn(command, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
+    const stdout = [];
+    const stderr = [];
+    child.stdout.on("data", (chunk) => stdout.push(chunk));
+    child.stderr.on("data", (chunk) => stderr.push(chunk));
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGTERM");
+      setTimeout(() => child.kill("SIGKILL"), 2_000).unref();
+    }, timeoutMs);
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: -1,
+        elapsedMs: Number(process.hrtime.bigint() - started) / 1e6,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        timedOut,
+        error: error.message,
+      });
+    });
+    child.on("close", (exitCode, signal) => {
+      clearTimeout(timer);
+      resolve({
+        exitCode: exitCode ?? -1,
+        signal,
+        elapsedMs: Number(process.hrtime.bigint() - started) / 1e6,
+        stdout: Buffer.concat(stdout).toString("utf8"),
+        stderr: Buffer.concat(stderr).toString("utf8"),
+        timedOut,
+      });
+    });
+  });
+}
+
+async function runJson(command, args, environment, timeoutMs) {
+  const result = await runProcess(command, args, {
+    cwd: root,
+    env: environment,
+    timeoutMs,
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`${path.basename(command)} fixture query failed with exit ${result.exitCode}`);
+  }
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`${path.basename(command)} fixture query returned invalid JSON`);
+  }
+}
+
+function sortedUnique(values) {
+  return [...new Set(values)].sort();
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+async function resolveExecutable(command, searchPath) {
+  if (command.includes(path.sep)) return path.resolve(command);
+  for (const directory of (searchPath ?? "").split(path.delimiter).filter(Boolean)) {
+    const candidate = path.join(directory, command);
+    try {
+      await access(candidate, fsConstants.X_OK);
+      return candidate;
+    } catch {}
+  }
+  throw new Error(`executable not found on PATH: ${command}`);
+}
+
+function exactDriveQuery(query, driveName) {
+  if (!driveName || typeof query !== "string") return false;
+  const escaped = driveName.replaceAll("'", "\\'");
+  return query.replaceAll(/\s+/g, " ").trim() === `name = '${escaped}' and trashed = false`;
+}
+
+function allowedGogFlags(args, allowed) {
+  return args.every((arg) => allowed.has(arg));
+}
+
+function allowedGogDriveArgs(args, driveName) {
+  if (!exactDriveQuery(args[2], driveName)) return false;
+  if (!args.includes("--raw-query")) return false;
+  if (!args.includes("--no-all-drives")) return false;
+  for (let index = 3; index < args.length; index += 1) {
+    const arg = args[index];
+    if (["--json", "--results-only", "--no-input", "--no-all-drives", "--raw-query"].includes(arg)) continue;
+    if (arg === "--max") {
+      const value = Number(args[index + 1]);
+      if (!Number.isInteger(value) || value < 1 || value > 1000) return false;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--max=")) {
+      const value = Number(arg.slice("--max=".length));
+      if (!Number.isInteger(value) || value < 1 || value > 1000) return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+function parseGwsParams(args, validate) {
+  let params = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--page-all") continue;
+    if (arg === "--format") {
+      if (args[index + 1] !== "json") return false;
+      index += 1;
+      continue;
+    }
+    if (arg === "--page-limit") {
+      const value = Number(args[index + 1]);
+      if (!Number.isInteger(value) || value < 1 || value > 100) return false;
+      index += 1;
+      continue;
+    }
+    if (arg !== "--params" || index + 1 >= args.length) return false;
+    try {
+      params = JSON.parse(args[index + 1]);
+    } catch {
+      return false;
+    }
+    index += 1;
+  }
+  return validate(params);
+}
+
+export function allowedAgentArgs(cli, args, driveName = "") {
+  if (!Array.isArray(args) || args.some((arg) => typeof arg !== "string")) return false;
+  if (args.length === 1 && (args[0] === "--help" || args[0] === "--version")) return true;
+  if (args[0] === "schema") return true;
+  if (["gmail", "calendar", "drive"].includes(args[0]) && args.includes("--help")) return true;
+  if (cli === "gog") {
+    if (args.slice(0, 3).join(" ") === "gmail labels list") {
+      return allowedGogFlags(args.slice(3), new Set(["--json", "--results-only", "--no-input"]));
+    }
+    if (args.slice(0, 2).join(" ") === "calendar calendars") {
+      return allowedGogFlags(args.slice(2), new Set(["--json", "--results-only", "--no-input", "--all"]));
+    }
+    if (args.slice(0, 2).join(" ") === "drive search") return allowedGogDriveArgs(args, driveName);
+    return false;
+  }
+  if (args.slice(0, 4).join(" ") === "gmail users labels list") {
+    return parseGwsParams(args.slice(4), (params) =>
+      Object.keys(params).every((key) => key === "userId") && params.userId === "me");
+  }
+  if (args.slice(0, 3).join(" ") === "calendar calendarList list") {
+    return parseGwsParams(args.slice(3), (params) =>
+      Object.keys(params).every((key) => ["maxResults", "showDeleted", "showHidden"].includes(key))
+      && (params.maxResults == null || (Number.isInteger(params.maxResults) && params.maxResults >= 1 && params.maxResults <= 250))
+      && (params.showDeleted == null || params.showDeleted === false)
+      && (params.showHidden == null || typeof params.showHidden === "boolean"));
+  }
+  if (args.slice(0, 3).join(" ") === "drive files list") {
+    const allowedFields = new Set([
+      "files(id,name)", "files(id,name,trashed)",
+      "nextPageToken,files(id,name)", "nextPageToken,files(id,name,trashed)",
+      "nextPageToken,incompleteSearch,files(id,name,trashed)",
+    ]);
+    return parseGwsParams(args.slice(3), (params) =>
+      Object.keys(params).every((key) => ["q", "pageSize", "fields", "spaces", "corpora", "supportsAllDrives"].includes(key))
+      && exactDriveQuery(params.q, driveName)
+      && (params.pageSize == null || (Number.isInteger(params.pageSize) && params.pageSize >= 1 && params.pageSize <= 1000))
+      && (params.fields == null || allowedFields.has(params.fields.replaceAll(/\s+/g, "")))
+      && (params.spaces == null || params.spaces === "drive")
+      && (params.corpora == null || params.corpora === "user")
+      && (params.supportsAllDrives == null || params.supportsAllDrives === true));
+  }
+  return false;
+}
+
+async function startCliProxy(cli, options, environment) {
+  const executable = await resolveExecutable(cli === "gog" ? options.gog : options.gws, environment.PATH);
+  const socketDirectory = await mkdtemp(path.join(os.tmpdir(), "gog-agent-proxy-"));
+  await chmod(socketDirectory, 0o700);
+  const socketPath = path.join(socketDirectory, "cli.sock");
+  const sockets = new Set();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
+    let request = "";
+    socket.setEncoding("utf8");
+    socket.on("data", async (chunk) => {
+      request += chunk;
+      if (!request.includes("\n")) return;
+      socket.pause();
+      try {
+        const args = JSON.parse(request.slice(0, request.indexOf("\n")));
+        if (!allowedAgentArgs(cli, args, options.driveName)) {
+          socket.end(`${JSON.stringify({ exitCode: 2, stdout: "", stderr: "command blocked by eval read-only policy\n" })}\n`);
+          return;
+        }
+        const commandArgs = cli === "gog"
+          ? ["--account", options.account, "--no-input", ...args]
+          : args;
+        const result = await runProcess(executable, commandArgs, {
+          cwd: root,
+          env: cli === "gog" ? { ...environment, GOG_HELP: "agent" } : environment,
+          timeoutMs: options.timeoutMs,
+        });
+        socket.end(`${JSON.stringify({
+          exitCode: result.exitCode,
+          stdout: result.stdout,
+          stderr: result.stderr,
+        })}\n`);
+      } catch {
+        socket.end(`${JSON.stringify({ exitCode: 2, stdout: "", stderr: "invalid eval proxy request\n" })}\n`);
+      }
+    });
+  });
+  try {
+    await new Promise((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    await chmod(socketPath, 0o600);
+  } catch (error) {
+    await rm(socketDirectory, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    socketPath,
+    close: async () => {
+      for (const socket of sockets) socket.destroy();
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await rm(socketDirectory, { recursive: true, force: true });
+    },
+  };
+}
+
+export function fixturesAgree(gog, gws) {
+  return JSON.stringify(gog) === JSON.stringify(gws);
+}
+
+async function loadFixtures(options, environment) {
+  const gogBase = ["--account", options.account, "--no-input"];
+  const gogLabels = await runJson(options.gog, [
+    ...gogBase, "gmail", "labels", "list", "--json", "--results-only",
+  ], environment, options.timeoutMs);
+  const gwsLabels = await runJson(options.gws, [
+    "gmail", "users", "labels", "list", "--params", JSON.stringify({ userId: "me" }),
+    "--format", "json",
+  ], environment, options.timeoutMs);
+  const normalizeLabel = (labels) => (labels ?? [])
+    .filter((label) => label.id === "INBOX")
+    .map(({ id, name, type }) => ({ id, name, type }));
+
+  const gogCalendars = await runJson(options.gog, [
+    ...gogBase, "calendar", "calendars", "--json", "--results-only",
+  ], environment, options.timeoutMs);
+  const gwsCalendars = await runJson(options.gws, [
+    "calendar", "calendarList", "list", "--params", JSON.stringify({ maxResults: 250 }),
+    "--format", "json",
+  ], environment, options.timeoutMs);
+  const normalizeCalendar = (calendars) => (calendars ?? [])
+    .filter((calendar) => calendar.primary === true)
+    .map(({ id, timeZone }) => ({ id, timeZone }));
+
+  const fixtures = {
+    gmail: normalizeLabel(gogLabels),
+    calendar: normalizeCalendar(gogCalendars),
+  };
+  const peerFixtures = {
+    gmail: normalizeLabel(gwsLabels.labels),
+    calendar: normalizeCalendar(gwsCalendars.items),
+  };
+
+  if (options.driveName) {
+    const exactQuery = `name = '${options.driveName.replaceAll("'", "\\'")}' and trashed = false`;
+    const gogDrive = await runJson(options.gog, [
+      ...gogBase, "drive", "search", exactQuery, "--raw-query", "--no-all-drives", "--json", "--results-only", "--max", "100",
+    ], environment, options.timeoutMs);
+    const escaped = options.driveName.replaceAll("'", "\\'");
+    const gwsDrive = await runJson(options.gws, [
+      "drive", "files", "list", "--params", JSON.stringify({
+        q: `name = '${escaped}' and trashed = false`,
+        pageSize: 100,
+        fields: "files(id,name)",
+      }),
+      "--format", "json",
+    ], environment, options.timeoutMs);
+    fixtures.drive = {
+      name: options.driveName,
+      ids: sortedUnique(gogDrive.filter((file) => file.name === options.driveName).map((file) => file.id)),
+    };
+    peerFixtures.drive = {
+      name: options.driveName,
+      ids: sortedUnique((gwsDrive.files ?? []).filter((file) => file.name === options.driveName).map((file) => file.id)),
+    };
+  }
+
+  if (!fixturesAgree(fixtures, peerFixtures)) {
+    throw new Error("gog and gws fixture queries disagree; refusing to score agent output");
+  }
+  if (fixtures.gmail.length !== 1 || fixtures.calendar.length !== 1) {
+    throw new Error("test account is missing a unique INBOX label or primary calendar");
+  }
+  if (fixtures.drive && fixtures.drive.ids.length === 0) {
+    throw new Error("the requested Drive fixture does not exist; refusing to score an empty task");
+  }
+  return fixtures;
+}
+
+export function buildPrompt(driveName = "", executable = "workspace-cli") {
+  const driveTask = driveName
+    ? `\n3. Search the default Drive corpus for every non-trashed file whose name is exactly ${JSON.stringify(driveName)}. Do not broaden to shared-drive or all-drive corpora. Return sorted unique file IDs.`
+    : "";
+  const driveShape = driveName ? ',"drive":{"name":"string","ids":["string"]}' : "";
+  return `Use only the shell executable ${JSON.stringify(executable)} to inspect the authenticated Google Workspace account. Do not use a browser, web search, MCP connector, another Google CLI, or prior knowledge. Inspect that executable's help or schema when needed.
+
+Tasks:
+1. Find the Gmail system INBOX label. Return its id, name, and type.
+2. Find the primary calendar. Return its id and timeZone.${driveTask}
+
+Return only one JSON object with this exact shape:
+{"gmail":{"id":"string","name":"string","type":"string"},"calendar":{"id":"string","timeZone":"string"}${driveShape}}
+Do not include prose or markdown.`;
+}
+
+export function extractJson(text) {
+  const trimmed = text.trim();
+  const unfenced = trimmed.replace(/^```(?:json)?\s*/i, "").replace(/\s*```$/, "");
+  const start = unfenced.indexOf("{");
+  const end = unfenced.lastIndexOf("}");
+  if (start < 0 || end < start) throw new Error("agent did not return a JSON object");
+  return JSON.parse(unfenced.slice(start, end + 1));
+}
+
+export function scoreAnswers(answers, fixtures) {
+  const checks = [
+    {
+      name: "gmail.inbox",
+      pass: JSON.stringify(answers?.gmail) === JSON.stringify(fixtures.gmail[0]),
+    },
+    {
+      name: "calendar.primary",
+      pass: JSON.stringify(answers?.calendar) === JSON.stringify(fixtures.calendar[0]),
+    },
+  ];
+  if (fixtures.drive) {
+    checks.push({
+      name: "drive.exact_name",
+      pass: answers?.drive?.name === fixtures.drive.name
+        && JSON.stringify(sortedUnique(answers?.drive?.ids ?? [])) === JSON.stringify(fixtures.drive.ids),
+    });
+  }
+  return { checks, passed: checks.filter((check) => check.pass).length, total: checks.length };
+}
+
+export function parseCodex(stdout) {
+  const events = stdout.split("\n").filter(Boolean).map((line) => JSON.parse(line));
+  const messages = events
+    .filter((event) => event.type === "item.completed" && event.item?.type === "agent_message")
+    .map((event) => event.item.text)
+    .filter(Boolean);
+  const usage = [...events].reverse().find((event) => event.type === "turn.completed")?.usage ?? {};
+  const toolTypes = new Set([
+    "command_execution", "local_shell_call", "mcp_tool_call", "web_search", "web_search_call",
+  ]);
+  const toolCalls = events.filter((event) => event.type === "item.completed" && toolTypes.has(event.item?.type)).length;
+  const input = usage.input_tokens ?? 0;
+  const cacheRead = usage.cached_input_tokens ?? 0;
+  const output = usage.output_tokens ?? 0;
+  return {
+    text: messages.at(-1) ?? "",
+    metrics: {
+      input_tokens: input,
+      cache_read_tokens: cacheRead,
+      output_tokens: output,
+      reasoning_tokens: usage.reasoning_output_tokens ?? 0,
+      total_tokens: input + output,
+      uncached_tokens: Math.max(0, input - cacheRead) + output,
+      tool_calls: toolCalls,
+    },
+  };
+}
+
+async function countOpenClawTools(sessionId) {
+  const sessionPath = path.join(os.homedir(), ".openclaw", "agents", "main", "sessions", `${sessionId}.jsonl`);
+  try {
+    const lines = (await readFile(sessionPath, "utf8")).split("\n").filter(Boolean);
+    let count = 0;
+    for (const line of lines) {
+      const event = JSON.parse(line);
+      for (const content of event.message?.content ?? []) {
+        if (content.type === "toolCall") count += 1;
+      }
+    }
+    return count;
+  } catch {
+    return null;
+  }
+}
+
+async function parseOpenClaw(stdout, sessionId) {
+  const result = JSON.parse(stdout);
+  const meta = result.result?.meta ?? {};
+  const usage = meta.agentMeta?.usage ?? {};
+  return {
+    text: meta.finalAssistantVisibleText
+      ?? result.result?.payloads?.map((payload) => payload.text).filter(Boolean).at(-1)
+      ?? "",
+    model: meta.agentMeta?.model ?? null,
+    provider: meta.agentMeta?.provider ?? null,
+    metrics: {
+      input_tokens: usage.input ?? 0,
+      cache_read_tokens: usage.cacheRead ?? 0,
+      output_tokens: usage.output ?? 0,
+      reasoning_tokens: 0,
+      total_tokens: usage.total ?? ((usage.input ?? 0) + (usage.cacheRead ?? 0) + (usage.output ?? 0)),
+      uncached_tokens: (usage.input ?? 0) + (usage.output ?? 0),
+      tool_calls: await countOpenClawTools(sessionId),
+    },
+  };
+}
+
+async function createRunDirectory(options, socketPath) {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "workspace-agent-"));
+  const binDirectory = path.join(directory, "bin");
+  await mkdir(binDirectory);
+  const wrapper = path.join(binDirectory, "workspace-cli");
+  const client = path.join(binDirectory, "workspace-cli-client.mjs");
+  const script = `#!/bin/sh\nexec ${shellQuote(process.execPath)} "$(dirname "$0")/workspace-cli-client.mjs" "$@"\n`;
+  await writeFile(client, `import net from "node:net";
+const socket = net.createConnection(${JSON.stringify(socketPath)});
+let response = "";
+socket.setEncoding("utf8");
+socket.on("connect", () => socket.write(JSON.stringify(process.argv.slice(2)) + "\\n"));
+socket.on("data", (chunk) => { response += chunk; });
+socket.on("end", () => {
+  try {
+    const result = JSON.parse(response.trim());
+    process.stdout.write(result.stdout ?? "");
+    process.stderr.write(result.stderr ?? "");
+    process.exitCode = result.exitCode ?? 1;
+  } catch {
+    process.stderr.write("invalid eval proxy response\\n");
+    process.exitCode = 2;
+  }
+});
+socket.on("error", () => {
+  process.stderr.write("eval proxy unavailable\\n");
+  process.exitCode = 2;
+});
+`);
+  await writeFile(wrapper, script);
+  await chmod(wrapper, 0o755);
+  const schema = path.join(directory, "answer-schema.json");
+  await writeFile(schema, `${JSON.stringify({
+    type: "object",
+    additionalProperties: false,
+    required: ["gmail", "calendar", ...(options.driveName ? ["drive"] : [])],
+    properties: {
+      gmail: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "name", "type"],
+        properties: { id: { type: "string" }, name: { type: "string" }, type: { type: "string" } },
+      },
+      calendar: {
+        type: "object",
+        additionalProperties: false,
+        required: ["id", "timeZone"],
+        properties: { id: { type: "string" }, timeZone: { type: "string" } },
+      },
+      ...(options.driveName ? {
+        drive: {
+          type: "object",
+          additionalProperties: false,
+          required: ["name", "ids"],
+          properties: { name: { type: "string" }, ids: { type: "array", items: { type: "string" } } },
+        },
+      } : {}),
+    },
+  }, null, 2)}\n`);
+  return { directory, binDirectory, schema, wrapper };
+}
+
+export function agentEnvironment(environment, binDirectory) {
+  const allowed = [
+    "HOME", "USER", "LOGNAME", "SHELL", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "COLORTERM",
+    "TMPDIR", "TMP", "TEMP", "NO_COLOR", "CODEX_HOME", "OPENCLAW_HOME",
+    "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME",
+  ];
+  const safe = {};
+  for (const key of allowed) {
+    if (environment[key] != null) safe[key] = environment[key];
+  }
+  safe.PATH = `${binDirectory}:${environment.PATH ?? "/usr/bin:/bin"}`;
+  return safe;
+}
+
+async function runAgent(agent, cli, repetition, fixtures, options, environment) {
+  const proxy = await startCliProxy(cli, options, environment);
+  const runDirectory = await createRunDirectory(options, proxy.socketPath);
+  const prompt = buildPrompt(options.driveName, runDirectory.wrapper);
+  const env = agentEnvironment(environment, runDirectory.binDirectory);
+  const sessionId = `gog-eval-${cli}-${Date.now()}-${Math.random().toString(16).slice(2, 10)}`;
+  const command = agent === "codex" ? "codex" : "openclaw";
+  const args = agent === "codex"
+    ? [
+      "exec", "--ephemeral", "--skip-git-repo-check", "--json", "--sandbox", "danger-full-access",
+      "-c", 'model_reasoning_effort="low"', "-C", runDirectory.directory,
+      ...(options.codexModel ? ["--model", options.codexModel] : []),
+      "--output-schema", runDirectory.schema, prompt,
+    ]
+    : [
+      "agent", "--agent", "main", "--session-id", sessionId, "--message", prompt,
+      ...(options.openclawModel ? ["--model", options.openclawModel] : []),
+      "--thinking", "low", "--json", "--timeout", String(Math.ceil(options.timeoutMs / 1000)),
+    ];
+  let processResult;
+  try {
+    processResult = await runProcess(command, args, {
+      cwd: runDirectory.directory,
+      env,
+      timeoutMs: options.timeoutMs,
+    });
+  } finally {
+    await proxy.close();
+  }
+  await writeFile(path.join(runDirectory.directory, "agent.stdout.log"), processResult.stdout);
+  await writeFile(path.join(runDirectory.directory, "agent.stderr.log"), processResult.stderr);
+  process.stderr.write(`artifacts=${runDirectory.directory}\n`);
+  const base = {
+    agent,
+    cli,
+    repetition,
+    exit_code: processResult.exitCode,
+    elapsed_ms: Math.round(processResult.elapsedMs),
+    timed_out: processResult.timedOut,
+  };
+  try {
+    if (processResult.exitCode !== 0) throw new Error(`agent exited ${processResult.exitCode}`);
+    const parsed = agent === "codex"
+      ? parseCodex(processResult.stdout)
+      : await parseOpenClaw(processResult.stdout, sessionId);
+    const answers = extractJson(parsed.text);
+    const score = scoreAnswers(answers, fixtures);
+    return {
+      ...base,
+      model: parsed.model ?? (agent === "codex" ? options.codexModel || "default" : "unknown"),
+      provider: parsed.provider ?? null,
+      metrics: { ...parsed.metrics, elapsed_ms: base.elapsed_ms },
+      checks: score.checks,
+      passed: score.passed,
+      total: score.total,
+      success: score.passed === score.total,
+    };
+  } catch (error) {
+    return {
+      ...base,
+      metrics: { elapsed_ms: base.elapsed_ms },
+      checks: Object.keys(fixtures).map((name) => ({ name, pass: false })),
+      passed: 0,
+      total: Object.keys(fixtures).length,
+      success: false,
+      error: error.message,
+    };
+  }
+}
+
+function median(values) {
+  const sorted = values.filter((value) => Number.isFinite(value)).sort((a, b) => a - b);
+  if (sorted.length === 0) return null;
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[middle] : (sorted[middle - 1] + sorted[middle]) / 2;
+}
+
+function aggregate(runs) {
+  return {
+    runs: runs.length,
+    successes: runs.filter((run) => run.success).length,
+    median_total_tokens: median(runs.map((run) => run.metrics.total_tokens)),
+    median_uncached_tokens: median(runs.map((run) => run.metrics.uncached_tokens)),
+    median_tool_calls: median(runs.map((run) => run.metrics.tool_calls)),
+    median_elapsed_ms: median(runs.map((run) => run.metrics.elapsed_ms)),
+  };
+}
+
+export function compareAggregates(gog, gws) {
+  if (gog.successes === 0 && gws.successes === 0) {
+    return { winner: "tie", criterion: "no_correct_runs" };
+  }
+  const criteria = [
+    ["successes", "higher"],
+    ["median_total_tokens", "lower"],
+    ["median_tool_calls", "lower"],
+    ["median_elapsed_ms", "lower"],
+  ];
+  for (const [field, direction] of criteria) {
+    const left = gog[field];
+    const right = gws[field];
+    if (left == null || right == null || left === right) continue;
+    const gogWins = direction === "higher" ? left > right : left < right;
+    return { winner: gogWins ? "gog" : "gws", criterion: field };
+  }
+  return { winner: "tie", criterion: null };
+}
+
+export function summarize(runs, agents) {
+  const byAgent = {};
+  for (const agent of agents) {
+    const gog = aggregate(runs.filter((run) => run.agent === agent && run.cli === "gog"));
+    const gws = aggregate(runs.filter((run) => run.agent === agent && run.cli === "gws"));
+    byAgent[agent] = { gog, gws, comparison: compareAggregates(gog, gws) };
+  }
+  const comparisons = Object.values(byAgent).map((entry) => entry.comparison.winner);
+  return {
+    by_agent: byAgent,
+    gog_better: comparisons.every((winner) => winner === "gog" || winner === "tie")
+      && comparisons.some((winner) => winner === "gog"),
+  };
+}
+
+export async function runEvaluation(options, environment = process.env) {
+  const fixtures = await loadFixtures(options, environment);
+  const runs = [];
+  for (let repetition = 1; repetition <= options.repetitions; repetition += 1) {
+    for (const agent of options.agents) {
+      const cliOrder = repetition % 2 === 1 ? ["gog", "gws"] : ["gws", "gog"];
+      for (const cli of cliOrder) {
+        process.stderr.write(`agent=${agent} cli=${cli} repetition=${repetition}\n`);
+        runs.push(await runAgent(agent, cli, repetition, fixtures, options, environment));
+      }
+    }
+  }
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    configuration: {
+      agents: options.agents,
+      repetitions: options.repetitions,
+      tasks: Object.keys(fixtures),
+      requested_models: {
+        codex: options.codexModel || "default",
+        openclaw: options.openclawModel || "default",
+      },
+    },
+    runs,
+    summary: summarize(runs, options.agents),
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const report = await runEvaluation(options);
+  const output = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.out) await writeFile(options.out, output);
+  process.stdout.write(output);
+  if (!report.summary.gog_better) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/eval-gws-agents.test.mjs
+++ b/scripts/eval-gws-agents.test.mjs
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentEnvironment,
+  allowedAgentArgs,
+  buildPrompt,
+  compareAggregates,
+  extractJson,
+  fixturesAgree,
+  parseCodex,
+  parseArgs,
+  scoreAnswers,
+} from "./eval-gws-agents.mjs";
+
+test("parseCodex counts legacy and current tool item types", () => {
+  const events = [
+    { type: "item.completed", item: { type: "command_execution" } },
+    { type: "item.completed", item: { type: "local_shell_call" } },
+    { type: "item.completed", item: { type: "web_search_call" } },
+    { type: "item.completed", item: { type: "agent_message", text: '{"ok":true}' } },
+    { type: "turn.completed", usage: { input_tokens: 10, cached_input_tokens: 4, output_tokens: 2 } },
+  ];
+  const parsed = parseCodex(events.map((event) => JSON.stringify(event)).join("\n"));
+  assert.equal(parsed.metrics.tool_calls, 3);
+  assert.equal(parsed.metrics.total_tokens, 12);
+  assert.equal(parsed.metrics.uncached_tokens, 8);
+});
+
+test("allowedAgentArgs blocks credential and mutation commands", () => {
+  assert.equal(allowedAgentArgs("gog", ["gmail", "labels", "list", "--json"]), true);
+  assert.equal(allowedAgentArgs("gog", [
+    "drive", "search", "name = 'fixture' and trashed = false", "--raw-query", "--no-all-drives", "--max", "100", "--json",
+  ], "fixture"), true);
+  assert.equal(allowedAgentArgs("gws", [
+    "drive", "files", "list", "--params",
+    '{"q":"name = \'fixture\' and trashed = false","fields":"files(id,name)","spaces":"drive","corpora":"user"}',
+    "--format", "json", "--page-limit", "100",
+  ], "fixture"), true);
+  assert.equal(allowedAgentArgs("gog", ["auth", "tokens", "export"]), false);
+  assert.equal(allowedAgentArgs("gws", ["auth", "export", "--unmasked"]), false);
+  assert.equal(allowedAgentArgs("gog", ["gmail", "labels", "delete", "LABEL_1"]), false);
+  assert.equal(allowedAgentArgs("gog", ["drive", "delete", "file-id"]), false);
+  assert.equal(allowedAgentArgs("gog", ["drive", "search", "other file", "--json"], "fixture"), false);
+  assert.equal(allowedAgentArgs("gog", ["drive", "search", "fixture", "--json"], "fixture"), false);
+  assert.equal(allowedAgentArgs("gog", [
+    "drive", "search", "name = 'fixture' and trashed = false", "--raw-query", "--json",
+  ], "fixture"), false);
+  assert.equal(allowedAgentArgs("gws", [
+    "drive", "files", "list", "--params",
+    '{"q":"trashed = false","fields":"files(id,name,owners)"}',
+  ], "fixture"), false);
+});
+
+test("agentEnvironment excludes unrelated credentials", () => {
+  const env = agentEnvironment({
+    HOME: "/home/test",
+    PATH: "/usr/bin",
+    LANG: "C",
+    GITHUB_TOKEN: "secret",
+    GOG_KEYRING_PASSWORD: "secret",
+    OPENAI_API_KEY: "secret",
+  }, "/tmp/eval-bin");
+  assert.deepEqual(env, {
+    HOME: "/home/test",
+    LANG: "C",
+    PATH: "/tmp/eval-bin:/usr/bin",
+  });
+});
+
+test("parseArgs requires an account and validates agents", () => {
+  assert.throws(() => parseArgs([], {}), /account/);
+  assert.throws(() => parseArgs(["--account", "test@example.com", "--agents", "other"], {}), /agents/);
+  assert.equal(parseArgs(["--account", "test@example.com", "--repetitions", "2"], {}).repetitions, 2);
+});
+
+test("buildPrompt adds optional Drive task without revealing answers", () => {
+  const prompt = buildPrompt("fixture doc");
+  assert.match(prompt, /fixture doc/);
+  assert.match(prompt, /workspace-cli/);
+  assert.doesNotMatch(prompt, /clawdbot/);
+});
+
+test("extractJson accepts plain and fenced JSON", () => {
+  assert.deepEqual(extractJson('{"ok":true}'), { ok: true });
+  assert.deepEqual(extractJson('```json\n{"ok":true}\n```'), { ok: true });
+});
+
+test("scoreAnswers requires exact task results", () => {
+  const fixtures = {
+    gmail: [{ id: "INBOX", name: "INBOX", type: "system" }],
+    calendar: [{ id: "primary@example.com", timeZone: "UTC" }],
+    drive: { name: "fixture", ids: ["a", "b"] },
+  };
+  const score = scoreAnswers({
+    gmail: fixtures.gmail[0],
+    calendar: fixtures.calendar[0],
+    drive: { name: "fixture", ids: ["b", "a", "a"] },
+  }, fixtures);
+  assert.equal(score.passed, 3);
+  assert.equal(score.total, 3);
+});
+
+test("fixture agreement is order-sensitive after normalization", () => {
+  assert.equal(fixturesAgree({ ids: ["a", "b"] }, { ids: ["a", "b"] }), true);
+  assert.equal(fixturesAgree({ ids: ["a", "b"] }, { ids: ["b", "a"] }), false);
+});
+
+test("comparison prioritizes correctness over efficiency", () => {
+  assert.deepEqual(compareAggregates(
+    { successes: 0, median_total_tokens: null, median_tool_calls: null, median_elapsed_ms: 10 },
+    { successes: 0, median_total_tokens: null, median_tool_calls: null, median_elapsed_ms: 20 },
+  ), { winner: "tie", criterion: "no_correct_runs" });
+  assert.deepEqual(compareAggregates(
+    { successes: 2, median_total_tokens: 200, median_tool_calls: 4, median_elapsed_ms: 10 },
+    { successes: 1, median_total_tokens: 10, median_tool_calls: 1, median_elapsed_ms: 1 },
+  ), { winner: "gog", criterion: "successes" });
+  assert.deepEqual(compareAggregates(
+    { successes: 2, median_total_tokens: 100, median_tool_calls: 4, median_elapsed_ms: 10 },
+    { successes: 2, median_total_tokens: 150, median_tool_calls: 1, median_elapsed_ms: 1 },
+  ), { winner: "gog", criterion: "median_total_tokens" });
+});

--- a/scripts/eval-gws.mjs
+++ b/scripts/eval-gws.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+import { readFile, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import path from "node:path";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function parseArgs(argv) {
+  const options = {
+    gog: path.join(root, "bin", "gog"),
+    gws: "gws",
+    scenarios: path.join(root, "evals", "gws", "scenarios.json"),
+    out: "",
+    timeoutMs: 30_000,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    switch (key) {
+      case "--gog": options.gog = value; index += 1; break;
+      case "--gws": options.gws = value; index += 1; break;
+      case "--scenarios": options.scenarios = value; index += 1; break;
+      case "--out": options.out = value; index += 1; break;
+      case "--timeout-ms": options.timeoutMs = Number(value); index += 1; break;
+      default: throw new Error(`unknown argument: ${key}`);
+    }
+  }
+  if (!Number.isFinite(options.timeoutMs) || options.timeoutMs <= 0) {
+    throw new Error("--timeout-ms must be positive");
+  }
+  return options;
+}
+
+export function runCase(binary, spec, timeoutMs, environment = process.env) {
+  const started = process.hrtime.bigint();
+  const result = spawnSync(binary, spec.args, {
+    encoding: "utf8",
+    timeout: timeoutMs,
+    env: environment,
+  });
+  const elapsedMs = Number(process.hrtime.bigint() - started) / 1e6;
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  const exitCode = result.status ?? (result.error ? -1 : 0);
+  const checks = [];
+  checks.push({name: "exit", pass: (spec.exit ?? [0]).includes(exitCode), actual: exitCode, expected: spec.exit ?? [0]});
+  for (const expected of spec.contains ?? []) {
+    checks.push({name: `contains:${expected}`, pass: `${stdout}\n${stderr}`.includes(expected)});
+  }
+  if (spec.json) {
+    let valid = false;
+    try { JSON.parse(stdout); valid = true; } catch {}
+    checks.push({name: "json", pass: valid});
+  }
+  return {
+    args: spec.args,
+    exit_code: exitCode,
+    elapsed_ms: Math.round(elapsedMs * 100) / 100,
+    stdout_bytes: Buffer.byteLength(stdout),
+    stderr_bytes: Buffer.byteLength(stderr),
+    stdout_lines: stdout === "" ? 0 : stdout.trimEnd().split("\n").length,
+    checks,
+    pass: checks.every((check) => check.pass),
+    error: result.error?.message,
+  };
+}
+
+export async function runEvaluation(options) {
+  const suite = JSON.parse(await readFile(options.scenarios, "utf8"));
+  if (suite.schema_version !== 1 || !Array.isArray(suite.scenarios)) {
+    throw new Error("invalid scenario file");
+  }
+  const environment = {...process.env};
+  delete environment.GOG_ACCESS_TOKEN;
+  delete environment.GOOGLE_WORKSPACE_CLI_TOKEN;
+  const scenarios = suite.scenarios.map((scenario) => ({
+    id: scenario.id,
+    description: scenario.description,
+    gog: runCase(options.gog, scenario.gog, options.timeoutMs, environment),
+    gws: runCase(options.gws, scenario.gws, options.timeoutMs, environment),
+  }));
+  return {
+    schema_version: 1,
+    generated_at: new Date().toISOString(),
+    host: {platform: process.platform, arch: process.arch, node: process.version},
+    binaries: {gog: options.gog, gws: options.gws},
+    scenarios,
+    summary: {
+      gog_passed: scenarios.filter((scenario) => scenario.gog.pass).length,
+      gws_passed: scenarios.filter((scenario) => scenario.gws.pass).length,
+      total: scenarios.length,
+    },
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const report = await runEvaluation(options);
+  const output = `${JSON.stringify(report, null, 2)}\n`;
+  if (options.out) await writeFile(options.out, output);
+  process.stdout.write(output);
+  if (report.summary.gog_passed !== report.summary.total || report.summary.gws_passed !== report.summary.total) process.exitCode = 1;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/scripts/eval-gws.test.mjs
+++ b/scripts/eval-gws.test.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseArgs, runCase } from "./eval-gws.mjs";
+
+test("parseArgs validates timeout", () => {
+  assert.throws(() => parseArgs(["--timeout-ms", "0"]), /positive/);
+  assert.equal(parseArgs(["--gog", "/tmp/gog"]).gog, "/tmp/gog");
+});
+
+test("runCase records assertions and metrics", () => {
+  const result = runCase(process.execPath, {
+    args: ["-e", "process.stdout.write(JSON.stringify({ok:true}))"],
+    exit: [0],
+    contains: ["ok"],
+    json: true,
+  }, 5_000, process.env);
+  assert.equal(result.pass, true);
+  assert.equal(result.exit_code, 0);
+  assert.ok(result.stdout_bytes > 0);
+  assert.ok(result.elapsed_ms >= 0);
+});


### PR DESCRIPTION
## Summary

Adds reproducible structural and live-agent comparisons between gog and Google's Discovery-driven `gws` CLI, then uses the measured failure mode to improve gog's agent discoverability.

The initial counterbalanced Codex baseline was not acceptable: both CLIs were correct, but gog used 105,980 median total tokens and 8 tool calls versus GWS at 78,019 tokens and 4.5 calls. The branch now adds compact `GOG_HELP=agent` root help with executable Gmail, Calendar, and Drive recipes. The final committed-code matrix reverses the token result while retaining full correctness.

## What changed

- Retains the credential-free structural suite for help, schema, invalid-command behavior, output size, and latency.
- Adds a live Codex/OpenClaw suite with identical Gmail-label, primary-calendar, and exact-name Drive tasks through a neutral executable path.
- Records correctness assertions, input/cache/output/reasoning tokens, normalized uncached tokens, tool-call counts, latency, exit state, and timeouts.
- Counterbalances provider prompt caches by reversing CLI order on the second repetition.
- Adds `GOG_HELP=agent`, reducing gog root help from 6,501 bytes to 778 bytes while keeping recipes, targeted schema discovery, stable-output guidance, and exit codes.
- Updates the gog skill, comparison methodology, Make targets, tests, and changelog.

## Final live result

Two repetitions per agent/CLI pair; CLI order reversed on repetition two. All 24 task assertions passed.

| Agent | CLI | Correct runs | Median total tokens | Median uncached tokens | Median tool calls | Median latency |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| Codex | gog | 2/2 | 94,078.5 | 15,230.5 | 7 | 13,735 ms |
| Codex | GWS | 2/2 | 97,546 | 21,770 | 7 | 13,676 ms |
| OpenClaw | gog | 2/2 | 38,350.5 | 2,638.5 | 7 | 41,124.5 ms |
| OpenClaw | GWS | 2/2 | 45,727 | 8,735 | 7 | 45,597 ms |

Correctness is the first comparison criterion. With correctness tied, gog uses 3.6% fewer total tokens in Codex and 16.1% fewer in OpenClaw. OpenClaw also completes 9.8% faster; Codex latency is effectively tied (gog is 59 ms slower). Codex used its configured default model; OpenClaw reported `gpt-5.5` through the OpenAI provider.

## Safety and methodology

- Agents receive no parent-shell credential variables.
- Authentication remains in the evaluator parent process behind a credential-free local proxy.
- The proxy uses a private `0700` temporary directory and `0600` Unix socket.
- The proxy accepts only help/schema plus exact task-scoped Gmail, Calendar, and Drive reads; credential, mutation, full-text, shared-drive, broad-field, and unbounded-pagination requests are rejected.
- Direct fixture queries must agree between gog and GWS before scoring; a requested Drive fixture must be non-empty.
- Reports omit API responses, file IDs, account addresses, and raw transcripts. Local diagnostic traces stay in printed temporary artifact directories.
- Results remain stratified by agent because fixed prompt/cache overhead differs substantially.

## Reproduce

Structural suite:

```bash
make build
npm install --prefix /tmp/gws-eval @googleworkspace/cli@0.22.5
GWS_BIN=/tmp/gws-eval/node_modules/.bin/gws make eval-gws
```

Live suite, using the same disposable read-only account in both CLIs:

```bash
GOG_EVAL_ACCOUNT=test-account@example.com \
GOG_EVAL_DRIVE_NAME='exact fixture file name' \
GWS_BIN=/tmp/gws-eval/node_modules/.bin/gws \
make eval-gws-agents
```

The Drive task is optional. Model defaults can be pinned with `GOG_EVAL_CODEX_MODEL` and `GOG_EVAL_OPENCLAW_MODEL`.

## Validation

- Final live committed-code matrix: 8 agent runs, 24/24 assertions, gog wins both correctness-first comparisons on total tokens.
- `make ci`: 0 lint issues; all Go and Node tests pass; generated docs and coverage checks pass.
- Autoreview: clean, no accepted/actionable findings after fixes for environment isolation, non-empty fixtures, tool-call compatibility, exact proxy scoping, private socket permissions, explicit GWS JSON, and My Drive-only exact queries.

## Product conclusion

GWS's regular Discovery grammar remains a strong long-tail primitive. Gog can outperform it on curated workflows when root discovery is compact and executable. This PR preserves gog's stable output, safety, and multi-account model while making the first agent turn materially cheaper.
