### PR TITLE
fix(secrets): prompt re-auth on a corrupt stored token instead of failing fatally

### DIFF
--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -236,7 +236,10 @@ func tokenSourceForAccountScopesWithStoredScopeCheck(
 	var tok secrets.Token
 
 	if t, err := store.GetToken(client, email); err != nil {
-		if errors.Is(err, keyring.ErrKeyNotFound) {
+		// An absent or corrupt stored token is equivalent to "no usable credential":
+		// surface AuthRequiredError so the caller can prompt re-auth, instead of
+		// failing every command with a non-actionable decode error.
+		if errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, secrets.ErrCorruptToken) {
 			return nil, &AuthRequiredError{Service: serviceLabel, Email: email, Client: client, Cause: err}
 		}
 

--- a/internal/secrets/token.go
+++ b/internal/secrets/token.go
@@ -27,6 +27,10 @@ type Token struct {
 var (
 	errMissingEmail        = errors.New("missing email")
 	errMissingRefreshToken = errors.New("missing refresh token")
+	// ErrCorruptToken signals a token entry is present in the keyring but cannot
+	// be decoded (e.g. interrupted write, stored-shape change). Callers should
+	// treat it equivalently to a missing token and prompt re-authentication.
+	ErrCorruptToken = errors.New("stored token is corrupt")
 )
 
 type storedToken struct {
@@ -187,7 +191,7 @@ func (s *KeyringStore) getTokenNoLockOptions(client string, email string, migrat
 
 	var st storedToken
 	if err := json.Unmarshal(item.Data, &st); err != nil {
-		return Token{}, fmt.Errorf("decode token: %w", err)
+		return Token{}, fmt.Errorf("decode token: %w: %w", ErrCorruptToken, err)
 	}
 
 	return Token{
@@ -432,7 +436,7 @@ func (s *KeyringStore) getTokenBySubjectNoLock(client string, subject string) (T
 
 	var st storedToken
 	if err := json.Unmarshal(item.Data, &st); err != nil {
-		return Token{}, fmt.Errorf("decode token: %w", err)
+		return Token{}, fmt.Errorf("decode token: %w: %w", ErrCorruptToken, err)
 	}
 
 	return Token{


### PR DESCRIPTION
## Problem

A present-but-undecodable token entry (interrupted write, stored-shape change across versions) made every command fail with a fatal, non-actionable `get token for <email>: decode token: …`. An **absent** token correctly mapped to `AuthRequiredError` → re-auth; a **corrupt** one didn't, even though the recovery is identical: re-authenticate. The user had no way out except manually deleting the keyring entry.

Closes #872.

## Fix

**Option A from the issue.** Introduce an exported sentinel `secrets.ErrCorruptToken`, wrap the `json.Unmarshal` failure with it (both decode sites in `getTokenNoLockOptions` — primary key path and subject-key path), and widen the classifier at the call site:

```go
if errors.Is(err, keyring.ErrKeyNotFound) || errors.Is(err, secrets.ErrCorruptToken) {
    return nil, &AuthRequiredError{Service: serviceLabel, Email: email, Client: client, Cause: err}
}
```

The narrower scope is deliberate. Mapping *all* non-`ErrKeyNotFound` errors to re-auth (Option C in the issue) would mask genuinely transient / operational store faults the code intentionally surfaces today: macOS Keychain locked in a headless env, file-backend wrong password, EACCES, etc. Only the **decode-corruption** case — which is semantically equivalent to "no usable credential" — is widened.

Same pattern as [`openclaw/mcporter#208`](https://github.com/openclaw/mcporter/pull/208) (corrupt cred cache → degrade to re-auth; keep security-gating material fail-closed).

## Verification

Go 1.26.2:

- New `internal/secrets/token_corrupt_test.go` seeds an in-memory keyring with `{not-json` under the primary token key and asserts:
  - `errors.Is(err, ErrCorruptToken) == true`
  - `errors.Is(err, ErrKeyNotFound) == false`
  - Control: an absent entry still classifies as `ErrKeyNotFound` (unchanged).
- **Negative control:** with the `ErrCorruptToken` wrap reverted on `token.go`, the new test fails with the exact pre-fix message — `decode token: invalid character 'n' looking for beginning of object key string`. With the fix in place, it passes.
- `go test ./internal/secrets/... ./internal/googleapi/...` — both suites pass, no regressions.
- `gofmt -l` clean, `go vet` clean.
