### PR TITLE
fix(auth): retry stale scoped token once after 403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.31.2 - Unreleased
 
 - YouTube: add opt-in `videos list --parts all` full metadata while preserving the existing compact default and explicit owner-only part requests. (#871) — thanks @coeur-de-loup.
+- Auth: retry one replayable Google API request after an `insufficient scopes` 403 by refreshing stored OAuth credentials, while preserving ordinary permission failures and non-replayable requests. (#889) — thanks @ortonom.
 - CLI: add read-only `update status` / `update check` release metadata, platform asset, checksum, and install-method reporting. (#882) — thanks @titus7490.
 - Docs: add `docs format --spacing-mode` for setting paragraph spacing collapse behavior alongside `--space-above` and `--space-below`. (#885) — thanks @odyssey4me.
 

--- a/internal/googleapi/client.go
+++ b/internal/googleapi/client.go
@@ -148,10 +148,18 @@ func authenticatedTransportWithStoredScopeCheck(
 		}
 	}
 
-	return readOnlyTransportFromContext(ctx, NewRetryTransport(&oauth2.Transport{
+	retryTransport := NewRetryTransport(&oauth2.Transport{
 		Source: ts,
 		Base:   newBaseTransport(),
-	})), nil
+	})
+
+	if refresher, ok := ts.(interface {
+		ForceRefresh(context.Context) error
+	}); ok {
+		retryTransport.RefreshAuth = refresher.ForceRefresh
+	}
+
+	return readOnlyTransportFromContext(ctx, retryTransport), nil
 }
 
 func optionsForAccountScopes(ctx context.Context, serviceLabel string, email string, scopes []string) ([]option.ClientOption, error) {

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -65,45 +65,42 @@ func newResettableOAuthTokenSource(newSource func(*oauth2.Token) oauth2.TokenSou
 
 func (r *resettableOAuthTokenSource) Token() (*oauth2.Token, error) {
 	r.mu.Lock()
-	source := r.source
-	r.mu.Unlock()
+	defer r.mu.Unlock()
 
-	t, err := source.Token()
+	t, err := r.source.Token()
 	if err != nil {
 		return nil, fmt.Errorf("resettable oauth token source: %w", err)
 	}
 
-	r.rememberRefreshToken(t)
+	r.rememberRefreshTokenLocked(t)
 
 	return t, nil
 }
 
 func (r *resettableOAuthTokenSource) ForceRefresh(context.Context) (*oauth2.Token, error) {
 	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	refreshToken := r.refreshToken
 	r.source = r.newSource(&oauth2.Token{RefreshToken: refreshToken})
-	source := r.source
-	r.mu.Unlock()
 
-	t, err := source.Token()
+	t, err := r.source.Token()
 	if err != nil {
 		return nil, fmt.Errorf("resettable oauth token source refresh: %w", err)
 	}
 
-	r.rememberRefreshToken(t)
+	r.rememberRefreshTokenLocked(t)
 
 	return t, nil
 }
 
-func (r *resettableOAuthTokenSource) rememberRefreshToken(t *oauth2.Token) {
+func (r *resettableOAuthTokenSource) rememberRefreshTokenLocked(t *oauth2.Token) {
 	if t == nil {
 		return
 	}
 
 	if refreshToken := strings.TrimSpace(t.RefreshToken); refreshToken != "" {
-		r.mu.Lock()
 		r.refreshToken = refreshToken
-		r.mu.Unlock()
 	}
 }
 

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -35,8 +35,76 @@ type persistingTokenSource struct {
 	tok secrets.Token
 }
 
+type forceRefreshTokenSource interface {
+	ForceRefresh(context.Context) (*oauth2.Token, error)
+}
+
+var (
+	errBaseTokenSourceCannotForceRefresh = errors.New("base token source cannot force refresh")
+	errBaseTokenSourceReturnedNilToken   = errors.New("base token source returned nil token")
+)
+
+type resettableOAuthTokenSource struct {
+	mu           sync.Mutex
+	source       oauth2.TokenSource
+	newSource    func(*oauth2.Token) oauth2.TokenSource
+	refreshToken string
+}
+
 type tokenAliasDeleter interface {
 	DeleteTokenAlias(client string, email string) error
+}
+
+func newResettableOAuthTokenSource(newSource func(*oauth2.Token) oauth2.TokenSource, initial *oauth2.Token) *resettableOAuthTokenSource {
+	return &resettableOAuthTokenSource{
+		source:       newSource(initial),
+		newSource:    newSource,
+		refreshToken: strings.TrimSpace(initial.RefreshToken),
+	}
+}
+
+func (r *resettableOAuthTokenSource) Token() (*oauth2.Token, error) {
+	r.mu.Lock()
+	source := r.source
+	r.mu.Unlock()
+
+	t, err := source.Token()
+	if err != nil {
+		return nil, fmt.Errorf("resettable oauth token source: %w", err)
+	}
+
+	r.rememberRefreshToken(t)
+
+	return t, nil
+}
+
+func (r *resettableOAuthTokenSource) ForceRefresh(context.Context) (*oauth2.Token, error) {
+	r.mu.Lock()
+	refreshToken := r.refreshToken
+	r.source = r.newSource(&oauth2.Token{RefreshToken: refreshToken})
+	source := r.source
+	r.mu.Unlock()
+
+	t, err := source.Token()
+	if err != nil {
+		return nil, fmt.Errorf("resettable oauth token source refresh: %w", err)
+	}
+
+	r.rememberRefreshToken(t)
+
+	return t, nil
+}
+
+func (r *resettableOAuthTokenSource) rememberRefreshToken(t *oauth2.Token) {
+	if t == nil {
+		return
+	}
+
+	if refreshToken := strings.TrimSpace(t.RefreshToken); refreshToken != "" {
+		r.mu.Lock()
+		r.refreshToken = refreshToken
+		r.mu.Unlock()
+	}
 }
 
 func newPersistingTokenSource(base oauth2.TokenSource, store secrets.Store, client string, email string, tok secrets.Token, serviceLabel string, updateEmailReferences googleauth.EmailReferenceUpdater) oauth2.TokenSource {
@@ -55,6 +123,30 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 	t, err := p.base.Token()
 	if err != nil {
 		return nil, fmt.Errorf("base token source: %w", err)
+	}
+
+	return p.persistToken(t)
+}
+
+func (p *persistingTokenSource) ForceRefresh(ctx context.Context) error {
+	refresher, ok := p.base.(forceRefreshTokenSource)
+	if !ok {
+		return errBaseTokenSourceCannotForceRefresh
+	}
+
+	t, err := refresher.ForceRefresh(ctx)
+	if err != nil {
+		return fmt.Errorf("force token refresh: %w", err)
+	}
+
+	_, err = p.persistToken(t)
+
+	return err
+}
+
+func (p *persistingTokenSource) persistToken(t *oauth2.Token) (*oauth2.Token, error) {
+	if t == nil {
+		return nil, errBaseTokenSourceReturnedNilToken
 	}
 
 	refreshToken := strings.TrimSpace(t.RefreshToken)
@@ -126,26 +218,26 @@ func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
 	}
 
 	if err := p.store.SetToken(p.client, persistEmail, updated); err != nil {
-		slog.Warn("persist refreshed token metadata failed", "email", persistEmail, "client", p.client, "err", err)
+		slog.Warn("persist refreshed token metadata failed", "email", persistEmail, "client", p.client, "err", err) //nolint:gosec // logged values are token metadata identifiers for auth diagnostics
 		return t, nil
 	}
 
 	if !strings.EqualFold(p.email, persistEmail) {
 		if err := googleauth.MigrateStoredEmailReferences(p.store, p.updateEmailReferences, p.client, p.email, persistEmail); err != nil {
-			slog.Warn("migrate renamed token email references failed", "old_email", p.email, "new_email", persistEmail, "client", p.client, "err", err)
+			slog.Warn("migrate renamed token email references failed", "old_email", p.email, "new_email", persistEmail, "client", p.client, "err", err) //nolint:gosec // logged values are token metadata identifiers for auth diagnostics
 		}
 
 		aliasDeleter, ok := p.store.(tokenAliasDeleter)
 		if !ok {
-			slog.Debug("token store cannot delete renamed email alias", "old_email", p.email, "new_email", persistEmail, "client", p.client)
+			slog.Debug("token store cannot delete renamed email alias", "old_email", p.email, "new_email", persistEmail, "client", p.client) //nolint:gosec // logged values are token metadata identifiers for auth diagnostics
 		} else if err := aliasDeleter.DeleteTokenAlias(p.client, p.email); err != nil {
-			slog.Warn("delete renamed token alias failed", "old_email", p.email, "new_email", persistEmail, "client", p.client, "err", err)
+			slog.Warn("delete renamed token alias failed", "old_email", p.email, "new_email", persistEmail, "client", p.client, "err", err) //nolint:gosec // logged values are token metadata identifiers for auth diagnostics
 		}
 	}
 
 	p.tok = updated
 	p.email = persistEmail
-	slog.Debug("persisted refreshed token metadata", "email", persistEmail, "client", p.client)
+	slog.Debug("persisted refreshed token metadata", "email", persistEmail, "client", p.client) //nolint:gosec // logged values are token metadata identifiers for auth diagnostics
 
 	return t, nil
 }
@@ -276,7 +368,9 @@ func tokenSourceForAccountScopesWithStoredScopeCheck(
 	// Ensure refresh-token exchanges don't hang forever.
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{Timeout: tokenExchangeTimeout})
 
-	baseSource := cfg.TokenSource(ctx, &oauth2.Token{
+	baseSource := newResettableOAuthTokenSource(func(t *oauth2.Token) oauth2.TokenSource {
+		return cfg.TokenSource(ctx, t)
+	}, &oauth2.Token{
 		RefreshToken: tok.RefreshToken,
 		AccessToken:  strings.TrimSpace(tok.AccessToken),
 		Expiry:       tok.AccessTokenExpiresAt,

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -82,13 +82,13 @@ func (r *resettableOAuthTokenSource) ForceRefresh(context.Context) (*oauth2.Toke
 	defer r.mu.Unlock()
 
 	refreshToken := r.refreshToken
-	r.source = r.newSource(&oauth2.Token{RefreshToken: refreshToken})
-
-	t, err := r.source.Token()
+	candidate := r.newSource(&oauth2.Token{RefreshToken: refreshToken})
+	t, err := candidate.Token()
 	if err != nil {
 		return nil, fmt.Errorf("resettable oauth token source refresh: %w", err)
 	}
 
+	r.source = candidate
 	r.rememberRefreshTokenLocked(t)
 
 	return t, nil

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -118,12 +118,15 @@ func newPersistingTokenSource(base oauth2.TokenSource, store secrets.Store, clie
 }
 
 func (p *persistingTokenSource) Token() (*oauth2.Token, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	t, err := p.base.Token()
 	if err != nil {
 		return nil, fmt.Errorf("base token source: %w", err)
 	}
 
-	return p.persistToken(t)
+	return p.persistTokenLocked(t)
 }
 
 func (p *persistingTokenSource) ForceRefresh(ctx context.Context) error {
@@ -132,25 +135,25 @@ func (p *persistingTokenSource) ForceRefresh(ctx context.Context) error {
 		return errBaseTokenSourceCannotForceRefresh
 	}
 
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	t, err := refresher.ForceRefresh(ctx)
 	if err != nil {
 		return fmt.Errorf("force token refresh: %w", err)
 	}
 
-	_, err = p.persistToken(t)
+	_, err = p.persistTokenLocked(t)
 
 	return err
 }
 
-func (p *persistingTokenSource) persistToken(t *oauth2.Token) (*oauth2.Token, error) {
+func (p *persistingTokenSource) persistTokenLocked(t *oauth2.Token) (*oauth2.Token, error) {
 	if t == nil {
 		return nil, errBaseTokenSourceReturnedNilToken
 	}
 
 	refreshToken := strings.TrimSpace(t.RefreshToken)
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	updated := p.tok
 	changed := false

--- a/internal/googleapi/client_auth.go
+++ b/internal/googleapi/client_auth.go
@@ -83,6 +83,7 @@ func (r *resettableOAuthTokenSource) ForceRefresh(context.Context) (*oauth2.Toke
 
 	refreshToken := r.refreshToken
 	candidate := r.newSource(&oauth2.Token{RefreshToken: refreshToken})
+
 	t, err := candidate.Token()
 	if err != nil {
 		return nil, fmt.Errorf("resettable oauth token source refresh: %w", err)

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -63,6 +63,12 @@ type rotatingTokenSource struct {
 	next int
 }
 
+type blockingRefreshTokenSource struct {
+	tokenStarted   chan struct{}
+	releaseToken   chan struct{}
+	refreshStarted chan struct{}
+}
+
 func (s *rotatingTokenSource) Token() (*oauth2.Token, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -73,6 +79,19 @@ func (s *rotatingTokenSource) Token() (*oauth2.Token, error) {
 		AccessToken:  fmt.Sprintf("access-%d", s.next),
 		RefreshToken: fmt.Sprintf("refresh-%d", s.next),
 	}, nil
+}
+
+func (s *blockingRefreshTokenSource) Token() (*oauth2.Token, error) {
+	close(s.tokenStarted)
+	<-s.releaseToken
+
+	return &oauth2.Token{AccessToken: "stale", RefreshToken: "refresh"}, nil
+}
+
+func (s *blockingRefreshTokenSource) ForceRefresh(context.Context) (*oauth2.Token, error) {
+	close(s.refreshStarted)
+
+	return &oauth2.Token{AccessToken: "fresh", RefreshToken: "refresh"}, nil
 }
 
 func (s *stubStore) Keys() ([]string, error) { return nil, nil }
@@ -406,6 +425,63 @@ func TestPersistingTokenSource_ConcurrentTokenCalls(t *testing.T) {
 
 	if store.setCalls != callers {
 		t.Fatalf("SetToken calls = %d, want %d", store.setCalls, callers)
+	}
+}
+
+func TestPersistingTokenSourceSerializesTokenReadWithForceRefresh(t *testing.T) {
+	t.Parallel()
+
+	base := &blockingRefreshTokenSource{
+		tokenStarted:   make(chan struct{}),
+		releaseToken:   make(chan struct{}),
+		refreshStarted: make(chan struct{}),
+	}
+	stored := secrets.Token{
+		Client:       config.DefaultClientName,
+		Email:        "a@b.com",
+		RefreshToken: "refresh",
+	}
+	store := &stubStore{tok: stored}
+	source := newPersistingTokenSource(
+		base,
+		store,
+		config.DefaultClientName,
+		"a@b.com",
+		stored,
+		"",
+		nil,
+	).(*persistingTokenSource)
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := source.Token()
+		readDone <- err
+	}()
+	<-base.tokenStarted
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- source.ForceRefresh(context.Background())
+	}()
+
+	select {
+	case <-base.refreshStarted:
+		close(base.releaseToken)
+		<-readDone
+		<-refreshDone
+		t.Fatal("forced refresh overlapped an in-flight token read")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(base.releaseToken)
+	if err := <-readDone; err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if err := <-refreshDone; err != nil {
+		t.Fatalf("force refresh: %v", err)
+	}
+	if store.lastSet.AccessToken != "fresh" {
+		t.Fatalf("persisted access token = %q, want fresh", store.lastSet.AccessToken)
 	}
 }
 

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -430,22 +430,27 @@ func TestResettableOAuthTokenSourceSerializesRefreshWithTokenRead(t *testing.T) 
 	}, &oauth2.Token{RefreshToken: "refresh"})
 
 	readDone := make(chan error, 1)
+
 	go func() {
 		_, err := source.Token()
 		readDone <- err
 	}()
+
 	<-started
 
 	refreshDone := make(chan error, 1)
+
 	go func() {
 		_, err := source.ForceRefresh(context.Background())
 		refreshDone <- err
 	}()
 
 	close(release)
+
 	if err := <-readDone; err != nil {
 		t.Fatalf("read token: %v", err)
 	}
+
 	if err := <-refreshDone; err != nil {
 		t.Fatalf("force refresh: %v", err)
 	}
@@ -454,6 +459,7 @@ func TestResettableOAuthTokenSourceSerializesRefreshWithTokenRead(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read refreshed token: %v", err)
 	}
+
 	if token.AccessToken != "fresh" {
 		t.Fatalf("access token = %q, want fresh", token.AccessToken)
 	}

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -465,6 +465,45 @@ func TestResettableOAuthTokenSourceSerializesRefreshWithTokenRead(t *testing.T) 
 	}
 }
 
+func TestResettableOAuthTokenSourcePreservesSourceWhenRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	var oldSourceReads int
+	var newSourceCalls int
+	source := newResettableOAuthTokenSource(func(token *oauth2.Token) oauth2.TokenSource {
+		newSourceCalls++
+		if newSourceCalls == 1 {
+			return tokenSourceFunc(func() (*oauth2.Token, error) {
+				oldSourceReads++
+				return &oauth2.Token{AccessToken: "cached", RefreshToken: token.RefreshToken}, nil
+			})
+		}
+
+		return tokenSourceFunc(func() (*oauth2.Token, error) {
+			return nil, errBoom
+		})
+	}, &oauth2.Token{RefreshToken: "refresh"})
+
+	if _, err := source.Token(); err != nil {
+		t.Fatalf("read cached token: %v", err)
+	}
+
+	if _, err := source.ForceRefresh(context.Background()); !errors.Is(err, errBoom) {
+		t.Fatalf("force refresh error = %v, want %v", err, errBoom)
+	}
+
+	token, err := source.Token()
+	if err != nil {
+		t.Fatalf("read cached token after failed refresh: %v", err)
+	}
+	if token.AccessToken != "cached" {
+		t.Fatalf("access token = %q, want cached", token.AccessToken)
+	}
+	if oldSourceReads != 2 {
+		t.Fatalf("old source reads = %d, want 2", oldSourceReads)
+	}
+}
+
 func TestPersistingTokenSource_PersistsAccessToken(t *testing.T) {
 	stored := secrets.Token{
 		Client:       config.DefaultClientName,

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -29,6 +29,12 @@ var (
 	errNope = errors.New("nope")
 )
 
+type tokenSourceFunc func() (*oauth2.Token, error)
+
+func (f tokenSourceFunc) Token() (*oauth2.Token, error) {
+	return f()
+}
+
 type stubStore struct {
 	lastClient string
 	lastEmail  string
@@ -400,6 +406,56 @@ func TestPersistingTokenSource_ConcurrentTokenCalls(t *testing.T) {
 
 	if store.setCalls != callers {
 		t.Fatalf("SetToken calls = %d, want %d", store.setCalls, callers)
+	}
+}
+
+func TestResettableOAuthTokenSourceSerializesRefreshWithTokenRead(t *testing.T) {
+	t.Parallel()
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var newSourceCalls int
+	source := newResettableOAuthTokenSource(func(token *oauth2.Token) oauth2.TokenSource {
+		newSourceCalls++
+		if newSourceCalls == 1 {
+			return tokenSourceFunc(func() (*oauth2.Token, error) {
+				close(started)
+				<-release
+
+				return &oauth2.Token{AccessToken: "stale", RefreshToken: token.RefreshToken}, nil
+			})
+		}
+
+		return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "fresh", RefreshToken: token.RefreshToken})
+	}, &oauth2.Token{RefreshToken: "refresh"})
+
+	readDone := make(chan error, 1)
+	go func() {
+		_, err := source.Token()
+		readDone <- err
+	}()
+	<-started
+
+	refreshDone := make(chan error, 1)
+	go func() {
+		_, err := source.ForceRefresh(context.Background())
+		refreshDone <- err
+	}()
+
+	close(release)
+	if err := <-readDone; err != nil {
+		t.Fatalf("read token: %v", err)
+	}
+	if err := <-refreshDone; err != nil {
+		t.Fatalf("force refresh: %v", err)
+	}
+
+	token, err := source.Token()
+	if err != nil {
+		t.Fatalf("read refreshed token: %v", err)
+	}
+	if token.AccessToken != "fresh" {
+		t.Fatalf("access token = %q, want fresh", token.AccessToken)
 	}
 }
 

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -496,9 +496,11 @@ func TestResettableOAuthTokenSourcePreservesSourceWhenRefreshFails(t *testing.T)
 	if err != nil {
 		t.Fatalf("read cached token after failed refresh: %v", err)
 	}
+
 	if token.AccessToken != "cached" {
 		t.Fatalf("access token = %q, want cached", token.AccessToken)
 	}
+
 	if oldSourceReads != 2 {
 		t.Fatalf("old source reads = %d, want 2", oldSourceReads)
 	}

--- a/internal/googleapi/client_more_test.go
+++ b/internal/googleapi/client_more_test.go
@@ -453,13 +453,16 @@ func TestPersistingTokenSourceSerializesTokenReadWithForceRefresh(t *testing.T) 
 	).(*persistingTokenSource)
 
 	readDone := make(chan error, 1)
+
 	go func() {
 		_, err := source.Token()
 		readDone <- err
 	}()
+
 	<-base.tokenStarted
 
 	refreshDone := make(chan error, 1)
+
 	go func() {
 		refreshDone <- source.ForceRefresh(context.Background())
 	}()
@@ -474,12 +477,15 @@ func TestPersistingTokenSourceSerializesTokenReadWithForceRefresh(t *testing.T) 
 	}
 
 	close(base.releaseToken)
+
 	if err := <-readDone; err != nil {
 		t.Fatalf("read token: %v", err)
 	}
+
 	if err := <-refreshDone; err != nil {
 		t.Fatalf("force refresh: %v", err)
 	}
+
 	if store.lastSet.AccessToken != "fresh" {
 		t.Fatalf("persisted access token = %q, want fresh", store.lastSet.AccessToken)
 	}

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -11,10 +11,14 @@ import (
 	"math/big"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 )
 
-const maxBufferedReplayBodyBytes = int64(16 << 20)
+const (
+	maxBufferedReplayBodyBytes    = int64(16 << 20)
+	maxAuthRetryResponseBodyBytes = int64(1 << 20)
+)
 
 var errRequestBodyTooLarge = errors.New("request body too large to buffer for retry")
 
@@ -26,6 +30,7 @@ type RetryTransport struct {
 	MaxRetries5xx  int
 	BaseDelay      time.Duration
 	CircuitBreaker *CircuitBreaker
+	RefreshAuth    func(context.Context) error
 }
 
 // NewRetryTransport creates a RetryTransport with sensible defaults.
@@ -57,6 +62,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	retries429 := 0
 	retries5xx := 0
+	retriedAuth := false
 
 	for {
 		// Reset body for retry
@@ -132,6 +138,28 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			retries5xx++
 
 			continue
+		}
+
+		if resp.StatusCode == http.StatusForbidden && t.RefreshAuth != nil && !retriedAuth && replayable {
+			insufficientScopes, detectErr := responseIndicatesInsufficientScopes(resp)
+			if detectErr != nil {
+				slog.Debug("could not inspect auth failure response for retry", "err", detectErr)
+				return resp, nil
+			}
+
+			if insufficientScopes {
+				slog.Debug("insufficient scopes response, refreshing auth token and retrying")
+
+				drainAndClose(resp.Body)
+
+				if err := t.RefreshAuth(req.Context()); err != nil {
+					return nil, fmt.Errorf("refresh auth after insufficient scopes response: %w", err)
+				}
+
+				retriedAuth = true
+
+				continue
+			}
 		}
 
 		// Other errors (4xx except 429): don't retry
@@ -248,4 +276,33 @@ func drainAndClose(body io.ReadCloser) {
 	}
 	_, _ = io.Copy(io.Discard, io.LimitReader(body, 1<<20))
 	_ = body.Close()
+}
+
+func responseIndicatesInsufficientScopes(resp *http.Response) (bool, error) {
+	if resp == nil || resp.Body == nil {
+		return false, nil
+	}
+
+	if resp.ContentLength > maxAuthRetryResponseBodyBytes {
+		return false, nil
+	}
+
+	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxAuthRetryResponseBodyBytes+1))
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+	if err != nil {
+		return false, fmt.Errorf("read auth failure response: %w", err)
+	}
+
+	if int64(len(bodyBytes)) > maxAuthRetryResponseBodyBytes {
+		return false, nil
+	}
+
+	text := strings.ToLower(string(bodyBytes))
+	normalized := strings.NewReplacer("_", " ", "-", " ").Replace(text)
+
+	return strings.Contains(normalized, "insufficient authentication scopes") ||
+		strings.Contains(normalized, "insufficient scopes") ||
+		strings.Contains(normalized, "access token scope insufficient"), nil
 }

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -314,5 +314,7 @@ func responseIndicatesInsufficientScopes(resp *http.Response) (bool, error) {
 
 	return strings.Contains(normalized, "insufficient authentication scopes") ||
 		strings.Contains(normalized, "insufficient scopes") ||
+		strings.Contains(normalized, "insufficientpermissions") ||
+		strings.Contains(normalized, "insufficient permission") ||
 		strings.Contains(normalized, "access token scope insufficient"), nil
 }

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -288,16 +288,26 @@ func responseIndicatesInsufficientScopes(resp *http.Response) (bool, error) {
 	}
 
 	bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxAuthRetryResponseBodyBytes+1))
-	_ = resp.Body.Close()
-	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
-
 	if err != nil {
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{Reader: io.MultiReader(bytes.NewReader(bodyBytes), resp.Body), Closer: resp.Body}
+
 		return false, fmt.Errorf("read auth failure response: %w", err)
 	}
 
 	if int64(len(bodyBytes)) > maxAuthRetryResponseBodyBytes {
+		resp.Body = struct {
+			io.Reader
+			io.Closer
+		}{Reader: io.MultiReader(bytes.NewReader(bodyBytes), resp.Body), Closer: resp.Body}
+
 		return false, nil
 	}
+
+	_ = resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(bodyBytes))
 
 	text := strings.ToLower(string(bodyBytes))
 	normalized := strings.NewReplacer("_", " ", "-", " ").Replace(text)

