### PR TITLE
feat(docs): list pending suggestions

### DIFF
--- a/.agents/skills/gog-docs/SKILL.md
+++ b/.agents/skills/gog-docs/SKILL.md
@@ -68,6 +68,7 @@ gog --readonly --account user@example.com docs cat DOCUMENT_ID --json --wrap-unt
 | `section-columns` | Set the column count for a document section |
 | `sed` | Regex find/replace (sed-style: s/pattern/replacement/g) |
 | `structure` | Show document structure with numbered paragraphs |
+| `suggestions` | List pending text suggestions |
 | `table-column` | Insert or delete native table columns |
 | `table-column-width` | Set or reset native table column widths |
 | `table-merge` | Merge a native table cell range |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - YouTube: add opt-in `videos list --parts all` full metadata while preserving the existing compact default and explicit owner-only part requests. (#871) — thanks @coeur-de-loup.
 - Auth: retry one replayable Google API request after an `insufficient scopes` 403 by refreshing stored OAuth credentials, while preserving ordinary permission failures and non-replayable requests. (#889) — thanks @ortonom.
 - CLI: add read-only `update status` / `update check` release metadata, platform asset, checksum, and install-method reporting. (#882) — thanks @titus7490.
+- Docs: add `docs suggestions list` for read-only pending text insertions and deletions, including exact UTF-16 ranges, segment context, and tab selection. (#876)
 - Docs: add `docs format --spacing-mode` for setting paragraph spacing collapse behavior alongside `--space-above` and `--space-below`. (#885) — thanks @odyssey4me.
 
 ## 0.31.1 - 2026-06-26

--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -291,6 +291,8 @@ Generated from `gog schema --json`.
     - [`gog docs (doc) section-columns --count=INT <docId> [flags]`](commands/gog-docs-section-columns.md) - Set the column count for a document section
     - [`gog docs (doc) sed <docId> [<expression>] [flags]`](commands/gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [`gog docs (doc) structure (struct) <docId> [flags]`](commands/gog-docs-structure.md) - Show document structure with numbered paragraphs
+    - [`gog docs (doc) suggestions <command>`](commands/gog-docs-suggestions.md) - List pending text suggestions
+      - [`gog docs (doc) suggestions list (ls) <docId> [flags]`](commands/gog-docs-suggestions-list.md) - List pending text insertions and deletions
     - [`gog docs (doc) table-column <command>`](commands/gog-docs-table-column.md) - Insert or delete native table columns
       - [`gog docs (doc) table-column delete (rm,remove,del) --col=INT <docId> [flags]`](commands/gog-docs-table-column-delete.md) - Delete a native table column
       - [`gog docs (doc) table-column insert (add,append) <docId> [flags]`](commands/gog-docs-table-column-insert.md) - Insert a native table column

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -2,7 +2,7 @@
 
 Every `gog` command has a generated docs page. The source of truth is the live CLI schema; run `make docs-commands` after changing command names, flags, help text, aliases, or arguments.
 
-Generated pages: 702.
+Generated pages: 704.
 
 ## Top-level Commands
 

--- a/docs/commands/README.md
+++ b/docs/commands/README.md
@@ -344,6 +344,8 @@ Generated pages: 702.
     - [gog docs section-columns](gog-docs-section-columns.md) - Set the column count for a document section
     - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
     - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
+    - [gog docs suggestions](gog-docs-suggestions.md) - List pending text suggestions
+      - [gog docs suggestions list](gog-docs-suggestions-list.md) - List pending text insertions and deletions
     - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns
       - [gog docs table-column delete](gog-docs-table-column-delete.md) - Delete a native table column
       - [gog docs table-column insert](gog-docs-table-column-insert.md) - Insert a native table column

--- a/docs/commands/gog-docs-suggestions-list.md
+++ b/docs/commands/gog-docs-suggestions-list.md
@@ -1,0 +1,47 @@
+# `gog docs suggestions list`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List pending text insertions and deletions
+
+## Usage
+
+```bash
+gog docs (doc) suggestions list (ls) <docId> [flags]
+```
+
+## Parent
+
+- [gog docs suggestions](gog-docs-suggestions.md)
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--tab` | `string` |  | Tab title or ID (omit for the first tab) |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs suggestions](gog-docs-suggestions.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs-suggestions.md
+++ b/docs/commands/gog-docs-suggestions.md
@@ -1,0 +1,50 @@
+# `gog docs suggestions`
+
+> Generated from `gog schema --json`. Do not edit this page by hand; run `make docs-commands`.
+
+List pending text suggestions
+
+## Usage
+
+```bash
+gog docs (doc) suggestions <command>
+```
+
+## Parent
+
+- [gog docs](gog-docs.md)
+
+## Subcommands
+
+- [gog docs suggestions list](gog-docs-suggestions-list.md) - List pending text insertions and deletions
+
+## Flags
+
+| Flag | Type | Default | Help |
+| --- | --- | --- | --- |
+| `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
+| `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
+| `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
+| `--color` | `string` | auto | Color output: auto\|always\|never |
+| `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |
+| `-n`<br>`--dry-run`<br>`--dryrun`<br>`--noop`<br>`--preview` | `bool` |  | Do not make changes; print intended actions and exit successfully |
+| `--enable-commands` | `string` |  | Comma-separated list of enabled command prefixes; dot paths allowed (restricts CLI) |
+| `--enable-commands-exact` | `string` |  | Comma-separated list of exact enabled commands; dot paths allowed and parent commands do not enable children |
+| `-y`<br>`--force`<br>`--assume-yes`<br>`--yes` | `bool` |  | Skip confirmations for destructive commands |
+| `--gmail-no-send` | `bool` | false | Block Gmail send operations (agent safety) |
+| `-h`<br>`--help` | `kong.helpFlag` |  | Show context-sensitive help. |
+| `--home` | `string` |  | Override gogcli config/data/state/cache root (equivalent to GOG_HOME) |
+| `-j`<br>`--json`<br>`--machine` | `bool` | false | Output JSON to stdout (best for scripting) |
+| `--no-input`<br>`--non-interactive`<br>`--noninteractive` | `bool` |  | Never prompt; fail instead (useful for CI) |
+| `-p`<br>`--plain`<br>`--tsv` | `bool` | false | Output stable, parseable text to stdout (TSV; no colors) |
+| `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
+| `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
+| `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
+| `--version` | `kong.VersionFlag` |  | Print version and exit |
+| `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |
+
+## See Also
+
+- [gog docs](gog-docs.md)
+- [Command index](README.md)

--- a/docs/commands/gog-docs.md
+++ b/docs/commands/gog-docs.md
@@ -56,6 +56,7 @@ gog docs (doc) <command> [flags]
 - [gog docs section-columns](gog-docs-section-columns.md) - Set the column count for a document section
 - [gog docs sed](gog-docs-sed.md) - Regex find/replace (sed-style: s/pattern/replacement/g)
 - [gog docs structure](gog-docs-structure.md) - Show document structure with numbered paragraphs
+- [gog docs suggestions](gog-docs-suggestions.md) - List pending text suggestions
 - [gog docs table-column](gog-docs-table-column.md) - Insert or delete native table columns
 - [gog docs table-column-width](gog-docs-table-column-width.md) - Set or reset native table column widths
 - [gog docs table-merge](gog-docs-table-merge.md) - Merge a native table cell range

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -500,3 +500,22 @@ gog docs raw <docId> --all-tabs --json
 default response. `--all-tabs` returns the canonical recursive `tabs` tree.
 
 See [Raw API Dumps](raw-api.md) for lossless-output safety notes.
+
+## Pending Text Suggestions
+
+List pending suggested insertions and deletions without changing the document:
+
+```bash
+gog docs suggestions list <docId>
+gog docs suggestions list <docId> --tab "Review" --json
+```
+
+The command requests Google's inline suggestions view and reports each
+suggestion ID, insertion/deletion kind, UTF-16 range, text, and document
+segment. Contiguous runs for the same suggestion are combined. The current
+surface intentionally excludes style-only suggestions and accept/reject
+mutation. Google Docs API responses do not expose suggestion authors.
+
+Command page:
+
+- [`gog docs suggestions list`](commands/gog-docs-suggestions-list.md)

--- a/docs/docs-editing.md
+++ b/docs/docs-editing.md
@@ -512,9 +512,11 @@ gog docs suggestions list <docId> --tab "Review" --json
 
 The command requests Google's inline suggestions view and reports each
 suggestion ID, insertion/deletion kind, UTF-16 range, text, and document
-segment. Contiguous runs for the same suggestion are combined. The current
-surface intentionally excludes style-only suggestions and accept/reject
-mutation. Google Docs API responses do not expose suggestion authors.
+segment. Contiguous runs for the same suggestion are combined, and structural
+suggestions on tables, rows, cells, and tables of contents are carried into
+their nested text. The current surface intentionally excludes style-only
+suggestions and accept/reject mutation. Google Docs API responses do not expose
+suggestion authors.
 
 Command page:
 

--- a/internal/cmd/docs.go
+++ b/internal/cmd/docs.go
@@ -62,6 +62,7 @@ type DocsCmd struct {
 	Images           DocsImagesCmd           `cmd:"" name:"images" help:"List document images"`
 	Headings         DocsHeadingsCmd         `cmd:"" name:"headings" help:"List document headings"`
 	Paragraphs       DocsParagraphsCmd       `cmd:"" name:"paragraphs" help:"List document paragraphs"`
+	Suggestions      DocsSuggestionsCmd      `cmd:"" name:"suggestions" help:"List pending text suggestions"`
 	NamedRanges      DocsNamedRangesCmd      `cmd:"" name:"named-range" aliases:"named-ranges,namedranges,nr" help:"Manage named ranges"`
 	Raw              DocsRawCmd              `cmd:"" name:"raw" help:"Dump raw Google Docs API response as JSON (Documents.Get; lossless; for scripting and LLM consumption)"`
 	PageLayout       DocsPageLayoutCmd       `cmd:"" name:"page-layout" aliases:"set-page-layout,page-setup" help:"Set page layout (pageless|pages) on an existing Google Doc"`

--- a/internal/cmd/docs_suggestions.go
+++ b/internal/cmd/docs_suggestions.go
@@ -151,6 +151,18 @@ func collectDocsSuggestionSegment(
 			if element == nil {
 				continue
 			}
+			if element.SectionBreak != nil {
+				appendDocsSuggestionRange(
+					items,
+					lastByKey,
+					segment,
+					element.StartIndex,
+					element.EndIndex,
+					"",
+					mergeDocsSuggestionIDs(insertionIDs, element.SectionBreak.SuggestedInsertionIds),
+					mergeDocsSuggestionIDs(deletionIDs, element.SectionBreak.SuggestedDeletionIds),
+				)
+			}
 			if element.Paragraph != nil {
 				for _, paragraphElement := range element.Paragraph.Elements {
 					if paragraphElement == nil {
@@ -211,12 +223,33 @@ func appendDocsSuggestionElement(
 	if !ok {
 		return
 	}
+	appendDocsSuggestionRange(
+		items,
+		lastByKey,
+		segment,
+		element.StartIndex,
+		element.EndIndex,
+		text,
+		mergeDocsSuggestionIDs(inheritedInsertionIDs, insertionIDs),
+		mergeDocsSuggestionIDs(inheritedDeletionIDs, deletionIDs),
+	)
+}
 
+func appendDocsSuggestionRange(
+	items *[]docsSuggestionListItem,
+	lastByKey map[string]int,
+	segment string,
+	startIndex int64,
+	endIndex int64,
+	text string,
+	insertionIDs []string,
+	deletionIDs []string,
+) {
 	appendIDs := func(kind string, ids []string) {
 		for _, id := range sortedUniqueStrings(ids) {
 			key := kind + "\x00" + id
-			if index, ok := lastByKey[key]; ok && (*items)[index].EndIndex == element.StartIndex {
-				(*items)[index].EndIndex = element.EndIndex
+			if index, ok := lastByKey[key]; ok && (*items)[index].EndIndex == startIndex {
+				(*items)[index].EndIndex = endIndex
 				(*items)[index].Text += text
 				continue
 			}
@@ -224,16 +257,16 @@ func appendDocsSuggestionElement(
 				SuggestionID: id,
 				Kind:         kind,
 				Segment:      segment,
-				StartIndex:   element.StartIndex,
-				EndIndex:     element.EndIndex,
+				StartIndex:   startIndex,
+				EndIndex:     endIndex,
 				Text:         text,
 			})
 			lastByKey[key] = len(*items) - 1
 		}
 	}
 
-	appendIDs("insertion", mergeDocsSuggestionIDs(inheritedInsertionIDs, insertionIDs))
-	appendIDs("deletion", mergeDocsSuggestionIDs(inheritedDeletionIDs, deletionIDs))
+	appendIDs("insertion", insertionIDs)
+	appendIDs("deletion", deletionIDs)
 }
 
 func docsParagraphElementSuggestions(element *docs.ParagraphElement) (

--- a/internal/cmd/docs_suggestions.go
+++ b/internal/cmd/docs_suggestions.go
@@ -107,18 +107,18 @@ func enumerateDocsSuggestions(doc *docs.Document) []docsSuggestionListItem {
 	}
 
 	items := make([]docsSuggestionListItem, 0)
-	collectDocsSuggestionSegment(&items, "body", bodyContent(doc.Body))
+	collectDocsSuggestionSegment(&items, doc, "body", bodyContent(doc.Body))
 	for _, id := range sortedDocsMapKeys(doc.Headers) {
 		header := doc.Headers[id]
-		collectDocsSuggestionSegment(&items, "header:"+id, header.Content)
+		collectDocsSuggestionSegment(&items, doc, "header:"+id, header.Content)
 	}
 	for _, id := range sortedDocsMapKeys(doc.Footers) {
 		footer := doc.Footers[id]
-		collectDocsSuggestionSegment(&items, "footer:"+id, footer.Content)
+		collectDocsSuggestionSegment(&items, doc, "footer:"+id, footer.Content)
 	}
 	for _, id := range sortedDocsMapKeys(doc.Footnotes) {
 		footnote := doc.Footnotes[id]
-		collectDocsSuggestionSegment(&items, "footnote:"+id, footnote.Content)
+		collectDocsSuggestionSegment(&items, doc, "footnote:"+id, footnote.Content)
 	}
 	return items
 }
@@ -141,6 +141,7 @@ func sortedDocsMapKeys[T any](values map[string]T) []string {
 
 func collectDocsSuggestionSegment(
 	items *[]docsSuggestionListItem,
+	doc *docs.Document,
 	segment string,
 	content []*docs.StructuralElement,
 ) {
@@ -164,6 +165,14 @@ func collectDocsSuggestionSegment(
 				)
 			}
 			if element.Paragraph != nil {
+				appendDocsParagraphMapSuggestions(
+					items,
+					lastByKey,
+					doc,
+					segment,
+					element.StartIndex,
+					element.Paragraph,
+				)
 				for _, paragraphElement := range element.Paragraph.Elements {
 					if paragraphElement == nil {
 						continue
@@ -173,6 +182,7 @@ func collectDocsSuggestionSegment(
 						lastByKey,
 						segment,
 						paragraphElement,
+						doc.InlineObjects,
 						insertionIDs,
 						deletionIDs,
 					)
@@ -211,15 +221,61 @@ func collectDocsSuggestionSegment(
 	walk(content, nil, nil)
 }
 
+func appendDocsParagraphMapSuggestions(
+	items *[]docsSuggestionListItem,
+	lastByKey map[string]int,
+	doc *docs.Document,
+	segment string,
+	anchorIndex int64,
+	paragraph *docs.Paragraph,
+) {
+	if paragraph.Bullet != nil {
+		if list, ok := doc.Lists[paragraph.Bullet.ListId]; ok {
+			appendDocsSuggestionRange(
+				items,
+				lastByKey,
+				segment,
+				anchorIndex,
+				anchorIndex,
+				"",
+				[]string{list.SuggestedInsertionId},
+				list.SuggestedDeletionIds,
+			)
+		}
+	}
+
+	objectIDs := append([]string(nil), paragraph.PositionedObjectIds...)
+	for _, suggestionID := range sortedDocsMapKeys(paragraph.SuggestedPositionedObjectIds) {
+		objectIDs = append(objectIDs, paragraph.SuggestedPositionedObjectIds[suggestionID].ObjectIds...)
+	}
+	for _, objectID := range sortedUniqueStrings(objectIDs) {
+		object, ok := doc.PositionedObjects[objectID]
+		if !ok {
+			continue
+		}
+		appendDocsSuggestionRange(
+			items,
+			lastByKey,
+			segment,
+			anchorIndex,
+			anchorIndex,
+			"",
+			[]string{object.SuggestedInsertionId},
+			object.SuggestedDeletionIds,
+		)
+	}
+}
+
 func appendDocsSuggestionElement(
 	items *[]docsSuggestionListItem,
 	lastByKey map[string]int,
 	segment string,
 	element *docs.ParagraphElement,
+	inlineObjects map[string]docs.InlineObject,
 	inheritedInsertionIDs []string,
 	inheritedDeletionIDs []string,
 ) {
-	text, insertionIDs, deletionIDs, ok := docsParagraphElementSuggestions(element)
+	text, insertionIDs, deletionIDs, ok := docsParagraphElementSuggestions(element, inlineObjects)
 	if !ok {
 		return
 	}
@@ -269,7 +325,10 @@ func appendDocsSuggestionRange(
 	appendIDs("deletion", deletionIDs)
 }
 
-func docsParagraphElementSuggestions(element *docs.ParagraphElement) (
+func docsParagraphElementSuggestions(
+	element *docs.ParagraphElement,
+	inlineObjects map[string]docs.InlineObject,
+) (
 	text string,
 	insertionIDs []string,
 	deletionIDs []string,
@@ -294,7 +353,13 @@ func docsParagraphElementSuggestions(element *docs.ParagraphElement) (
 	case element.HorizontalRule != nil:
 		return "", element.HorizontalRule.SuggestedInsertionIds, element.HorizontalRule.SuggestedDeletionIds, true
 	case element.InlineObjectElement != nil:
-		return "", element.InlineObjectElement.SuggestedInsertionIds, element.InlineObjectElement.SuggestedDeletionIds, true
+		insertionIDs := element.InlineObjectElement.SuggestedInsertionIds
+		deletionIDs := element.InlineObjectElement.SuggestedDeletionIds
+		if object, ok := inlineObjects[element.InlineObjectElement.InlineObjectId]; ok {
+			insertionIDs = mergeDocsSuggestionIDs(insertionIDs, []string{object.SuggestedInsertionId})
+			deletionIDs = mergeDocsSuggestionIDs(deletionIDs, object.SuggestedDeletionIds)
+		}
+		return "", insertionIDs, deletionIDs, true
 	case element.PageBreak != nil:
 		return "", element.PageBreak.SuggestedInsertionIds, element.PageBreak.SuggestedDeletionIds, true
 	case element.Person != nil:

--- a/internal/cmd/docs_suggestions.go
+++ b/internal/cmd/docs_suggestions.go
@@ -145,8 +145,8 @@ func collectDocsSuggestionSegment(
 	content []*docs.StructuralElement,
 ) {
 	lastByKey := make(map[string]int)
-	var walk func([]*docs.StructuralElement)
-	walk = func(elements []*docs.StructuralElement) {
+	var walk func([]*docs.StructuralElement, []string, []string)
+	walk = func(elements []*docs.StructuralElement, insertionIDs, deletionIDs []string) {
 		for _, element := range elements {
 			if element == nil {
 				continue
@@ -156,22 +156,47 @@ func collectDocsSuggestionSegment(
 					if paragraphElement == nil || paragraphElement.TextRun == nil {
 						continue
 					}
-					appendDocsSuggestionRuns(items, lastByKey, segment, paragraphElement)
+					appendDocsSuggestionRuns(
+						items,
+						lastByKey,
+						segment,
+						paragraphElement,
+						insertionIDs,
+						deletionIDs,
+					)
 				}
 			}
 			if element.Table != nil {
+				tableInsertions := mergeDocsSuggestionIDs(insertionIDs, element.Table.SuggestedInsertionIds)
+				tableDeletions := mergeDocsSuggestionIDs(deletionIDs, element.Table.SuggestedDeletionIds)
 				for _, row := range element.Table.TableRows {
+					if row == nil {
+						continue
+					}
+					rowInsertions := mergeDocsSuggestionIDs(tableInsertions, row.SuggestedInsertionIds)
+					rowDeletions := mergeDocsSuggestionIDs(tableDeletions, row.SuggestedDeletionIds)
 					for _, cell := range row.TableCells {
-						walk(cell.Content)
+						if cell == nil {
+							continue
+						}
+						walk(
+							cell.Content,
+							mergeDocsSuggestionIDs(rowInsertions, cell.SuggestedInsertionIds),
+							mergeDocsSuggestionIDs(rowDeletions, cell.SuggestedDeletionIds),
+						)
 					}
 				}
 			}
 			if element.TableOfContents != nil {
-				walk(element.TableOfContents.Content)
+				walk(
+					element.TableOfContents.Content,
+					mergeDocsSuggestionIDs(insertionIDs, element.TableOfContents.SuggestedInsertionIds),
+					mergeDocsSuggestionIDs(deletionIDs, element.TableOfContents.SuggestedDeletionIds),
+				)
 			}
 		}
 	}
-	walk(content)
+	walk(content, nil, nil)
 }
 
 func appendDocsSuggestionRuns(
@@ -179,6 +204,8 @@ func appendDocsSuggestionRuns(
 	lastByKey map[string]int,
 	segment string,
 	element *docs.ParagraphElement,
+	inheritedInsertionIDs []string,
+	inheritedDeletionIDs []string,
 ) {
 	appendIDs := func(kind string, ids []string) {
 		for _, id := range sortedUniqueStrings(ids) {
@@ -200,8 +227,16 @@ func appendDocsSuggestionRuns(
 		}
 	}
 
-	appendIDs("insertion", element.TextRun.SuggestedInsertionIds)
-	appendIDs("deletion", element.TextRun.SuggestedDeletionIds)
+	appendIDs("insertion", mergeDocsSuggestionIDs(inheritedInsertionIDs, element.TextRun.SuggestedInsertionIds))
+	appendIDs("deletion", mergeDocsSuggestionIDs(inheritedDeletionIDs, element.TextRun.SuggestedDeletionIds))
+}
+
+func mergeDocsSuggestionIDs(groups ...[]string) []string {
+	var values []string
+	for _, group := range groups {
+		values = append(values, group...)
+	}
+	return sortedUniqueStrings(values)
 }
 
 func sortedUniqueStrings(values []string) []string {

--- a/internal/cmd/docs_suggestions.go
+++ b/internal/cmd/docs_suggestions.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"google.golang.org/api/docs/v1"
+
+	"github.com/steipete/gogcli/internal/outfmt"
+)
+
+type DocsSuggestionsCmd struct {
+	List DocsSuggestionsListCmd `cmd:"" name:"list" aliases:"ls" help:"List pending text insertions and deletions"`
+}
+
+type DocsSuggestionsListCmd struct {
+	DocID string `arg:"" name:"docId" help:"Doc ID"`
+	Tab   string `name:"tab" help:"Tab title or ID (omit for the first tab)"`
+}
+
+type docsSuggestionListItem struct {
+	SuggestionID string `json:"suggestionId"`
+	Kind         string `json:"kind"`
+	Segment      string `json:"segment"`
+	StartIndex   int64  `json:"startIndex"`
+	EndIndex     int64  `json:"endIndex"`
+	Text         string `json:"text"`
+}
+
+func (c *DocsSuggestionsListCmd) Run(ctx context.Context, flags *RootFlags) error {
+	id := normalizeGoogleID(strings.TrimSpace(c.DocID))
+	if id == "" {
+		return usage("empty docId")
+	}
+
+	svc, err := requireDocsService(ctx, flags)
+	if err != nil {
+		return err
+	}
+
+	tabQuery := strings.TrimSpace(c.Tab)
+	call := svc.Documents.Get(id).
+		SuggestionsViewMode("SUGGESTIONS_INLINE").
+		Context(ctx)
+	if tabQuery != "" {
+		call = call.IncludeTabsContent(true)
+	}
+	doc, err := call.Do()
+	if err != nil {
+		if isDocsNotFound(err) {
+			return fmt.Errorf("doc not found or not a Google Doc (id=%s)", id)
+		}
+		return err
+	}
+	if doc == nil {
+		return fmt.Errorf("doc not found")
+	}
+
+	tabID := ""
+	if tabQuery != "" {
+		tab, tabErr := findTab(flattenTabs(doc.Tabs), tabQuery)
+		if tabErr != nil {
+			return tabErr
+		}
+		projected, projectErr := projectRawDocumentTab(doc, tab)
+		if projectErr != nil {
+			return projectErr
+		}
+		doc = projected
+		if tab.TabProperties != nil {
+			tabID = tab.TabProperties.TabId
+		}
+	}
+
+	items := enumerateDocsSuggestions(doc)
+	if outfmt.IsJSON(ctx) {
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{
+			"documentId":  doc.DocumentId,
+			"tabId":       tabID,
+			"suggestions": items,
+		})
+	}
+
+	w, flush := tableWriter(ctx)
+	defer flush()
+	if !outfmt.IsPlain(ctx) {
+		fmt.Fprintln(w, "SUGGESTION ID\tKIND\tSEGMENT\tSTART\tEND\tTEXT")
+	}
+	for _, item := range items {
+		fmt.Fprintf(w, "%s\t%s\t%s\t%d\t%d\t%s\n",
+			item.SuggestionID,
+			item.Kind,
+			item.Segment,
+			item.StartIndex,
+			item.EndIndex,
+			docsTSVField(item.Text),
+		)
+	}
+	return nil
+}
+
+func enumerateDocsSuggestions(doc *docs.Document) []docsSuggestionListItem {
+	if doc == nil {
+		return []docsSuggestionListItem{}
+	}
+
+	items := make([]docsSuggestionListItem, 0)
+	collectDocsSuggestionSegment(&items, "body", bodyContent(doc.Body))
+	for _, id := range sortedDocsMapKeys(doc.Headers) {
+		header := doc.Headers[id]
+		collectDocsSuggestionSegment(&items, "header:"+id, header.Content)
+	}
+	for _, id := range sortedDocsMapKeys(doc.Footers) {
+		footer := doc.Footers[id]
+		collectDocsSuggestionSegment(&items, "footer:"+id, footer.Content)
+	}
+	for _, id := range sortedDocsMapKeys(doc.Footnotes) {
+		footnote := doc.Footnotes[id]
+		collectDocsSuggestionSegment(&items, "footnote:"+id, footnote.Content)
+	}
+	return items
+}
+
+func bodyContent(body *docs.Body) []*docs.StructuralElement {
+	if body == nil {
+		return nil
+	}
+	return body.Content
+}
+
+func sortedDocsMapKeys[T any](values map[string]T) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func collectDocsSuggestionSegment(
+	items *[]docsSuggestionListItem,
+	segment string,
+	content []*docs.StructuralElement,
+) {
+	lastByKey := make(map[string]int)
+	var walk func([]*docs.StructuralElement)
+	walk = func(elements []*docs.StructuralElement) {
+		for _, element := range elements {
+			if element == nil {
+				continue
+			}
+			if element.Paragraph != nil {
+				for _, paragraphElement := range element.Paragraph.Elements {
+					if paragraphElement == nil || paragraphElement.TextRun == nil {
+						continue
+					}
+					appendDocsSuggestionRuns(items, lastByKey, segment, paragraphElement)
+				}
+			}
+			if element.Table != nil {
+				for _, row := range element.Table.TableRows {
+					for _, cell := range row.TableCells {
+						walk(cell.Content)
+					}
+				}
+			}
+			if element.TableOfContents != nil {
+				walk(element.TableOfContents.Content)
+			}
+		}
+	}
+	walk(content)
+}
+
+func appendDocsSuggestionRuns(
+	items *[]docsSuggestionListItem,
+	lastByKey map[string]int,
+	segment string,
+	element *docs.ParagraphElement,
+) {
+	appendIDs := func(kind string, ids []string) {
+		for _, id := range sortedUniqueStrings(ids) {
+			key := kind + "\x00" + id
+			if index, ok := lastByKey[key]; ok && (*items)[index].EndIndex == element.StartIndex {
+				(*items)[index].EndIndex = element.EndIndex
+				(*items)[index].Text += element.TextRun.Content
+				continue
+			}
+			*items = append(*items, docsSuggestionListItem{
+				SuggestionID: id,
+				Kind:         kind,
+				Segment:      segment,
+				StartIndex:   element.StartIndex,
+				EndIndex:     element.EndIndex,
+				Text:         element.TextRun.Content,
+			})
+			lastByKey[key] = len(*items) - 1
+		}
+	}
+
+	appendIDs("insertion", element.TextRun.SuggestedInsertionIds)
+	appendIDs("deletion", element.TextRun.SuggestedDeletionIds)
+}
+
+func sortedUniqueStrings(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(set))
+	for value := range set {
+		result = append(result, value)
+	}
+	sort.Strings(result)
+	return result
+}

--- a/internal/cmd/docs_suggestions.go
+++ b/internal/cmd/docs_suggestions.go
@@ -153,10 +153,10 @@ func collectDocsSuggestionSegment(
 			}
 			if element.Paragraph != nil {
 				for _, paragraphElement := range element.Paragraph.Elements {
-					if paragraphElement == nil || paragraphElement.TextRun == nil {
+					if paragraphElement == nil {
 						continue
 					}
-					appendDocsSuggestionRuns(
+					appendDocsSuggestionElement(
 						items,
 						lastByKey,
 						segment,
@@ -199,7 +199,7 @@ func collectDocsSuggestionSegment(
 	walk(content, nil, nil)
 }
 
-func appendDocsSuggestionRuns(
+func appendDocsSuggestionElement(
 	items *[]docsSuggestionListItem,
 	lastByKey map[string]int,
 	segment string,
@@ -207,12 +207,17 @@ func appendDocsSuggestionRuns(
 	inheritedInsertionIDs []string,
 	inheritedDeletionIDs []string,
 ) {
+	text, insertionIDs, deletionIDs, ok := docsParagraphElementSuggestions(element)
+	if !ok {
+		return
+	}
+
 	appendIDs := func(kind string, ids []string) {
 		for _, id := range sortedUniqueStrings(ids) {
 			key := kind + "\x00" + id
 			if index, ok := lastByKey[key]; ok && (*items)[index].EndIndex == element.StartIndex {
 				(*items)[index].EndIndex = element.EndIndex
-				(*items)[index].Text += element.TextRun.Content
+				(*items)[index].Text += text
 				continue
 			}
 			*items = append(*items, docsSuggestionListItem{
@@ -221,14 +226,51 @@ func appendDocsSuggestionRuns(
 				Segment:      segment,
 				StartIndex:   element.StartIndex,
 				EndIndex:     element.EndIndex,
-				Text:         element.TextRun.Content,
+				Text:         text,
 			})
 			lastByKey[key] = len(*items) - 1
 		}
 	}
 
-	appendIDs("insertion", mergeDocsSuggestionIDs(inheritedInsertionIDs, element.TextRun.SuggestedInsertionIds))
-	appendIDs("deletion", mergeDocsSuggestionIDs(inheritedDeletionIDs, element.TextRun.SuggestedDeletionIds))
+	appendIDs("insertion", mergeDocsSuggestionIDs(inheritedInsertionIDs, insertionIDs))
+	appendIDs("deletion", mergeDocsSuggestionIDs(inheritedDeletionIDs, deletionIDs))
+}
+
+func docsParagraphElementSuggestions(element *docs.ParagraphElement) (
+	text string,
+	insertionIDs []string,
+	deletionIDs []string,
+	ok bool,
+) {
+	switch {
+	case element.TextRun != nil:
+		return element.TextRun.Content,
+			element.TextRun.SuggestedInsertionIds,
+			element.TextRun.SuggestedDeletionIds,
+			true
+	case element.AutoText != nil:
+		return "", element.AutoText.SuggestedInsertionIds, element.AutoText.SuggestedDeletionIds, true
+	case element.ColumnBreak != nil:
+		return "", element.ColumnBreak.SuggestedInsertionIds, element.ColumnBreak.SuggestedDeletionIds, true
+	case element.DateElement != nil:
+		return "", element.DateElement.SuggestedInsertionIds, element.DateElement.SuggestedDeletionIds, true
+	case element.Equation != nil:
+		return "", element.Equation.SuggestedInsertionIds, element.Equation.SuggestedDeletionIds, true
+	case element.FootnoteReference != nil:
+		return "", element.FootnoteReference.SuggestedInsertionIds, element.FootnoteReference.SuggestedDeletionIds, true
+	case element.HorizontalRule != nil:
+		return "", element.HorizontalRule.SuggestedInsertionIds, element.HorizontalRule.SuggestedDeletionIds, true
+	case element.InlineObjectElement != nil:
+		return "", element.InlineObjectElement.SuggestedInsertionIds, element.InlineObjectElement.SuggestedDeletionIds, true
+	case element.PageBreak != nil:
+		return "", element.PageBreak.SuggestedInsertionIds, element.PageBreak.SuggestedDeletionIds, true
+	case element.Person != nil:
+		return "", element.Person.SuggestedInsertionIds, element.Person.SuggestedDeletionIds, true
+	case element.RichLink != nil:
+		return "", element.RichLink.SuggestedInsertionIds, element.RichLink.SuggestedDeletionIds, true
+	default:
+		return "", nil, nil, false
+	}
 }
 
 func mergeDocsSuggestionIDs(groups ...[]string) []string {

--- a/internal/cmd/docs_suggestions_test.go
+++ b/internal/cmd/docs_suggestions_test.go
@@ -15,7 +15,8 @@ import (
 func TestEnumerateDocsSuggestions(t *testing.T) {
 	t.Parallel()
 
-	tableCellContent := suggestionContent(10, 14, "cell", "table", nil)
+	tableCellContent := suggestionContent(10, 14, "cell", "table-run")
+	tocContent := suggestionContent(20, 23, "toc", "toc-run")
 	doc := &docs.Document{
 		Body: &docs.Body{Content: []*docs.StructuralElement{
 			{
@@ -35,14 +36,24 @@ func TestEnumerateDocsSuggestions(t *testing.T) {
 				}},
 			},
 			{
-				Table: &docs.Table{TableRows: []*docs.TableRow{{
-					TableCells: []*docs.TableCell{{Content: tableCellContent}},
+				Table: &docs.Table{SuggestedInsertionIds: []string{"table-structure"}, TableRows: []*docs.TableRow{{
+					SuggestedDeletionIds: []string{"row-structure"},
+					TableCells: []*docs.TableCell{{
+						Content:               tableCellContent,
+						SuggestedInsertionIds: []string{"cell-structure", "table-structure"},
+					}},
 				}}},
+			},
+			{
+				TableOfContents: &docs.TableOfContents{
+					Content:              tocContent,
+					SuggestedDeletionIds: []string{"toc-structure"},
+				},
 			},
 		}},
 		Headers: map[string]docs.Header{
-			"z": {Content: suggestionContent(3, 5, "zz", "header-z", nil)},
-			"a": {Content: suggestionContent(1, 3, "aa", "header-a", nil)},
+			"z": {Content: suggestionContent(3, 5, "zz", "header-z")},
+			"a": {Content: suggestionContent(1, 3, "aa", "header-a")},
 		},
 	}
 
@@ -51,7 +62,12 @@ func TestEnumerateDocsSuggestions(t *testing.T) {
 		{SuggestionID: "insert", Kind: "insertion", Segment: "body", StartIndex: 1, EndIndex: 6, Text: "hello"},
 		{SuggestionID: "nested", Kind: "insertion", Segment: "body", StartIndex: 1, EndIndex: 4, Text: "hel"},
 		{SuggestionID: "delete", Kind: "deletion", Segment: "body", StartIndex: 6, EndIndex: 7, Text: "!"},
-		{SuggestionID: "table", Kind: "insertion", Segment: "body", StartIndex: 10, EndIndex: 14, Text: "cell"},
+		{SuggestionID: "cell-structure", Kind: "insertion", Segment: "body", StartIndex: 10, EndIndex: 14, Text: "cell"},
+		{SuggestionID: "table-run", Kind: "insertion", Segment: "body", StartIndex: 10, EndIndex: 14, Text: "cell"},
+		{SuggestionID: "table-structure", Kind: "insertion", Segment: "body", StartIndex: 10, EndIndex: 14, Text: "cell"},
+		{SuggestionID: "row-structure", Kind: "deletion", Segment: "body", StartIndex: 10, EndIndex: 14, Text: "cell"},
+		{SuggestionID: "toc-run", Kind: "insertion", Segment: "body", StartIndex: 20, EndIndex: 23, Text: "toc"},
+		{SuggestionID: "toc-structure", Kind: "deletion", Segment: "body", StartIndex: 20, EndIndex: 23, Text: "toc"},
 		{SuggestionID: "header-a", Kind: "insertion", Segment: "header:a", StartIndex: 1, EndIndex: 3, Text: "aa"},
 		{SuggestionID: "header-z", Kind: "insertion", Segment: "header:z", StartIndex: 3, EndIndex: 5, Text: "zz"},
 	}
@@ -191,14 +207,13 @@ func TestDocsSuggestionsList_EmptyDocID(t *testing.T) {
 	}
 }
 
-func suggestionContent(start, end int64, text, insertionID string, deletionIDs []string) []*docs.StructuralElement {
+func suggestionContent(start, end int64, text, insertionID string) []*docs.StructuralElement {
 	run := &docs.ParagraphElement{
 		StartIndex: start,
 		EndIndex:   end,
 		TextRun: &docs.TextRun{
 			Content:               text,
 			SuggestedInsertionIds: []string{insertionID},
-			SuggestedDeletionIds:  deletionIDs,
 		},
 	}
 	return []*docs.StructuralElement{{Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{run}}}}

--- a/internal/cmd/docs_suggestions_test.go
+++ b/internal/cmd/docs_suggestions_test.go
@@ -167,6 +167,28 @@ func TestEnumerateDocsSuggestions_NonTextParagraphElements(t *testing.T) {
 	}
 }
 
+func TestEnumerateDocsSuggestions_SectionBreak(t *testing.T) {
+	t.Parallel()
+
+	doc := &docs.Document{Body: &docs.Body{Content: []*docs.StructuralElement{{
+		StartIndex: 8,
+		EndIndex:   9,
+		SectionBreak: &docs.SectionBreak{
+			SuggestedInsertionIds: []string{"insert"},
+			SuggestedDeletionIds:  []string{"delete"},
+		},
+	}}}}
+
+	got := enumerateDocsSuggestions(doc)
+	want := []docsSuggestionListItem{
+		{SuggestionID: "insert", Kind: "insertion", Segment: "body", StartIndex: 8, EndIndex: 9},
+		{SuggestionID: "delete", Kind: "deletion", Segment: "body", StartIndex: 8, EndIndex: 9},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("suggestions mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 func TestDocsSuggestionsList_JSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/docs_suggestions_test.go
+++ b/internal/cmd/docs_suggestions_test.go
@@ -76,6 +76,97 @@ func TestEnumerateDocsSuggestions(t *testing.T) {
 	}
 }
 
+func TestEnumerateDocsSuggestions_NonTextParagraphElements(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		element *docs.ParagraphElement
+	}{
+		{
+			name: "auto text",
+			element: &docs.ParagraphElement{AutoText: &docs.AutoText{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "column break",
+			element: &docs.ParagraphElement{ColumnBreak: &docs.ColumnBreak{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "date",
+			element: &docs.ParagraphElement{DateElement: &docs.DateElement{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "equation",
+			element: &docs.ParagraphElement{Equation: &docs.Equation{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "footnote reference",
+			element: &docs.ParagraphElement{FootnoteReference: &docs.FootnoteReference{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "horizontal rule",
+			element: &docs.ParagraphElement{HorizontalRule: &docs.HorizontalRule{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "inline object",
+			element: &docs.ParagraphElement{InlineObjectElement: &docs.InlineObjectElement{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "page break",
+			element: &docs.ParagraphElement{PageBreak: &docs.PageBreak{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "person chip",
+			element: &docs.ParagraphElement{Person: &docs.Person{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+		{
+			name: "rich link chip",
+			element: &docs.ParagraphElement{RichLink: &docs.RichLink{
+				SuggestedInsertionIds: []string{"insert"}, SuggestedDeletionIds: []string{"delete"},
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.element.StartIndex = 4
+			tt.element.EndIndex = 5
+			doc := &docs.Document{Body: &docs.Body{Content: []*docs.StructuralElement{{
+				Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{tt.element}},
+			}}}}
+
+			got := enumerateDocsSuggestions(doc)
+			want := []docsSuggestionListItem{
+				{SuggestionID: "insert", Kind: "insertion", Segment: "body", StartIndex: 4, EndIndex: 5},
+				{SuggestionID: "delete", Kind: "deletion", Segment: "body", StartIndex: 4, EndIndex: 5},
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("suggestions mismatch\n got: %#v\nwant: %#v", got, want)
+			}
+		})
+	}
+}
+
 func TestDocsSuggestionsList_JSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/docs_suggestions_test.go
+++ b/internal/cmd/docs_suggestions_test.go
@@ -1,0 +1,205 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+
+	"google.golang.org/api/docs/v1"
+)
+
+func TestEnumerateDocsSuggestions(t *testing.T) {
+	t.Parallel()
+
+	tableCellContent := suggestionContent(10, 14, "cell", "table", nil)
+	doc := &docs.Document{
+		Body: &docs.Body{Content: []*docs.StructuralElement{
+			{
+				Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{
+					{StartIndex: 1, EndIndex: 4, TextRun: &docs.TextRun{
+						Content: "hel", SuggestedInsertionIds: []string{"nested", "insert", "insert"},
+					}},
+					{StartIndex: 4, EndIndex: 6, TextRun: &docs.TextRun{
+						Content: "lo", SuggestedInsertionIds: []string{"insert"},
+					}},
+					{StartIndex: 6, EndIndex: 7, TextRun: &docs.TextRun{
+						Content: "!", SuggestedDeletionIds: []string{"delete"},
+					}},
+					{StartIndex: 7, EndIndex: 8, TextRun: &docs.TextRun{
+						Content: "x", SuggestedTextStyleChanges: map[string]docs.SuggestedTextStyle{"style": {}},
+					}},
+				}},
+			},
+			{
+				Table: &docs.Table{TableRows: []*docs.TableRow{{
+					TableCells: []*docs.TableCell{{Content: tableCellContent}},
+				}}},
+			},
+		}},
+		Headers: map[string]docs.Header{
+			"z": {Content: suggestionContent(3, 5, "zz", "header-z", nil)},
+			"a": {Content: suggestionContent(1, 3, "aa", "header-a", nil)},
+		},
+	}
+
+	got := enumerateDocsSuggestions(doc)
+	want := []docsSuggestionListItem{
+		{SuggestionID: "insert", Kind: "insertion", Segment: "body", StartIndex: 1, EndIndex: 6, Text: "hello"},
+		{SuggestionID: "nested", Kind: "insertion", Segment: "body", StartIndex: 1, EndIndex: 4, Text: "hel"},
+		{SuggestionID: "delete", Kind: "deletion", Segment: "body", StartIndex: 6, EndIndex: 7, Text: "!"},
+		{SuggestionID: "table", Kind: "insertion", Segment: "body", StartIndex: 10, EndIndex: 14, Text: "cell"},
+		{SuggestionID: "header-a", Kind: "insertion", Segment: "header:a", StartIndex: 1, EndIndex: 3, Text: "aa"},
+		{SuggestionID: "header-z", Kind: "insertion", Segment: "header:z", StartIndex: 3, EndIndex: 5, Text: "zz"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("suggestions mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestDocsSuggestionsList_JSON(t *testing.T) {
+	t.Parallel()
+
+	srv := newDocsRawTestServerWithRequest(t, 0, map[string]any{
+		"documentId": "doc1",
+		"body": map[string]any{"content": []any{map[string]any{
+			"paragraph": map[string]any{"elements": []any{map[string]any{
+				"startIndex": 1,
+				"endIndex":   6,
+				"textRun": map[string]any{
+					"content":               "draft",
+					"suggestedInsertionIds": []any{"suggestion-1"},
+				},
+			}}},
+		}}},
+	}, func(r *http.Request) {
+		if got := r.URL.Query().Get("suggestionsViewMode"); got != "SUGGESTIONS_INLINE" {
+			t.Fatalf("suggestionsViewMode=%q", got)
+		}
+		if _, ok := r.URL.Query()["includeTabsContent"]; ok {
+			t.Fatalf("default request unexpectedly set includeTabsContent: %s", r.URL.RawQuery)
+		}
+	})
+	defer srv.Close()
+
+	output := &bytes.Buffer{}
+	ctx := newCmdRuntimeJSONOutputContext(t, output, io.Discard)
+	ctx = withDocsTestService(ctx, newMockDocsService(t, srv))
+	cmd := &DocsSuggestionsListCmd{}
+	if err := runKong(t, cmd, []string{"doc1"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+
+	var got struct {
+		DocumentID  string                   `json:"documentId"`
+		TabID       string                   `json:"tabId"`
+		Suggestions []docsSuggestionListItem `json:"suggestions"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+		t.Fatalf("decode output: %v\n%s", err, output.String())
+	}
+	if got.DocumentID != "doc1" || got.TabID != "" || len(got.Suggestions) != 1 {
+		t.Fatalf("unexpected output: %#v", got)
+	}
+	if got.Suggestions[0].SuggestionID != "suggestion-1" || got.Suggestions[0].Text != "draft" {
+		t.Fatalf("unexpected suggestion: %#v", got.Suggestions[0])
+	}
+}
+
+func TestDocsSuggestionsList_Tab(t *testing.T) {
+	t.Parallel()
+
+	srv := newDocsRawTestServerWithRequest(t, 0, map[string]any{
+		"documentId": "doc1",
+		"tabs": []any{map[string]any{
+			"tabProperties": map[string]any{"tabId": "tab-1", "title": "Review"},
+			"documentTab": map[string]any{
+				"body": map[string]any{"content": []any{map[string]any{
+					"paragraph": map[string]any{"elements": []any{map[string]any{
+						"startIndex": 2,
+						"endIndex":   5,
+						"textRun": map[string]any{
+							"content":              "old",
+							"suggestedDeletionIds": []any{"suggestion-2"},
+						},
+					}}},
+				}}},
+			},
+		}},
+	}, func(r *http.Request) {
+		if got := r.URL.Query().Get("suggestionsViewMode"); got != "SUGGESTIONS_INLINE" {
+			t.Fatalf("suggestionsViewMode=%q", got)
+		}
+		if got := r.URL.Query().Get("includeTabsContent"); got != "true" {
+			t.Fatalf("includeTabsContent=%q", got)
+		}
+	})
+	defer srv.Close()
+
+	output := &bytes.Buffer{}
+	ctx := newCmdRuntimeJSONOutputContext(t, output, io.Discard)
+	ctx = withDocsTestService(ctx, newMockDocsService(t, srv))
+	cmd := &DocsSuggestionsListCmd{}
+	if err := runKong(t, cmd, []string{"doc1", "--tab", "Review"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !bytes.Contains(output.Bytes(), []byte(`"tabId": "tab-1"`)) ||
+		!bytes.Contains(output.Bytes(), []byte(`"kind": "deletion"`)) {
+		t.Fatalf("unexpected output: %s", output.String())
+	}
+}
+
+func TestDocsSuggestionsList_Text(t *testing.T) {
+	t.Parallel()
+
+	srv := newDocsRawTestServer(t, 0, map[string]any{
+		"documentId": "doc1",
+		"body": map[string]any{"content": []any{map[string]any{
+			"paragraph": map[string]any{"elements": []any{map[string]any{
+				"startIndex": 1,
+				"endIndex":   3,
+				"textRun": map[string]any{
+					"content":               "a\tb\n",
+					"suggestedInsertionIds": []any{"suggestion-1"},
+				},
+			}}},
+		}}},
+	})
+	defer srv.Close()
+
+	output := &bytes.Buffer{}
+	ctx := newCmdRuntimeOutputContext(t, output, io.Discard)
+	ctx = withDocsTestService(ctx, newMockDocsService(t, srv))
+	if err := runKong(t, &DocsSuggestionsListCmd{}, []string{"doc1"}, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	want := "SUGGESTION ID  KIND       SEGMENT  START  END  TEXT\nsuggestion-1   insertion  body     1      3    a\\tb\\n\n"
+	if output.String() != want {
+		t.Fatalf("output mismatch\n got: %q\nwant: %q", output.String(), want)
+	}
+}
+
+func TestDocsSuggestionsList_EmptyDocID(t *testing.T) {
+	t.Parallel()
+
+	err := (&DocsSuggestionsListCmd{}).Run(context.Background(), &RootFlags{})
+	if err == nil {
+		t.Fatal("expected empty docId error")
+	}
+}
+
+func suggestionContent(start, end int64, text, insertionID string, deletionIDs []string) []*docs.StructuralElement {
+	run := &docs.ParagraphElement{
+		StartIndex: start,
+		EndIndex:   end,
+		TextRun: &docs.TextRun{
+			Content:               text,
+			SuggestedInsertionIds: []string{insertionID},
+			SuggestedDeletionIds:  deletionIDs,
+		},
+	}
+	return []*docs.StructuralElement{{Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{run}}}}
+}

--- a/internal/cmd/docs_suggestions_test.go
+++ b/internal/cmd/docs_suggestions_test.go
@@ -189,6 +189,92 @@ func TestEnumerateDocsSuggestions_SectionBreak(t *testing.T) {
 	}
 }
 
+func TestEnumerateDocsSuggestions_PositionedObjects(t *testing.T) {
+	t.Parallel()
+
+	doc := &docs.Document{
+		Body: &docs.Body{Content: []*docs.StructuralElement{{
+			StartIndex: 10,
+			EndIndex:   20,
+			Paragraph: &docs.Paragraph{
+				PositionedObjectIds: []string{"deleted"},
+				SuggestedPositionedObjectIds: map[string]docs.ObjectReferences{
+					"insert-suggestion": {ObjectIds: []string{"inserted"}},
+				},
+			},
+		}}},
+		PositionedObjects: map[string]docs.PositionedObject{
+			"inserted": {SuggestedInsertionId: "insert-suggestion"},
+			"deleted":  {SuggestedDeletionIds: []string{"delete-suggestion"}},
+		},
+	}
+
+	got := enumerateDocsSuggestions(doc)
+	want := []docsSuggestionListItem{
+		{SuggestionID: "delete-suggestion", Kind: "deletion", Segment: "body", StartIndex: 10, EndIndex: 10},
+		{SuggestionID: "insert-suggestion", Kind: "insertion", Segment: "body", StartIndex: 10, EndIndex: 10},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("suggestions mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestEnumerateDocsSuggestions_InlineObjectMap(t *testing.T) {
+	t.Parallel()
+
+	doc := &docs.Document{
+		Body: &docs.Body{Content: []*docs.StructuralElement{{
+			Paragraph: &docs.Paragraph{Elements: []*docs.ParagraphElement{{
+				StartIndex:          4,
+				EndIndex:            5,
+				InlineObjectElement: &docs.InlineObjectElement{InlineObjectId: "image"},
+			}}},
+		}}},
+		InlineObjects: map[string]docs.InlineObject{
+			"image": {
+				SuggestedInsertionId: "insert",
+				SuggestedDeletionIds: []string{"delete"},
+			},
+		},
+	}
+
+	got := enumerateDocsSuggestions(doc)
+	want := []docsSuggestionListItem{
+		{SuggestionID: "insert", Kind: "insertion", Segment: "body", StartIndex: 4, EndIndex: 5},
+		{SuggestionID: "delete", Kind: "deletion", Segment: "body", StartIndex: 4, EndIndex: 5},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("suggestions mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestEnumerateDocsSuggestions_ListMap(t *testing.T) {
+	t.Parallel()
+
+	doc := &docs.Document{
+		Body: &docs.Body{Content: []*docs.StructuralElement{{
+			StartIndex: 3,
+			EndIndex:   7,
+			Paragraph:  &docs.Paragraph{Bullet: &docs.Bullet{ListId: "list"}},
+		}}},
+		Lists: map[string]docs.List{
+			"list": {
+				SuggestedInsertionId: "insert",
+				SuggestedDeletionIds: []string{"delete"},
+			},
+		},
+	}
+
+	got := enumerateDocsSuggestions(doc)
+	want := []docsSuggestionListItem{
+		{SuggestionID: "insert", Kind: "insertion", Segment: "body", StartIndex: 3, EndIndex: 3},
+		{SuggestionID: "delete", Kind: "deletion", Segment: "body", StartIndex: 3, EndIndex: 3},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("suggestions mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
 func TestDocsSuggestionsList_JSON(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/safety_profile_test.go
+++ b/internal/cmd/safety_profile_test.go
@@ -164,6 +164,35 @@ func TestBundledSafetyProfilesExposeAutomationSchema(t *testing.T) {
 	}
 }
 
+func TestBundledSafetyProfilesAllowDocsSuggestions(t *testing.T) {
+	setTestConfigHome(t)
+
+	for _, profile := range []string{"agent-safe.yaml", "readonly.yaml"} {
+		profile := profile
+		t.Run(profile, func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join("..", "..", "safety-profiles", profile))
+			if err != nil {
+				t.Fatalf("read %s: %v", profile, err)
+			}
+			withBakedSafetyProfile(t, string(raw))
+
+			out := captureStdout(t, func() {
+				_ = captureStderr(t, func() {
+					if err := Execute([]string{"docs", "suggestions", "list", "--help"}); err != nil {
+						t.Fatalf("Execute: %v", err)
+					}
+				})
+			})
+			if !strings.Contains(out, "List pending text insertions and deletions") {
+				t.Fatalf("expected docs suggestions help in %s profile, got: %q", profile, out)
+			}
+			if strings.Contains(out, "blocked by baked safety profile") {
+				t.Fatalf("expected docs suggestions to be allowed by %s profile, got: %q", profile, out)
+			}
+		})
+	}
+}
+
 func TestReadonlySafetyProfileFiltersHelp(t *testing.T) {
 	setTestConfigHome(t)
 	raw, err := os.ReadFile(filepath.Join("..", "..", "safety-profiles", "readonly.yaml"))

--- a/safety-profiles/agent-safe.yaml
+++ b/safety-profiles/agent-safe.yaml
@@ -139,6 +139,8 @@ docs:
   info: true
   cat: true
   list-tabs: true
+  suggestions:
+    list: true
   create: false
   copy: false
   write: false

--- a/safety-profiles/readonly.yaml
+++ b/safety-profiles/readonly.yaml
@@ -144,6 +144,8 @@ docs:
   info: true
   cat: true
   list-tabs: true
+  suggestions:
+    list: true
   create: false
   copy: false
   write: false


### PR DESCRIPTION
Closes #876.

## Summary

- add `gog docs suggestions list <docId> [--tab title-or-id]`
- request `SUGGESTIONS_INLINE` explicitly and emit pending insertions/deletions with suggestion ID, segment, UTF-16 range, and text when present
- cover every current Docs suggestion-ID carrier: text and non-text paragraph elements, section/table/row/cell/TOC structures, and list/inline/positioned-object maps
- combine contiguous runs, preserve nested IDs, traverse body/header/footer/footnote/tab content, and expose the read-only command in both baked safety profiles
- add stable JSON/TSV output, generated command references and service-skill metadata, user docs, changelog, and focused regressions

Style-only suggestions and accept/reject mutation remain intentionally out of scope. The Docs API response does not expose suggestion authors.

## Exact-head proof

- head `cdcd3019d9951e3de6314c5a37982b54987948a6`
- focused suggestion tests passed 20 consecutive runs
- focused race test passed
- full local `make ci` passed
- final autoreview clean (0.86); no accepted/actionable findings
- exact binary `v0.31.2-0.20260703130353-cdcd3019d995`; SHA-256 `d8942a7bcb8b42dd942ee77e49ca96f9c95b0b59fa2ff1072b3e48df89ad8167`
- both baked safe-profile builds expose `docs suggestions list`
- authenticated disposable-Doc proof with `steipete@gmail.com`: default-tab JSON, explicit-tab JSON, and plain reads passed; Drive modified time stayed unchanged; all temporary documents were trashed
- source-blind behavior validation: 5 pass, 0 fail, 1 blocked (live pending-suggestion creation)
- push CI: https://github.com/openclaw/gogcli/actions/runs/28662855313
- PR CI: https://github.com/openclaw/gogcli/actions/runs/28662858925
- Docker build: https://github.com/openclaw/gogcli/actions/runs/28662858984

## Live-proof limit

Google's Docs API can read but cannot create a pending suggestion. The existing-profile Chrome bridge had no attached tabs, so an authenticated UI-created pending insertion/deletion could not be induced safely. Empty live reads, tab projection, read-only behavior, and cleanup are live-proven; actual pending-suggestion rendering is API-type-exhaustive and fixture-proven rather than backed by a live pending suggestion.
