### PR TITLE
fix(gmail): render quoted and forwarded dates in Gmail's human style

### DIFF
--- a/internal/cmd/execute_gmail_forward_test.go
+++ b/internal/cmd/execute_gmail_forward_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -60,6 +61,7 @@ func mockOriginalMessage(withAttachment bool) map[string]any {
 }
 
 func TestExecute_GmailForward_Basic(t *testing.T) {
+	t.Setenv("GOG_TIMEZONE", "UTC")
 	var sentRaw string
 	var sentThreadID string
 
@@ -115,8 +117,9 @@ func TestExecute_GmailForward_Basic(t *testing.T) {
 	if !strings.Contains(sentRaw, "From: Alice <alice@example.com>") {
 		t.Errorf("expected original From in forwarded body")
 	}
-	if !strings.Contains(sentRaw, "Date: Mon, 10 Mar 2026 09:00:00 -0400") {
-		t.Errorf("expected original Date in forwarded body")
+	// Original Date (09:00 -0400) reformatted to Gmail style in UTC.
+	if !strings.Contains(sentRaw, "Date: Tue, Mar 10, 2026 at 1:00 PM") {
+		t.Errorf("expected reformatted original Date in forwarded body")
 	}
 
 	// Verify note text.
@@ -319,13 +322,15 @@ func TestFormatForwardedMessage(t *testing.T) {
 		"bob@example.com",
 		"carol@example.com",
 		"Body text here.",
+		time.UTC,
 	)
 
 	checks := []string{
 		"See below",
 		"---------- Forwarded message ---------",
 		"From: Alice <alice@example.com>",
-		"Date: Mon, 10 Mar 2026 09:00:00 -0400",
+		// 09:00 -0400 rendered in UTC; weekday is recomputed (Mar 10 2026 is a Tue).
+		"Date: Tue, Mar 10, 2026 at 1:00 PM",
 		"Subject: Test Subject",
 		"To: bob@example.com",
 		"Cc: carol@example.com",
@@ -339,7 +344,7 @@ func TestFormatForwardedMessage(t *testing.T) {
 }
 
 func TestFormatForwardedMessage_NoNote(t *testing.T) {
-	result := formatForwardedMessage("", "from@x.com", "", "Subj", "to@x.com", "", "Body.")
+	result := formatForwardedMessage("", "from@x.com", "", "Subj", "to@x.com", "", "Body.", time.UTC)
 	if strings.HasPrefix(result, "\n\n------") {
 		// Should not have leading blank lines when note is empty.
 		t.Errorf("expected no leading blank lines when note is empty")
@@ -353,15 +358,20 @@ func TestFormatForwardedMessageHTML(t *testing.T) {
 	result := formatForwardedMessageHTML(
 		"Check this out",
 		"Alice <alice@example.com>",
-		"Mon, 10 Mar 2026",
+		"Mon, 10 Mar 2026 09:00:00 -0400",
 		"Test",
 		"bob@example.com",
 		"",
 		"<p>Original content</p>",
+		time.UTC,
 	)
 
 	if !strings.Contains(result, "Check this out") {
 		t.Error("missing note in HTML")
+	}
+	// Date (09:00 -0400) reformatted to Gmail style in UTC.
+	if !strings.Contains(result, "Tue, Mar 10, 2026 at 1:00 PM") {
+		t.Errorf("missing reformatted date in HTML, got:\n%s", result)
 	}
 	if !strings.Contains(result, "Forwarded message") {
 		t.Error("missing forward separator in HTML")

--- a/internal/cmd/gmail_compose.go
+++ b/internal/cmd/gmail_compose.go
@@ -167,7 +167,13 @@ func prepareComposeReply(ctx context.Context, svc *gmail.Service, replyToMessage
 	if err != nil {
 		return nil, "", "", err
 	}
-	plainBody, htmlBody = applyQuoteToBodies(plainBody, htmlBody, quote, info)
+	if quote {
+		loc, locErr := mailDateLocation(ctx, stderrWriter(ctx))
+		if locErr != nil {
+			return nil, "", "", locErr
+		}
+		plainBody, htmlBody = applyQuoteToBodies(plainBody, htmlBody, quote, info, loc)
+	}
 	return info, plainBody, htmlBody, nil
 }
 

--- a/internal/cmd/gmail_date.go
+++ b/internal/cmd/gmail_date.go
@@ -6,7 +6,21 @@ import (
 	"time"
 )
 
-func formatGmailDateInLocation(raw string, loc *time.Location) string {
+const (
+	// listDateLayout renders message-list and thread dates, e.g. "2026-06-17 00:29".
+	listDateLayout = "2006-01-02 15:04"
+	// quoteDateLayout renders dates in the Gmail-style human form used for reply
+	// attributions and forwarded-message headers, e.g. "Wed, Jun 17, 2026 at 12:29 AM".
+	quoteDateLayout = "Mon, Jan 2, 2006 at 3:04 PM"
+)
+
+// formatMailDateInLocation parses an RFC 2822 Date header and renders it with
+// layout, converted into loc (a nil loc falls back to time.Local). Empty input
+// and dates that cannot be parsed are returned trimmed and otherwise unchanged,
+// so an unexpected Date value never breaks the output. A parseable date's
+// weekday is recomputed from the instant in loc, which also corrects a wrong
+// weekday in the source header.
+func formatMailDateInLocation(raw string, loc *time.Location, layout string) string {
 	raw = strings.TrimSpace(raw)
 	if raw == "" {
 		return ""
@@ -15,9 +29,21 @@ func formatGmailDateInLocation(raw string, loc *time.Location) string {
 		loc = time.Local
 	}
 	if t, err := mailParseDate(raw); err == nil {
-		return t.In(loc).Format("2006-01-02 15:04")
+		return t.In(loc).Format(layout)
 	}
 	return raw
+}
+
+// formatGmailDateInLocation renders a Date header for message and thread listings.
+func formatGmailDateInLocation(raw string, loc *time.Location) string {
+	return formatMailDateInLocation(raw, loc, listDateLayout)
+}
+
+// formatQuoteDate renders an original message's Date header in the Gmail-style
+// human form used for quoted replies and forwarded-message headers, converted
+// into loc (matching how Gmail shows the attribution in the reader's timezone).
+func formatQuoteDate(raw string, loc *time.Location) string {
+	return formatMailDateInLocation(raw, loc, quoteDateLayout)
 }
 
 func mailParseDate(s string) (time.Time, error) {

--- a/internal/cmd/gmail_drafts_cmd_test.go
+++ b/internal/cmd/gmail_drafts_cmd_test.go
@@ -510,6 +510,7 @@ func TestGmailDraftsCreateCmd_WithFromAndReply(t *testing.T) {
 }
 
 func TestGmailDraftsCreateCmd_WithQuote(t *testing.T) {
+	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Original plain line"
 	originalHTML := "<p>Original <b>HTML</b></p>"
 
@@ -527,7 +528,7 @@ func TestGmailDraftsCreateCmd_WithQuote(t *testing.T) {
 			if !strings.Contains(s, "Hello reply") {
 				t.Fatalf("missing body in raw:\n%s", s)
 			}
-			if !strings.Contains(s, "On Mon, 1 Jan 2024 00:00:00 +0000, Alice <alice@example.com> wrote:") {
+			if !strings.Contains(s, "On Mon, Jan 1, 2024 at 12:00 AM, Alice <alice@example.com> wrote:") {
 				t.Fatalf("missing quoted attribution in raw:\n%s", s)
 			}
 			if !strings.Contains(s, "> Original plain line") {
@@ -920,6 +921,7 @@ func TestGmailDraftsUpdateCmd_PreservesToWhenNotProvided(t *testing.T) {
 }
 
 func TestGmailDraftsUpdateCmd_WithQuoteFromExistingThread(t *testing.T) {
+	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Original thread message"
 	originalHTML := "<div>Original <i>thread</i> HTML</div>"
 
@@ -1044,7 +1046,7 @@ func TestGmailDraftsUpdateCmd_WithQuoteFromExistingThread(t *testing.T) {
 			if !strings.Contains(s, "Updated body") {
 				t.Fatalf("missing body in raw:\n%s", s)
 			}
-			if !strings.Contains(s, "On Tue, 2 Jan 2024 03:04:05 +0000, Bob <bob@example.com> wrote:") {
+			if !strings.Contains(s, "On Tue, Jan 2, 2024 at 3:04 AM, Bob <bob@example.com> wrote:") {
 				t.Fatalf("missing quoted attribution in raw:\n%s", s)
 			}
 			if !strings.Contains(s, "> Original thread message") {
@@ -1154,6 +1156,7 @@ func TestGmailDraftsUpdateCmd_QuoteRequiresNonDraftNonSelfThreadMessage(t *testi
 }
 
 func TestGmailDraftsUpdateCmd_WithQuoteAndReplyToMessageID(t *testing.T) {
+	t.Setenv("GOG_TIMEZONE", "UTC")
 	originalPlain := "Quoted from explicit message id"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1185,7 +1188,7 @@ func TestGmailDraftsUpdateCmd_WithQuoteAndReplyToMessageID(t *testing.T) {
 			if !strings.Contains(s, "Updated body") {
 				t.Fatalf("missing body in raw:\n%s", s)
 			}
-			if !strings.Contains(s, "On Wed, 3 Jan 2024 06:07:08 +0000, Carol <carol@example.com> wrote:") {
+			if !strings.Contains(s, "On Wed, Jan 3, 2024 at 6:07 AM, Carol <carol@example.com> wrote:") {
 				t.Fatalf("missing quoted attribution in raw:\n%s", s)
 			}
 			if !strings.Contains(s, "> Quoted from explicit message id") {

--- a/internal/cmd/gmail_forward.go
+++ b/internal/cmd/gmail_forward.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"net/mail"
 	"strings"
+	"time"
 
 	"github.com/steipete/gogcli/internal/gmailcontent"
 	"github.com/steipete/gogcli/internal/ui"
@@ -79,13 +80,20 @@ func (c *GmailForwardCmd) Run(ctx context.Context, flags *RootFlags) error {
 	// Build forward subject (avoid stacking prefixes).
 	fwdSubject := buildForwardSubject(origSubject)
 
+	// Resolve the timezone for the forwarded Date header from the same
+	// configured/local source as the reply quote and the outgoing Date header.
+	loc, err := mailDateLocation(ctx, stderrWriter(ctx))
+	if err != nil {
+		return err
+	}
+
 	// Build forwarded body (plain text).
-	fwdPlain := formatForwardedMessage(note, origFrom, origDate, origSubject, origTo, origCc, origPlain)
+	fwdPlain := formatForwardedMessage(note, origFrom, origDate, origSubject, origTo, origCc, origPlain, loc)
 
 	// Build forwarded body (HTML) if original had HTML.
 	var fwdHTML string
 	if origHTML != "" {
-		fwdHTML = formatForwardedMessageHTML(note, origFrom, origDate, origSubject, origTo, origCc, origHTML)
+		fwdHTML = formatForwardedMessageHTML(note, origFrom, origDate, origSubject, origTo, origCc, origHTML, loc)
 	}
 
 	// Preserve CID-backed inline resources required by the forwarded HTML and,
@@ -130,10 +138,10 @@ type forwardedHeader struct {
 	value string
 }
 
-func forwardedMessageHeaders(from, date, subject, to, cc string) []forwardedHeader {
+func forwardedMessageHeaders(from, date, subject, to, cc string, loc *time.Location) []forwardedHeader {
 	return []forwardedHeader{
 		{"From", from},
-		{"Date", date},
+		{"Date", formatQuoteDate(date, loc)},
 		{"Subject", subject},
 		{"To", to},
 		{"Cc", cc},
@@ -170,7 +178,7 @@ func stripForwardPrefix(subject string) string {
 }
 
 // formatForwardedMessage builds the plain-text forwarded body.
-func formatForwardedMessage(note, from, date, subject, to, cc, body string) string {
+func formatForwardedMessage(note, from, date, subject, to, cc, body string, loc *time.Location) string {
 	var sb strings.Builder
 
 	if strings.TrimSpace(note) != "" {
@@ -179,7 +187,7 @@ func formatForwardedMessage(note, from, date, subject, to, cc, body string) stri
 	}
 
 	sb.WriteString("---------- Forwarded message ---------\n")
-	for _, h := range forwardedMessageHeaders(from, date, subject, to, cc) {
+	for _, h := range forwardedMessageHeaders(from, date, subject, to, cc, loc) {
 		if h.value != "" {
 			fmt.Fprintf(&sb, "%s: %s\n", h.label, h.value)
 		}
@@ -197,7 +205,7 @@ func formatForwardedMessage(note, from, date, subject, to, cc, body string) stri
 }
 
 // formatForwardedMessageHTML builds the HTML forwarded body.
-func formatForwardedMessageHTML(note, from, date, subject, to, cc, htmlContent string) string {
+func formatForwardedMessageHTML(note, from, date, subject, to, cc, htmlContent string, loc *time.Location) string {
 	var sb strings.Builder
 
 	if strings.TrimSpace(note) != "" {
@@ -210,7 +218,7 @@ func formatForwardedMessageHTML(note, from, date, subject, to, cc, htmlContent s
 	sb.WriteString(`<div style="margin:0 0 10px 0;color:#777">---------- Forwarded message ---------</div>`)
 	sb.WriteString(`<div style="margin:0 0 10px 0;color:#777">`)
 
-	for _, h := range forwardedMessageHeaders(from, date, subject, to, cc) {
+	for _, h := range forwardedMessageHeaders(from, date, subject, to, cc, loc) {
 		if h.value != "" {
 			displayName := html.EscapeString(h.value)
 			// Format the From address more nicely if it has a name part.

--- a/internal/cmd/gmail_reply.go
+++ b/internal/cmd/gmail_reply.go
@@ -6,6 +6,7 @@ import (
 	"html"
 	"net/mail"
 	"strings"
+	"time"
 
 	"google.golang.org/api/gmail/v1"
 
@@ -257,7 +258,7 @@ func escapeTextToHTML(value string) string {
 	return strings.ReplaceAll(value, "\n", "<br>\n")
 }
 
-func applyQuoteToBodies(plainBody string, htmlBody string, quote bool, info *replyInfo) (string, string) {
+func applyQuoteToBodies(plainBody string, htmlBody string, quote bool, info *replyInfo, loc *time.Location) (string, string) {
 	if !quote || info == nil {
 		return plainBody, htmlBody
 	}
@@ -278,7 +279,7 @@ func applyQuoteToBodies(plainBody string, htmlBody string, quote bool, info *rep
 
 	outPlain := userPlain
 	if quotedPlain != "" && (!hasHTMLReply || strings.TrimSpace(userPlain) != "") {
-		outPlain += formatQuotedMessage(info.FromAddr, info.Date, quotedPlain)
+		outPlain += formatQuotedMessage(info.FromAddr, info.Date, quotedPlain, loc)
 	}
 
 	quoteContent := info.BodyHTML
@@ -289,7 +290,7 @@ func applyQuoteToBodies(plainBody string, htmlBody string, quote bool, info *rep
 		return outPlain, htmlBody
 	}
 
-	quoteHTML := formatQuotedMessageHTMLWithContent(info.FromAddr, info.Date, quoteContent)
+	quoteHTML := formatQuotedMessageHTMLWithContent(info.FromAddr, info.Date, quoteContent, loc)
 
 	outHTML := htmlBody
 	if strings.TrimSpace(outHTML) == "" {
@@ -302,7 +303,7 @@ func applyQuoteToBodies(plainBody string, htmlBody string, quote bool, info *rep
 }
 
 // formatQuotedMessage formats the original message as a quoted reply.
-func formatQuotedMessage(from, date, body string) string {
+func formatQuotedMessage(from, date, body string, loc *time.Location) string {
 	if body == "" {
 		return ""
 	}
@@ -310,9 +311,10 @@ func formatQuotedMessage(from, date, body string) string {
 	var sb strings.Builder
 	sb.WriteString("\n\n")
 
+	displayDate := formatQuoteDate(date, loc)
 	switch {
-	case date != "" && from != "":
-		fmt.Fprintf(&sb, "On %s, %s wrote:\n", date, from)
+	case displayDate != "" && from != "":
+		fmt.Fprintf(&sb, "On %s, %s wrote:\n", displayDate, from)
 	case from != "":
 		fmt.Fprintf(&sb, "%s wrote:\n", from)
 	default:
@@ -329,14 +331,14 @@ func formatQuotedMessage(from, date, body string) string {
 	return sb.String()
 }
 
-func formatQuotedMessageHTMLWithContent(from, date, htmlContent string) string {
+func formatQuotedMessageHTMLWithContent(from, date, htmlContent string, loc *time.Location) string {
 	senderName := from
 	if addr, err := mail.ParseAddress(from); err == nil && addr.Name != "" {
 		senderName = addr.Name
 	}
 
-	dateStr := date
-	if date == "" {
+	dateStr := formatQuoteDate(date, loc)
+	if dateStr == "" {
 		dateStr = "an earlier date"
 	}
 

--- a/internal/cmd/gmail_send_quote_test.go
+++ b/internal/cmd/gmail_send_quote_test.go
@@ -4,14 +4,15 @@ import (
 	"encoding/base64"
 	"strings"
 	"testing"
+	"time"
 
 	"google.golang.org/api/gmail/v1"
 )
 
 func TestFormatQuotedMessage(t *testing.T) {
-	got := formatQuotedMessage("Alice <a@example.com>", "Mon, 1 Jan 2024 00:00:00 +0000", "l1\nl2")
+	got := formatQuotedMessage("Alice <a@example.com>", "Mon, 1 Jan 2024 00:00:00 +0000", "l1\nl2", time.UTC)
 	wantContains := []string{
-		"\n\nOn Mon, 1 Jan 2024 00:00:00 +0000, Alice <a@example.com> wrote:\n",
+		"\n\nOn Mon, Jan 1, 2024 at 12:00 AM, Alice <a@example.com> wrote:\n",
 		"> l1\n",
 		"> l2\n",
 	}
@@ -22,8 +23,34 @@ func TestFormatQuotedMessage(t *testing.T) {
 	}
 }
 
+func TestFormatQuoteDate(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		loc  *time.Location
+		want string
+	}{
+		{"rfc2822 in utc", "Wed, 17 Jun 2026 00:29:51 +0000", time.UTC, "Wed, Jun 17, 2026 at 12:29 AM"},
+		{"converts offset into loc", "Wed, 17 Jun 2026 00:29:51 -0500", time.UTC, "Wed, Jun 17, 2026 at 5:29 AM"},
+		{"empty stays empty", "", time.UTC, ""},
+		{"unparseable returns trimmed raw", "  not a date  ", time.UTC, "not a date"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatQuoteDate(tc.raw, tc.loc); got != tc.want {
+				t.Fatalf("formatQuoteDate(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+
+	// A nil loc falls back to time.Local rather than panicking.
+	if got := formatQuoteDate("Wed, 17 Jun 2026 00:29:51 +0000", nil); got == "" {
+		t.Fatal("formatQuoteDate with nil loc returned empty")
+	}
+}
+
 func TestFormatQuotedMessageHTMLWithContent_EscapesHeader_NotBody(t *testing.T) {
-	out := formatQuotedMessageHTMLWithContent(`"><script>alert(1)</script>`, `<b>bad</b>`, `<b>ok</b>`)
+	out := formatQuotedMessageHTMLWithContent(`"><script>alert(1)</script>`, `<b>bad</b>`, `<b>ok</b>`, time.UTC)
 	if strings.Contains(out, "<script>") {
 		t.Fatalf("expected script tag to be escaped, got %q", out)
 	}
@@ -32,6 +59,20 @@ func TestFormatQuotedMessageHTMLWithContent_EscapesHeader_NotBody(t *testing.T) 
 	}
 	if !strings.Contains(out, "<b>ok</b>") {
 		t.Fatalf("expected htmlContent to be preserved, got %q", out)
+	}
+}
+
+func TestFormatQuotedMessageHTMLWithContent_Date(t *testing.T) {
+	// A parseable date is reformatted to Gmail style, converted into loc.
+	out := formatQuotedMessageHTMLWithContent("Alice <a@example.com>", "Wed, 17 Jun 2026 00:29:51 +0000", "<p>body</p>", time.UTC)
+	if !strings.Contains(out, "On Wed, Jun 17, 2026 at 12:29 AM, Alice wrote:") {
+		t.Fatalf("expected reformatted attribution date, got %q", out)
+	}
+
+	// An empty date falls back to "an earlier date".
+	out = formatQuotedMessageHTMLWithContent("Alice <a@example.com>", "", "<p>body</p>", time.UTC)
+	if !strings.Contains(out, "On an earlier date, Alice wrote:") {
+		t.Fatalf("expected 'an earlier date' fallback, got %q", out)
 	}
 }
 
@@ -82,6 +123,7 @@ func TestApplyQuoteToBodiesDerivesPlainReplyFromHTML(t *testing.T) {
 			Body:     "Original plain",
 			BodyHTML: "<p>Original HTML</p>",
 		},
+		time.UTC,
 	)
 
 	if !strings.Contains(plain, "HTML reply") {
@@ -104,6 +146,7 @@ func TestApplyQuoteToBodiesOmitsNonVisibleHTMLFromPlainReply(t *testing.T) {
 			Body:     "Original plain",
 			BodyHTML: "<p>Original HTML</p>",
 		},
+		time.UTC,
 	)
 
 	if !strings.Contains(plain, "Visible reply") || !strings.Contains(plain, "> Original plain") {
@@ -125,6 +168,7 @@ func TestApplyQuoteToBodiesDerivesPlainQuoteFromHTMLOriginal(t *testing.T) {
 			FromAddr: "sender@example.com",
 			BodyHTML: "<p>HTML-only original</p>",
 		},
+		time.UTC,
 	)
 
 	if !strings.Contains(plain, "HTML reply") || !strings.Contains(plain, "> HTML-only original") {
@@ -144,6 +188,7 @@ func TestApplyQuoteToBodiesKeepsImageOnlyReplyHTMLOnly(t *testing.T) {
 			Body:     "Original plain",
 			BodyHTML: "<p>Original HTML</p>",
 		},
+		time.UTC,
 	)
 
 	if strings.TrimSpace(plain) != "" {


### PR DESCRIPTION
## What

Reply and forward attributions emitted the original message's **raw RFC 2822 `Date`** header verbatim — `On Wed, 17 Jun 2026 00:29:51 -0500, … wrote:` and `Date: Wed, 17 Jun 2026 00:29:51 -0500`. This reformats it to the human style Gmail uses — `On Wed, Jun 17, 2026 at 12:29 AM, … wrote:` — across all four render paths: reply plain, reply HTML, forward plain, forward HTML.

## Why

The raw RFC 2822 date is jarring in a quoted reply/forward; Gmail (and most clients) render a human-readable attribution. This brings gog's reply/forward output in line.

## Timezone behavior

Like Gmail, the timestamp is **converted into the active user's timezone** (Gmail renders the quoted date in your timezone, not the original sender's offset). The location is resolved via the existing `mailDateLocation` helper — the same one already used for the outgoing `Date` header — so it **honors `GOG_TIMEZONE` / `default_timezone` and falls back to local**. An unparseable `Date` is left as-is so it never breaks the block. (A parseable date's weekday is recomputed from the instant, which also corrects a wrong weekday in the source header.)

## Changes

- New `formatQuoteDate(raw, loc)`, applied in `formatQuotedMessage`, `formatQuotedMessageHTMLWithContent`, and `forwardedMessageHeaders`.
- `prepareComposeReply` and `GmailForwardCmd.Run` resolve `loc` via `mailDateLocation`.
- `formatQuoteDate` and the existing `formatGmailDateInLocation` now share a small `formatMailDateInLocation` core — they differed only in the output layout, so this removes the duplication rather than adding a near-twin.

## Behavior proof

Live against a real account. **Redacted in both the commands and the output:** the real address appears as `<me>`, message ids as `<src>` / `<reply>` / `<reply-utc>` / `<fwd>`, and thread ids as `<thread>` / `<fwd-thread>`. Each `gmail get` is piped to the relevant lines. (`gmail get` renders the text/plain part; the text/html attribution carries the identical date via the same `formatQuoteDate` and is covered by unit tests.)

```console
# Source message — its raw RFC 2822 Date header is the input that gets reformatted:
$ ./bin/gog gmail get <src> --account <me> | grep '^date'
date	Tue, 23 Jun 2026 01:00:54 -0500

# Reply (local tz, PDT). The send returns the new message id used below:
$ ./bin/gog gmail reply <src> --account <me> --to <me> --body "Reply body for proof (default tz)." --json
{
  "from": "<me>",
  "messageId": "<reply>",
  "threadId": "<thread>"
}
# read it back — quote attribution reformatted to Gmail style:
$ ./bin/gog gmail get <reply> --account <me> | grep 'wrote:'
On Mon, Jun 22, 2026 at 11:00 PM, <me> wrote:

# Same source replied with GOG_TIMEZONE=UTC — converted, not just reformatted
# (11:00 PM Mon PDT == 6:00 AM Tue UTC):
$ GOG_TIMEZONE=UTC ./bin/gog gmail reply <src> --account <me> --to <me> --body "Reply body (UTC tz)." --json
{
  "from": "<me>",
  "messageId": "<reply-utc>",
  "threadId": "<thread>"
}
$ ./bin/gog gmail get <reply-utc> --account <me> | grep 'wrote:'
On Tue, Jun 23, 2026 at 6:00 AM, <me> wrote:

# Forward — the forwarded header block's Date is reformatted too:
$ ./bin/gog gmail forward <src> --account <me> --to <me> --note "Forward proof note." --json
{
  "from": "<me>",
  "messageId": "<fwd>",
  "threadId": "<fwd-thread>"
}
$ ./bin/gog gmail get <fwd> --account <me> | sed -n '/Forwarded message/,/^$/p'
---------- Forwarded message ---------
From: <me>
Date: Mon, Jun 22, 2026 at 11:00 PM
Subject: gog date-format proof — source
To: <me>

Source message body for the quoted-date proof.
```

## Testing

- Unit: `formatQuoteDate` (offset→tz conversion, empty, unparseable fallback); `formatQuotedMessage` and `formatQuotedMessageHTMLWithContent` assert the reformatted attribution (incl. the empty-date → "an earlier date" fallback); `formatForwardedMessage`/`…HTML` assert the reformatted `Date:` line.
- Command: draft and forward tests assert the rendered attribution end-to-end, with `GOG_TIMEZONE` pinned for determinism.
- `make fmt-check lint docs-check` clean.
