### PR TITLE
feat(calendar): add --event-types filter to calendar events

### DIFF
--- a/docs/commands/gog-calendar-events.md
+++ b/docs/commands/gog-calendar-events.md
@@ -31,6 +31,7 @@ gog calendar (cal) events (list,ls) [<calendarId> ...] [flags]
 | `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
 | `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
 | `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `--event-types` | `[]string` |  | Filter to event types (repeatable or comma-separated): default, birthday, focus-time, from-gmail, out-of-office, working-location |
 | `--fail-empty`<br>`--non-empty`<br>`--require-results` | `bool` |  | Exit with code 3 if no results |
 | `--fields` | `string` |  | Comma-separated fields to return |
 | `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -273,7 +273,8 @@ Drive hierarchy semantics:
 - `gog calendar create-calendar <summary> [--description D] [--timezone TZ] [--location L]`
 - `gog calendar delete-calendar <ownedSecondaryCalendarId>`
 - `gog calendar acl <calendarId>`
-- `gog calendar events <calendarId> [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339] [--to RFC3339] [--max N] [--page TOKEN] [--query Q] [--weekday]`
+- `gog calendar events <calendarId> [--cal ID_OR_NAME] [--calendars CSV] [--all] [--from RFC3339] [--to RFC3339] [--max N] [--page TOKEN] [--query Q] [--event-types TYPES] [--weekday]`
+  - `--event-types` filters to one or more event types (repeatable or comma-separated): `default`, `birthday`, `focus-time`, `from-gmail`, `out-of-office`, `working-location`. Unset returns all types (the API default).
 - `gog calendar event|get <calendarId> <eventId>`
 - `GOG_CALENDAR_WEEKDAY=1` defaults `--weekday` for `gog calendar events`
 - `gog calendar create <calendarId> --summary S --from DT --to DT [--timezone TZ] [--start-timezone TZ] [--end-timezone TZ] [--description D] [--location L|--location-search Q|--place-id ID] [--place-language LANG] [--place-region REGION] [--attendees a@b.com,c@d.com] [--all-day] [--event-type TYPE]`

--- a/internal/cmd/calendar_all_events_test.go
+++ b/internal/cmd/calendar_all_events_test.go
@@ -63,7 +63,7 @@ func TestListAllCalendarsEvents_JSON(t *testing.T) {
 	ctx := newCmdJSONContext(t)
 
 	jsonOut := captureStdout(t, func() {
-		if runErr := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "", ""); runErr != nil {
+		if runErr := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); runErr != nil {
 			t.Fatalf("listAllCalendarsEvents: %v", runErr)
 		}
 	})
@@ -126,7 +126,7 @@ func TestListAllCalendarsEvents_SortByStart(t *testing.T) {
 
 	ctx := newCmdJSONContext(t)
 	jsonOut := captureStdout(t, func() {
-		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "start", "asc"); err != nil {
+		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "start", "asc"); err != nil {
 			t.Fatalf("listAllCalendarsEvents: %v", err)
 		}
 	})
@@ -153,7 +153,7 @@ func TestListAllCalendarsEvents_SortByStart(t *testing.T) {
 
 	// Descending order flips it.
 	jsonOut = captureStdout(t, func() {
-		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "start", "desc"); err != nil {
+		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "start", "desc"); err != nil {
 			t.Fatalf("listAllCalendarsEvents desc: %v", err)
 		}
 	})

