### PR TITLE
[codex] update worker vulnerable transitive deps

### DIFF
--- a/internal/tracking/worker/pnpm-lock.yaml
+++ b/internal/tracking/worker/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 overrides:
   esbuild: 0.28.1
-  undici: 7.25.0
-  vite: 7.3.2
+  undici: 7.28.0
+  vite: 7.3.5
 
 importers:
 
@@ -33,7 +33,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(vite@7.3.2)
+        version: 4.1.8(vite@7.3.5)
       wrangler:
         specifier: ^4.98.0
         version: 4.98.0(@cloudflare/workers-types@4.20260607.1)
@@ -906,7 +906,7 @@ packages:
     resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
     peerDependencies:
       msw: ^2.4.9
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       msw:
         optional: true
@@ -1108,15 +1108,15 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici@7.25.0:
-    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  vite@7.3.2:
-    resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
+  vite@7.3.5:
+    resolution: {integrity: sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -1171,7 +1171,7 @@ packages:
       '@vitest/ui': 4.1.8
       happy-dom: '*'
       jsdom: '*'
-      vite: 7.3.2
+      vite: 7.3.5
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -1727,13 +1727,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@7.3.2)':
+  '@vitest/mocker@4.1.8(vite@7.3.5)':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2
+      vite: 7.3.5
 
   '@vitest/pretty-format@4.1.8':
     dependencies:
@@ -1827,7 +1827,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.25.0
+      undici: 7.28.0
       workerd: 1.20260603.1
       ws: 8.20.1
       youch: 4.1.0-beta.10
@@ -2001,13 +2001,13 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici@7.25.0: {}
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
 
-  vite@7.3.2:
+  vite@7.3.5:
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -2018,10 +2018,10 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  vitest@4.1.8(vite@7.3.2):
+  vitest@4.1.8(vite@7.3.5):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.2)
+      '@vitest/mocker': 4.1.8(vite@7.3.5)
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -2038,7 +2038,7 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.2
+      vite: 7.3.5
       why-is-node-running: 2.3.0
     transitivePeerDependencies:
       - msw

--- a/internal/tracking/worker/pnpm-workspace.yaml
+++ b/internal/tracking/worker/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
 overrides:
   esbuild: 0.28.1
-  undici: 7.25.0
-  vite: 7.3.2
+  undici: 7.28.0
+  vite: 7.3.5


### PR DESCRIPTION
## Summary
- bump the worker pnpm overrides for `undici` from 7.25.0 to 7.28.0
- bump the worker pnpm overrides for `vite` from 7.3.2 to 7.3.5
- refresh `pnpm-lock.yaml` so Vitest/Wrangler resolve the patched versions

## Why
Dependabot reports open alerts against `internal/tracking/worker/pnpm-lock.yaml`:
- `undici` vulnerable ranges ending before 7.28.0: alerts 24, 25, 26, 27, 29, 30
- `vite` vulnerable ranges ending at 7.3.4: alerts 21, 23

## Validation
- `pnpm install --lockfile-only --ignore-scripts`
- `CI=true npx pnpm@10.33.2 install --frozen-lockfile`
- `CI=true npx pnpm@10.33.2 lint`
- `CI=true npx pnpm@10.33.2 typecheck`
- `CI=true npx pnpm@10.33.2 build`
- `CI=true npx pnpm@10.33.2 test`
