### PR TITLE
Support Docs smart chips in cat output

### DIFF
--- a/docs/commands/gog-docs-cat.md
+++ b/docs/commands/gog-docs-cat.md
@@ -21,6 +21,7 @@ gog docs (doc) cat (text,read) <docId> [flags]
 | `--access-token` | `string` |  | Use provided access token directly (bypasses stored refresh tokens; token expires in ~1h) |
 | `-a`<br>`--account`<br>`--acct` | `string` |  | Account email, alias, or auto for authenticated Google API commands |
 | `--all-tabs` | `bool` |  | Show all tabs with headers |
+| `--chips` | `bool` |  | Render Google Docs smart chips inline in text output |
 | `--client` | `string` |  | OAuth client name (selects stored credentials + token bucket) |
 | `--color` | `string` | auto | Color output: auto\|always\|never |
 | `--disable-commands` | `string` |  | Comma-separated list of disabled commands; dot paths allowed |

--- a/internal/cmd/docs_commands_test.go
+++ b/internal/cmd/docs_commands_test.go
@@ -353,6 +353,59 @@ func newTabsTestServer(t *testing.T) (*docs.Service, func()) {
 	return docSvc, srv.Close
 }
 
+func newSmartChipDocsTestServer(t *testing.T) (*docs.Service, func()) {
+	t.Helper()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/v1/documents/") || r.Method != http.MethodGet {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"documentId": "doc1",
+			"title":      "Smart chip doc",
+			"body": map[string]any{"content": []any{map[string]any{
+				"paragraph": map[string]any{"elements": []any{
+					map[string]any{"startIndex": 1, "endIndex": 11, "textRun": map[string]any{"content": "Reviewer: "}},
+					map[string]any{"startIndex": 11, "endIndex": 12, "person": map[string]any{
+						"personProperties": map[string]any{"name": "Sample Person", "email": "sample@example.com"},
+					}},
+					map[string]any{"startIndex": 12, "endIndex": 17, "textRun": map[string]any{"content": "\nDue: "}},
+					map[string]any{"startIndex": 17, "endIndex": 18, "dateElement": map[string]any{
+						"dateId": "date-1",
+						"dateElementProperties": map[string]any{
+							"displayText": "Jul 8, 2026",
+							"timestamp":   "1783468800",
+						},
+					}},
+					map[string]any{"startIndex": 18, "endIndex": 24, "textRun": map[string]any{"content": "\nFile: "}},
+					map[string]any{"startIndex": 24, "endIndex": 25, "richLink": map[string]any{
+						"richLinkProperties": map[string]any{
+							"title":    "Plan Doc",
+							"uri":      "https://docs.google.com/document/d/plan",
+							"mimeType": "application/vnd.google-apps.document",
+						},
+					}},
+					map[string]any{"startIndex": 25, "endIndex": 26, "textRun": map[string]any{"content": "\n"}},
+				}},
+			}}},
+		})
+	}))
+
+	docSvc, err := docs.NewService(context.Background(),
+		option.WithoutAuthentication(),
+		option.WithHTTPClient(srv.Client()),
+		option.WithEndpoint(srv.URL+"/"),
+	)
+	if err != nil {
+		t.Fatalf("NewDocsService: %v", err)
+	}
+
+	return docSvc, srv.Close
+}
+
 func runDocsCatCommand(t *testing.T, svc *docs.Service, args []string, jsonMode bool) executeTestResult {
 	t.Helper()
 
@@ -626,6 +679,81 @@ func TestDocsCat_CaseInsensitiveTabTitle(t *testing.T) {
 	out := result.stdout
 	if !strings.Contains(out, "details text") {
 		t.Fatalf("case-insensitive match failed, got: %q", out)
+	}
+}
+
+func TestDocsCat_SmartChipsAreOptInForTextOutput(t *testing.T) {
+	t.Parallel()
+
+	docSvc, cleanup := newSmartChipDocsTestServer(t)
+	defer cleanup()
+
+	result := runDocsCatCommand(t, docSvc, []string{"doc1"}, false)
+	if result.err != nil {
+		t.Fatalf("cat: %v", result.err)
+	}
+	if got, want := result.stdout, "Reviewer: \nDue: \nFile: \n"; got != want {
+		t.Fatalf("default text changed\n got: %q\nwant: %q", got, want)
+	}
+
+	result = runDocsCatCommand(t, docSvc, []string{"doc1", "--chips"}, false)
+	if result.err != nil {
+		t.Fatalf("cat --chips: %v", result.err)
+	}
+	want := "Reviewer: @Sample Person <sample@example.com>\nDue: Jul 8, 2026\nFile: [Plan Doc](https://docs.google.com/document/d/plan)\n"
+	if result.stdout != want {
+		t.Fatalf("unexpected rendered chip text\n got: %q\nwant: %q", result.stdout, want)
+	}
+}
+
+func TestDocsCat_JSONAddsSmartChipDataWithoutChangingText(t *testing.T) {
+	t.Parallel()
+
+	docSvc, cleanup := newSmartChipDocsTestServer(t)
+	defer cleanup()
+
+	result := runDocsCatCommand(t, docSvc, []string{"doc1"}, true)
+	if result.err != nil {
+		t.Fatalf("cat --json: %v", result.err)
+	}
+
+	var out struct {
+		Text         string `json:"text"`
+		RenderedText string `json:"renderedText"`
+		Chips        []struct {
+			Type       string `json:"type"`
+			Text       string `json:"text"`
+			StartIndex int64  `json:"startIndex"`
+			EndIndex   int64  `json:"endIndex"`
+			Name       string `json:"name"`
+			Email      string `json:"email"`
+			Display    string `json:"displayText"`
+			Title      string `json:"title"`
+			URI        string `json:"uri"`
+		} `json:"chips"`
+	}
+	if err := json.Unmarshal([]byte(result.stdout), &out); err != nil {
+		t.Fatalf("JSON parse: %v\nraw: %q", err, result.stdout)
+	}
+	if got, want := out.Text, "Reviewer: \nDue: \nFile: \n"; got != want {
+		t.Fatalf("text changed\n got: %q\nwant: %q", got, want)
+	}
+	if !strings.Contains(out.RenderedText, "@Sample Person <sample@example.com>") ||
+		!strings.Contains(out.RenderedText, "Jul 8, 2026") ||
+		!strings.Contains(out.RenderedText, "[Plan Doc](https://docs.google.com/document/d/plan)") {
+		t.Fatalf("renderedText missing smart chip renderings: %q", out.RenderedText)
+	}
+	if len(out.Chips) != 3 {
+		t.Fatalf("chips length = %d, want 3: %#v", len(out.Chips), out.Chips)
+	}
+	if out.Chips[0].Type != "person" || out.Chips[0].Name != "Sample Person" || out.Chips[0].Email != "sample@example.com" {
+		t.Fatalf("unexpected person chip: %#v", out.Chips[0])
+	}
+	if out.Chips[1].Type != "date" || out.Chips[1].Display != "Jul 8, 2026" {
+		t.Fatalf("unexpected date chip: %#v", out.Chips[1])
+	}
+	if out.Chips[2].Type != "richLink" || out.Chips[2].Title != "Plan Doc" || out.Chips[2].URI != "https://docs.google.com/document/d/plan" {
+		t.Fatalf("unexpected rich link chip: %#v", out.Chips[2])
 	}
 }
 

--- a/internal/cmd/docs_read.go
+++ b/internal/cmd/docs_read.go
@@ -23,6 +23,7 @@ type DocsCatCmd struct {
 	AllTabs  bool   `name:"all-tabs" help:"Show all tabs with headers"`
 	Raw      bool   `name:"raw" help:"Output the raw Google Docs API JSON response without modifications"`
 	Numbered bool   `name:"numbered" short:"N" help:"Prefix each paragraph with its number"`
+	Chips    bool   `name:"chips" help:"Render Google Docs smart chips inline in text output"`
 }
 
 func (c *DocsCatCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFlags) error {
@@ -92,7 +93,11 @@ func (c *DocsCatCmd) Run(ctx context.Context, kctx *kong.Context, flags *RootFla
 
 	text := docsPlainText(doc, c.MaxBytes)
 	if outfmt.IsJSON(ctx) {
-		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"text": text})
+		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), docsTextJSON(text, docsRenderedText(doc, c.MaxBytes, true)))
+	}
+	if c.Chips {
+		_, err = io.WriteString(stdoutWriter(ctx), docsRenderedText(doc, c.MaxBytes, false).Text)
+		return err
 	}
 	_, err = io.WriteString(stdoutWriter(ctx), text)
 	return err