--- a/internal/cmd/calendar_event_type.go
+++ b/internal/cmd/calendar_event_type.go
@@ -6,7 +6,9 @@ import (
 
 const (
 	eventTypeDefault         = "default"
+	eventTypeBirthday        = "birthday"
 	eventTypeFocusTime       = "focusTime"
+	eventTypeFromGmail       = "fromGmail"
 	eventTypeOutOfOffice     = "outOfOffice"
 	eventTypeWorkingLocation = "workingLocation"
 
@@ -18,23 +20,55 @@ const (
 	defaultOOOAutoDecline   = literalAll
 )
 
+// eventTypeAliases maps user-supplied event type spellings (canonical and
+// friendly aliases, all lowercase) to the canonical Calendar API eventType
+// value. It is the single source of truth for both the create/update path
+// (which further restricts to creatableEventTypes) and the events.list
+// eventTypes filter (which accepts every type the API can return).
+var eventTypeAliases = map[string]string{
+	"default":          eventTypeDefault,
+	"birthday":         eventTypeBirthday,
+	"focus":            eventTypeFocusTime,
+	"focus-time":       eventTypeFocusTime,
+	"focustime":        eventTypeFocusTime,
+	"focus_time":       eventTypeFocusTime,
+	"from-gmail":       eventTypeFromGmail,
+	"fromgmail":        eventTypeFromGmail,
+	"from_gmail":       eventTypeFromGmail,
+	"ooo":              eventTypeOutOfOffice,
+	"out-of-office":    eventTypeOutOfOffice,
+	"outofoffice":      eventTypeOutOfOffice,
+	"out_of_office":    eventTypeOutOfOffice,
+	"wl":               eventTypeWorkingLocation,
+	"working-location": eventTypeWorkingLocation,
+	"workinglocation":  eventTypeWorkingLocation,
+	"working_location": eventTypeWorkingLocation,
+}
+
+// creatableEventTypes are the event types that can be set when creating or
+// updating an event. birthday and fromGmail are read-only — they sync from
+// Google Contacts and Gmail — so the create/update path rejects them, even
+// though they remain valid values for the events.list filter.
+var creatableEventTypes = map[string]bool{
+	eventTypeDefault:         true,
+	eventTypeFocusTime:       true,
+	eventTypeOutOfOffice:     true,
+	eventTypeWorkingLocation: true,
+}
+
+// normalizeEventType maps a user-supplied event type to a canonical value for
+// the create/update path, which accepts only the user-creatable types. An empty
+// value returns an empty string so callers can fall back to the boolean
+// event-type flags.
 func normalizeEventType(raw string) (string, error) {
 	raw = strings.TrimSpace(strings.ToLower(raw))
 	if raw == "" {
 		return "", nil
 	}
-	switch raw {
-	case eventTypeDefault:
-		return eventTypeDefault, nil
-	case "focus", "focus-time", "focustime", "focus_time":
-		return eventTypeFocusTime, nil
-	case "out-of-office", "ooo", "outofoffice", "out_of_office":
-		return eventTypeOutOfOffice, nil
-	case "working-location", "workinglocation", "working_location", "wl":
-		return eventTypeWorkingLocation, nil
-	default:
-		return "", usagef("invalid event type: %q (must be %s, focus-time, out-of-office, or working-location)", raw, eventTypeDefault)
+	if canonical, ok := eventTypeAliases[raw]; ok && creatableEventTypes[canonical] {
+		return canonical, nil
 	}
+	return "", usagef("invalid event type: %q (must be one of: default, focus-time, out-of-office, working-location)", raw)
 }
 
 func resolveEventType(raw string, focusFlags, oooFlags, workingFlags bool) (string, error) {
@@ -82,4 +116,46 @@ func resolveEventType(raw string, focusFlags, oooFlags, workingFlags bool) (stri
 		}
 	}
 	return eventType, nil
+}
+
+// normalizeFilterEventType maps a user-supplied event type (canonical or a
+// friendly alias) to a canonical Calendar API eventType value for the
+// events.list eventTypes filter. Unlike normalizeEventType, it accepts every
+// type the API can return — including the read-only birthday and fromGmail,
+// which are common things to filter on.
+func normalizeFilterEventType(raw string) (string, error) {
+	if canonical, ok := eventTypeAliases[strings.TrimSpace(strings.ToLower(raw))]; ok {
+		return canonical, nil
+	}
+	return "", usagef("invalid event type: %q (must be one of: default, birthday, focus-time, from-gmail, out-of-office, working-location)", raw)
+}
+
+// resolveFilterEventTypes flattens repeated and comma-separated --event-types
+// values into a deduplicated list of canonical Calendar API eventType values,
+// preserving first-seen order. A nil/empty slice (flag absent) leaves the
+// request unfiltered — the API default of returning all types — while a flag
+// that resolves to no values (e.g. --event-types "") is a usage error.
+func resolveFilterEventTypes(raw []string) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]string, 0, len(raw))
+	seen := make(map[string]struct{})
+	for _, item := range raw {
+		for _, part := range splitCSV(item) {
+			canonical, err := normalizeFilterEventType(part)
+			if err != nil {
+				return nil, err
+			}
+			if _, ok := seen[canonical]; ok {
+				continue
+			}
+			seen[canonical] = struct{}{}
+			out = append(out, canonical)
+		}
+	}
+	if len(out) == 0 {
+		return nil, usage("--event-types must include at least one value")
+	}
+	return out, nil
 }

