### PR TITLE
feat(calendar): add --timezone display override to events and event

### DIFF
--- a/docs/commands.generated.md
+++ b/docs/commands.generated.md
@@ -93,7 +93,7 @@ Generated from `gog schema --json`.
     - [`gog calendar (cal) create-calendar (new-calendar) <summary> [flags]`](commands/gog-calendar-create-calendar.md) - Create a new secondary calendar
     - [`gog calendar (cal) delete (rm,del,remove) <calendarId> <eventId> [flags]`](commands/gog-calendar-delete.md) - Delete an event
     - [`gog calendar (cal) delete-calendar <calendarId>`](commands/gog-calendar-delete-calendar.md) - Delete an owned secondary calendar
-    - [`gog calendar (cal) event (get,info,show) <calendarId> <eventId>`](commands/gog-calendar-event.md) - Get event
+    - [`gog calendar (cal) event (get,info,show) <calendarId> <eventId> [flags]`](commands/gog-calendar-event.md) - Get event
     - [`gog calendar (cal) events (list,ls) [<calendarId> ...] [flags]`](commands/gog-calendar-events.md) - List events from a calendar or all calendars
     - [`gog calendar (cal) focus-time (focus) --from=STRING --to=STRING [<calendarId>] [flags]`](commands/gog-calendar-focus-time.md) - Create a Focus Time block
     - [`gog calendar (cal) freebusy [<calendarIds>] [flags]`](commands/gog-calendar-freebusy.md) - Get free/busy

--- a/docs/commands/gog-calendar-event.md
+++ b/docs/commands/gog-calendar-event.md
@@ -7,7 +7,7 @@ Get event
 ## Usage
 
 ```bash
-gog calendar (cal) event (get,info,show) <calendarId> <eventId>
+gog calendar (cal) event (get,info,show) <calendarId> <eventId> [flags]
 ```
 
 ## Parent
@@ -36,6 +36,7 @@ gog calendar (cal) event (get,info,show) <calendarId> <eventId>
 | `--readonly` | `bool` | false | Block mutating API requests at runtime; auth add also requests read-only OAuth scopes |
 | `--results-only` | `bool` |  | In JSON mode, emit only the primary result (drops envelope fields like nextPageToken) |
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
+| `--timezone`<br>`--tz` | `string` |  | Display timezone for event times (IANA name, e.g. America/New_York, or 'local' for the system timezone). Default: the calendar's own timezone |
 | `-v`<br>`--verbose` | `bool` |  | Enable verbose logging |
 | `--version` | `kong.VersionFlag` |  | Print version and exit |
 | `--wrap-untrusted` | `bool` | false | In JSON/raw output, wrap fetched text fields in external untrusted-content markers |

--- a/docs/commands/gog-calendar-events.md
+++ b/docs/commands/gog-calendar-events.md
@@ -53,6 +53,7 @@ gog calendar (cal) events (list,ls) [<calendarId> ...] [flags]
 | `--select`<br>`--pick`<br>`--project` | `string` |  | In JSON mode, select comma-separated fields (best-effort; supports dot paths). Desire path: use --fields for most commands. |
 | `--shared-prop-filter` | `string` |  | Filter by shared extended property (key=value) |
 | `--sort` | `string` |  | Sort events by start\|end\|summary\|calendar (default: keep API order; with --all, start is recommended for chronological output) |
+| `--timezone`<br>`--tz` | `string` |  | Display timezone for event times (IANA name, e.g. America/New_York, or 'local' for the system timezone). Default: each calendar's own timezone |
 | `--to` | `string` |  | End time (RFC3339 with timezone, date, or relative: now, today, tomorrow, monday) |
 | `--today` | `bool` |  | Today only (timezone-aware) |
 | `--tomorrow` | `bool` |  | Tomorrow only (timezone-aware) |

