### PR TITLE
feat(update): add release status check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.31.2 - Unreleased
 
+- CLI: add read-only `update status` / `update check` release metadata, platform asset, checksum, and install-method reporting. (#882) — thanks @titus7490.
 - Docs: add `docs format --spacing-mode` for setting paragraph spacing collapse behavior alongside `--space-above` and `--space-below`. (#885) — thanks @odyssey4me.
 
 ## 0.31.1 - 2026-06-26

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -672,6 +672,8 @@ Generated from `gog schema --json`.
     - [`gog tasks (task) update (edit,set) <tasklistId> <taskId> [flags]`](commands/gog-tasks-update.md) - Update a task
   - [`gog time <command> [flags]`](commands/gog-time.md) - Local time utilities
     - [`gog time now [flags]`](commands/gog-time-now.md) - Show current time
+  - [`gog update <command> [flags]`](commands/gog-update.md) - Check gogcli release status
+    - [`gog update status (check) [flags]`](commands/gog-update-status.md) - Show installed and latest gogcli release status
   - [`gog upload (up,put) <localPath> [flags]`](commands/gog-upload.md) - Upload a file to Drive (alias for 'drive upload')
   - [`gog version [flags]`](commands/gog-version.md) - Print version
   - [`gog whoami (who-am-i) [flags]`](commands/gog-whoami.md) - Show your profile (alias for 'people me')

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 700.
+Generated pages: 702.
 
 ## Top-level Commands
 
@@ -46,6 +46,7 @@ Generated pages: 700.
 - [gog status](gog-status.md) - Show auth/config status (alias for 'auth status')
 - [gog tasks](gog-tasks.md) - Google Tasks
 - [gog time](gog-time.md) - Local time utilities
+- [gog update](gog-update.md) - Check gogcli release status
 - [gog upload](gog-upload.md) - Upload a file to Drive (alias for 'drive upload')
 - [gog version](gog-version.md) - Print version
 - [gog whoami](gog-whoami.md) - Show your profile (alias for 'people me')
@@ -724,6 +725,8 @@ Generated pages: 700.
     - [gog tasks update](gog-tasks-update.md) - Update a task
   - [gog time](gog-time.md) - Local time utilities
     - [gog time now](gog-time-now.md) - Show current time
+  - [gog update](gog-update.md) - Check gogcli release status
+    - [gog update status](gog-update-status.md) - Show installed and latest gogcli release status
   - [gog upload](gog-upload.md) - Upload a file to Drive (alias for 'drive upload')
   - [gog version](gog-version.md) - Print version
   - [gog whoami](gog-whoami.md) - Show your profile (alias for 'people me')

--- a/docs/commands/gog-update-status.md
+++ b/docs/commands/gog-update-status.md
@@ -1,0 +1,47 @@
+# `gog update status`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Show installed and latest gogcli release status
+
+## Usage
+
+```bash
+gog update status (check) [flags]
+```
+
+## Parent
+
+- [gog update](gog-update.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--timeout` | `time.Duration` | 10s | HTTP timeout for GitHub release metadata |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog update](gog-update.md)
+- [Command index](README.md)

--- a/docs/commands/gog-update.md
+++ b/docs/commands/gog-update.md
@@ -1,0 +1,50 @@
+# `gog update`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+Check gogcli release status
+
+## Usage
+
+```bash
+gog update <command> [flags]
+```
+
+## Parent
+
+- [gog](gog.md)
+
+## Subcommands
+
+- [gog update status](gog-update-status.md) - Show installed and latest gogcli release status
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog](gog.md)
+- [Command index](README.md)

--- a/docs/commands/gog.md
+++ b/docs/commands/gog.md
@@ -56,6 +56,7 @@ gog <command> [flags]
 - [gog status](gog-status.md) - Show auth/config status (alias for 'auth status')
 - [gog tasks](gog-tasks.md) - Google Tasks
 - [gog time](gog-time.md) - Local time utilities
+- [gog update](gog-update.md) - Check gogcli release status
 - [gog upload](gog-upload.md) - Upload a file to Drive (alias for 'drive upload')
 - [gog version](gog-version.md) - Print version
 - [gog whoami](gog-whoami.md) - Show your profile (alias for 'people me')

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -51,7 +51,7 @@ func gmailWatchStatePath(layout config.Layout, account string) (string, error) {
 func sanitizeAccountForPath(account string) string {
 	clean := strings.TrimSpace(strings.ToLower(account))
 	if clean == "" {
-		return trackingUnknown
+		return "unknown"
 	}
 
 	var builder strings.Builder

--- a/internal/cmd/gmail_watch_state.go
+++ b/internal/cmd/gmail_watch_state.go
@@ -51,7 +51,7 @@ func gmailWatchStatePath(layout config.Layout, account string) (string, error) {
 func sanitizeAccountForPath(account string) string {
 	clean := strings.TrimSpace(strings.ToLower(account))
 	if clean == "" {
-		return "unknown"
+		return trackingUnknown
 	}
 
 	var builder strings.Builder

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -86,6 +86,7 @@ type CLI struct {
 	Maps          MapsCmd               `cmd:"" aliases:"map" help:"Google Maps"`
 	Classroom     ClassroomCmd          `cmd:"" aliases:"class" help:"Google Classroom"`
 	Time          TimeCmd               `cmd:"" help:"Local time utilities"`
+	Update        UpdateCmd             `cmd:"" help:"Check gogcli release status"`
 	Gmail         GmailCmd              `cmd:"" aliases:"mail,email" help:"Gmail"`
 	Chat          ChatCmd               `cmd:"" help:"Google Chat"`
 	Contacts      ContactsCmd           `cmd:"" aliases:"contact" help:"Google Contacts"`

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -188,16 +188,16 @@ func updateClient(timeout time.Duration) *http.Client {
 	return &clone
 }
 
-func fetchLatestGitHubRelease(ctx context.Context, client *http.Client, url string) (githubRelease, error) {
+func fetchLatestGitHubRelease(ctx context.Context, client *http.Client, endpoint string) (githubRelease, error) {
 	var release githubRelease
-	apiErr := fetchUpdateJSON(ctx, client, url, &release)
+	apiErr := fetchUpdateJSON(ctx, client, endpoint, &release)
 	if apiErr == nil {
 		return release, nil
 	}
 
 	fallback, fallbackErr := fetchLatestGitHubReleaseRedirect(ctx, client, updateLatestWebURL)
 	if fallbackErr != nil {
-		return githubRelease{}, fmt.Errorf("fetch latest release: API: %v; web fallback: %w", apiErr, fallbackErr)
+		return githubRelease{}, fmt.Errorf("fetch latest release: API: %s; web fallback: %w", apiErr.Error(), fallbackErr)
 	}
 	return fallback, nil
 }
@@ -258,8 +258,8 @@ func updateReleaseAssetURL(tag string, assetName string) string {
 		url.PathEscape(tag) + "/" + url.PathEscape(assetName)
 }
 
-func fetchUpdateJSON(ctx context.Context, client *http.Client, url string, dst any) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func fetchUpdateJSON(ctx context.Context, client *http.Client, endpoint string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return err
 	}
@@ -285,8 +285,8 @@ func fetchUpdateJSON(ctx context.Context, client *http.Client, url string, dst a
 	return nil
 }
 
-func fetchAssetChecksum(ctx context.Context, client *http.Client, url string, assetName string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+func fetchAssetChecksum(ctx context.Context, client *http.Client, endpoint string, assetName string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return "", fmt.Errorf("fetch checksums.txt: %w", err)
 	}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -1,0 +1,370 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+	"github.com/steipete/gogcli/internal/ui"
+)
+
+const (
+	updateDefaultLatestReleaseURL = "https://api.github.com/repos/openclaw/gogcli/releases/latest"
+	updateDefaultTimeout          = 10 * time.Second
+)
+
+var (
+	updateHTTPClient       = http.DefaultClient
+	updateLatestReleaseURL = updateDefaultLatestReleaseURL
+)
+
+type UpdateCmd struct {
+	Status UpdateStatusCmd `cmd:"" name:"status" aliases:"check" help:"Show installed and latest gogcli release status"`
+}
+
+type UpdateStatusCmd struct {
+	Timeout time.Duration `name:"timeout" help:"HTTP timeout for GitHub release metadata" default:"10s"`
+}
+
+type updateStatusReport struct {
+	CurrentVersion      string   `json:"current_version"`
+	CurrentCommit       string   `json:"current_commit,omitempty"`
+	CurrentDate         string   `json:"current_date,omitempty"`
+	LatestVersion       string   `json:"latest_version,omitempty"`
+	LatestURL           string   `json:"latest_url,omitempty"`
+	UpdateAvailable     bool     `json:"update_available"`
+	Platform            string   `json:"platform"`
+	PlatformAsset       string   `json:"platform_asset,omitempty"`
+	PlatformAssetURL    string   `json:"platform_asset_url,omitempty"`
+	ChecksumAvailable   bool     `json:"checksum_available"`
+	ChecksumsURL        string   `json:"checksums_url,omitempty"`
+	PlatformAssetSHA256 string   `json:"platform_asset_sha256,omitempty"`
+	InstallMethod       string   `json:"install_method"`
+	Executable          string   `json:"executable,omitempty"`
+	SelfUpdateSupported bool     `json:"self_update_supported"`
+	Warnings            []string `json:"warnings,omitempty"`
+}
+
+type githubRelease struct {
+	TagName string               `json:"tag_name"`
+	Name    string               `json:"name"`
+	HTMLURL string               `json:"html_url"`
+	Assets  []githubReleaseAsset `json:"assets"`
+}
+
+type githubReleaseAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+func (c *UpdateStatusCmd) Run(ctx context.Context) error {
+	report, err := buildUpdateStatusReport(ctx, c.Timeout)
+	if err != nil {
+		return err
+	}
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), report)
+	}
+	writeUpdateStatusText(ctx, report)
+	return nil
+}
+
+func buildUpdateStatusReport(ctx context.Context, timeout time.Duration) (updateStatusReport, error) {
+	current := resolvedVersion()
+	platform := runtime.GOOS + "/" + runtime.GOARCH
+	installMethod, executable, installWarnings := detectUpdateInstallMethod()
+	report := updateStatusReport{
+		CurrentVersion:      current,
+		CurrentCommit:       strings.TrimSpace(commit),
+		CurrentDate:         strings.TrimSpace(date),
+		Platform:            platform,
+		InstallMethod:       installMethod,
+		Executable:          executable,
+		SelfUpdateSupported: installMethod == "standalone",
+		Warnings:            installWarnings,
+	}
+
+	client := updateClient(timeout)
+	release, err := fetchLatestGitHubRelease(ctx, client, updateLatestReleaseURL)
+	if err != nil {
+		return updateStatusReport{}, err
+	}
+	report.LatestVersion = strings.TrimSpace(release.TagName)
+	report.LatestURL = strings.TrimSpace(release.HTMLURL)
+	if report.LatestVersion == "" {
+		report.Warnings = append(report.Warnings, "latest release did not include tag_name")
+	}
+
+	updateAvailable, versionsComparable := updateAvailable(current, report.LatestVersion)
+	report.UpdateAvailable = updateAvailable
+	if !versionsComparable {
+		report.Warnings = append(report.Warnings, "could not compare current and latest release versions")
+	}
+
+	assetName := platformAssetName(report.LatestVersion, runtime.GOOS, runtime.GOARCH)
+	if assetName != "" {
+		report.PlatformAsset = assetName
+		if asset, ok := findReleaseAsset(release.Assets, assetName); ok {
+			report.PlatformAssetURL = asset.BrowserDownloadURL
+		} else {
+			report.Warnings = append(report.Warnings, "no release asset found for "+platform)
+		}
+	}
+
+	if checksumAsset, ok := findReleaseAsset(release.Assets, "checksums.txt"); ok {
+		report.ChecksumAvailable = true
+		report.ChecksumsURL = checksumAsset.BrowserDownloadURL
+		if report.PlatformAsset != "" {
+			sum, checksumErr := fetchAssetChecksum(ctx, client, checksumAsset.BrowserDownloadURL, report.PlatformAsset)
+			if checksumErr != nil {
+				report.Warnings = append(report.Warnings, checksumErr.Error())
+			} else {
+				report.PlatformAssetSHA256 = sum
+			}
+		}
+	} else {
+		report.Warnings = append(report.Warnings, "checksums.txt not found on latest release")
+	}
+
+	return report, nil
+}
+
+func writeUpdateStatusText(ctx context.Context, report updateStatusReport) {
+	u := ui.FromContext(ctx)
+	if u == nil {
+		return
+	}
+	u.Out().Linef("current_version\t%s", report.CurrentVersion)
+	if report.CurrentCommit != "" {
+		u.Out().Linef("current_commit\t%s", report.CurrentCommit)
+	}
+	if report.CurrentDate != "" {
+		u.Out().Linef("current_date\t%s", report.CurrentDate)
+	}
+	u.Out().Linef("latest_version\t%s", report.LatestVersion)
+	u.Out().Linef("update_available\t%t", report.UpdateAvailable)
+	u.Out().Linef("platform\t%s", report.Platform)
+	if report.PlatformAsset != "" {
+		u.Out().Linef("platform_asset\t%s", report.PlatformAsset)
+	}
+	if report.PlatformAssetSHA256 != "" {
+		u.Out().Linef("platform_asset_sha256\t%s", report.PlatformAssetSHA256)
+	}
+	u.Out().Linef("install_method\t%s", report.InstallMethod)
+	u.Out().Linef("self_update_supported\t%t", report.SelfUpdateSupported)
+	for _, warning := range report.Warnings {
+		u.Out().Linef("warning\t%s", warning)
+	}
+}
+
+func updateClient(timeout time.Duration) *http.Client {
+	if timeout <= 0 {
+		timeout = updateDefaultTimeout
+	}
+	if updateHTTPClient == nil {
+		return &http.Client{Timeout: timeout}
+	}
+	if updateHTTPClient.Timeout != 0 {
+		return updateHTTPClient
+	}
+	clone := *updateHTTPClient
+	clone.Timeout = timeout
+	return &clone
+}
+
+func fetchLatestGitHubRelease(ctx context.Context, client *http.Client, url string) (githubRelease, error) {
+	var release githubRelease
+	if err := fetchUpdateJSON(ctx, client, url, &release); err != nil {
+		return githubRelease{}, fmt.Errorf("fetch latest release: %w", err)
+	}
+	return release, nil
+}
+
+func fetchUpdateJSON(ctx context.Context, client *http.Client, url string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", "gogcli/"+resolvedVersion())
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		msg := strings.TrimSpace(string(body))
+		if msg == "" {
+			msg = resp.Status
+		}
+		return fmt.Errorf("github returned %s: %s", resp.Status, msg)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(dst); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	return nil
+}
+
+func fetchAssetChecksum(ctx context.Context, client *http.Client, url string, assetName string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksums.txt: %w", err)
+	}
+	req.Header.Set("User-Agent", "gogcli/"+resolvedVersion())
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch checksums.txt: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("fetch checksums.txt: github returned %s", resp.Status)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[len(fields)-1], "*")
+		if name == assetName {
+			return fields[0], nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("read checksums.txt: %w", err)
+	}
+	return "", fmt.Errorf("checksum for %s not found in checksums.txt", assetName)
+}
+
+func findReleaseAsset(assets []githubReleaseAsset, name string) (githubReleaseAsset, bool) {
+	for _, asset := range assets {
+		if asset.Name == name {
+			return asset, true
+		}
+	}
+	return githubReleaseAsset{}, false
+}
+
+func platformAssetName(tag string, goos string, goarch string) string {
+	version := strings.TrimPrefix(strings.TrimSpace(tag), "v")
+	if version == "" {
+		return ""
+	}
+	ext := ".tar.gz"
+	if goos == "windows" {
+		ext = ".zip"
+	}
+	return fmt.Sprintf("gogcli_%s_%s_%s%s", version, goos, goarch, ext)
+}
+
+func updateAvailable(current string, latest string) (bool, bool) {
+	cmp, ok := compareReleaseVersions(current, latest)
+	if !ok {
+		return false, false
+	}
+	return cmp < 0, true
+}
+
+func compareReleaseVersions(current string, latest string) (int, bool) {
+	currentParts, okCurrent := releaseVersionParts(current)
+	latestParts, okLatest := releaseVersionParts(latest)
+	if !okCurrent || !okLatest {
+		return 0, false
+	}
+	maxLen := len(currentParts)
+	if len(latestParts) > maxLen {
+		maxLen = len(latestParts)
+	}
+	for i := 0; i < maxLen; i++ {
+		currentPart := 0
+		if i < len(currentParts) {
+			currentPart = currentParts[i]
+		}
+		latestPart := 0
+		if i < len(latestParts) {
+			latestPart = latestParts[i]
+		}
+		if currentPart < latestPart {
+			return -1, true
+		}
+		if currentPart > latestPart {
+			return 1, true
+		}
+	}
+	return 0, true
+}
+
+func releaseVersionParts(value string) ([]int, bool) {
+	v := strings.TrimSpace(value)
+	v = strings.TrimPrefix(v, "v")
+	if v == "" || v == sentinelDev {
+		return nil, false
+	}
+	if idx := strings.IndexAny(v, "-+"); idx >= 0 {
+		v = v[:idx]
+	}
+	fields := strings.Split(v, ".")
+	if len(fields) == 0 {
+		return nil, false
+	}
+	parts := make([]int, 0, len(fields))
+	for _, field := range fields {
+		if field == "" {
+			return nil, false
+		}
+		n, err := strconv.Atoi(field)
+		if err != nil || n < 0 {
+			return nil, false
+		}
+		parts = append(parts, n)
+	}
+	return parts, true
+}
+
+func detectUpdateInstallMethod() (method string, executable string, warnings []string) {
+	exe, err := os.Executable()
+	if err != nil {
+		return trackingUnknown, "", []string{"could not determine executable path: " + err.Error()}
+	}
+	resolved := exe
+	if resolvedExe, evalErr := filepath.EvalSymlinks(exe); evalErr == nil {
+		resolved = resolvedExe
+	}
+	lower := strings.ToLower(resolved)
+	switch {
+	case isDockerRuntime():
+		method = "docker"
+	case strings.Contains(lower, "/cellar/") || strings.Contains(lower, "/homebrew/") || strings.Contains(lower, "/linuxbrew/"):
+		method = "homebrew"
+	case strings.Contains(lower, string(filepath.Separator)+"go-build") || strings.HasSuffix(lower, ".test"):
+		method = "source"
+	default:
+		method = "standalone"
+	}
+	return method, resolved, nil
+}
+
+func isDockerRuntime() bool {
+	if _, err := os.Stat("/.dockerenv"); err == nil {
+		return true
+	}
+	data, err := os.ReadFile("/proc/1/cgroup")
+	if err != nil {
+		return false
+	}
+	text := strings.ToLower(string(data))
+	return strings.Contains(text, "docker") || strings.Contains(text, "kubepods") || strings.Contains(text, "containerd")
+}

--- a/internal/cmd/update.go
+++ b/internal/cmd/update.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"bufio"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -20,12 +23,15 @@ import (
 
 const (
 	updateDefaultLatestReleaseURL = "https://api.github.com/repos/openclaw/gogcli/releases/latest"
+	updateDefaultLatestWebURL     = "https://github.com/openclaw/gogcli/releases/latest"
 	updateDefaultTimeout          = 10 * time.Second
+	updateInstallUnknown          = "unknown"
 )
 
 var (
 	updateHTTPClient       = http.DefaultClient
 	updateLatestReleaseURL = updateDefaultLatestReleaseURL
+	updateLatestWebURL     = updateDefaultLatestWebURL
 )
 
 type UpdateCmd struct {
@@ -51,15 +57,15 @@ type updateStatusReport struct {
 	PlatformAssetSHA256 string   `json:"platform_asset_sha256,omitempty"`
 	InstallMethod       string   `json:"install_method"`
 	Executable          string   `json:"executable,omitempty"`
-	SelfUpdateSupported bool     `json:"self_update_supported"`
 	Warnings            []string `json:"warnings,omitempty"`
 }
 
 type githubRelease struct {
-	TagName string               `json:"tag_name"`
-	Name    string               `json:"name"`
-	HTMLURL string               `json:"html_url"`
-	Assets  []githubReleaseAsset `json:"assets"`
+	TagName         string               `json:"tag_name"`
+	Name            string               `json:"name"`
+	HTMLURL         string               `json:"html_url"`
+	Assets          []githubReleaseAsset `json:"assets"`
+	SyntheticAssets bool                 `json:"-"`
 }
 
 type githubReleaseAsset struct {
@@ -84,14 +90,13 @@ func buildUpdateStatusReport(ctx context.Context, timeout time.Duration) (update
 	platform := runtime.GOOS + "/" + runtime.GOARCH
 	installMethod, executable, installWarnings := detectUpdateInstallMethod()
 	report := updateStatusReport{
-		CurrentVersion:      current,
-		CurrentCommit:       strings.TrimSpace(commit),
-		CurrentDate:         strings.TrimSpace(date),
-		Platform:            platform,
-		InstallMethod:       installMethod,
-		Executable:          executable,
-		SelfUpdateSupported: installMethod == "standalone",
-		Warnings:            installWarnings,
+		CurrentVersion: current,
+		CurrentCommit:  strings.TrimSpace(commit),
+		CurrentDate:    strings.TrimSpace(date),
+		Platform:       platform,
+		InstallMethod:  installMethod,
+		Executable:     executable,
+		Warnings:       installWarnings,
 	}
 
 	client := updateClient(timeout)
@@ -116,6 +121,8 @@ func buildUpdateStatusReport(ctx context.Context, timeout time.Duration) (update
 		report.PlatformAsset = assetName
 		if asset, ok := findReleaseAsset(release.Assets, assetName); ok {
 			report.PlatformAssetURL = asset.BrowserDownloadURL
+		} else if release.SyntheticAssets {
+			report.PlatformAssetURL = updateReleaseAssetURL(release.TagName, assetName)
 		} else {
 			report.Warnings = append(report.Warnings, "no release asset found for "+platform)
 		}
@@ -161,7 +168,6 @@ func writeUpdateStatusText(ctx context.Context, report updateStatusReport) {
 		u.Out().Linef("platform_asset_sha256\t%s", report.PlatformAssetSHA256)
 	}
 	u.Out().Linef("install_method\t%s", report.InstallMethod)
-	u.Out().Linef("self_update_supported\t%t", report.SelfUpdateSupported)
 	for _, warning := range report.Warnings {
 		u.Out().Linef("warning\t%s", warning)
 	}
@@ -184,10 +190,72 @@ func updateClient(timeout time.Duration) *http.Client {
 
 func fetchLatestGitHubRelease(ctx context.Context, client *http.Client, url string) (githubRelease, error) {
 	var release githubRelease
-	if err := fetchUpdateJSON(ctx, client, url, &release); err != nil {
-		return githubRelease{}, fmt.Errorf("fetch latest release: %w", err)
+	apiErr := fetchUpdateJSON(ctx, client, url, &release)
+	if apiErr == nil {
+		return release, nil
 	}
-	return release, nil
+
+	fallback, fallbackErr := fetchLatestGitHubReleaseRedirect(ctx, client, updateLatestWebURL)
+	if fallbackErr != nil {
+		return githubRelease{}, fmt.Errorf("fetch latest release: API: %v; web fallback: %w", apiErr, fallbackErr)
+	}
+	return fallback, nil
+}
+
+func fetchLatestGitHubReleaseRedirect(ctx context.Context, client *http.Client, latestURL string) (githubRelease, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, latestURL, nil)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	req.Header.Set("User-Agent", "gogcli/"+resolvedVersion())
+
+	redirectClient := *client
+	redirectClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err := redirectClient.Do(req)
+	if err != nil {
+		return githubRelease{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 300 || resp.StatusCode >= 400 {
+		return githubRelease{}, fmt.Errorf("github returned %s", resp.Status)
+	}
+
+	location := strings.TrimSpace(resp.Header.Get("Location"))
+	if location == "" {
+		return githubRelease{}, fmt.Errorf("github redirect did not include Location")
+	}
+	resolved, err := req.URL.Parse(location)
+	if err != nil {
+		return githubRelease{}, fmt.Errorf("parse github redirect: %w", err)
+	}
+	if !strings.EqualFold(resolved.Hostname(), "github.com") {
+		return githubRelease{}, fmt.Errorf("unexpected github redirect host %q", resolved.Hostname())
+	}
+	const tagPath = "/openclaw/gogcli/releases/tag/"
+	if !strings.HasPrefix(resolved.EscapedPath(), tagPath) {
+		return githubRelease{}, fmt.Errorf("unexpected github release redirect path %q", resolved.EscapedPath())
+	}
+	tag, err := url.PathUnescape(strings.TrimPrefix(resolved.EscapedPath(), tagPath))
+	if err != nil || tag == "" || strings.Contains(tag, "/") {
+		return githubRelease{}, fmt.Errorf("invalid github release tag in redirect")
+	}
+
+	return githubRelease{
+		TagName:         tag,
+		HTMLURL:         resolved.String(),
+		SyntheticAssets: true,
+		Assets: []githubReleaseAsset{{
+			Name:               "checksums.txt",
+			BrowserDownloadURL: updateReleaseAssetURL(tag, "checksums.txt"),
+		}},
+	}, nil
+}
+
+func updateReleaseAssetURL(tag string, assetName string) string {
+	return "https://github.com/openclaw/gogcli/releases/download/" +
+		url.PathEscape(tag) + "/" + url.PathEscape(assetName)
 }
 
 func fetchUpdateJSON(ctx context.Context, client *http.Client, url string, dst any) error {
@@ -232,7 +300,7 @@ func fetchAssetChecksum(ctx context.Context, client *http.Client, url string, as
 		return "", fmt.Errorf("fetch checksums.txt: github returned %s", resp.Status)
 	}
 
-	scanner := bufio.NewScanner(resp.Body)
+	scanner := bufio.NewScanner(io.LimitReader(resp.Body, 1<<20))
 	for scanner.Scan() {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) < 2 {
@@ -240,7 +308,12 @@ func fetchAssetChecksum(ctx context.Context, client *http.Client, url string, as
 		}
 		name := strings.TrimPrefix(fields[len(fields)-1], "*")
 		if name == assetName {
-			return fields[0], nil
+			sum := strings.ToLower(fields[0])
+			decoded, decodeErr := hex.DecodeString(sum)
+			if decodeErr != nil || len(decoded) != sha256.Size {
+				return "", fmt.Errorf("invalid checksum for %s in checksums.txt", assetName)
+			}
+			return sum, nil
 		}
 	}
 	if err := scanner.Err(); err != nil {
@@ -337,7 +410,7 @@ func releaseVersionParts(value string) ([]int, bool) {
 func detectUpdateInstallMethod() (method string, executable string, warnings []string) {
 	exe, err := os.Executable()
 	if err != nil {
-		return trackingUnknown, "", []string{"could not determine executable path: " + err.Error()}
+		return updateInstallUnknown, "", []string{"could not determine executable path: " + err.Error()}
 	}
 	resolved := exe
 	if resolvedExe, evalErr := filepath.EvalSymlinks(exe); evalErr == nil {

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -13,12 +13,14 @@ import (
 func TestUpdateStatusCmdJSON(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldLatestURL := updateLatestReleaseURL
+	oldLatestWebURL := updateLatestWebURL
 	oldVersion := version
 	oldCommit := commit
 	oldDate := date
 	defer func() {
 		updateHTTPClient = oldClient
 		updateLatestReleaseURL = oldLatestURL
+		updateLatestWebURL = oldLatestWebURL
 		version = oldVersion
 		commit = oldCommit
 		date = oldDate
@@ -43,7 +45,7 @@ func TestUpdateStatusCmdJSON(t *testing.T) {
 				]
 			}`, assetName, serverURL+"/download/"+assetName, serverURL+"/checksums.txt")
 		case "/checksums.txt":
-			_, _ = fmt.Fprintf(w, "0123456789abcdef  %s\n", assetName)
+			_, _ = fmt.Fprintf(w, "%s  %s\n", strings.Repeat("a", 64), assetName)
 		default:
 			http.NotFound(w, r)
 		}
@@ -77,7 +79,7 @@ func TestUpdateStatusCmdJSON(t *testing.T) {
 	if parsed.PlatformAsset != assetName {
 		t.Fatalf("platform_asset = %q, want %q", parsed.PlatformAsset, assetName)
 	}
-	if parsed.PlatformAssetSHA256 != "0123456789abcdef" {
+	if parsed.PlatformAssetSHA256 != strings.Repeat("a", 64) {
 		t.Fatalf("platform_asset_sha256 = %q", parsed.PlatformAssetSHA256)
 	}
 	if !parsed.ChecksumAvailable {
@@ -85,13 +87,59 @@ func TestUpdateStatusCmdJSON(t *testing.T) {
 	}
 }
 
+func TestFetchAssetChecksumRejectsMalformedDigest(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprintln(w, "not-a-sha256  archive.tar.gz")
+	}))
+	defer server.Close()
+
+	_, err := fetchAssetChecksum(t.Context(), server.Client(), server.URL, "archive.tar.gz")
+	if err == nil || !strings.Contains(err.Error(), "invalid checksum") {
+		t.Fatalf("expected invalid checksum error, got %v", err)
+	}
+}
+
+func TestFetchLatestGitHubReleaseFallsBackToWebRedirect(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/latest":
+			http.Error(w, "rate limited", http.StatusForbidden)
+		case "/releases/latest":
+			http.Redirect(w, r, "https://github.com/openclaw/gogcli/releases/tag/v0.31.1", http.StatusFound)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	oldWebURL := updateLatestWebURL
+	updateLatestWebURL = server.URL + "/releases/latest"
+	t.Cleanup(func() { updateLatestWebURL = oldWebURL })
+
+	release, err := fetchLatestGitHubRelease(t.Context(), server.Client(), server.URL+"/api/latest")
+	if err != nil {
+		t.Fatalf("fetch latest release: %v", err)
+	}
+	if release.TagName != "v0.31.1" || !release.SyntheticAssets {
+		t.Fatalf("unexpected fallback release: %#v", release)
+	}
+	checksum, ok := findReleaseAsset(release.Assets, "checksums.txt")
+	if !ok || checksum.BrowserDownloadURL != "https://github.com/openclaw/gogcli/releases/download/v0.31.1/checksums.txt" {
+		t.Fatalf("unexpected checksum asset: %#v", checksum)
+	}
+}
+
 func TestUpdateStatusCheckAlias(t *testing.T) {
 	oldClient := updateHTTPClient
 	oldLatestURL := updateLatestReleaseURL
+	oldLatestWebURL := updateLatestWebURL
 	oldVersion := version
 	defer func() {
 		updateHTTPClient = oldClient
 		updateLatestReleaseURL = oldLatestURL
+		updateLatestWebURL = oldLatestWebURL
 		version = oldVersion
 	}()
 	version = "v0.31.1"

--- a/internal/cmd/update_test.go
+++ b/internal/cmd/update_test.go
@@ -1,0 +1,138 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestUpdateStatusCmdJSON(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldLatestURL := updateLatestReleaseURL
+	oldVersion := version
+	oldCommit := commit
+	oldDate := date
+	defer func() {
+		updateHTTPClient = oldClient
+		updateLatestReleaseURL = oldLatestURL
+		version = oldVersion
+		commit = oldCommit
+		date = oldDate
+	}()
+
+	version = "v0.31.0"
+	commit = "abc1234"
+	date = "2026-06-26T10:00:00Z"
+
+	var serverURL string
+	assetName := platformAssetName("v0.31.1", runtime.GOOS, runtime.GOARCH)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/latest":
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = fmt.Fprintf(w, `{
+				"tag_name": "v0.31.1",
+				"html_url": "https://github.com/openclaw/gogcli/releases/tag/v0.31.1",
+				"assets": [
+					{"name": %q, "browser_download_url": %q},
+					{"name": "checksums.txt", "browser_download_url": %q}
+				]
+			}`, assetName, serverURL+"/download/"+assetName, serverURL+"/checksums.txt")
+		case "/checksums.txt":
+			_, _ = fmt.Fprintf(w, "0123456789abcdef  %s\n", assetName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+	serverURL = server.URL
+	updateHTTPClient = server.Client()
+	updateLatestReleaseURL = server.URL + "/latest"
+
+	result := executeWithTestRuntime(t, []string{"--json", "update", "status"}, nil)
+	if result.err != nil {
+		t.Fatalf("execute: %v\nstderr=%s", result.err, result.stderr)
+	}
+
+	var parsed updateStatusReport
+	if err := json.Unmarshal([]byte(result.stdout), &parsed); err != nil {
+		t.Fatalf("json parse: %v\nstdout=%s", err, result.stdout)
+	}
+	if parsed.CurrentVersion != "v0.31.0" {
+		t.Fatalf("current_version = %q", parsed.CurrentVersion)
+	}
+	if parsed.CurrentCommit != "abc1234" {
+		t.Fatalf("current_commit = %q", parsed.CurrentCommit)
+	}
+	if parsed.LatestVersion != "v0.31.1" {
+		t.Fatalf("latest_version = %q", parsed.LatestVersion)
+	}
+	if !parsed.UpdateAvailable {
+		t.Fatalf("expected update_available")
+	}
+	if parsed.PlatformAsset != assetName {
+		t.Fatalf("platform_asset = %q, want %q", parsed.PlatformAsset, assetName)
+	}
+	if parsed.PlatformAssetSHA256 != "0123456789abcdef" {
+		t.Fatalf("platform_asset_sha256 = %q", parsed.PlatformAssetSHA256)
+	}
+	if !parsed.ChecksumAvailable {
+		t.Fatalf("expected checksum_available")
+	}
+}
+
+func TestUpdateStatusCheckAlias(t *testing.T) {
+	oldClient := updateHTTPClient
+	oldLatestURL := updateLatestReleaseURL
+	oldVersion := version
+	defer func() {
+		updateHTTPClient = oldClient
+		updateLatestReleaseURL = oldLatestURL
+		version = oldVersion
+	}()
+	version = "v0.31.1"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/latest" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"tag_name":"v0.31.1","assets":[]}`)
+	}))
+	defer server.Close()
+	updateHTTPClient = server.Client()
+	updateLatestReleaseURL = server.URL + "/latest"
+
+	result := executeWithTestRuntime(t, []string{"--json", "update", "check"}, nil)
+	if result.err != nil {
+		t.Fatalf("execute: %v\nstderr=%s", result.err, result.stderr)
+	}
+	if !strings.Contains(result.stdout, `"update_available": false`) {
+		t.Fatalf("unexpected stdout: %s", result.stdout)
+	}
+}
+
+func TestUpdateVersionComparison(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+		ok      bool
+	}{
+		{current: "v0.31.0", latest: "v0.31.1", want: true, ok: true},
+		{current: "v0.31.1", latest: "v0.31.1", want: false, ok: true},
+		{current: "v0.31.2-dev", latest: "v0.31.1", want: false, ok: true},
+		{current: "dev", latest: "v0.31.1", want: false, ok: false},
+	}
+	for _, tt := range tests {
+		got, ok := updateAvailable(tt.current, tt.latest)
+		if got != tt.want || ok != tt.ok {
+			t.Fatalf("updateAvailable(%q, %q) = (%t, %t), want (%t, %t)", tt.current, tt.latest, got, ok, tt.want, tt.ok)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- add `gog update status` with `check` alias for read-only release status checks
- report current/latest versions, update availability, platform release asset, checksum URL/SHA-256, and install method
- fall back from GitHub's rate-limited API to the canonical `releases/latest` redirect, then validate the published checksum before reporting it
- generate command docs for the new update namespace

## Notes

- This intentionally does not write binaries, restart services, or perform self-update.
- The command gives automation and production wrappers a stable JSON primitive they can gate with their own health checks and rollback policy.

## Testing

- `make ci`
- `go test ./internal/cmd -run 'Test(Update|Fetch)' -count=1`
- built-binary live JSON, plain, and `check` alias proof against the current GitHub release and `checksums.txt`
- forced the API-rate-limit path; the release-page redirect fallback still returned the exact tag, platform asset, and validated 64-hex checksum
- timeout failure behavior verified
- maintainer pre-commit and exact-head autoreview: clean

Maintainer repair rebased the contributor commit onto current `main`, removed an unrelated constant coupling and misleading self-update capability field, bounded checksum reads, added strict digest validation, and added the changelog entry with contributor credit.
