### PR TITLE
youtube videos list: add opt-in --parts all without changing defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.31.2 - Unreleased
 
+- YouTube: add opt-in `videos list --parts all` full metadata while preserving the existing compact default and explicit owner-only part requests. (#871) — thanks @coeur-de-loup.
 - CLI: add read-only `update status` / `update check` release metadata, platform asset, checksum, and install-method reporting. (#882) — thanks @titus7490.
 - Docs: add `docs format --spacing-mode` for setting paragraph spacing collapse behavior alongside `--space-above` and `--space-below`. (#885) — thanks @odyssey4me.
 

--- a/docs/commands/gog-youtube-videos-list.md
+++ b/docs/commands/gog-youtube-videos-list.md
@@ -37,6 +37,7 @@ gog youtube (yt) videos (video) list (ls) [flags]
 | `--my-rating` | `string` |  | Your rated videos: like (liked videos) or dislike (requires -a account) |
 | `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
 | `--page` | `string` |  | Page token |
+| `--parts` | `string` |  | Comma-separated videos.list parts or 'all' (default: snippet,contentDetails,statistics) |
 | `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--region` | `string` |  | Region code (e.g. US) for chart |

--- a/docs/youtube.md
+++ b/docs/youtube.md
@@ -67,6 +67,22 @@ gog yt videos list --my-rating dislike --account you@gmail.com --json
 Both reads work with the default `youtube.readonly` scope; no extra scope is
 required.
 
+## Choose video fields
+
+`videos list` keeps its compact historical default: `snippet`,
+`contentDetails`, and `statistics`. Request every field available for arbitrary
+videos with `--parts all`, or pass an exact comma-separated list:
+
+```bash
+gog yt videos list --id VIDEO_ID --parts all --json
+gog yt videos list --id YOUR_VIDEO_ID --parts snippet,fileDetails --account you@gmail.com --json
+```
+
+`all` excludes the owner-only `fileDetails`, `processingDetails`, and
+`suggestions` parts. Explicit lists are passed through unchanged so authenticated
+owners can request those fields for their own uploads. Do not combine `all` with
+other part names.
+
 ## Manage subscriptions
 
 List one page or fetch every page:

--- a/internal/cmd/youtube.go
+++ b/internal/cmd/youtube.go
@@ -16,24 +16,27 @@ import (
 
 const youtubeForceSSLOAuthScope = "https://www.googleapis.com/auth/youtube.force-ssl"
 
-// youtubeVideoAllParts is every videos.list part that is readable for an
-// arbitrary (non-owned) video. The owner-only parts fileDetails,
-// processingDetails and suggestions are deliberately excluded — the API returns
-// them only for videos the authenticated account itself uploaded, so requesting
-// them for other people's liked/playlist videos errors. The Google SDK simply
-// omits parts that have no data for a given video (e.g. liveStreamingDetails on
-// a non-live video), so requesting the full set is safe and tolerant of
-// per-video partial responses.
-var youtubeVideoAllParts = []string{
+var youtubeVideoDefaultParts = []string{
 	"snippet",
 	"contentDetails",
 	"statistics",
+}
+
+// youtubeVideoAllNonOwnerParts matches every videos.list part documented as
+// readable for arbitrary videos. Owner-only parts remain available through an
+// explicit --parts list for callers querying their own uploads.
+var youtubeVideoAllNonOwnerParts = []string{
+	"contentDetails",
+	"id",
+	"liveStreamingDetails",
+	"localizations",
+	"paidProductPlacementDetails",
+	"player",
+	"recordingDetails",
+	"snippet",
+	"statistics",
 	"status",
 	"topicDetails",
-	"recordingDetails",
-	"liveStreamingDetails",
-	"player",
-	"localizations",
 }
 
 type YouTubeCmd struct {
@@ -92,20 +95,30 @@ type YouTubeVideosListCmd struct {
 	Chart    string `name:"chart" help:"Chart: mostPopular (regionCode required)"`
 	Region   string `name:"region" help:"Region code (e.g. US) for chart"`
 	MyRating string `name:"my-rating" help:"Your rated videos: like (liked videos) or dislike (requires -a account)"`
-	Parts    string `name:"parts" help:"Comma-separated videos.list parts (default: every part readable for non-owned videos)"`
+	Parts    string `name:"parts" help:"Comma-separated videos.list parts or 'all' (default: snippet,contentDetails,statistics)"`
 	Max      int64  `name:"max" aliases:"limit" help:"Max results" default:"25"`
 	Page     string `name:"page" help:"Page token"`
 }
 
-// resolveParts returns the requested videos.list parts. An empty/blank --parts
-// flag (the default) yields the full non-owner part set so callers get complete
-// metadata without having to enumerate parts. An explicit --parts narrows it.
-func (c *YouTubeVideosListCmd) resolveParts() []string {
+func (c *YouTubeVideosListCmd) resolveParts() ([]string, error) {
 	parts := splitCSV(c.Parts)
 	if len(parts) == 0 {
-		return append([]string(nil), youtubeVideoAllParts...)
+		return append([]string(nil), youtubeVideoDefaultParts...), nil
 	}
-	return parts
+	all := false
+	for _, part := range parts {
+		if part == literalAll {
+			all = true
+			break
+		}
+	}
+	if !all {
+		return parts, nil
+	}
+	if len(parts) != 1 {
+		return nil, usage("--parts all cannot be combined with explicit parts")
+	}
+	return append([]string(nil), youtubeVideoAllNonOwnerParts...), nil
 }
 
 func (c *YouTubeVideosListCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -142,9 +155,12 @@ func (c *YouTubeVideosListCmd) Run(ctx context.Context, flags *RootFlags) error 
 	if myRating != "" && myRating != "like" && myRating != "dislike" {
 		return usage("--my-rating must be like or dislike")
 	}
+	parts, err := c.resolveParts()
+	if err != nil {
+		return err
+	}
 
 	var svc *youtube.Service
-	var err error
 	if myRating != "" {
 		// myRating reads are per-user and require OAuth, not an API key.
 		account, accErr := requireAccount(flags)
@@ -159,7 +175,7 @@ func (c *YouTubeVideosListCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 
-	call := svc.Videos.List(c.resolveParts()).
+	call := svc.Videos.List(parts).
 		MaxResults(c.Max).
 		PageToken(c.Page)
 	switch {

--- a/internal/cmd/youtube.go
+++ b/internal/cmd/youtube.go
@@ -16,6 +16,26 @@ import (
 
 const youtubeForceSSLOAuthScope = "https://www.googleapis.com/auth/youtube.force-ssl"
 
+// youtubeVideoAllParts is every videos.list part that is readable for an
+// arbitrary (non-owned) video. The owner-only parts fileDetails,
+// processingDetails and suggestions are deliberately excluded — the API returns
+// them only for videos the authenticated account itself uploaded, so requesting
+// them for other people's liked/playlist videos errors. The Google SDK simply
+// omits parts that have no data for a given video (e.g. liveStreamingDetails on
+// a non-live video), so requesting the full set is safe and tolerant of
+// per-video partial responses.
+var youtubeVideoAllParts = []string{
+	"snippet",
+	"contentDetails",
+	"statistics",
+	"status",
+	"topicDetails",
+	"recordingDetails",
+	"liveStreamingDetails",
+	"player",
+	"localizations",
+}
+
 type YouTubeCmd struct {
 	Activities    YouTubeActivitiesCmd    `cmd:"" name:"activities" aliases:"activity" help:"List channel activities"`
 	Videos        YouTubeVideosCmd        `cmd:"" name:"videos" aliases:"video" help:"List or get videos"`
@@ -72,8 +92,20 @@ type YouTubeVideosListCmd struct {
 	Chart    string `name:"chart" help:"Chart: mostPopular (regionCode required)"`
 	Region   string `name:"region" help:"Region code (e.g. US) for chart"`
 	MyRating string `name:"my-rating" help:"Your rated videos: like (liked videos) or dislike (requires -a account)"`
+	Parts    string `name:"parts" help:"Comma-separated videos.list parts (default: every part readable for non-owned videos)"`
 	Max      int64  `name:"max" aliases:"limit" help:"Max results" default:"25"`
 	Page     string `name:"page" help:"Page token"`
+}
+
+// resolveParts returns the requested videos.list parts. An empty/blank --parts
+// flag (the default) yields the full non-owner part set so callers get complete
+// metadata without having to enumerate parts. An explicit --parts narrows it.
+func (c *YouTubeVideosListCmd) resolveParts() []string {
+	parts := splitCSV(c.Parts)
+	if len(parts) == 0 {
+		return append([]string(nil), youtubeVideoAllParts...)
+	}
+	return parts
 }
 
 func (c *YouTubeVideosListCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -127,7 +159,7 @@ func (c *YouTubeVideosListCmd) Run(ctx context.Context, flags *RootFlags) error 
 		return err
 	}
 
-	call := svc.Videos.List([]string{"snippet", "contentDetails", "statistics"}).
+	call := svc.Videos.List(c.resolveParts()).
 		MaxResults(c.Max).
 		PageToken(c.Page)
 	switch {

--- a/internal/cmd/youtube_test.go
+++ b/internal/cmd/youtube_test.go
@@ -758,6 +758,210 @@ func TestYouTubeVideosListMyRatingUsesOAuthService(t *testing.T) {
 	}
 }
 
+// youtubePartValues collects the videos.list "part" selector from a request.
+// The Google SDK may send part either comma-joined or as repeated query params,
+// so normalize both into a flat slice.
+func youtubePartValues(r *http.Request) []string {
+	var out []string
+	for _, raw := range r.URL.Query()["part"] {
+		out = append(out, strings.Split(raw, ",")...)
+	}
+	return out
+}
+
+func TestYouTubeVideosListRequestsAllNonOwnerParts(t *testing.T) {
+	var gotParts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/youtube/v3/videos" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		gotParts = youtubePartValues(r)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	ctx := withYouTubeTestServices(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), youtubeTestServices{
+		Account: fixedYouTubeTestService(svc),
+		APIKey:  unexpectedYouTubeTestService(t, "API key service should not be used when account is configured"),
+	})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	wantParts := []string{
+		"snippet", "contentDetails", "statistics", "status", "topicDetails",
+		"recordingDetails", "liveStreamingDetails", "player", "localizations",
+	}
+	if len(gotParts) != len(wantParts) {
+		t.Fatalf("parts = %v (%d), want %d parts %v", gotParts, len(gotParts), len(wantParts), wantParts)
+	}
+	gotSet := make(map[string]bool, len(gotParts))
+	for _, p := range gotParts {
+		gotSet[p] = true
+	}
+	for _, p := range wantParts {
+		if !gotSet[p] {
+			t.Fatalf("part list %v is missing %q", gotParts, p)
+		}
+	}
+	// Owner-only parts must never be requested for arbitrary (non-owned) videos.
+	for _, owner := range []string{"fileDetails", "processingDetails", "suggestions"} {
+		if gotSet[owner] {
+			t.Fatalf("part list %v must not request owner-only part %q", gotParts, owner)
+		}
+	}
+}
+
+func TestYouTubeVideosListPartsOverride(t *testing.T) {
+	var gotParts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/youtube/v3/videos" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		gotParts = youtubePartValues(r)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	ctx := withYouTubeTestServices(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), youtubeTestServices{
+		Account: fixedYouTubeTestService(svc),
+	})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--parts", "snippet, statistics", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	if len(gotParts) != 2 || gotParts[0] != "snippet" || gotParts[1] != "statistics" {
+		t.Fatalf("parts = %v, want [snippet statistics]", gotParts)
+	}
+}
+
+func TestYouTubeVideosListJSONSerializesNonCoreParts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/youtube/v3/videos" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id": "vidRich",
+					"snippet": map[string]any{
+						"title":       "Rich Video",
+						"publishedAt": "2026-01-02T03:04:05Z",
+						"thumbnails": map[string]any{
+							"default":  map[string]any{"url": "https://img/d.jpg", "width": 120, "height": 90},
+							"high":     map[string]any{"url": "https://img/h.jpg", "width": 480, "height": 360},
+							"maxres":   map[string]any{"url": "https://img/m.jpg", "width": 1280, "height": 720},
+						},
+					},
+					"status": map[string]any{
+						"privacyStatus": "public",
+						"uploadStatus":  "processed",
+						"madeForKids":   false,
+					},
+					"topicDetails": map[string]any{
+						"topicCategories": []string{"https://en.wikipedia.org/wiki/Music"},
+					},
+					"liveStreamingDetails": map[string]any{
+						"actualStartTime": "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	var stdout bytes.Buffer
+	ctx := withYouTubeTestServices(newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard), youtubeTestServices{
+		Account: fixedYouTubeTestService(svc),
+	})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vidRich", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com", JSON: true})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	var got struct {
+		Items []struct {
+			ID     string `json:"id"`
+			Status struct {
+				PrivacyStatus string `json:"privacyStatus"`
+				UploadStatus  string `json:"uploadStatus"`
+			} `json:"status"`
+			TopicDetails struct {
+				TopicCategories []string `json:"topicCategories"`
+			} `json:"topicDetails"`
+			Snippet struct {
+				Thumbnails map[string]struct {
+					URL string `json:"url"`
+				} `json:"thumbnails"`
+			} `json:"snippet"`
+			LiveStreamingDetails struct {
+				ActualStartTime string `json:"actualStartTime"`
+			} `json:"liveStreamingDetails"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json output %q: %v", stdout.String(), err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items len = %d: %s", len(got.Items), stdout.String())
+	}
+	item := got.Items[0]
+	if item.Status.PrivacyStatus != "public" {
+		t.Fatalf("status.privacyStatus = %q (non-core status part dropped): %s", item.Status.PrivacyStatus, stdout.String())
+	}
+	if len(item.TopicDetails.TopicCategories) != 1 {
+		t.Fatalf("topicDetails.topicCategories = %v (non-core topicDetails part dropped): %s", item.TopicDetails.TopicCategories, stdout.String())
+	}
+	for _, size := range []string{"default", "high", "maxres"} {
+		if item.Snippet.Thumbnails[size].URL == "" {
+			t.Fatalf("thumbnail size %q missing from JSON (compacted): %s", size, stdout.String())
+		}
+	}
+	if item.LiveStreamingDetails.ActualStartTime == "" {
+		t.Fatalf("liveStreamingDetails.actualStartTime dropped: %s", stdout.String())
+	}
+}
+
+// A video with no liveStreamingDetails (a normal non-live video) must still
+// serialize cleanly — the SDK omits parts with no data, never errors.
+func TestYouTubeVideosListToleratesPartialParts(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id":      "vidPlain",
+					"snippet": map[string]any{"title": "Plain Video"},
+					"status":  map[string]any{"privacyStatus": "unlisted"},
+				},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	var stdout bytes.Buffer
+	ctx := withYouTubeTestServices(newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard), youtubeTestServices{
+		Account: fixedYouTubeTestService(svc),
+	})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vidPlain", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com", JSON: true})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+	var got struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("json output %q: %v", stdout.String(), err)
+	}
+	if len(got.Items) != 1 {
+		t.Fatalf("items len = %d: %s", len(got.Items), stdout.String())
+	}
+}
+
 func TestYouTubeVideosListMyRatingValidation(t *testing.T) {
 	ctx := withYouTubeTestServices(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), youtubeTestServices{
 		Account: unexpectedYouTubeTestService(t, "should not reach service with invalid my-rating"),

--- a/internal/cmd/youtube_test.go
+++ b/internal/cmd/youtube_test.go
@@ -762,11 +762,35 @@ func TestYouTubeVideosListMyRatingUsesOAuthService(t *testing.T) {
 // The Google SDK may send part either comma-joined or as repeated query params,
 // so normalize both into a flat slice.
 func youtubePartValues(r *http.Request) []string {
-	var out []string
-	for _, raw := range r.URL.Query()["part"] {
+	values := r.URL.Query()["part"]
+	out := make([]string, 0, len(values))
+	for _, raw := range values {
 		out = append(out, strings.Split(raw, ",")...)
 	}
 	return out
+}
+
+func TestYouTubeVideosListPreservesDefaultParts(t *testing.T) {
+	var gotParts []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotParts = youtubePartValues(r)
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []map[string]any{}})
+	}))
+	defer srv.Close()
+
+	svc := newGoogleTestServiceWithEndpoint(t, srv.Client(), srv.URL+"/", youtube.NewService)
+	ctx := withYouTubeTestServices(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), youtubeTestServices{
+		Account: fixedYouTubeTestService(svc),
+	})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
+	if err != nil {
+		t.Fatalf("runKong: %v", err)
+	}
+
+	want := []string{"snippet", "contentDetails", "statistics"}
+	if strings.Join(gotParts, ",") != strings.Join(want, ",") {
+		t.Fatalf("parts = %v, want %v", gotParts, want)
+	}
 }
 
 func TestYouTubeVideosListRequestsAllNonOwnerParts(t *testing.T) {
@@ -785,28 +809,23 @@ func TestYouTubeVideosListRequestsAllNonOwnerParts(t *testing.T) {
 		Account: fixedYouTubeTestService(svc),
 		APIKey:  unexpectedYouTubeTestService(t, "API key service should not be used when account is configured"),
 	})
