### PR TITLE
feat(docs): honor --tab when setting page layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.30.1 - Unreleased
 
+- Docs: honor `--tab` when setting document layout so `page-layout --tab` (and `write --pageless --tab`) target the specified tab instead of always the default tab. Page layout is per-tab; previously these silently no-opped on secondary tabs of multi-tab documents. (#878) — thanks @atmasphere.
 - Auth: recover from corrupt stored OAuth token payloads by routing only classified decode corruption through the normal re-authentication flow while preserving operational keyring errors. (#872, #874) — thanks @KrasimirKralev.
 - Calendar: add repeatable or comma-separated `events --event-types` filtering across single, selected, and all-calendar listings while preserving the existing unfiltered default. (#870) — thanks @malob.
 - Gmail: render quoted-reply and forwarded-message dates in Gmail's human-readable style using the configured account timezone. (#873) — thanks @malob.

--- a/docs/commands/gog-docs-page-layout.md
+++ b/docs/commands/gog-docs-page-layout.md
@@ -44,6 +44,7 @@ gog docs (doc) page-layout (set-page-layout,page-setup) <docId> [flags]
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Target a specific tab by title or ID (see docs list-tabs). Page layout is per-tab; omit for the default tab. |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/internal/cmd/docs_edit.go
+++ b/internal/cmd/docs_edit.go
@@ -204,8 +204,21 @@ func (c *DocsWriteCmd) applyDocumentStyle(ctx context.Context, svc *docs.Service
 	if c.Pageless {
 		mode = docsDocumentModePageless
 	}
+	// Document-style fields are per-tab. Resolve --tab to a concrete tab ID so
+	// pageless/layout lands on the targeted tab rather than silently hitting the
+	// default tab. resolveDocsTabID is a no-op when the tab is already a concrete
+	// ID (as in the plain-text path) and skipped entirely when no tab was given.
+	tabID := ""
+	if tab := strings.TrimSpace(c.Tab); tab != "" {
+		resolved, err := resolveDocsTabID(ctx, svc, docID, tab)
+		if err != nil {
+			return fmt.Errorf("resolve tab %q: %w", tab, err)
+		}
+		tabID = resolved
+	}
 	if err := setDocumentStyle(ctx, svc, docID, docsDocumentStyleOptions{
 		Mode:            mode,
+		TabID:           tabID,
 		DocsLayoutFlags: c.Layout,
 	}); err != nil {
 		return fmt.Errorf("set document style: %w", err)

--- a/internal/cmd/docs_layout.go
+++ b/internal/cmd/docs_layout.go
@@ -58,6 +58,10 @@ func (f DocsLayoutFlags) dryRunPayload() map[string]any {
 
 type docsDocumentStyleOptions struct {
 	Mode string
+	// TabID, when set, targets a specific tab. Document-style fields (e.g.
+	// documentMode/pageless) are per-tab; an empty TabID applies to the
+	// document's default tab.
+	TabID string
 	DocsLayoutFlags
 }
 
@@ -141,6 +145,7 @@ func buildUpdateDocumentStyleRequest(opts docsDocumentStyleOptions) (*docs.Updat
 	return &docs.UpdateDocumentStyleRequest{
 		DocumentStyle: style,
 		Fields:        strings.Join(fields, ","),
+		TabId:         strings.TrimSpace(opts.TabID),
 	}, nil
 }
 

--- a/internal/cmd/docs_layout_tab_test.go
+++ b/internal/cmd/docs_layout_tab_test.go
@@ -1,0 +1,42 @@
+package cmd
+
+import "testing"
+
+// buildUpdateDocumentStyleRequest must carry the TabId through to the Docs API
+// so document-style changes (e.g. pageless) can target a non-default tab.
+// Regression guard for: page-layout/write --pageless silently hitting only the
+// default tab in multi-tab docs.
+func TestBuildUpdateDocumentStyleRequest_TabID(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildUpdateDocumentStyleRequest(docsDocumentStyleOptions{
+		Mode:  docsDocumentModePageless,
+		TabID: "t.abc123",
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if req.TabId != "t.abc123" {
+		t.Fatalf("expected TabId t.abc123, got %q", req.TabId)
+	}
+	if req.DocumentStyle == nil || req.DocumentStyle.DocumentFormat == nil ||
+		req.DocumentStyle.DocumentFormat.DocumentMode != docsDocumentModePageless {
+		t.Fatalf("expected pageless documentMode, got %#v", req.DocumentStyle)
+	}
+}
+
+// Default behaviour (no tab) must leave TabId empty so the request applies to
+// the document's default tab, preserving existing single-tab behaviour.
+func TestBuildUpdateDocumentStyleRequest_NoTabID(t *testing.T) {
+	t.Parallel()
+
+	req, err := buildUpdateDocumentStyleRequest(docsDocumentStyleOptions{
+		Mode: docsDocumentModePageless,
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if req.TabId != "" {
+		t.Fatalf("expected empty TabId, got %q", req.TabId)
+	}
+}

--- a/internal/cmd/docs_set_page_layout.go
+++ b/internal/cmd/docs_set_page_layout.go
@@ -22,6 +22,8 @@ type DocsPageLayoutCmd struct {
 	DocID       string          `arg:"" name:"docId" help:"Doc ID"`
 	Layout      string          `name:"layout" enum:"pageless,pages,paged" default:"pageless" help:"Page layout: pageless or pages"`
 	LayoutFlags DocsLayoutFlags `embed:""`
+	Tab         string          `name:"tab" help:"Target a specific tab by title or ID (see docs list-tabs). Page layout is per-tab; omit for the default tab."`
+	TabID       string          `name:"tab-id" hidden:"" help:"(deprecated) Use --tab"`
 }
 
 func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -40,12 +42,20 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		}
 	}
 
+	tab, err := resolveTabArg(ctx, c.Tab, c.TabID)
+	if err != nil {
+		return err
+	}
+
 	dryRunPayload := map[string]any{
 		"documentId": docID,
 	}
 	if mode != "" {
 		dryRunPayload["layout"] = c.Layout
 		dryRunPayload["mode"] = mode
+	}
+	if tab != "" {
+		dryRunPayload["tab"] = tab
 	}
 	for k, v := range c.LayoutFlags.dryRunPayload() {
 		dryRunPayload[k] = v
@@ -59,8 +69,17 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 		return err
 	}
 
+	tabID := ""
+	if tab != "" {
+		tabID, err = resolveDocsTabID(ctx, svc, docID, tab)
+		if err != nil {
+			return fmt.Errorf("resolve tab %q: %w", tab, err)
+		}
+	}
+
 	if err := setDocumentStyle(ctx, svc, docID, docsDocumentStyleOptions{
 		Mode:            mode,
+		TabID:           tabID,
 		DocsLayoutFlags: c.LayoutFlags,
 	}); err != nil {
 		if isDocsNotFound(err) {
@@ -77,6 +96,9 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 			payload["layout"] = c.Layout
 			payload["mode"] = mode
 		}
+		if tabID != "" {
+			payload["tabId"] = tabID
+		}
 		for k, v := range c.LayoutFlags.dryRunPayload() {
 			payload[k] = v
 		}
@@ -86,6 +108,9 @@ func (c *DocsPageLayoutCmd) Run(ctx context.Context, kctx *kong.Context, flags *
 	u.Out().Linef("documentId\t%s", docID)
 	if mode != "" {
 		u.Out().Linef("layout\t%s", c.Layout)
+	}
+	if tabID != "" {
+		u.Out().Linef("tabId\t%s", tabID)
 	}
 	for k, v := range c.LayoutFlags.dryRunPayload() {
 		u.Out().Linef("%s\t%s", k, v)

--- a/internal/cmd/docs_set_page_layout_test.go
+++ b/internal/cmd/docs_set_page_layout_test.go
@@ -105,6 +105,53 @@ func TestDocsPageLayoutCmd_Pages(t *testing.T) {
 	}
 }
 
+func TestDocsPageLayoutCmd_TabTitleTargetsResolvedTab(t *testing.T) {
+	t.Parallel()
+
+	var update *docs.UpdateDocumentStyleRequest
+	docSvc, cleanup := newDocsServiceForTest(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/documents/doc1":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"documentId": "doc1",
+				"tabs": []map[string]any{{
+					"tabProperties": map[string]any{"tabId": "t.secondary", "title": "Secondary"},
+					"documentTab": map[string]any{
+						"body": map[string]any{"content": []map[string]any{{"startIndex": 0, "endIndex": 2}}},
+					},
+				}},
+			})
+		case r.Method == http.MethodPost && strings.Contains(r.URL.Path, ":batchUpdate"):
+			var req docs.BatchUpdateDocumentRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if len(req.Requests) != 1 {
+				t.Fatalf("requests = %d, want 1", len(req.Requests))
+			}
+			update = req.Requests[0].UpdateDocumentStyle
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"documentId": "doc1"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer cleanup()
+
+	flags := &RootFlags{Account: "a@b.com"}
+	ctx := withDocsTestService(newCmdRuntimeOutputContext(t, io.Discard, io.Discard), docSvc)
+	if err := runKong(t, &DocsPageLayoutCmd{}, []string{"doc1", "--tab", "Secondary"}, ctx, flags); err != nil {
+		t.Fatalf("page-layout tab: %v", err)
+	}
+	if update == nil {
+		t.Fatal("missing UpdateDocumentStyle request")
+	}
+	if update.TabId != "t.secondary" {
+		t.Fatalf("tabId = %q, want t.secondary", update.TabId)
+	}
+}
+
 func TestDocsPageLayoutCmd_EmptyDocID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

Add `--tab` support to `docs page-layout` so document-layout changes can target a specific tab, and fix `docs write --pageless` silently no-opping on secondary tabs of multi-tab documents.

## Why

Document-style fields (`documentMode`/pageless, page size, margins) are **per-tab** in the Docs API. `page-layout` and `write --pageless` built an `UpdateDocumentStyleRequest` but never set `TabId`, so the change always applied to the document's default tab. On a multi-tab document, setting pageless on a non-default tab reported success while nothing actually changed — `documentFormat.documentMode` stayed `PAGES` on the targeted tab.

## Changes

- `docs page-layout`: add `--tab` (title or ID, with the existing deprecated `--tab-id` alias), resolved to a concrete tab ID via `resolveDocsTabID`.
- `docs_layout.go`: thread `TabID` through `docsDocumentStyleOptions` onto `UpdateDocumentStyleRequest.TabId`.
- `docs write`: resolve `--tab` in `applyDocumentStyle` so `--pageless`/layout flags land on the targeted tab across every write path, including the markdown/Drive-replace path that never resolved the tab.
- Behaviour is unchanged when `--tab` is omitted (empty `TabId` → default tab).

## Tests

- New unit tests for the request builder (`TabID` set → request carries it; omitted → empty, default-tab behaviour preserved).
- `make fmt-check lint deadcode test` all pass locally; regenerated `docs/commands/gog-docs-page-layout.md` and updated `CHANGELOG.md`.
- Verified end-to-end against the live Docs API: `page-layout --layout pageless --tab <id>` flips `documentFormat.documentMode` to `PAGELESS` on the targeted secondary tab (confirmed by reading that tab back).