--- a/internal/cmd/calendar_event_type_test.go
+++ b/internal/cmd/calendar_event_type_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestNormalizeEventType(t *testing.T) {
 	cases := []struct {
@@ -34,4 +37,102 @@ func TestResolveEventTypeConflicts(t *testing.T) {
 	requireUsageError(t, err)
 	_, err = resolveEventType("nope", false, false, false)
 	requireUsageError(t, err)
+}
+
+func TestNormalizeFilterEventType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"default", eventTypeDefault},
+		{"birthday", eventTypeBirthday},
+		{"BIRTHDAY", eventTypeBirthday},
+		{"focus-time", eventTypeFocusTime},
+		{"focusTime", eventTypeFocusTime},
+		{"from-gmail", eventTypeFromGmail},
+		{"fromGmail", eventTypeFromGmail},
+		{"ooo", eventTypeOutOfOffice},
+		{"out-of-office", eventTypeOutOfOffice},
+		{"wl", eventTypeWorkingLocation},
+		{"  workingLocation  ", eventTypeWorkingLocation},
+	}
+	for _, tc := range cases {
+		got, err := normalizeFilterEventType(tc.in)
+		if err != nil {
+			t.Fatalf("normalizeFilterEventType(%q): %v", tc.in, err)
+		}
+		if got != tc.want {
+			t.Fatalf("normalizeFilterEventType(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeFilterEventTypeInvalid(t *testing.T) {
+	// "gmail" is intentionally not an alias (too ambiguous); only "from-gmail"
+	// and its spellings map to fromGmail.
+	for _, in := range []string{"nope", "meeting", "gmail", ""} {
+		if _, err := normalizeFilterEventType(in); err == nil {
+			t.Fatalf("normalizeFilterEventType(%q): expected usage error", in)
+		}
+	}
+}
+
+func TestCreatableEventTypesAreAliased(t *testing.T) {
+	// Invariant: every creatable type must be reachable through the shared
+	// eventTypeAliases map, so normalizeEventType can never reject a type that
+	// creatableEventTypes claims is creatable. (The reverse need not hold:
+	// the alias map is a superset that also includes the read-only types.)
+	canonical := make(map[string]bool, len(eventTypeAliases))
+	for _, c := range eventTypeAliases {
+		canonical[c] = true
+	}
+	for ct := range creatableEventTypes {
+		if !canonical[ct] {
+			t.Fatalf("creatable event type %q has no entry in eventTypeAliases", ct)
+		}
+	}
+}
+
+func TestNormalizeEventTypeRejectsFilterOnlyTypes(t *testing.T) {
+	// birthday and fromGmail are valid filter values but are not user-creatable,
+	// so the create/update normalizer must reject them.
+	for _, in := range []string{"birthday", "fromGmail", "from-gmail"} {
+		if _, err := normalizeEventType(in); err == nil {
+			t.Fatalf("normalizeEventType(%q): expected usage error (not creatable)", in)
+		}
+	}
+}
+
+func TestResolveFilterEventTypes(t *testing.T) {
+	// Repeated and comma-separated values, with aliases, are flattened,
+	// canonicalized, and deduplicated in first-seen order.
+	got, err := resolveFilterEventTypes([]string{"birthday, workingLocation", "wl", "focus-time"})
+	if err != nil {
+		t.Fatalf("resolveFilterEventTypes: %v", err)
+	}
+	want := []string{eventTypeBirthday, eventTypeWorkingLocation, eventTypeFocusTime}
+	if !slices.Equal(got, want) {
+		t.Fatalf("resolveFilterEventTypes = %v, want %v", got, want)
+	}
+
+	// Flag absent (nil or empty slice) leaves the request unfiltered.
+	for _, in := range [][]string{nil, {}} {
+		got, err := resolveFilterEventTypes(in)
+		if err != nil {
+			t.Fatalf("resolveFilterEventTypes(%v): %v", in, err)
+		}
+		if got != nil {
+			t.Fatalf("resolveFilterEventTypes(%v) = %v, want nil", in, got)
+		}
+	}
+
+	// A flag that is present but resolves to no values is a usage error.
+	if _, err := resolveFilterEventTypes([]string{"", "  "}); err == nil {
+		t.Fatal("resolveFilterEventTypes(blanks): expected usage error")
+	}
+
+	// An invalid value anywhere is surfaced as an error.
+	if _, err := resolveFilterEventTypes([]string{"default", "bogus"}); err == nil {
+		t.Fatal("resolveFilterEventTypes: expected error for invalid type")
+	}
 }

--- a/internal/cmd/calendar_events_cmds.go
+++ b/internal/cmd/calendar_events_cmds.go
@@ -24,6 +24,7 @@ type CalendarEventsCmd struct {
 	AllPages          bool     `name:"all-pages" aliases:"allpages" help:"Fetch all pages"`
 	FailEmpty         bool     `name:"fail-empty" aliases:"non-empty,require-results" help:"Exit with code 3 if no results"`
 	Query             string   `name:"query" help:"Free text search"`
+	EventTypes        []string `name:"event-types" help:"Filter to event types (repeatable or comma-separated): default, birthday, focus-time, from-gmail, out-of-office, working-location"`
 	All               bool     `name:"all" help:"Fetch events from all calendars"`
 	PrivatePropFilter string   `name:"private-prop-filter" help:"Filter by private extended property (key=value)"`
 	SharedPropFilter  string   `name:"shared-prop-filter" help:"Filter by shared extended property (key=value)"`
@@ -88,8 +89,13 @@ func (c *CalendarEventsCmd) Run(ctx context.Context, flags *RootFlags) error {
 
 	from, to := timeRange.FormatRFC3339()
 
+	eventTypes, err := resolveFilterEventTypes(c.EventTypes)
+	if err != nil {
+		return err
+	}
+
 	if c.All {
-		return listAllCalendarsEvents(ctx, svc, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, c.Weekday, c.Location, c.Sort, c.Order)
+		return listAllCalendarsEvents(ctx, svc, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order)
 	}
 	if len(calInputs) > 0 {
 		ids, err := resolveCalendarIDs(ctx, store, svc, calInputs)
@@ -99,9 +105,9 @@ func (c *CalendarEventsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if len(ids) == 0 {
 			return usage("no calendars specified")
 		}
-		return listSelectedCalendarsEvents(ctx, svc, ids, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, c.Weekday, c.Location, c.Sort, c.Order)
+		return listSelectedCalendarsEvents(ctx, svc, ids, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order)
 	}
-	return listCalendarEvents(ctx, svc, calendarID, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, c.Weekday, c.Location, c.Sort, c.Order)
+	return listCalendarEvents(ctx, svc, calendarID, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order)
 }
 
 func normalizeCalendarEventsArgs(args []string) (string, error) {

--- a/internal/cmd/calendar_events_test.go
+++ b/internal/cmd/calendar_events_test.go
@@ -6,7 +6,9 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"maps"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -30,7 +32,7 @@ func TestListCalendarEvents_JSON(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 
@@ -82,7 +84,7 @@ func TestListCalendarEvents_TableUsesCalendarTimezone(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 	text := output.String()
@@ -127,7 +129,7 @@ func TestListCalendarEvents_TableIncludesLocation(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 	text := output.String()
@@ -137,7 +139,7 @@ func TestListCalendarEvents_TableIncludesLocation(t *testing.T) {
 	}
 
 	output.Reset()
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", false, true, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, true, "", ""); err != nil {
 		t.Fatalf("listCalendarEvents with location: %v", err)
 	}
 	text = output.String()
@@ -160,7 +162,7 @@ func TestListCalendarEvents_JSONUsesCalendarTimezoneForLocalFields(t *testing.T)
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 
@@ -300,6 +302,97 @@ func TestCalendarEventsCmd_CalendarsFlag(t *testing.T) {
 	if calls["c1"] == 0 || calls["c2"] == 0 || calls["c3"] != 0 {
 		t.Fatalf("unexpected calendar calls: %#v", calls)
 	}
+}
+
+func TestCalendarEventsCmd_EventTypesAcrossCalendars(t *testing.T) {
+	// The --event-types filter must reach the events.list call for every
+	// calendar on the multi-calendar paths (--cal/--calendars and --all), not
+	// just the single-calendar path covered by
+	// TestCalendarEventsListCall_EventTypesFilter.
+	want := []string{eventTypeBirthday, eventTypeDefault}
+
+	var mu sync.Mutex
+	captured := make(map[string][]string) // calendarID -> eventTypes query on its events request
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/calendarList") &&
+			!strings.Contains(r.URL.Path, "/calendarList/primary") &&
+			r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"id": "c1", "summary": "Work"},
+					{"id": "c2", "summary": "Family"},
+					{"id": "c3", "summary": "Other"},
+				},
+			})
+		case strings.HasSuffix(r.URL.Path, "/events") && r.Method == http.MethodGet:
+			calID := ""
+			parts := strings.Split(r.URL.Path, "/")
+			for i, p := range parts {
+				if p == "calendars" && i+1 < len(parts) {
+					calID = parts[i+1]
+					break
+				}
+			}
+			mu.Lock()
+			captured[calID] = r.URL.Query()["eventTypes"]
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	run := func(t *testing.T, mutate func(*CalendarEventsCmd)) map[string][]string {
+		t.Helper()
+		mu.Lock()
+		captured = make(map[string][]string)
+		mu.Unlock()
+		svc, closeServer := newCalendarServiceForTest(t, withPrimaryCalendar(handler))
+		defer closeServer()
+
+		ctx := withCalendarTestService(newCmdRuntimeJSONOutputContext(t, &bytes.Buffer{}, io.Discard), svc)
+		cmd := &CalendarEventsCmd{
+			From:       "2025-01-01T00:00:00Z",
+			To:         "2025-01-02T00:00:00Z",
+			Max:        10,
+			EventTypes: []string{"birthday", "default"},
+		}
+		mutate(cmd)
+		if err := cmd.Run(ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		return maps.Clone(captured)
+	}
+
+	assertReached := func(t *testing.T, got map[string][]string, cals ...string) {
+		t.Helper()
+		for _, cal := range cals {
+			ets, ok := got[cal]
+			if !ok {
+				t.Fatalf("calendar %s was not queried; captured=%v", cal, got)
+			}
+			if !slices.Equal(ets, want) {
+				t.Fatalf("calendar %s eventTypes = %v, want %v", cal, ets, want)
+			}
+		}
+	}
+
+	t.Run("--calendars", func(t *testing.T) {
+		got := run(t, func(c *CalendarEventsCmd) { c.Calendars = "1,Family" })
+		assertReached(t, got, "c1", "c2")
+	})
+
+	t.Run("--all", func(t *testing.T) {
+		got := run(t, func(c *CalendarEventsCmd) { c.All = true })
+		assertReached(t, got, "c1", "c2", "c3")
+	})
 }
 
 func TestCalendarEventsCmd_ListSelectors(t *testing.T) {

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -14,7 +14,7 @@ import (
 	"github.com/steipete/gogcli/internal/ui"
 )
 
-func calendarEventsListCall(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, query, privatePropFilter, sharedPropFilter, fields, pageToken string) *calendar.EventsListCall {
+func calendarEventsListCall(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, pageToken string) *calendar.EventsListCall {
 	call := svc.Events.List(calendarID).
 		TimeMin(from).
 		TimeMax(to).
@@ -23,6 +23,9 @@ func calendarEventsListCall(ctx context.Context, svc *calendar.Service, calendar
 		OrderBy("startTime").
 		ShowDeleted(false).
 		Context(ctx)
+	if len(eventTypes) > 0 {
+		call = call.EventTypes(eventTypes...)
+	}
 	if strings.TrimSpace(pageToken) != "" {
 		call = call.PageToken(pageToken)
 	}
@@ -41,10 +44,10 @@ func calendarEventsListCall(ctx context.Context, svc *calendar.Service, calendar
 	return call
 }
 
-func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
+func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
 	calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calendarID, nil)
 	fetch := func(pageToken string) ([]*calendar.Event, string, error) {
-		resp, err := calendarEventsListCall(ctx, svc, calendarID, from, to, maxResults, query, privatePropFilter, sharedPropFilter, fields, pageToken).Do()
+		resp, err := calendarEventsListCall(ctx, svc, calendarID, from, to, maxResults, query, privatePropFilter, sharedPropFilter, fields, eventTypes, pageToken).Do()
 		if err != nil {
 			return nil, "", err
 		}
@@ -111,7 +114,7 @@ type calendarTimezoneHint struct {
 	loc      *time.Location
 }
 
-func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
+func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
 	u := ui.FromContext(ctx)
 
 	calendars, err := listCalendarList(ctx, svc)
@@ -135,14 +138,14 @@ func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to
 		u.Err().Println("No calendars")
 		return nil
 	}
-	return listCalendarIDsEvents(ctx, svc, ids, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, showWeekday, showLocation, calendarTimezoneHints(calendars), sortKey, sortOrder)
+	return listCalendarIDsEvents(ctx, svc, ids, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, eventTypes, showWeekday, showLocation, calendarTimezoneHints(calendars), sortKey, sortOrder)
 }
 
-func listSelectedCalendarsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
-	return listCalendarIDsEvents(ctx, svc, calendarIDs, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, showWeekday, showLocation, nil, sortKey, sortOrder)
+func listSelectedCalendarsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
+	return listCalendarIDsEvents(ctx, svc, calendarIDs, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, eventTypes, showWeekday, showLocation, nil, sortKey, sortOrder)
 }
 
-func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, showWeekday bool, showLocation bool, timezoneHints map[string]calendarTimezoneHint, sortKey, sortOrder string) error {
+func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, timezoneHints map[string]calendarTimezoneHint, sortKey, sortOrder string) error {
 	u := ui.FromContext(ctx)
 	all := []*eventWithCalendar{}
 	nextPages := []calendarEventsNextPage{}
@@ -153,7 +156,7 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 		}
 		calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calID, timezoneHints)
 		fetch := func(pageToken string) ([]*calendar.Event, string, error) {
-			resp, err := calendarEventsListCall(ctx, svc, calID, from, to, maxResults, query, privatePropFilter, sharedPropFilter, fields, pageToken).Do()
+			resp, err := calendarEventsListCall(ctx, svc, calID, from, to, maxResults, query, privatePropFilter, sharedPropFilter, fields, eventTypes, pageToken).Do()
 			if err != nil {
 				return nil, "", err
 			}

--- a/internal/cmd/calendar_list_test.go
+++ b/internal/cmd/calendar_list_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
 
 	"google.golang.org/api/calendar/v3"
@@ -34,7 +35,48 @@ func TestCalendarEventsListCall_HidesCancelledEvents(t *testing.T) {
 		t.Fatalf("NewService: %v", err)
 	}
 
-	if _, err := calendarEventsListCall(context.Background(), svc, "primary", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", 10, "", "", "", "", "").Do(); err != nil {
+	if _, err := calendarEventsListCall(context.Background(), svc, "primary", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", 10, "", "", "", "", nil, "").Do(); err != nil {
 		t.Fatalf("Do: %v", err)
+	}
+}
+
+func TestCalendarEventsListCall_EventTypesFilter(t *testing.T) {
+	cases := []struct {
+		name       string
+		eventTypes []string
+		want       []string
+	}{
+		// No filter: the eventTypes query param must be absent, preserving the
+		// API default of returning all event types (non-breaking).
+		{"unset omits the filter", nil, nil},
+		// Filter: the requested types are sent as repeated eventTypes params.
+		{"sends requested types", []string{eventTypeBirthday, eventTypeDefault}, []string{eventTypeBirthday, eventTypeDefault}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotTypes []string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotTypes = r.URL.Query()["eventTypes"]
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"items": []any{}})
+			}))
+			defer srv.Close()
+
+			svc, err := calendar.NewService(context.Background(),
+				option.WithHTTPClient(srv.Client()),
+				option.WithEndpoint(srv.URL+"/"),
+				option.WithoutAuthentication(),
+			)
+			if err != nil {
+				t.Fatalf("NewService: %v", err)
+			}
+
+			if _, err := calendarEventsListCall(context.Background(), svc, "primary", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z", 10, "", "", "", "", tc.eventTypes, "").Do(); err != nil {
+				t.Fatalf("Do: %v", err)
+			}
+			if !slices.Equal(gotTypes, tc.want) {
+				t.Fatalf("eventTypes query = %v, want %v", gotTypes, tc.want)
+			}
+		})
 	}
 }