-	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--parts", "all", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
 	if err != nil {
 		t.Fatalf("runKong: %v", err)
 	}
 
 	wantParts := []string{
-		"snippet", "contentDetails", "statistics", "status", "topicDetails",
-		"recordingDetails", "liveStreamingDetails", "player", "localizations",
+		"contentDetails", "id", "liveStreamingDetails", "localizations",
+		"paidProductPlacementDetails", "player", "recordingDetails", "snippet",
+		"statistics", "status", "topicDetails",
 	}
-	if len(gotParts) != len(wantParts) {
-		t.Fatalf("parts = %v (%d), want %d parts %v", gotParts, len(gotParts), len(wantParts), wantParts)
+	if strings.Join(gotParts, ",") != strings.Join(wantParts, ",") {
+		t.Fatalf("parts = %v, want %v", gotParts, wantParts)
 	}
 	gotSet := make(map[string]bool, len(gotParts))
-	for _, p := range gotParts {
-		gotSet[p] = true
+	for _, part := range gotParts {
+		gotSet[part] = true
 	}
-	for _, p := range wantParts {
-		if !gotSet[p] {
-			t.Fatalf("part list %v is missing %q", gotParts, p)
-		}
-	}
-	// Owner-only parts must never be requested for arbitrary (non-owned) videos.
 	for _, owner := range []string{"fileDetails", "processingDetails", "suggestions"} {
 		if gotSet[owner] {
 			t.Fatalf("part list %v must not request owner-only part %q", gotParts, owner)
@@ -829,12 +848,23 @@ func TestYouTubeVideosListPartsOverride(t *testing.T) {
 	ctx := withYouTubeTestServices(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), youtubeTestServices{
 		Account: fixedYouTubeTestService(svc),
 	})
-	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--parts", "snippet, statistics", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--parts", "snippet, fileDetails", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
 	if err != nil {
 		t.Fatalf("runKong: %v", err)
 	}
-	if len(gotParts) != 2 || gotParts[0] != "snippet" || gotParts[1] != "statistics" {
-		t.Fatalf("parts = %v, want [snippet statistics]", gotParts)
+	if len(gotParts) != 2 || gotParts[0] != "snippet" || gotParts[1] != "fileDetails" {
+		t.Fatalf("parts = %v, want [snippet fileDetails]", gotParts)
+	}
+}
+
+func TestYouTubeVideosListRejectsMixedAllParts(t *testing.T) {
+	ctx := withYouTubeTestServices(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), youtubeTestServices{
+		Account: unexpectedYouTubeTestService(t, "invalid --parts must not create a service"),
+		APIKey:  unexpectedYouTubeTestService(t, "invalid --parts must not create a service"),
+	})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vid1", "--parts", "all,status", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com"})
+	if err == nil || ExitCode(err) != 2 || !strings.Contains(err.Error(), "--parts all cannot be combined with explicit parts") {
+		t.Fatalf("expected mixed all usage error, got %v", err)
 	}
 }
 
@@ -851,9 +881,9 @@ func TestYouTubeVideosListJSONSerializesNonCoreParts(t *testing.T) {
 						"title":       "Rich Video",
 						"publishedAt": "2026-01-02T03:04:05Z",
 						"thumbnails": map[string]any{
-							"default":  map[string]any{"url": "https://img/d.jpg", "width": 120, "height": 90},
-							"high":     map[string]any{"url": "https://img/h.jpg", "width": 480, "height": 360},
-							"maxres":   map[string]any{"url": "https://img/m.jpg", "width": 1280, "height": 720},
+							"default": map[string]any{"url": "https://img/d.jpg", "width": 120, "height": 90},
+							"high":    map[string]any{"url": "https://img/h.jpg", "width": 480, "height": 360},
+							"maxres":  map[string]any{"url": "https://img/m.jpg", "width": 1280, "height": 720},
 						},
 					},
 					"status": map[string]any{
@@ -867,6 +897,9 @@ func TestYouTubeVideosListJSONSerializesNonCoreParts(t *testing.T) {
 					"liveStreamingDetails": map[string]any{
 						"actualStartTime": "2026-01-01T00:00:00Z",
 					},
+					"paidProductPlacementDetails": map[string]any{
+						"hasPaidProductPlacement": true,
+					},
 				},
 			},
 		})