--- a/internal/cmd/calendar_all_events_test.go
+++ b/internal/cmd/calendar_all_events_test.go
@@ -63,7 +63,7 @@ func TestListAllCalendarsEvents_JSON(t *testing.T) {
 	ctx := newCmdJSONContext(t)
 
 	jsonOut := captureStdout(t, func() {
-		if runErr := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); runErr != nil {
+		if runErr := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", nil); runErr != nil {
 			t.Fatalf("listAllCalendarsEvents: %v", runErr)
 		}
 	})
@@ -126,7 +126,7 @@ func TestListAllCalendarsEvents_SortByStart(t *testing.T) {
 
 	ctx := newCmdJSONContext(t)
 	jsonOut := captureStdout(t, func() {
-		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "start", "asc"); err != nil {
+		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "start", "asc", nil); err != nil {
 			t.Fatalf("listAllCalendarsEvents: %v", err)
 		}
 	})
@@ -153,7 +153,7 @@ func TestListAllCalendarsEvents_SortByStart(t *testing.T) {
 
 	// Descending order flips it.
 	jsonOut = captureStdout(t, func() {
-		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "start", "desc"); err != nil {
+		if err := listAllCalendarsEvents(ctx, svc, "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "start", "desc", nil); err != nil {
 			t.Fatalf("listAllCalendarsEvents desc: %v", err)
 		}
 	})

--- a/internal/cmd/calendar_changed.go
+++ b/internal/cmd/calendar_changed.go
@@ -101,7 +101,7 @@ func (c *CalendarChangedCmd) resolveSince() (time.Time, error) {
 }
 
 func (c *CalendarChangedCmd) listChangedSingle(ctx context.Context, svc *calendar.Service, calendarID, since string) error {
-	calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calendarID, nil)
+	calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calendarID, nil, nil)
 
 	items, err := fetchChangedEvents(ctx, svc, calendarID, since)
 	if err != nil {
@@ -130,7 +130,7 @@ func (c *CalendarChangedCmd) listChangedMulti(ctx context.Context, svc *calendar
 		if calID == "" {
 			continue
 		}
-		calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calID, hints)
+		calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calID, hints, nil)
 		items, err := fetchChangedEvents(ctx, svc, calID, since)
 		if err != nil {
 			u.Err().Linef("calendar %s: %v", calID, err)

--- a/internal/cmd/calendar_events_cmds.go
+++ b/internal/cmd/calendar_events_cmds.go
@@ -33,6 +33,7 @@ type CalendarEventsCmd struct {
 	Location          bool     `name:"location" help:"Include event LOCATION column in table output"`
 	Sort              string   `name:"sort" help:"Sort events by start|end|summary|calendar (default: keep API order; with --all, start is recommended for chronological output)" enum:"start,end,summary,calendar," default:""`
 	Order             string   `name:"order" help:"Sort order" enum:"asc,desc" default:"asc"`
+	Timezone          string   `name:"timezone" aliases:"tz" help:"Display timezone for event times (IANA name, e.g. America/New_York, or 'local' for the system timezone). Default: each calendar's own timezone"`
 }
 
 func (c *CalendarEventsCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -61,6 +62,10 @@ func (c *CalendarEventsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 	if calendarID != "" && len(calInputs) > 0 {
 		return usage("calendarId not allowed with --cal/--calendars")
+	}
+	displayTZ, err := displayTimezoneOverride(c.Timezone)
+	if err != nil {
+		return err
 	}
 
 	svc, err := calendarService(ctx, account)
@@ -95,7 +100,7 @@ func (c *CalendarEventsCmd) Run(ctx context.Context, flags *RootFlags) error {
 	}
 
 	if c.All {
-		return listAllCalendarsEvents(ctx, svc, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order)
+		return listAllCalendarsEvents(ctx, svc, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order, displayTZ)
 	}
 	if len(calInputs) > 0 {
 		ids, err := resolveCalendarIDs(ctx, store, svc, calInputs)
@@ -105,9 +110,9 @@ func (c *CalendarEventsCmd) Run(ctx context.Context, flags *RootFlags) error {
 		if len(ids) == 0 {
 			return usage("no calendars specified")
 		}
-		return listSelectedCalendarsEvents(ctx, svc, ids, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order)
+		return listSelectedCalendarsEvents(ctx, svc, ids, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order, displayTZ)
 	}
-	return listCalendarEvents(ctx, svc, calendarID, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order)
+	return listCalendarEvents(ctx, svc, calendarID, from, to, c.Max, c.Page, c.AllPages, c.FailEmpty, c.Query, c.PrivatePropFilter, c.SharedPropFilter, c.Fields, eventTypes, c.Weekday, c.Location, c.Sort, c.Order, displayTZ)
 }
 
 func normalizeCalendarEventsArgs(args []string) (string, error) {
@@ -133,6 +138,7 @@ func normalizeCalendarEventsArgs(args []string) (string, error) {
 type CalendarEventCmd struct {
 	CalendarID string `arg:"" name:"calendarId" help:"Calendar ID"`
 	EventID    string `arg:"" name:"eventId" help:"Event ID"`
+	Timezone   string `name:"timezone" aliases:"tz" help:"Display timezone for event times (IANA name, e.g. America/New_York, or 'local' for the system timezone). Default: the calendar's own timezone"`
 }
 
 func (c *CalendarEventCmd) Run(ctx context.Context, flags *RootFlags) error {
@@ -159,12 +165,17 @@ func (c *CalendarEventCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return err
 	}
 
+	displayTZ, err := displayTimezoneOverride(c.Timezone)
+	if err != nil {
+		return err
+	}
+
 	event, err := svc.Events.Get(calendarID, eventID).Do()
 	if err != nil {
 		return err
 	}
 	redactCalendarEventForOutput(ctx, event)
-	tz, loc, _ := getCalendarLocation(ctx, svc, calendarID)
+	tz, loc := calendarDisplayTimezone(ctx, svc, calendarID, nil, displayTZ)
 	if outfmt.IsJSON(ctx) {
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"event": wrapEventWithDaysWithTimezone(event, tz, loc)})
 	}

--- a/internal/cmd/calendar_events_test.go
+++ b/internal/cmd/calendar_events_test.go
@@ -32,7 +32,7 @@ func TestListCalendarEvents_JSON(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2025-01-01T00:00:00Z", "2025-01-02T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", nil); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 
@@ -48,33 +48,37 @@ func TestListCalendarEvents_JSON(t *testing.T) {
 	}
 }
 
-func calendarTimezoneEventsHandler() http.Handler {
+// cal1EventsHandler serves /calendars/cal1 with the given timezone and
+// /calendars/cal1/events with the given items.
+func cal1EventsHandler(timezone string, items []map[string]any) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/calendars/cal1" && r.Method == http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"id":       "cal1",
-				"timeZone": "Africa/Windhoek",
+				"timeZone": timezone,
 			})
 			return
 		case strings.Contains(r.URL.Path, "/calendars/cal1/events") && r.Method == http.MethodGet:
 			w.Header().Set("Content-Type", "application/json")
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"items": []map[string]any{
-					{
-						"id":      "e1",
-						"summary": "Followup",
-						"start":   map[string]any{"dateTime": "2026-04-08T20:00:00+13:00"},
-						"end":     map[string]any{"dateTime": "2026-04-08T20:20:00+13:00"},
-					},
-				},
-			})
+			_ = json.NewEncoder(w).Encode(map[string]any{"items": items})
 			return
 		default:
 			http.NotFound(w, r)
 			return
 		}
