### PR TITLE
feat(auth): pass login_hint in auth add OAuth flows

### DIFF
--- a/internal/cmd/auth_add.go
+++ b/internal/cmd/auth_add.go
@@ -172,6 +172,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 				DisableIncludeGrantedScopes: disableIncludeGrantedScopes,
 				Client:                      client,
 				RedirectURI:                 redirectURI,
+				LoginHint:                   strings.TrimSpace(c.Email),
 			})
 			if manualErr != nil {
 				return manualErr
@@ -238,6 +239,7 @@ func (c *AuthAddCmd) Run(ctx context.Context, flags *RootFlags) error {
 		ListenAddr:                  strings.TrimSpace(c.ListenAddr),
 		RedirectURI:                 redirectURI,
 		RequireState:                c.Remote,
+		LoginHint:                   strings.TrimSpace(c.Email),
 	})
 	if err != nil {
 		return err

--- a/internal/googleauth/oauth_flow.go
+++ b/internal/googleauth/oauth_flow.go
@@ -33,6 +33,7 @@ type AuthorizeOptions struct {
 	ListenAddr                  string
 	RedirectURI                 string
 	RequireState                bool
+	LoginHint                   string
 	ManualStateStore            *ManualStateStore
 }
 
@@ -257,7 +258,7 @@ func authorizeServer(ctx context.Context, opts AuthorizeOptions, creds config.Cl
 	}()
 
 	codeVerifier := generateVerifierFn()
-	authURL := cfg.AuthCodeURL(state, pkceAuthURLParams(opts.ForceConsent, !opts.DisableIncludeGrantedScopes, codeVerifier)...)
+	authURL := cfg.AuthCodeURL(state, authorizeURLParams(opts, codeVerifier)...)
 
 	fmt.Fprintln(os.Stderr, "Opening browser for authorization…")
 	fmt.Fprintln(os.Stderr, "If the browser doesn't open, visit this URL:")
@@ -317,6 +318,19 @@ func authURLParams(forceConsent bool, includeGrantedScopes bool) []oauth2.AuthCo
 
 func pkceAuthURLParams(forceConsent bool, includeGrantedScopes bool, codeVerifier string) []oauth2.AuthCodeOption {
 	return append(authURLParams(forceConsent, includeGrantedScopes), oauth2.S256ChallengeOption(codeVerifier))
+}
+
+// authorizeURLParams builds the auth URL params for an authorize flow,
+// adding login_hint to pre-select the account when the expected email is
+// known (prevents the consent from silently completing as the browser's
+// default account).
+func authorizeURLParams(opts AuthorizeOptions, codeVerifier string) []oauth2.AuthCodeOption {
+	params := pkceAuthURLParams(opts.ForceConsent, !opts.DisableIncludeGrantedScopes, codeVerifier)
+	if opts.LoginHint != "" {
+		params = append(params, oauth2.SetAuthURLParam("login_hint", opts.LoginHint))
+	}
+
+	return params
 }
 
 func randomState() (string, error) {

--- a/internal/googleauth/oauth_flow_manual.go
+++ b/internal/googleauth/oauth_flow_manual.go
@@ -133,7 +133,7 @@ func authorizeManualInteractive(ctx context.Context, opts AuthorizeOptions, cfg 
 	}
 
 	cfg.RedirectURL = setup.redirectURI
-	authURL := cfg.AuthCodeURL(setup.state, pkceAuthURLParams(opts.ForceConsent, !opts.DisableIncludeGrantedScopes, setup.codeVerifier)...)
+	authURL := cfg.AuthCodeURL(setup.state, authorizeURLParams(opts, setup.codeVerifier)...)
 
 	fmt.Fprintln(os.Stderr, "Visit this URL to authorize:")
 	fmt.Fprintln(os.Stderr, authURL)
@@ -270,7 +270,7 @@ func ManualAuthURL(ctx context.Context, opts AuthorizeOptions) (ManualAuthURLRes
 	}
 
 	return ManualAuthURLResult{
-		URL:         cfg.AuthCodeURL(setup.state, pkceAuthURLParams(opts.ForceConsent, !opts.DisableIncludeGrantedScopes, setup.codeVerifier)...),
+		URL:         cfg.AuthCodeURL(setup.state, authorizeURLParams(opts, setup.codeVerifier)...),
 		StateReused: setup.reused,
 	}, nil
 }

--- a/internal/googleauth/oauth_flow_more_test.go
+++ b/internal/googleauth/oauth_flow_more_test.go
@@ -208,3 +208,36 @@ func TestResolveServerRedirectURIUsesIPv6LoopbackListener(t *testing.T) {
 		t.Fatalf("expected IPv6 listener redirect, got %q", got)
 	}
 }
+
+func TestAuthorizeURLParamsLoginHint(t *testing.T) {
+	t.Parallel()
+
+	cfg := oauth2.Config{
+		ClientID:    "id",
+		Endpoint:    oauth2.Endpoint{AuthURL: "https://example.com/auth"},
+		RedirectURL: "http://localhost",
+		Scopes:      []string{"s1"},
+	}
+
+	withHint := cfg.AuthCodeURL("state", authorizeURLParams(AuthorizeOptions{LoginHint: "test@example.com"}, "verifier")...)
+
+	parsedHint, err := url.Parse(withHint)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if loginHint := parsedHint.Query().Get("login_hint"); loginHint != "test@example.com" {
+		t.Fatalf("expected login_hint=test@example.com, got %q", loginHint)
+	}
+
+	withoutHint := cfg.AuthCodeURL("state", authorizeURLParams(AuthorizeOptions{}, "verifier")...)
+
+	parsedNoHint, err := url.Parse(withoutHint)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+
+	if _, ok := parsedNoHint.Query()["login_hint"]; ok {
+		t.Fatalf("expected no login_hint param, got %q", parsedNoHint.Query().Get("login_hint"))
+	}
+}


### PR DESCRIPTION
## Problem

`gog auth add <email>` knows exactly which account it expects, but the auth URL it builds never tells Google. When the requested scopes were granted recently, Google **silently auto-approves as the browser's default account** — no account chooser ever appears — so the flow completes as the wrong user in about a second and `auth add` fails with:

```
authorized as alex@company-b.com, expected alex@company-a.com
```

For anyone juggling multiple Google accounts in one browser profile, this makes re-auth a game of roulette: the guard correctly rejects the mismatched grant, but there is no way to steer the consent to the right account short of incognito windows.

## Fix

Pass the expected email as `login_hint` in all three `auth add` flows (browser listener, `--manual`, `--remote`), so Google pre-selects the requested account. This mirrors what the interactive accounts manager already does (`accounts_manager.go` appends `login_hint` since the permission-upgrade UI landed) — this PR just extends the same pattern to `auth add`.

- `AuthorizeOptions` gains a `LoginHint` field
- new `authorizeURLParams` helper wraps `pkceAuthURLParams` and appends `login_hint` when set, used by all three call sites
- `auth add` wires `c.Email` into the options

## Testing

- new `TestAuthorizeURLParamsLoginHint` (mirrors the existing `accounts_server_test.go` login_hint assertions): param present when set, absent when empty
- `go test ./internal/googleauth/ ./internal/cmd/` pass, `go vet` clean, `gofmt` clean
- live-verified: `gog auth add user@example.com --remote --step 1` now emits `login_hint=user%40example.com` in the auth URL, and the browser flow lands on the hinted account instead of the profile default

🤖 Generated with [Claude Code](https://claude.com/claude-code)