### PR TITLE
fix(calendar): display event-local times in event timezone

### DIFF
--- a/internal/cmd/calendar_event_days.go
+++ b/internal/cmd/calendar_event_days.go
@@ -145,32 +145,33 @@ func loadEventLocation(tz string) (*time.Location, bool) {
 	return tryLoadTimezoneLocation(tz)
 }
 
-// resolveEventTimezone resolves the timezone and location for an event.
-// It tries the calendar timezone first, then falls back to the event's timezone.
-// Returns the resolved timezone name and location. If loc is already provided,
-// it will be used as-is (only calendarTimezone may be updated for display).
+// resolveEventTimezone resolves the timezone and location used for local
+// event display. Prefer the event's own timezone over the containing
+// calendar timezone: Google Calendar may return a DateTime rendered with the
+// calendar's UTC offset while also carrying the event timezone field. Showing
+// local fields in the calendar timezone makes conference/travel events look an
+// hour early/late (for example an Asia/Seoul event on an Asia/Hong_Kong
+// calendar). Fall back to the calendar timezone only when the event has none.
 func resolveEventTimezone(event *calendar.Event, calendarTimezone string, loc *time.Location) (string, *time.Location) {
 	calendarTimezone = strings.TrimSpace(calendarTimezone)
 	evTimezone := eventTimezone(event)
 
-	if loc == nil && calendarTimezone != "" {
+	if evTimezone != "" {
+		if loaded, ok := tryLoadTimezoneLocation(evTimezone); ok {
+			return evTimezone, loaded
+		}
+	}
+
+	if calendarTimezone != "" {
+		if loc != nil {
+			return calendarTimezone, loc
+		}
 		if loaded, ok := tryLoadTimezoneLocation(calendarTimezone); ok {
-			loc = loaded
-		} else {
-			calendarTimezone = ""
+			return calendarTimezone, loaded
 		}
 	}
-	if calendarTimezone == "" {
-		calendarTimezone = evTimezone
-		if loc == nil && calendarTimezone != "" {
-			if loaded, ok := tryLoadTimezoneLocation(calendarTimezone); ok {
-				loc = loaded
-			} else {
-				calendarTimezone = ""
-			}
-		}
-	}
-	return calendarTimezone, loc
+
+	return "", nil
 }
 
 func marshalCalendarEventWithFields(event *calendar.Event, fields map[string]string) ([]byte, error) {

--- a/internal/cmd/calendar_test.go
+++ b/internal/cmd/calendar_test.go
@@ -394,3 +394,33 @@ func hasStringValue(values []string, value string) bool {
 	}
 	return false
 }
+
+func TestWrapEventWithDaysPrefersEventTimezone(t *testing.T) {
+	event := &calendar.Event{
+		Start: &calendar.EventDateTime{
+			DateTime: "2026-07-07T07:30:00+08:00",
+			TimeZone: "Asia/Seoul",
+		},
+		End: &calendar.EventDateTime{
+			DateTime: "2026-07-07T08:30:00+08:00",
+			TimeZone: "Asia/Seoul",
+		},
+	}
+
+	wrapped := wrapEventWithDaysWithTimezone(event, "Asia/Hong_Kong", nil)
+	if wrapped == nil {
+		t.Fatal("expected wrapped event")
+	}
+	if wrapped.Timezone != "Asia/Seoul" {
+		t.Fatalf("Timezone = %q, want Asia/Seoul", wrapped.Timezone)
+	}
+	if wrapped.EventTimezone != "" {
+		t.Fatalf("EventTimezone = %q, want empty when it matches display timezone", wrapped.EventTimezone)
+	}
+	if wrapped.StartLocal != "2026-07-07T08:30:00+09:00" {
+		t.Fatalf("StartLocal = %q, want Seoul local time", wrapped.StartLocal)
+	}
+	if wrapped.EndLocal != "2026-07-07T09:30:00+09:00" {
+		t.Fatalf("EndLocal = %q, want Seoul local time", wrapped.EndLocal)
+	}
+}


### PR DESCRIPTION
## Summary
- Prefer an event's own `start.timeZone` / `end.timeZone` when computing local display fields (`startLocal`, `endLocal`, day-of-week, plain table output)
- Fall back to the containing calendar timezone only when the event has no valid timezone
- Add a regression test for an Asia/Seoul event on an Asia/Hong_Kong calendar, where Google may return the DateTime with the calendar offset while preserving the event timezone

## Why
Google Calendar events can carry a different timezone from the parent calendar. For example, an ICML conference event stored as `Asia/Seoul` on an `Asia/Hong_Kong` calendar may be returned as:

```json
{
  "dateTime": "2026-07-07T07:30:00+08:00",
  "timeZone": "Asia/Seoul"
}
```

That instant is `2026-07-07T08:30:00+09:00` in the event's own timezone. The current display path prefers the calendar timezone, so the derived local fields/table display can look one hour early for travel/conference events.

## Test plan
- `go test ./internal/cmd`
- `go test ./internal/cmd ./internal/...`