+	})
+}
+
+func calendarTimezoneEventsHandler() http.Handler {
+	return cal1EventsHandler("Africa/Windhoek", []map[string]any{
+		{
+			"id":      "e1",
+			"summary": "Followup",
+			"start":   map[string]any{"dateTime": "2026-04-08T20:00:00+13:00"},
+			"end":     map[string]any{"dateTime": "2026-04-08T20:20:00+13:00"},
+		},
 	})
 }
 
@@ -84,7 +88,7 @@ func TestListCalendarEvents_TableUsesCalendarTimezone(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", nil); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 	text := output.String()
@@ -129,7 +133,7 @@ func TestListCalendarEvents_TableIncludesLocation(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", nil); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 	text := output.String()
@@ -139,7 +143,7 @@ func TestListCalendarEvents_TableIncludesLocation(t *testing.T) {
 	}
 
 	output.Reset()
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, true, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, true, "", "", nil); err != nil {
 		t.Fatalf("listCalendarEvents with location: %v", err)
 	}
 	text = output.String()
@@ -162,7 +166,7 @@ func TestListCalendarEvents_JSONUsesCalendarTimezoneForLocalFields(t *testing.T)
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-04-08T00:00:00Z", "2026-04-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", nil); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 
@@ -555,5 +559,188 @@ func TestResolveCalendarIDs_UnrecognizedName(t *testing.T) {
 	}
 	if len(ids) != 2 || ids[0] != "c1" || ids[1] != "c2" {
 		t.Fatalf("unexpected ids: %v", ids)
+	}
+}
+
+// utcCalendarEventsHandler simulates the shape behind the --timezone flag: a
+// calendar whose own timezone is UTC (common for ICS/SportsEngine feed imports
+// and calendars created with default settings), so calendar-local display is
+// UTC wall-clock even though the viewer lives elsewhere.
+func utcCalendarEventsHandler() http.Handler {
+	return cal1EventsHandler("UTC", []map[string]any{
+		{
+			"id":      "e1",
+			"summary": "Swim Practice",
+			"start":   map[string]any{"dateTime": "2026-07-08T12:45:00Z"},
+			"end":     map[string]any{"dateTime": "2026-07-08T13:45:00Z"},
+		},
+	})
+}
+
+func TestListCalendarEvents_TimezoneOverrideTable(t *testing.T) {
+	svc, closeServer := newCalendarServiceForTest(t, utcCalendarEventsHandler())
+	defer closeServer()
+
+	override, err := displayTimezoneOverride("America/New_York")
+	if err != nil {
+		t.Fatalf("displayTimezoneOverride: %v", err)
+	}
+
+	var output bytes.Buffer
+	ctx := newCmdRuntimeOutputContext(t, &output, io.Discard)
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-07-08T00:00:00Z", "2026-07-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", override); err != nil {
+		t.Fatalf("listCalendarEvents: %v", err)
+	}
+	text := output.String()
+
+	if !strings.Contains(text, "2026-07-08T08:45:00-04:00") || !strings.Contains(text, "2026-07-08T09:45:00-04:00") {
+		t.Fatalf("expected override-local times, got: %q", text)
+	}
+	if strings.Contains(text, "2026-07-08T12:45:00Z") {
+		t.Fatalf("expected UTC wall-clock time to be re-rendered in the override timezone, got: %q", text)
+	}
+}
+
+func TestListCalendarEvents_TimezoneOverrideJSON(t *testing.T) {
+	svc, closeServer := newCalendarServiceForTest(t, utcCalendarEventsHandler())
+	defer closeServer()
+
+	override, err := displayTimezoneOverride("America/New_York")
+	if err != nil {
+		t.Fatalf("displayTimezoneOverride: %v", err)
+	}
+
+	var output bytes.Buffer
+	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-07-08T00:00:00Z", "2026-07-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", override); err != nil {
+		t.Fatalf("listCalendarEvents: %v", err)
+	}
+
+	var parsed struct {
+		Events []struct {
+			Timezone   string `json:"timezone"`
+			StartLocal string `json:"startLocal"`
+			EndLocal   string `json:"endLocal"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &parsed); err != nil {
+		t.Fatalf("json parse: %v", err)
+	}
+	if len(parsed.Events) != 1 {
+		t.Fatalf("unexpected events: %#v", parsed.Events)
+	}
+	event := parsed.Events[0]
+	if event.Timezone != "America/New_York" || event.StartLocal != "2026-07-08T08:45:00-04:00" || event.EndLocal != "2026-07-08T09:45:00-04:00" {
+		t.Fatalf("unexpected localized fields: %#v", event)
+	}
+}
+
+func TestListSelectedCalendarsEvents_TimezoneOverrideSkipsCalendarLookups(t *testing.T) {
+	// With an explicit display timezone there is no reason to fetch each
+	// calendar's timezone. The handler deliberately serves no /calendars/<id>
+	// endpoints, so any lookup would leave the localized fields empty.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "/calendars/c1/events") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"id": "e1", "summary": "Lacrosse", "start": map[string]any{"dateTime": "2026-07-08T20:00:00Z"}, "end": map[string]any{"dateTime": "2026-07-08T21:00:00Z"}},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/calendars/c2/events") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"id": "e2", "summary": "Standup", "start": map[string]any{"dateTime": "2026-07-08T14:00:00+02:00"}, "end": map[string]any{"dateTime": "2026-07-08T14:30:00+02:00"}},
+				},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	})
+	svc, closeServer := newCalendarServiceForTest(t, handler)
+	defer closeServer()
+
+	override, err := displayTimezoneOverride("America/New_York")
+	if err != nil {
+		t.Fatalf("displayTimezoneOverride: %v", err)
+	}
+
+	var output bytes.Buffer
+	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
+	if err := listSelectedCalendarsEvents(ctx, svc, []string{"c1", "c2"}, "2026-07-08T00:00:00Z", "2026-07-09T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", override); err != nil {
+		t.Fatalf("listSelectedCalendarsEvents: %v", err)
+	}
+
+	var parsed struct {
+		Events []struct {
+			Timezone   string `json:"timezone"`
+			StartLocal string `json:"startLocal"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &parsed); err != nil {
+		t.Fatalf("json parse: %v", err)
+	}
+	if len(parsed.Events) != 2 {
+		t.Fatalf("unexpected events: %#v", parsed.Events)
+	}
+	wantStarts := map[string]bool{
+		"2026-07-08T16:00:00-04:00": true, // 20:00Z
+		"2026-07-08T08:00:00-04:00": true, // 14:00+02:00
+	}
+	for _, event := range parsed.Events {
+		if !wantStarts[event.StartLocal] || event.Timezone != "America/New_York" {
+			t.Fatalf("unexpected localized fields: %#v", event)
+		}
+	}
+}
+
+func TestDisplayTimezoneOverride_InvalidAndEmpty(t *testing.T) {
+	_, err := displayTimezoneOverride("Not/AZone")
+	if err == nil {
+		t.Fatalf("expected error for invalid timezone")
+	}
+	var ee *ExitError
+	if !errors.As(err, &ee) || ee.Code != 2 {
+		t.Fatalf("expected usage error, got %v", err)
+	}
+
+	override, err := displayTimezoneOverride("  ")
+	if err != nil || override != nil {
+		t.Fatalf("expected nil override for empty value, got %#v, %v", override, err)
+	}
+}
+
+func TestCalendarEventsCmd_TimezoneFlag(t *testing.T) {
+	svc, closeServer := newCalendarServiceForTest(t, withPrimaryCalendar(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/calendars/primary/events") && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"id": "e1", "summary": "Swim Practice", "start": map[string]any{"dateTime": "2026-07-08T12:45:00Z"}, "end": map[string]any{"dateTime": "2026-07-08T13:45:00Z"}},
+				},
+			})
+			return
+		}
+		http.NotFound(w, r)
+	})))
+	defer closeServer()
+
+	var output bytes.Buffer
+	ctx := withCalendarTestService(newCmdRuntimeJSONOutputContext(t, &output, io.Discard), svc)
+	args := []string{"list", "--timezone", "America/New_York", "--from", "2026-07-08T00:00:00Z", "--to", "2026-07-09T00:00:00Z"}
+	if err := runKong(t, &CalendarEventsCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("calendar events list: %v", err)
+	}
+	out := output.String()
+	if !strings.Contains(out, "2026-07-08T08:45:00-04:00") {
+		t.Fatalf("expected override-local startLocal, got: %q", out)
+	}
+	if !strings.Contains(out, "America/New_York") {
+		t.Fatalf("expected override timezone in output, got: %q", out)
 	}
 }