@@ -878,7 +911,7 @@ func TestYouTubeVideosListJSONSerializesNonCoreParts(t *testing.T) {
 	ctx := withYouTubeTestServices(newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard), youtubeTestServices{
 		Account: fixedYouTubeTestService(svc),
 	})
-	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vidRich", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com", JSON: true})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vidRich", "--parts", "all", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com", JSON: true})
 	if err != nil {
 		t.Fatalf("runKong: %v", err)
 	}
@@ -901,6 +934,9 @@ func TestYouTubeVideosListJSONSerializesNonCoreParts(t *testing.T) {
 			LiveStreamingDetails struct {
 				ActualStartTime string `json:"actualStartTime"`
 			} `json:"liveStreamingDetails"`
+			PaidProductPlacementDetails struct {
+				HasPaidProductPlacement bool `json:"hasPaidProductPlacement"`
+			} `json:"paidProductPlacementDetails"`
 		} `json:"items"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
@@ -923,6 +959,9 @@ func TestYouTubeVideosListJSONSerializesNonCoreParts(t *testing.T) {
 	}
 	if item.LiveStreamingDetails.ActualStartTime == "" {
 		t.Fatalf("liveStreamingDetails.actualStartTime dropped: %s", stdout.String())
+	}
+	if !item.PaidProductPlacementDetails.HasPaidProductPlacement {
+		t.Fatalf("paidProductPlacementDetails.hasPaidProductPlacement dropped: %s", stdout.String())
 	}
 }
 
@@ -947,7 +986,7 @@ func TestYouTubeVideosListToleratesPartialParts(t *testing.T) {
 	ctx := withYouTubeTestServices(newCmdRuntimeJSONOutputContext(t, &stdout, io.Discard), youtubeTestServices{
 		Account: fixedYouTubeTestService(svc),
 	})
-	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vidPlain", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com", JSON: true})
+	err := runKong(t, &YouTubeVideosListCmd{}, []string{"--id", "vidPlain", "--parts", "all", "--max", "1"}, ctx, &RootFlags{Account: "me@example.com", JSON: true})
 	if err != nil {
 		t.Fatalf("runKong: %v", err)
 	}


### PR DESCRIPTION
## What

`gog youtube videos list` now supports explicit control over the YouTube
`videos.list` parts:

- omitted `--parts` preserves the historical
  `snippet,contentDetails,statistics` request and output shape;
- `--parts all` requests every part documented as readable for arbitrary
  videos;
- an explicit comma-separated list is passed through unchanged, including
  owner-only parts for authenticated requests against the caller's own uploads;
- `all` cannot be mixed with explicit part names.

## Why

Metadata archiving and analysis sometimes need the full provider response, but
changing the default would broaden existing script output. The opt-in selector
adds the capability without a compatibility break.

The `all` set follows the current
[official `videos.list` contract](https://developers.google.com/youtube/v3/docs/videos/list):
`contentDetails,id,liveStreamingDetails,localizations,paidProductPlacementDetails,player,recordingDetails,snippet,statistics,status,topicDetails`.
It excludes the owner-only `fileDetails`, `processingDetails`, and `suggestions`
parts. The API documents a fixed one-unit quota cost for the method.

## Proof

Exact candidate: `ee1a3e92400167f17fab748c3670b2c9824e61cb`.

- `go test ./internal/cmd -run 'TestYouTubeVideosList' -count=1`
- `make ci`
- Built candidate authenticated against the approved test account and a public,
  non-owned video: default, `all`, and explicit `status` requests all exited 0;
  `all` returned the eleven expected metadata groups; a repeat returned the same
  key set; mixed `all,status` exited 2 before provider lookup.
- Source-blind behavior contract: all four clauses passed, including the repeat
  and invalid-video anti-cheat probes.
- `autoreview --mode branch --base origin/main`: no accepted/actionable findings.

## Contributor credit

Original implementation by @coeur-de-loup; maintainer repair preserves the
contributor commit and adds the compatibility-safe default, current API part
set, docs, generated command reference, and changelog thanks.
