### PR TITLE
fix(ci): sync Docker Go version with go.mod

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
+      - name: Verify Docker Go version
+        run: make docker-version-check
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 ARG ALPINE_VERSION=3.24
 
 FROM golang:${GO_VERSION}-alpine AS build

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 # `make` should build the binary by default.
 .DEFAULT_GOAL := build
 
-.PHONY: build build-safe gog gogcli gog-help gogcli-help help fmt fmt-check lint deadcode test ci tools pnpm-gate docs-commands docs-site docs-check agent-skills agent-skills-check
+.PHONY: build build-safe gog gogcli gog-help gogcli-help help fmt fmt-check lint deadcode test ci tools pnpm-gate docker-version-check docs-commands docs-site docs-check agent-skills agent-skills-check
 .PHONY: worker-ci eval-gws eval-gws-agents eval-gws-test
 
 BIN_DIR := $(CURDIR)/bin
@@ -136,6 +136,15 @@ pnpm-gate:
 		echo "pnpm gate skipped (no package.json)"; \
 	fi
 
+docker-version-check:
+	@set -e; \
+	go_version="$$(awk '$$1 == "go" { print $$2; exit }' go.mod)"; \
+	docker_version="$$(sed -n 's/^ARG GO_VERSION=//p' Dockerfile)"; \
+	if [ -z "$$go_version" ] || [ -z "$$docker_version" ] || [ "$$docker_version" != "$$go_version" ]; then \
+		printf 'Docker Go version %s must match go.mod version %s\n' "$$docker_version" "$$go_version" >&2; \
+		exit 1; \
+	fi
+
 test:
 	@go test $(GO_TEST_FLAGS) $(TEST_FLAGS) $(TEST_PKGS)
 	@node --test scripts/eval-gws.test.mjs scripts/eval-gws-agents.test.mjs
@@ -149,7 +158,7 @@ eval-gws-agents: build
 eval-gws-test:
 	@node --test scripts/eval-gws.test.mjs scripts/eval-gws-agents.test.mjs
 
-ci: pnpm-gate fmt-check lint deadcode test docs-check agent-skills-check
+ci: pnpm-gate docker-version-check fmt-check lint deadcode test docs-check agent-skills-check
 
 worker-ci:
 	@pnpm -C internal/tracking/worker lint


### PR DESCRIPTION
## Summary

- Bump the Docker build image from Go 1.26.4 to Go 1.26.5 so it matches `go.mod`.
- Add `make docker-version-check` to fail closed whenever the Docker and module Go versions drift.
- Run that invariant in both the local `make ci` gate and the Docker GitHub workflow before image metadata/build steps.

## Root cause

The v0.33.1 preparation updated `go.mod` to Go 1.26.5 but left `Dockerfile` at Go 1.26.4. The Docker check triggered by review PR #910 then failed at `go mod download`. A future v0.33.1 tag would have hit the same failure in the image-publishing lane.

## Validation

- Exact `docker build --target build --progress=plain .` succeeds through `go mod download` and compilation on `golang:1.26.5-alpine`.
- `make ci`
- `make docker-version-check`
- Deliberate 1.26.4/1.26.5 mismatch fixture fails closed.
- `actionlint .github/workflows/docker.yml`
- `git diff --check`
- Changed-file Gitleaks scan
- Autoreview: clean, no accepted/actionable findings

This is the normal mergeable follow-up to the review-only release-contract mirror in #910. It performs no release, signing, notarization, Homebrew, or credential action.