--- a/internal/cmd/calendar_events_test.go
+++ b/internal/cmd/calendar_events_test.go
@@ -744,3 +744,49 @@ func TestCalendarEventsCmd_TimezoneFlag(t *testing.T) {
 		t.Fatalf("expected override timezone in output, got: %q", out)
 	}
 }
+
+func TestCalendarEventCmd_TimezoneOverrideCrossDateWeekday(t *testing.T) {
+	// 02:00Z on a Wednesday is 22:00 the previous day (Tuesday) in
+	// America/New_York; the plain printer must derive the weekday fields from
+	// the same display location as start-local/end-local.
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/users/me/calendarList" && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"items": []map[string]any{
+					{"id": "cal1", "summary": "Primary", "accessRole": "owner"},
+				},
+			})
+			return
+		case strings.Contains(r.URL.Path, "/calendars/cal1/events/e1") && r.Method == http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"id":      "e1",
+				"summary": "Late call",
+				"start":   map[string]any{"dateTime": "2026-07-08T02:00:00Z"},
+				"end":     map[string]any{"dateTime": "2026-07-08T03:00:00Z"},
+			})
+			return
+		default:
+			http.NotFound(w, r)
+			return
+		}
+	})
+	svc, closeServer := newCalendarServiceForTest(t, handler)
+	defer closeServer()
+
+	var output bytes.Buffer
+	ctx := withCalendarTestService(newCmdRuntimeOutputContext(t, &output, io.Discard), svc)
+	args := []string{"cal1", "e1", "--timezone", "America/New_York"}
+	if err := runKong(t, &CalendarEventCmd{}, args, ctx, &RootFlags{Account: "a@b.com"}); err != nil {
+		t.Fatalf("calendar event: %v", err)
+	}
+	out := output.String()
+	if !strings.Contains(out, "start-local\t2026-07-07T22:00:00-04:00") {
+		t.Fatalf("expected override-local start, got: %q", out)
+	}
+	if !strings.Contains(out, "start-day-of-week\tTuesday") || !strings.Contains(out, "end-day-of-week\tTuesday") {
+		t.Fatalf("expected weekday fields in the override timezone, got: %q", out)
+	}
+}