@@ -121,7 +126,11 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 		}
 		text := tabPlainText(tab, c.MaxBytes)
 		if outfmt.IsJSON(ctx) {
-			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"tab": tabJSON(tab, text)})
+			return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"tab": tabJSON(tab, text, tabRenderedText(tab, c.MaxBytes, true))})
+		}
+		if c.Chips {
+			_, err = io.WriteString(stdoutWriter(ctx), tabRenderedText(tab, c.MaxBytes, false).Text)
+			return err
 		}
 		_, err = io.WriteString(stdoutWriter(ctx), text)
 		return err
@@ -131,7 +140,7 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 		var out []map[string]any
 		for _, tab := range tabs {
 			text := tabPlainText(tab, c.MaxBytes)
-			out = append(out, tabJSON(tab, text))
+			out = append(out, tabJSON(tab, text, tabRenderedText(tab, c.MaxBytes, true)))
 		}
 		return outfmt.WriteJSON(ctx, stdoutWriter(ctx), map[string]any{"tabs": out})
 	}
@@ -148,6 +157,9 @@ func (c *DocsCatCmd) runWithTabs(ctx context.Context, svc *docs.Service, id stri
 			return err
 		}
 		text := tabPlainText(tab, c.MaxBytes)
+		if c.Chips {
+			text = tabRenderedText(tab, c.MaxBytes, false).Text
+		}
 		if _, err := io.WriteString(out, text); err != nil {
 			return err
 		}
