### PR TITLE
feat(calendar): support resource attendees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.31.1 - Unreleased
 
+- Calendar: add a `;resource` attendee modifier for event create, attendee replacement, and additive attendee updates. (#881) — thanks @titus7490.
+
 ## 0.31.0 - 2026-06-24
 
 - Gmail: preserve HTML fragments from `--signature-file` instead of escaping their markup, without broadening HTML detection for message display or reply quoting. (#879) — thanks @kesslerio.

--- a/docs/commands/gog-calendar-create.md
+++ b/docs/commands/gog-calendar-create.md
@@ -22,7 +22,7 @@ gog calendar (cal) create (add,new) <calendarId> [flags]
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--all-day` | `bool` |  | All-day event (use date-only in --from/--to) |
 | `--attachment` | `[]string` |  | File attachment URL (can be repeated) |
-| `--attendees` | `string` |  | Comma-separated attendee emails |
+| `--attendees` | `string` |  | Comma-separated attendee emails; modifiers: ;optional, ;resource, ;comment=TEXT |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--description` | `string` |  | Description |

--- a/docs/commands/gog-calendar-update.md
+++ b/docs/commands/gog-calendar-update.md
@@ -20,10 +20,10 @@ gog calendar (cal) update (edit,set) <calendarId> <eventId> [flags]
 | --- | --- | --- | --- |
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
-| `--add-attendee` | `string` |  | Comma-separated attendee emails to add (preserves existing attendees) |
+| `--add-attendee` | `string` |  | Comma-separated attendee emails to add (preserves existing attendees); modifiers: ;optional, ;resource, ;comment=TEXT |
 | `--all-day` | `bool` |  | All-day event (use date-only in --from/--to) |
 | `--attachment` | `[]string` |  | File attachment URL (can be repeated; replaces all; set empty to clear) |
-| `--attendees` | `string` |  | Comma-separated attendee emails (replaces all; set empty to clear) |
+| `--attendees` | `string` |  | Comma-separated attendee emails (replaces all; set empty to clear); modifiers: ;optional, ;resource, ;comment=TEXT |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--description` | `string` |  | New description (set empty to clear) |

--- a/internal/cmd/calendar_add_attendee_test.go
+++ b/internal/cmd/calendar_add_attendee_test.go
@@ -98,6 +98,23 @@ func TestMergeAttendeesNewHaveNeedsAction(t *testing.T) {
 	t.Error("new attendee not found in result")
 }
 
+func TestMergeAttendeesPreservesNewAttendeeModifiers(t *testing.T) {
+	got := mergeAttendees(nil, "room@resource.calendar.google.com;resource;optional;comment=Project room")
+	if len(got) != 1 {
+		t.Fatalf("expected 1 attendee, got %d", len(got))
+	}
+	attendee := got[0]
+	if attendee.Email != "room@resource.calendar.google.com" {
+		t.Fatalf("unexpected email: %#v", attendee)
+	}
+	if !attendee.Resource || !attendee.Optional || attendee.Comment != "Project room" {
+		t.Fatalf("expected resource, optional, and comment modifiers: %#v", attendee)
+	}
+	if attendee.ResponseStatus != "needsAction" {
+		t.Fatalf("expected needsAction response status, got %q", attendee.ResponseStatus)
+	}
+}
+
 func TestMergeAttendeesWithChange(t *testing.T) {
 	existing := []*calendar.EventAttendee{
 		{Email: "existing@test.com", ResponseStatus: "accepted"},

--- a/internal/cmd/calendar_attendees.go
+++ b/internal/cmd/calendar_attendees.go
@@ -55,7 +55,7 @@ func mergeAttendeesWithChange(existing []*calendar.EventAttendee, addCSV string)
 		}
 		email := attendee.Email
 		if !existingEmails[strings.ToLower(email)] {
-			attendee.ResponseStatus = "needsAction"
+			attendee.ResponseStatus = taskStatusNeedsAction
 			out = append(out, attendee)
 			existingEmails[strings.ToLower(email)] = true
 			added = true

--- a/internal/cmd/calendar_attendees.go
+++ b/internal/cmd/calendar_attendees.go
@@ -30,8 +30,8 @@ func mergeAttendees(existing []*calendar.EventAttendee, addCSV string) []*calend
 
 // mergeAttendeesWithChange returns the merged attendees and whether at least one attendee was added.
 func mergeAttendeesWithChange(existing []*calendar.EventAttendee, addCSV string) ([]*calendar.EventAttendee, bool) {
-	newEmails := splitCSV(addCSV)
-	if len(newEmails) == 0 {
+	newAttendees := buildAttendees(addCSV)
+	if len(newAttendees) == 0 {
 		return existing, false
 	}
 
@@ -44,17 +44,19 @@ func mergeAttendeesWithChange(existing []*calendar.EventAttendee, addCSV string)
 	}
 
 	// Start with existing attendees (preserving all metadata)
-	out := make([]*calendar.EventAttendee, 0, len(existing)+len(newEmails))
+	out := make([]*calendar.EventAttendee, 0, len(existing)+len(newAttendees))
 	out = append(out, existing...)
 
 	// Add new attendees that don't already exist
 	added := false
-	for _, email := range newEmails {
+	for _, attendee := range newAttendees {
+		if attendee == nil || attendee.Email == "" {
+			continue
+		}
+		email := attendee.Email
 		if !existingEmails[strings.ToLower(email)] {
-			out = append(out, &calendar.EventAttendee{
-				Email:          email,
-				ResponseStatus: "needsAction",
-			})
+			attendee.ResponseStatus = "needsAction"
+			out = append(out, attendee)
 			existingEmails[strings.ToLower(email)] = true
 			added = true
 		}
@@ -79,6 +81,10 @@ func parseAttendee(s string) *calendar.EventAttendee {
 		lower := strings.ToLower(raw)
 		if lower == "optional" {
 			attendee.Optional = true
+			continue
+		}
+		if lower == "resource" {
+			attendee.Resource = true
 			continue
 		}
 		if strings.HasPrefix(lower, "comment=") {

--- a/internal/cmd/calendar_create_update_test.go
+++ b/internal/cmd/calendar_create_update_test.go
@@ -719,7 +719,7 @@ func TestCalendarUpdateCmd_WithMeetScopeFutureExistingConferenceIsIdempotent(t *
 }
 
 func TestCalendarUpdateCmd_AddAttendee(t *testing.T) {
-	var patchedAttendees int
+	var patchedAttendees []*calendar.EventAttendee
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimPrefix(r.URL.Path, "/calendar/v3")
 		switch {
@@ -735,7 +735,7 @@ func TestCalendarUpdateCmd_AddAttendee(t *testing.T) {
 		case r.Method == http.MethodPatch && path == "/calendars/cal@example.com/events/ev":
 			var body calendar.Event
 			_ = json.NewDecoder(r.Body).Decode(&body)
-			patchedAttendees = len(body.Attendees)
+			patchedAttendees = body.Attendees
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id": "ev",
@@ -762,13 +762,20 @@ func TestCalendarUpdateCmd_AddAttendee(t *testing.T) {
 	if err := runKong(t, cmd, []string{
 		"cal@example.com",
 		"ev",
-		"--add-attendee", "b@example.com",
+		"--add-attendee", "room@resource.calendar.google.com;resource;optional;comment=Project room",
 		"--scope", "all",
 	}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
 		t.Fatalf("runKong: %v", err)
 	}
-	if patchedAttendees < 2 {
-		t.Fatalf("expected merged attendees, got %d", patchedAttendees)
+	if len(patchedAttendees) < 2 {
+		t.Fatalf("expected merged attendees, got %d", len(patchedAttendees))
+	}
+	added := patchedAttendees[len(patchedAttendees)-1]
+	if added.Email != "room@resource.calendar.google.com" || !added.Resource || !added.Optional || added.Comment != "Project room" {
+		t.Fatalf("unexpected added resource attendee: %#v", added)
+	}
+	if added.ResponseStatus != "needsAction" {
+		t.Fatalf("expected needsAction response status, got %q", added.ResponseStatus)
 	}
 }
 

--- a/internal/cmd/calendar_edit.go
+++ b/internal/cmd/calendar_edit.go
@@ -29,7 +29,7 @@ type CalendarCreateCmd struct {
 	PlaceID               string   `name:"place-id" help:"Resolve a Google Places ID and use it as event location"`
 	PlaceLanguage         string   `name:"place-language" help:"Places API language code for location lookup"`
 	PlaceRegion           string   `name:"place-region" help:"Places API region code for location lookup"`
-	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails"`
+	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails; modifiers: ;optional, ;resource, ;comment=TEXT"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
 	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated." sep:"none"`
 	Reminders             []string `name:"reminder" help:"Custom reminders as method:duration (e.g., popup:30m, email:1d). Can be repeated (max 5)."`
@@ -188,8 +188,8 @@ type CalendarUpdateCmd struct {
 	PlaceID               string   `name:"place-id" help:"Resolve a Google Places ID and use it as event location"`
 	PlaceLanguage         string   `name:"place-language" help:"Places API language code for location lookup"`
 	PlaceRegion           string   `name:"place-region" help:"Places API region code for location lookup"`
-	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails (replaces all; set empty to clear)"`
-	AddAttendee           string   `name:"add-attendee" help:"Comma-separated attendee emails to add (preserves existing attendees)"`
+	Attendees             string   `name:"attendees" help:"Comma-separated attendee emails (replaces all; set empty to clear); modifiers: ;optional, ;resource, ;comment=TEXT"`
+	AddAttendee           string   `name:"add-attendee" help:"Comma-separated attendee emails to add (preserves existing attendees); modifiers: ;optional, ;resource, ;comment=TEXT"`
 	Attachments           []string `name:"attachment" help:"File attachment URL (can be repeated; replaces all; set empty to clear)"`
 	AllDay                bool     `name:"all-day" help:"All-day event (use date-only in --from/--to)"`
 	Recurrence            []string `name:"rrule" help:"Recurrence rules (e.g., 'RRULE:FREQ=MONTHLY;BYMONTHDAY=11'). Can be repeated. Set empty to clear." sep:"none"`

--- a/internal/cmd/calendar_edit_patch_test.go
+++ b/internal/cmd/calendar_edit_patch_test.go
@@ -55,6 +55,34 @@ func TestCalendarUpdateBuildPatch(t *testing.T) {
 	}
 }
 
+func TestCalendarUpdateBuildPatchResourceAttendee(t *testing.T) {
+	cmd := &CalendarUpdateCmd{}
+	parser, err := kong.New(cmd, kong.Writers(io.Discard, io.Discard))
+	if err != nil {
+		t.Fatalf("kong.New: %v", err)
+	}
+	kctx, err := parser.Parse([]string{
+		"cal1",
+		"evt1",
+		"--attendees", "room@resource.calendar.google.com;resource;optional;comment=Project room",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	patch, changed, err := buildCalendarUpdatePatch(calendarUpdateInputFromCommand(cmd), calendarUpdateFieldsFromKong(kctx))
+	if err != nil {
+		t.Fatalf("buildUpdatePatch: %v", err)
+	}
+	if !changed || len(patch.Attendees) != 1 {
+		t.Fatalf("unexpected attendees patch: %#v", patch)
+	}
+	attendee := patch.Attendees[0]
+	if attendee.Email != "room@resource.calendar.google.com" || !attendee.Resource || !attendee.Optional || attendee.Comment != "Project room" {
+		t.Fatalf("unexpected resource attendee: %#v", attendee)
+	}
+}
+
 func TestCalendarUpdateBuildPatch_ClearFields(t *testing.T) {
 	cmd := &CalendarUpdateCmd{}
 	parser, err := kong.New(cmd, kong.Writers(io.Discard, io.Discard))

--- a/internal/cmd/calendar_event_plan_test.go
+++ b/internal/cmd/calendar_event_plan_test.go
@@ -147,6 +147,26 @@ func TestBuildCalendarCreatePlan(t *testing.T) {
 	}
 }
 
+func TestBuildCalendarCreatePlanResourceAttendee(t *testing.T) {
+	plan, err := buildCalendarCreatePlan(defaultConfigStoreForTest(t), calendarCreateInput{
+		CalendarID: "primary",
+		Summary:    "Room booking",
+		From:       "2026-05-10T10:00:00Z",
+		To:         "2026-05-10T11:00:00Z",
+		Attendees:  "room@resource.calendar.google.com;resource;comment=Project room",
+	}, calendarCreateFields{})
+	if err != nil {
+		t.Fatalf("buildCalendarCreatePlan: %v", err)
+	}
+	if len(plan.Event.Attendees) != 1 {
+		t.Fatalf("expected 1 attendee, got %#v", plan.Event.Attendees)
+	}
+	attendee := plan.Event.Attendees[0]
+	if attendee.Email != "room@resource.calendar.google.com" || !attendee.Resource || attendee.Comment != "Project room" {
+		t.Fatalf("unexpected resource attendee: %#v", attendee)
+	}
+}
+
 func TestBuildCalendarCreatePlanRejectsConferenceConflict(t *testing.T) {
 	_, err := buildCalendarCreatePlan(defaultConfigStoreForTest(t), calendarCreateInput{
 		CalendarID: "primary",

--- a/internal/cmd/calendar_test.go
+++ b/internal/cmd/calendar_test.go
@@ -151,15 +151,18 @@ func TestParseAttendee(t *testing.T) {
 		input    string
 		email    string
 		optional bool
+		resource bool
 		comment  string
 		isNil    bool
 	}{
-		{"alice@example.com", "alice@example.com", false, "", false},
-		{"bob@example.com;optional", "bob@example.com", true, "", false},
-		{"carol@example.com;comment=FYI only", "carol@example.com", false, "FYI only", false},
-		{"dave@example.com;OPTIONAL;comment=Hi", "dave@example.com", true, "Hi", false},
-		{";optional", "", false, "", true},
-		{"", "", false, "", true},
+		{"alice@example.com", "alice@example.com", false, false, "", false},
+		{"bob@example.com;optional", "bob@example.com", true, false, "", false},
+		{"carol@example.com;comment=FYI only", "carol@example.com", false, false, "FYI only", false},
+		{"dave@example.com;OPTIONAL;comment=Hi", "dave@example.com", true, false, "Hi", false},
+		{"room@example.com;RESOURCE", "room@example.com", false, true, "", false},
+		{"room@example.com;resource;optional;comment=Project room", "room@example.com", true, true, "Project room", false},
+		{";optional", "", false, false, "", true},
+		{"", "", false, false, "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -174,7 +177,7 @@ func TestParseAttendee(t *testing.T) {
 				t.Fatalf("expected attendee, got nil")
 				return
 			}
-			if got.Email != tt.email || got.Optional != tt.optional || got.Comment != tt.comment {
+			if got.Email != tt.email || got.Optional != tt.optional || got.Resource != tt.resource || got.Comment != tt.comment {
 				t.Fatalf("unexpected attendee: %#v", got)
 			}
 		})


### PR DESCRIPTION
## Summary

- add `;resource` as an attendee modifier for Google Calendar events
- support it consistently in `calendar create --attendees`, `calendar update --attendees`, and `calendar update --add-attendee`
- keep the existing `;optional` and `;comment=...` attendee modifiers working alongside it
- update generated command docs and focused Calendar tests

## Why

Google Calendar represents rooms and equipment as event attendees with `resource: true`. `gog` already exposes high-level Calendar create/update commands and attendee modifiers for `optional` and `comment`, but callers could not mark an attendee as a Calendar resource without dropping down to raw API calls.

This keeps the high-level CLI useful for generic Workspace room/resource booking while leaving organization-specific room selection, FreeBusy fallback, and acceptance checks outside gogcli.

## Compatibility

- Additive syntax only: existing `email`, `email;optional`, and `email;comment=...` inputs keep their behavior.
- No default behavior changes: attendees are only marked as resources when `;resource` is present.
- No OAuth scope changes, dependency changes, auth changes, or CODE-specific room aliases/workflows.
- `calendar update --add-attendee` still preserves existing attendee metadata and skips duplicate emails; use `--attendees` when replacing the attendee list is intended.

## Behavior proof

Dry-run from this branch shows the outgoing Calendar event payload sets `resource: true` and preserves the other attendee modifiers:

```console
$ ./bin/gog calendar create primary \
  --summary 'Resource attendee dry run' \
  --from 2026-06-26T10:00:00+02:00 \
  --to 2026-06-26T10:30:00+02:00 \
  --attendees 'room@resource.calendar.google.com;resource;optional;comment=Project room' \
  --dry-run --json
```

```json
{
  "dry_run": true,
  "op": "calendar.create",
  "request": {
    "event": {
      "attendees": [
        {
          "comment": "Project room",
          "email": "room@resource.calendar.google.com",
          "optional": true,
          "resource": true
        }
      ]
    }
  }
}
```

Live validation was also done outside this PR with a local Workspace room-booking wrapper using the same Calendar resource-attendee contract:

- created a disposable Google Calendar event with a room/resource attendee
- observed the room attendee reach `responseStatus: accepted`
- deleted the event and verified the event status became `cancelled`
- created a temporary blocker, then confirmed the booking wrapper returned `no_rooms_available` for the occupied slot and did not create a second booking
- removed all disposable test events afterward

The local room-selection wrapper is intentionally not included here; this PR only exposes the generic Google Calendar `EventAttendee.resource` field in the existing attendee syntax.

## Tests

- `go test -vet=off ./internal/cmd -run 'TestParseAttendee|TestMergeAttendees|TestCalendarUpdateCmd_AddAttendee|TestCalendarUpdateBuildPatchResourceAttendee|TestBuildCalendarCreatePlanResourceAttendee'`
- `go test -vet=off ./internal/cmd`
- `make docs-commands`
- `make build`
- `git diff --check origin/main...HEAD`
- `./bin/gog calendar create primary --summary 'Resource attendee dry run' --from 2026-06-26T10:00:00+02:00 --to 2026-06-26T10:30:00+02:00 --attendees 'room@resource.calendar.google.com;resource;optional;comment=Project room' --dry-run --json`
- `go test -vet=off ./...`