--- a/internal/cmd/calendar_list.go
+++ b/internal/cmd/calendar_list.go
@@ -44,8 +44,8 @@ func calendarEventsListCall(ctx context.Context, svc *calendar.Service, calendar
 	return call
 }
 
-func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
-	calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calendarID, nil)
+func listCalendarEvents(ctx context.Context, svc *calendar.Service, calendarID, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string, displayTZ *calendarTimezoneHint) error {
+	calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calendarID, nil, displayTZ)
 	fetch := func(pageToken string) ([]*calendar.Event, string, error) {
 		resp, err := calendarEventsListCall(ctx, svc, calendarID, from, to, maxResults, query, privatePropFilter, sharedPropFilter, fields, eventTypes, pageToken).Do()
 		if err != nil {
@@ -114,7 +114,7 @@ type calendarTimezoneHint struct {
 	loc      *time.Location
 }
 
-func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
+func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string, displayTZ *calendarTimezoneHint) error {
 	u := ui.FromContext(ctx)
 
 	calendars, err := listCalendarList(ctx, svc)
@@ -138,14 +138,14 @@ func listAllCalendarsEvents(ctx context.Context, svc *calendar.Service, from, to
 		u.Err().Println("No calendars")
 		return nil
 	}
-	return listCalendarIDsEvents(ctx, svc, ids, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, eventTypes, showWeekday, showLocation, calendarTimezoneHints(calendars), sortKey, sortOrder)
+	return listCalendarIDsEvents(ctx, svc, ids, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, eventTypes, showWeekday, showLocation, calendarTimezoneHints(calendars), sortKey, sortOrder, displayTZ)
 }
 
-func listSelectedCalendarsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string) error {
-	return listCalendarIDsEvents(ctx, svc, calendarIDs, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, eventTypes, showWeekday, showLocation, nil, sortKey, sortOrder)
+func listSelectedCalendarsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, sortKey, sortOrder string, displayTZ *calendarTimezoneHint) error {
+	return listCalendarIDsEvents(ctx, svc, calendarIDs, from, to, maxResults, page, allPages, failEmpty, query, privatePropFilter, sharedPropFilter, fields, eventTypes, showWeekday, showLocation, nil, sortKey, sortOrder, displayTZ)
 }
 