@@ -300,6 +312,58 @@ func docsPlainText(doc *docs.Document, maxBytes int64) string {
 	return buf.String()
 }
 
+type docsTextResult struct {
+	Text  string
+	Chips []docsSmartChip
+}
+
+type docsSmartChip struct {
+	Type       string `json:"type"`
+	Text       string `json:"text,omitempty"`
+	StartIndex int64  `json:"startIndex,omitempty"`
+	EndIndex   int64  `json:"endIndex,omitempty"`
+	Name       string `json:"name,omitempty"`
+	Email      string `json:"email,omitempty"`
+	DateID     string `json:"dateId,omitempty"`
+	Display    string `json:"displayText,omitempty"`
+	Timestamp  string `json:"timestamp,omitempty"`
+	Title      string `json:"title,omitempty"`
+	URI        string `json:"uri,omitempty"`
+	MimeType   string `json:"mimeType,omitempty"`
+}
+
+func docsRenderedText(doc *docs.Document, maxBytes int64, collectChips bool) docsTextResult {
+	if doc == nil || doc.Body == nil {
+		return docsTextResult{}
+	}
+
+	var result docsTextResult
+	var buf bytes.Buffer
+	for _, el := range doc.Body.Content {
+		if !appendDocsElementRenderedText(&buf, maxBytes, el, collectChips, &result.Chips) {
+			break
+		}
+	}
+	result.Text = buf.String()
+	return result
+}
+
+func tabRenderedText(tab *docs.Tab, maxBytes int64, collectChips bool) docsTextResult {
+	if tab == nil || tab.DocumentTab == nil || tab.DocumentTab.Body == nil {
+		return docsTextResult{}
+	}
+
+	var result docsTextResult
+	var buf bytes.Buffer
+	for _, el := range tab.DocumentTab.Body.Content {
+		if !appendDocsElementRenderedText(&buf, maxBytes, el, collectChips, &result.Chips) {
+			break
+		}
+	}
+	result.Text = buf.String()
+	return result
+}
+
 func appendDocsElementText(buf *bytes.Buffer, maxBytes int64, el *docs.StructuralElement) bool {
 	if el == nil {
 		return true
@@ -342,6 +406,126 @@ func appendDocsElementText(buf *bytes.Buffer, maxBytes int64, el *docs.Structura
 	return true
 }
 
+func appendDocsElementRenderedText(buf *bytes.Buffer, maxBytes int64, el *docs.StructuralElement, collectChips bool, chips *[]docsSmartChip) bool {
+	if el == nil {
+		return true
+	}
+
+	switch {
+	case el.Paragraph != nil:
+		for _, p := range el.Paragraph.Elements {
+			if p.TextRun != nil {
+				if !appendLimited(buf, maxBytes, p.TextRun.Content) {
+					return false
+				}
+				continue
+			}
+			chip, ok := renderDocsSmartChip(p)
+			if !ok {
+				continue
+			}
+			if collectChips {
+				*chips = append(*chips, chip)
+			}
+			if !appendLimited(buf, maxBytes, chip.Text) {
+				return false
+			}
+		}
+	case el.Table != nil:
+		for rowIdx, row := range el.Table.TableRows {
+			if rowIdx > 0 && !appendLimited(buf, maxBytes, "\n") {
+				return false
+			}
+			for cellIdx, cell := range row.TableCells {
+				if cellIdx > 0 && !appendLimited(buf, maxBytes, "\t") {
+					return false
+				}
+				for _, content := range cell.Content {
+					if !appendDocsElementRenderedText(buf, maxBytes, content, collectChips, chips) {
+						return false
+					}
+				}
+			}
+		}
+	case el.TableOfContents != nil:
+		for _, content := range el.TableOfContents.Content {
+			if !appendDocsElementRenderedText(buf, maxBytes, content, collectChips, chips) {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+func renderDocsSmartChip(p *docs.ParagraphElement) (docsSmartChip, bool) {
+	if p == nil {
+		return docsSmartChip{}, false
+	}
+
+	switch {
+	case p.Person != nil:
+		props := p.Person.PersonProperties
+		name, email := "", ""
+		if props != nil {
+			name = strings.TrimSpace(props.Name)
+			email = strings.TrimSpace(props.Email)
+		}
+		text := "@" + firstNonEmpty(name, email)
+		if name != "" && email != "" {
+			text = fmt.Sprintf("@%s <%s>", name, email)
+		}
+		return docsSmartChip{
+			Type:       "person",
+			Text:       text,
+			StartIndex: p.StartIndex,
+			EndIndex:   p.EndIndex,
+			Name:       name,
+			Email:      email,
+		}, text != "@"
+	case p.DateElement != nil:
+		props := p.DateElement.DateElementProperties
+		display, timestamp := "", ""
+		if props != nil {
+			display = strings.TrimSpace(props.DisplayText)
+			timestamp = strings.TrimSpace(props.Timestamp)
+		}
+		text := firstNonEmpty(display, timestamp)
+		return docsSmartChip{
+			Type:       "date",
+			Text:       text,
+			StartIndex: p.StartIndex,
+			EndIndex:   p.EndIndex,
+			DateID:     p.DateElement.DateId,
+			Display:    display,
+			Timestamp:  timestamp,
+		}, text != ""
+	case p.RichLink != nil:
+		props := p.RichLink.RichLinkProperties
+		title, uri, mimeType := "", "", ""
+		if props != nil {
+			title = strings.TrimSpace(props.Title)
+			uri = strings.TrimSpace(props.Uri)
+			mimeType = strings.TrimSpace(props.MimeType)
+		}
+		text := firstNonEmpty(title, uri)
+		if title != "" && uri != "" {
+			text = fmt.Sprintf("[%s](%s)", title, uri)
+		}
+		return docsSmartChip{
+			Type:       "richLink",
+			Text:       text,
+			StartIndex: p.StartIndex,
+			EndIndex:   p.EndIndex,
+			Title:      title,
+			URI:        uri,
+			MimeType:   mimeType,
+		}, text != ""
+	default:
+		return docsSmartChip{}, false
+	}
+}
+
 func appendLimited(buf *bytes.Buffer, maxBytes int64, s string) bool {
 	if maxBytes <= 0 {
 		_, _ = buf.WriteString(s)
@@ -372,8 +556,19 @@ func tabPlainText(tab *docs.Tab, maxBytes int64) string {
 	return buf.String()
 }
 
-func tabJSON(tab *docs.Tab, text string) map[string]any {
+func docsTextJSON(text string, rendered docsTextResult) map[string]any {
 	m := map[string]any{"text": text}
+	if rendered.Text != text {
+		m["renderedText"] = rendered.Text
+	}
+	if len(rendered.Chips) > 0 {
+		m["chips"] = rendered.Chips
+	}
+	return m
+}
+
+func tabJSON(tab *docs.Tab, text string, rendered docsTextResult) map[string]any {
+	m := docsTextJSON(text, rendered)
 	if tab.TabProperties != nil {
 		m["id"] = tab.TabProperties.TabId
 		m["title"] = tab.TabProperties.Title

--- a/internal/cmd/forms_modify.go
+++ b/internal/cmd/forms_modify.go
@@ -151,7 +151,7 @@ func buildQuestion(qType string, input *formsAddQuestionInput) (*formsapi.Questi
 			LowLabel:  input.ScaleLowLabel,
 			HighLabel: input.ScaleHighLabel,
 		}
-	case "date":
+	case strDate:
 		q.DateQuestion = &formsapi.DateQuestion{
 			IncludeTime: input.IncludeTime,
 			IncludeYear: input.IncludeYear,


### PR DESCRIPTION
Closes #907.

Summary
- Keeps existing plain-text output unchanged by default.
- Adds `--chips` for inline person/date/rich-link rendering.
- Adds additive `renderedText` and `chips` fields to JSON output when smart chips are present.

Evidence
- `make ci` passes.