--- a/internal/cmd/calendar_zoom_test.go
+++ b/internal/cmd/calendar_zoom_test.go
@@ -284,7 +284,7 @@ func TestListCalendarEventsJSONRedactsZoomDescription(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-05-18T00:00:00Z", "2026-05-19T00:00:00Z", 10, "", false, false, "", "", "", "", false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-05-18T00:00:00Z", "2026-05-19T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 	out := output.String()


### PR DESCRIPTION
## What

Adds an opt-in `--event-types` flag to `gog calendar events`, passed through to the Calendar API [`events.list` `eventTypes`](https://developers.google.com/workspace/calendar/api/v3/reference/events/list) parameter.

## Why

Without a filter, `events.list` returns every event type, so `birthday`, `workingLocation`, and `fromGmail` entries come back mixed in with regular events — with no way to focus on the common event types a caller is usually interested in, or to filter down to just the subset they want and clear out the rest. The API supports this server-side via the repeatable `eventTypes` parameter; this exposes it.

## Changes

- `--event-types` on `calendar events`, **repeatable or comma-separated**, honored across single-calendar, `--cal`/`--calendars`, and `--all` paths.
- Accepts all six API types plus friendly aliases: `default`, `birthday`, `focus-time`/`focusTime`, `from-gmail`/`fromGmail`, `out-of-office`/`ooo`, `working-location`/`wl`. Values are canonicalized and de-duplicated.
- **Default unchanged:** when the flag is omitted, no `eventTypes` param is sent, so all types are returned exactly as before. A flag that is present but resolves to no values (e.g. `--event-types ""`) is a usage error, matching `gmail watch --history-types`.
- Event-type aliases now live in a single shared `eventTypeAliases` map: the create/update path restricts to the user-creatable types, while the filter accepts all six (including the read-only `birthday`/`fromGmail`). This consolidated the previous create-path `switch`.
- Docs: `docs/spec.md` + regenerated command reference.

## Deliberately not in this PR (happy to add on your call)

- **No change to default output or the `--plain`/table columns.** `--plain` is the stable parseable contract, `--json` already includes `eventType`, and `event get` already prints it — so I left the human/TSV surfaces untouched to keep this strictly additive. If surfacing the event type in the list view would be useful, I'm happy to follow up; I'd defer to you on the form (e.g. a new column vs. an opt-in flag).
- **No default-view change.** Whether `events` should hide `birthday`/`workingLocation` by default is a reasonable question but a breaking one, so this PR just provides the filter and leaves the default as-is.
- **No signature refactor.** Threading `eventTypes` adds another positional param to the already-long `calendar_list.go` list helpers. I kept it consistent with the existing style rather than refactoring here, but I'd be happy to follow up with a small PR bundling those params into `query`/`view` structs if that cleanup would be welcome.

## Testing

- Unit: both normalizers (filter accepts all six + aliases; create/update rejects the read-only `birthday`/`fromGmail`), the flatten/dedupe resolver (incl. the present-but-empty error), and a guard test for the shared-map invariant (every creatable type is aliased).
- Wiring: asserts the `eventTypes` query param is sent (in order) when set and **absent when unset** — at the single-calendar call and across the `--cal`/`--all` paths.
- `make fmt-check lint docs-check` clean; calendar tests pass under `-race`.

### Live (real account, event-type tallies)

```
$ gog calendar events --days 60 --max 200 --json | jq -r '.events[].eventType' | sort | uniq -c
     34 birthday
    103 default
      3 fromGmail            # 140 total — unchanged default (all types)

$ gog calendar events --days 60 --max 200 --json --event-types default | jq -r '.events[].eventType' | sort | uniq -c
    103 default              # birthdays + fromGmail filtered out

$ gog calendar events --days 60 --max 200 --json --event-types birthday,working-location | jq -r '.events[].eventType' | sort | uniq -c
     34 birthday             # only requested types (no workingLocation events in window)
```

No `CHANGELOG.md` entry (treated as release-owned) — happy to add one if you'd prefer.