--- a/internal/googleapi/transport.go
+++ b/internal/googleapi/transport.go
@@ -150,11 +150,13 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 			if insufficientScopes {
 				slog.Debug("insufficient scopes response, refreshing auth token and retrying")
 
-				drainAndClose(resp.Body)
-
 				if err := t.RefreshAuth(req.Context()); err != nil {
-					return nil, fmt.Errorf("refresh auth after insufficient scopes response: %w", err)
+					slog.Debug("could not refresh auth after insufficient scopes response", "err", err)
+
+					return resp, nil
 				}
+
+				drainAndClose(resp.Body)
 
 				retriedAuth = true
 

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -38,6 +40,25 @@ func newTestResponse(status int, body string) *http.Response {
 		Body:       io.NopCloser(strings.NewReader(body)),
 		Header:     http.Header{},
 	}
+}
+
+type refreshableTestTokenSource struct {
+	token        string
+	refreshes    int
+	tokenRequest int
+}
+
+func (s *refreshableTestTokenSource) Token() (*oauth2.Token, error) {
+	s.tokenRequest++
+
+	return &oauth2.Token{AccessToken: s.token}, nil
+}
+
+func (s *refreshableTestTokenSource) ForceRefresh(context.Context) error {
+	s.refreshes++
+	s.token = "fresh-token"
+
+	return nil
 }
 
 func TestNewRetryTransportDefaults(t *testing.T) {
@@ -202,6 +223,174 @@ func TestRetryTransportRoundTripRetries5xx(t *testing.T) {
 
 	if cb.State() != circuitStateClosed {
 		t.Fatalf("expected circuit closed, got %s", cb.State())
+	}
+}
+
+func TestRetryTransportRefreshesAuthOnceForInsufficientScope403(t *testing.T) {
+	tokenSource := &refreshableTestTokenSource{token: "stale-token"}
+	var gotBodies []string
+	calls := 0
+
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read body: %w", err)
+		}
+
+		gotBodies = append(gotBodies, string(body))
+
+		switch calls {
+		case 1:
+			if got := req.Header.Get("Authorization"); got != "Bearer stale-token" {
+				t.Fatalf("first authorization = %q", got)
+			}
+
+			return newTestResponse(http.StatusForbidden, `{"error":{"code":403,"message":"Request had insufficient authentication scopes.","status":"PERMISSION_DENIED"}}`), nil
+		case 2:
+			if got := req.Header.Get("Authorization"); got != "Bearer fresh-token" {
+				t.Fatalf("second authorization = %q", got)
+			}
+
+			return newTestResponse(http.StatusOK, "ok"), nil
+		default:
+			t.Fatalf("unexpected call %d", calls)
+			return nil, errUnexpectedRequestBody
+		}
+	})
+
+	rt := &RetryTransport{
+		Base: &oauth2.Transport{
+			Source: tokenSource,
+			Base:   base,
+		},
+		MaxRetries429: 0,
+		MaxRetries5xx: 0,
+		BaseDelay:     0,
+		RefreshAuth:   tokenSource.ForceRefresh,
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", io.NopCloser(strings.NewReader("payload")))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.ContentLength = int64(len("payload"))
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+
+	if calls != 2 {
+		t.Fatalf("calls = %d, want 2", calls)
+	}
+
+	if tokenSource.refreshes != 1 {
+		t.Fatalf("refreshes = %d, want 1", tokenSource.refreshes)
+	}
+
+	if gotBodies[0] != "payload" || gotBodies[1] != "payload" {
+		t.Fatalf("unexpected bodies: %#v", gotBodies)
+	}
+}
+
+func TestRetryTransportDoesNotRefreshAuthForOrdinary403(t *testing.T) {
+	refreshes := 0
+	calls := 0
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		return newTestResponse(http.StatusForbidden, `{"error":{"code":403,"message":"The caller does not have permission","status":"PERMISSION_DENIED"}}`), nil
+	})
+
+	rt := &RetryTransport{
+		Base: base,
+		RefreshAuth: func(context.Context) error {
+			refreshes++
+
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+
+	if refreshes != 0 {
+		t.Fatalf("refreshes = %d, want 0", refreshes)
+	}
+}
+
+func TestRetryTransportDoesNotRefreshAuthForNonReplayableInsufficientScope403(t *testing.T) {
+	refreshes := 0
+	calls := 0
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		body, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, fmt.Errorf("read body: %w", err)
+		}
+
+		if string(body) != "payload" {
+			t.Fatalf("body = %q, want payload", body)
+		}
+
+		return newTestResponse(http.StatusForbidden, `{"error":{"message":"Request had insufficient authentication scopes."}}`), nil
+	})
+
+	rt := &RetryTransport{
+		Base: base,
+		RefreshAuth: func(context.Context) error {
+			refreshes++
+
+			return nil
+		},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "http://example.com", io.NopCloser(strings.NewReader("payload")))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.ContentLength = 0
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unexpected status: %d", resp.StatusCode)
+	}
+
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+
+	if refreshes != 0 {
+		t.Fatalf("refreshes = %d, want 0", refreshes)
 	}
 }
 

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -394,6 +394,36 @@ func TestRetryTransportDoesNotRefreshAuthForNonReplayableInsufficientScope403(t 
 	}
 }
 