-func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, timezoneHints map[string]calendarTimezoneHint, sortKey, sortOrder string) error {
+func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarIDs []string, from, to string, maxResults int64, page string, allPages bool, failEmpty bool, query, privatePropFilter, sharedPropFilter, fields string, eventTypes []string, showWeekday bool, showLocation bool, timezoneHints map[string]calendarTimezoneHint, sortKey, sortOrder string, displayTZ *calendarTimezoneHint) error {
 	u := ui.FromContext(ctx)
 	all := []*eventWithCalendar{}
 	nextPages := []calendarEventsNextPage{}
@@ -154,7 +154,7 @@ func listCalendarIDsEvents(ctx context.Context, svc *calendar.Service, calendarI
 		if calID == "" {
 			continue
 		}
-		calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calID, timezoneHints)
+		calendarTimezone, loc := calendarDisplayTimezone(ctx, svc, calID, timezoneHints, displayTZ)
 		fetch := func(pageToken string) ([]*calendar.Event, string, error) {
 			resp, err := calendarEventsListCall(ctx, svc, calID, from, to, maxResults, query, privatePropFilter, sharedPropFilter, fields, eventTypes, pageToken).Do()
 			if err != nil {
@@ -299,7 +299,10 @@ func eventDisplayLocation(e *eventWithCalendar) string {
 	return loc
 }
 
-func calendarDisplayTimezone(ctx context.Context, svc *calendar.Service, calendarID string, hints map[string]calendarTimezoneHint) (string, *time.Location) {
+func calendarDisplayTimezone(ctx context.Context, svc *calendar.Service, calendarID string, hints map[string]calendarTimezoneHint, override *calendarTimezoneHint) (string, *time.Location) {
+	if override != nil {
+		return override.timezone, override.loc
+	}
 	if hint, ok := hints[calendarID]; ok {
 		return hint.timezone, hint.loc
 	}
@@ -308,6 +311,21 @@ func calendarDisplayTimezone(ctx context.Context, svc *calendar.Service, calenda
 		return "", nil
 	}
 	return tz, loc
+}
+
+// displayTimezoneOverride resolves the --timezone display flag into an
+// override applied to every calendar in the listing. An empty value returns
+// nil, which keeps the default behavior of rendering each calendar's events
+// in that calendar's own timezone.
+func displayTimezoneOverride(value string) (*calendarTimezoneHint, error) {
+	loc, ok, err := parseTimezoneValue(flagTimezoneLabel, value, true)
+	if err != nil {
+		return nil, newUsageError(err)
+	}
+	if !ok {
+		return nil, nil //nolint:nilnil // intentional: nil means no override, caller uses per-calendar timezones
+	}
+	return &calendarTimezoneHint{timezone: loc.String(), loc: loc}, nil
 }
 
 func calendarTimezoneHints(calendars []*calendar.CalendarListEntry) map[string]calendarTimezoneHint {

--- a/internal/cmd/calendar_print.go
+++ b/internal/cmd/calendar_print.go
@@ -35,7 +35,7 @@ func printCalendarEventWithTimezone(u *ui.UI, event *calendar.Event, calendarTim
 	}
 
 	u.Out().Linef("start\t%s", eventStart(event))
-	startDay, endDay := eventDaysOfWeek(event)
+	startDay, endDay := eventDaysOfWeekInLocation(event, loc)
 	if startDay != "" {
 		u.Out().Linef("start-day-of-week\t%s", startDay)
 	}

--- a/internal/cmd/calendar_zoom_test.go
+++ b/internal/cmd/calendar_zoom_test.go
@@ -284,7 +284,7 @@ func TestListCalendarEventsJSONRedactsZoomDescription(t *testing.T) {
 
 	var output bytes.Buffer
 	ctx := newCmdRuntimeJSONOutputContext(t, &output, io.Discard)
-	if err := listCalendarEvents(ctx, svc, "cal1", "2026-05-18T00:00:00Z", "2026-05-19T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", ""); err != nil {
+	if err := listCalendarEvents(ctx, svc, "cal1", "2026-05-18T00:00:00Z", "2026-05-19T00:00:00Z", 10, "", false, false, "", "", "", "", nil, false, false, "", "", nil); err != nil {
 		t.Fatalf("listCalendarEvents: %v", err)
 	}
 	out := output.String()


### PR DESCRIPTION
## Summary

- Add `--timezone` / `--tz` to `calendar events` and `calendar event`: an explicit display-timezone override (IANA name, or `local` for the system timezone)
- Flag unset keeps today's behavior exactly: each calendar's events render in that calendar's own timezone (#493)
- With an override set, every calendar in an `--all`/`--cal`/`--calendars` listing renders uniformly, and the per-calendar timezone lookups are skipped (they'd be unused)

## Why

Real-world failure that motivated this: a household agent builds a daily schedule from `calendar events --all -j`. Two of the account's nine calendars have their **calendar timezone set to UTC** — one is a SportsEngine ICS feed import (import calendars commonly come in as UTC and can't be re-zoned), one a Google calendar created with default settings. Google returns their event times in the calendar's timezone, and since #493 the table output and `startLocal`/`endLocal` JSON fields render calendar-local — which for these calendars *is* UTC:

```
2026-07-08T12:45:00Z | UTC | RP Swim Practice
2026-07-08T20:00:00Z | UTC | Sound 2031 Boys Practice
```

That 12:45Z is an 8:45am (America/New_York) swim practice. The agent published the family's schedule shifted +4h — swim at "12:45p", an evening practice that was actually 4pm. The stored instants are all correct; there is just no way today to ask the CLI to *display* them where the viewer lives. `--timezone` closes that hole while keeping #493's calendar-local default:

```
$ gog calendar events --all --timezone America/New_York ...
2026-07-08T08:45:00-04:00 | America/New_York | RP Swim Practice
2026-07-08T16:00:00-04:00 | America/New_York | Sound 2031 Boys Practice
```

Notes:

- **Display-only.** `--from`/`--to`/`--today` range parsing is unchanged (still the primary calendar's timezone).
- **Orthogonal to #905** (event-timezone vs calendar-timezone display preference). #905 changes which *stored* timezone wins by default; this flag is an explicit viewer override on top of whichever default wins. For a feed-import calendar whose events are natively UTC, no default-preference change can produce viewer-local display — only an override can.
- Naming follows the existing read-side precedent (`gmail messages --timezone`) and the calendar write-side `--timezone`/`--tz` aliases (#844).

## Test plan

- `make fmt`, `make lint` (0 issues), `go test ./internal/...` — all packages pass
- New regressions: UTC-calendar table + JSON output render in the override timezone; multi-calendar path renders uniformly and skips `/calendars/<id>` lookups (test handler deliberately 404s them); invalid value → usage error exit 2; empty value → no override; Kong-level flag wiring end-to-end
- Live-verified against the real account that hit this (output above)
- `make docs-commands` regenerated

---

🤖 Implemented with [Claude Code](https://claude.com/claude-code), human-reviewed before submission.