+func TestResponseIndicatesInsufficientScopesRecognizesGoogleVariants(t *testing.T) {
+	tests := []string{
+		`{"error":{"errors":[{"reason":"insufficientPermissions"}],"code":403}}`,
+		`{"error":{"message":"Insufficient Permission","code":403}}`,
+		`{"error":{"message":"Insufficient Permissions","code":403}}`,
+	}
+
+	for _, body := range tests {
+		resp := newTestResponse(http.StatusForbidden, body)
+
+		insufficient, err := responseIndicatesInsufficientScopes(resp)
+		if err != nil {
+			t.Fatalf("detect insufficient scopes for %q: %v", body, err)
+		}
+		if !insufficient {
+			t.Fatalf("Google scope variant not recognized: %s", body)
+		}
+
+		preserved, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("read preserved response: %v", err)
+		}
+		_ = resp.Body.Close()
+
+		if string(preserved) != body {
+			t.Fatalf("response body = %q, want %q", preserved, body)
+		}
+	}
+}
+
 func TestResponseIndicatesInsufficientScopesPreservesOversizedUnknownLengthBody(t *testing.T) {
 	want := strings.Repeat("x", int(maxAuthRetryResponseBodyBytes)+128)
 	resp := newTestResponse(http.StatusForbidden, want)

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -403,6 +403,7 @@ func TestResponseIndicatesInsufficientScopesPreservesOversizedUnknownLengthBody(
 	if err != nil {
 		t.Fatalf("detect insufficient scopes: %v", err)
 	}
+
 	if insufficient {
 		t.Fatal("oversized response should not trigger an auth retry")
 	}

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -15,7 +15,10 @@ import (
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
-var errUnexpectedRequestBody = errors.New("unexpected request body")
+var (
+	errUnexpectedRequestBody = errors.New("unexpected request body")
+	errRefreshFailed         = errors.New("refresh failed")
+)
 
 func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
@@ -297,6 +300,59 @@ func TestRetryTransportRefreshesAuthOnceForInsufficientScope403(t *testing.T) {
 
 	if gotBodies[0] != "payload" || gotBodies[1] != "payload" {
 		t.Fatalf("unexpected bodies: %#v", gotBodies)
+	}
+}
+
+func TestRetryTransportPreservesInsufficientScope403WhenAuthRefreshFails(t *testing.T) {
+	const body = `{"error":{"errors":[{"reason":"insufficientPermissions"}],"message":"Insufficient Permission","code":403}}`
+
+	refreshes := 0
+	calls := 0
+	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		calls++
+
+		return newTestResponse(http.StatusForbidden, body), nil
+	})
+
+	rt := &RetryTransport{
+		Base: base,
+		RefreshAuth: func(context.Context) error {
+			refreshes++
+
+			return errRefreshFailed
+		},
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := rt.RoundTrip(req)
+	if err != nil {
+		t.Fatalf("round trip: %v", err)
+	}
+
+	gotBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response body: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+
+	if string(gotBody) != body {
+		t.Fatalf("response body = %q, want %q", gotBody, body)
+	}
+
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+
+	if refreshes != 1 {
+		t.Fatalf("refreshes = %d, want 1", refreshes)
 	}
 }
 

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -394,6 +394,30 @@ func TestRetryTransportDoesNotRefreshAuthForNonReplayableInsufficientScope403(t 
 	}
 }
 
+func TestResponseIndicatesInsufficientScopesPreservesOversizedUnknownLengthBody(t *testing.T) {
+	want := strings.Repeat("x", int(maxAuthRetryResponseBodyBytes)+128)
+	resp := newTestResponse(http.StatusForbidden, want)
+	resp.ContentLength = -1
+
+	insufficient, err := responseIndicatesInsufficientScopes(resp)
+	if err != nil {
+		t.Fatalf("detect insufficient scopes: %v", err)
+	}
+	if insufficient {
+		t.Fatal("oversized response should not trigger an auth retry")
+	}
+
+	got, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read preserved response: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if string(got) != want {
+		t.Fatalf("response body was not preserved: got %d bytes, want %d", len(got), len(want))
+	}
+}
+
 func TestRetryTransportCircuitBreakerOpen(t *testing.T) {
 	calls := 0
 	base := roundTripFunc(func(req *http.Request) (*http.Response, error) {

--- a/internal/googleapi/transport_more_test.go
+++ b/internal/googleapi/transport_more_test.go
@@ -408,6 +408,7 @@ func TestResponseIndicatesInsufficientScopesRecognizesGoogleVariants(t *testing.
 		if err != nil {
 			t.Fatalf("detect insufficient scopes for %q: %v", body, err)
 		}
+
 		if !insufficient {
 			t.Fatalf("Google scope variant not recognized: %s", body)
 		}


### PR DESCRIPTION
## Summary

- retry one replayable Google API request after a 403 response explicitly reports insufficient authentication scopes
- limit forced refresh/remint behavior to stored user OAuth; preserve ordinary 403s, direct tokens, ADC, service accounts, and non-replayable requests
- serialize token refresh/read state, preserve inspected response bodies, and recognize Google's `insufficientPermissions` and singular `Insufficient Permission` response variants

Closes #889.

Supersedes #890 after maintainer hardening while retaining its original implementation commit.

## Root cause

Since `1531013e`, the CLI persists and reuses a still-valid access token. `golang.org/x/oauth2` returns that cached token without contacting the token endpoint until expiry. If Google transiently rejects that token as under-scoped, the current retry transport treats the first non-429 4xx as terminal. The candidate now discards the rejected cached access token, mints through the stored refresh token, persists returned metadata, and replays once.

## Final exact-head proof

Exact head: `ac67db3a4dc4124d7659f96fc1152d0ca421bb32`

- `make ci`
- focused scope/retry regressions passed 20 consecutive runs
- focused race coverage passed
- final branch autoreview clean; no accepted/actionable findings; confidence 0.82
- built candidate: `v0.31.1-18-gac67db3a`; SHA-256 `c03f2e3cff64f75bf661f07c087a3df316667b149b7e5b1f37abb6125016e1a4`
- authenticated dedicated-test-account Contacts and Calendar read-only calls exited 0 with valid JSON
- source-blind behavior validation: 4 pass, 0 fail, 1 blocked; recovery/replay, ordinary-403, non-replayable-body, and live baseline clauses passed on the predecessor head; final follow-ups have exact detector-variant and failed-refresh response-preservation coverage

## Review repairs

- preserve the cached source when forced token minting fails
- serialize ordinary token persistence with forced refresh so an in-flight stale token cannot overwrite a newer token
- recognize Google's camelCase `insufficientPermissions` reason and singular permission message while leaving ordinary permission denials untouched
- return the intact original Google 403 when forced refresh fails, preserving existing re-auth guidance; focused regression proves one refresh attempt, no replay, and exact status/body preservation
- rebase onto current `main`, preserving the #871 changelog entry

## Live-proof caveat

Google's intermittent first-response 403 cannot be safely or deterministically forced on the real provider. The exact recovery branch is covered by replay, refresh, concurrency, ordinary-403, non-replayable-body, detector-variant, and response-preservation tests; final-head authenticated Contacts and Calendar smoke is green. Merge should wait for an item-specific waiver of the unforceable provider-403 proof requirement, or for a naturally observed redacted reproduction.
