### PR TITLE
feat(mcp): add account capability policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.34.1 - Unreleased
 
+- MCP: add optional global and per-account capability ceilings in `config.json`, with narrow persistent write authorization, runtime-only restriction, and fail-closed selector validation. (#913) — thanks @mcaldas.
+
 ## 0.34.0 - 2026-07-11
 
 - Calendar: add `--timezone` / `--tz` display overrides to `calendar events` and `calendar event`, including uniform multi-calendar output without changing range parsing. (#908) — thanks @bxxd.

--- a/README.md
+++ b/README.md
@@ -625,7 +625,8 @@ gog --account you@gmail.com \
 ```
 
 See [docs/mcp.md](docs/mcp.md) for client config, tool selection, safety
-behavior, mcporter examples, and troubleshooting.
+behavior, persistent global/per-account capability ceilings, mcporter examples,
+and troubleshooting.
 
 ## Auth and Accounts
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -46,6 +46,10 @@ gog --account you@example.com mcp \
 `--allow-write` is always required for write tools. A write tool that matches
 `--allow-tool` is still hidden until `--allow-write` is present.
 
+The exception is an explicit persistent MCP policy. It can authorize a narrow
+write surface without repeating `--allow-write` in every client definition;
+runtime flags can only reduce that configured surface.
+
 ## Why this is not `gog_exec`
 
 MCP clients are often LLM-driven. A generic "run this command" tool would expose
@@ -104,6 +108,48 @@ gog mcp --allow-tool calendar,sheets
 # All current write tools. Read tools are not included unless also selected.
 gog mcp --allow-write --allow-tool write
 ```
+
+## Persistent capability policy
+
+For several MCP clients or accounts, put the maximum registered tool surface in
+`config.json` instead of duplicating capability arguments. Without an `mcp`
+block, behavior is unchanged: all read tools are available, writes require
+`--allow-write`, and `--allow-tool` filters the result.
+
+```json5
+{
+  "mcp": {
+    "allow_tools": ["read"],
+    "allow_write": false,
+    "accounts": {
+      "personal@example.com": {
+        "allow_tools": ["read", "docs.*", "calendar.*"],
+        "allow_write": true
+      },
+      "work@example.com": {
+        "allow_tools": ["read"],
+        "allow_write": false
+      }
+    }
+  }
+}
+```
+
+An account entry is a complete replacement for the global policy, not a partial
+merge. Account keys are matched case-insensitively after aliases and automatic
+account selection are resolved, then that resolved account is pinned for every
+MCP child command. Per-account policies require stored account credentials;
+direct access tokens and ADC can use only the global policy because an account
+label does not prove the authenticated principal. An omitted `allow_tools` value defaults to
+`["read"]`; an explicitly empty list is rejected. `allow_write: true` requires
+an explicit tool list so a typo cannot accidentally expose every write tool.
+
+The configured policy is a ceiling. `--allow-tool` can intersect it with a
+smaller runtime set, `--readonly` removes all writes, and `--allow-write` cannot
+widen a read-only policy. Baked safety profiles remain the outer immutable
+ceiling. Unknown configured selectors and attempted write widening fail before
+the MCP server starts. Use `gog mcp --list-tools` with the same account and flags
+to inspect the final registered surface.
 
 ## Initial tools
 

--- a/internal/cmd/mcp.go
+++ b/internal/cmd/mcp.go
@@ -62,7 +62,13 @@ func (c *McpCmd) Run(ctx context.Context, flags *RootFlags) error {
 		return usage("--max-output-bytes must be greater than zero")
 	}
 
-	tools := mcpEnabledTools(*c)
+	tools, resolvedAccount, err := mcpEnabledToolsForRun(ctx, *c, flags)
+	if err != nil {
+		return err
+	}
+	if resolvedAccount != "" && flags != nil {
+		flags.Account = resolvedAccount
+	}
 	if len(tools) == 0 {
 		return usage("no MCP tools enabled")
 	}

--- a/internal/cmd/mcp_policy.go
+++ b/internal/cmd/mcp_policy.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/steipete/gogcli/internal/config"
+)
+
+func mcpEnabledToolsForRun(ctx context.Context, cmd McpCmd, flags *RootFlags) ([]mcpToolSpec, string, error) {
+	store, err := commandConfigStore(ctx)
+	if err != nil {
+		return nil, "", err
+	}
+	cfg, err := store.Read()
+	if err != nil {
+		return nil, "", err
+	}
+	if cfg.MCP == nil {
+		return mcpEnabledTools(cmd), "", nil
+	}
+
+	account := ""
+	if len(cfg.MCP.Accounts) > 0 {
+		account, err = resolveMCPPolicyAccount(flags)
+		if err != nil {
+			return nil, "", fmt.Errorf("resolve account for MCP policy: %w", err)
+		}
+	}
+	policy, err := selectMCPPolicy(*cfg.MCP, account)
+	if err != nil {
+		return nil, "", err
+	}
+	tools, err := mcpEnabledToolsWithPolicy(cmd, flags, policy)
+	return tools, account, err
+}
+
+func resolveMCPPolicyAccount(flags *RootFlags) (string, error) {
+	if hasDirectAccessToken(flags) || isADCAuthMode(flags) {
+		// Account values are only labels in these modes, so they must never select
+		// a per-account authorization policy. The global policy still applies.
+		return "", nil
+	}
+	return requireAccount(flags)
+}
+
+func selectMCPPolicy(cfg config.MCPConfig, account string) (config.MCPPolicy, error) {
+	policy, err := normalizeMCPPolicy(cfg.MCPPolicy)
+	if err != nil {
+		return config.MCPPolicy{}, fmt.Errorf("global MCP policy: %w", err)
+	}
+	normalizedAccount := normalizeMCPAccount(account)
+	seen := make(map[string]string, len(cfg.Accounts))
+	for configuredAccount, accountPolicy := range cfg.Accounts {
+		normalized := normalizeMCPAccount(configuredAccount)
+		if normalized == "" {
+			return config.MCPPolicy{}, usage("MCP policy account must not be empty")
+		}
+		if previous, ok := seen[normalized]; ok {
+			return config.MCPPolicy{}, usagef("duplicate MCP policy accounts %q and %q", previous, configuredAccount)
+		}
+		seen[normalized] = configuredAccount
+		normalizedPolicy, err := normalizeMCPPolicy(accountPolicy)
+		if err != nil {
+			return config.MCPPolicy{}, fmt.Errorf("MCP policy account %q: %w", configuredAccount, err)
+		}
+		if normalized == normalizedAccount {
+			// Account entries are complete policies, not inherited patches.
+			policy = normalizedPolicy
+		}
+	}
+	return policy, nil
+}
+
+func normalizeMCPPolicy(policy config.MCPPolicy) (config.MCPPolicy, error) {
+	explicitSelectors := splitCommaValues(policy.AllowTools)
+	selectorsProvided := policy.AllowTools != nil
+	if selectorsProvided && len(explicitSelectors) == 0 {
+		return config.MCPPolicy{}, usage("MCP policy allow_tools must contain at least one selector")
+	}
+	if policy.AllowWrite && !selectorsProvided {
+		return config.MCPPolicy{}, usage("MCP policy allow_write requires an explicit allow_tools list")
+	}
+	if !selectorsProvided {
+		explicitSelectors = []string{string(mcpRiskRead)}
+	}
+	for _, selector := range explicitSelectors {
+		if !mcpSelectorMatchesAnyTool(selector) {
+			return config.MCPPolicy{}, usagef("MCP policy allow_tools selector %q matches no tool", selector)
+		}
+	}
+	policy.AllowTools = explicitSelectors
+	return policy, nil
+}
+
+func mcpEnabledToolsWithPolicy(cmd McpCmd, flags *RootFlags, policy config.MCPPolicy) ([]mcpToolSpec, error) {
+	if cmd.AllowWrite && !policy.AllowWrite {
+		return nil, usage("--allow-write cannot widen the configured MCP policy")
+	}
+
+	allowWrite := policy.AllowWrite
+	if flags != nil && flags.ReadOnly {
+		allowWrite = false
+	}
+	runtimeAllow := splitCommaValues(cmd.AllowTool)
+	tools := make([]mcpToolSpec, 0, len(mcpAllTools()))
+	for _, tool := range mcpAllTools() {
+		if tool.Risk == mcpRiskWrite && !allowWrite {
+			continue
+		}
+		if !mcpToolAllowed(tool, policy.AllowTools) {
+			continue
+		}
+		if len(runtimeAllow) > 0 && !mcpToolAllowed(tool, runtimeAllow) {
+			continue
+		}
+		tools = append(tools, tool)
+	}
+	return tools, nil
+}
+
+func mcpSelectorMatchesAnyTool(selector string) bool {
+	for _, tool := range mcpAllTools() {
+		if mcpToolAllowed(tool, []string{selector}) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeMCPAccount(account string) string {
+	return strings.ToLower(strings.TrimSpace(account))
+}

--- a/internal/cmd/mcp_test.go
+++ b/internal/cmd/mcp_test.go
@@ -9,6 +9,9 @@ import (
 
 	mcpclient "github.com/mark3labs/mcp-go/client"
 	"github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/steipete/gogcli/internal/config"
+	"github.com/steipete/gogcli/internal/googleapi"
 )
 
 func TestMCPEnabledToolsDefaultReadOnly(t *testing.T) {
@@ -36,6 +39,137 @@ func TestMCPEnabledToolsAllowWriteAndFilter(t *testing.T) {
 	}
 	if hasMCPTool(tools, "gmail_search") {
 		t.Fatalf("gmail tool leaked through docs filter: %#v", toolNames(tools))
+	}
+}
+
+func TestMCPPolicyDefaultsToReadOnly(t *testing.T) {
+	policy, err := selectMCPPolicy(config.MCPConfig{}, "")
+	if err != nil {
+		t.Fatalf("selectMCPPolicy: %v", err)
+	}
+	tools, err := mcpEnabledToolsWithPolicy(McpCmd{}, &RootFlags{}, policy)
+	if err != nil {
+		t.Fatalf("mcpEnabledToolsWithPolicy: %v", err)
+	}
+	if !hasMCPTool(tools, "gmail_search") || hasMCPTool(tools, "docs_write") {
+		t.Fatalf("unexpected default policy tools: %#v", toolNames(tools))
+	}
+}
+
+func TestMCPPolicyAccountReplacesGlobalAndEnablesNarrowWrites(t *testing.T) {
+	cfg := config.MCPConfig{
+		MCPPolicy: config.MCPPolicy{AllowTools: []string{"read"}},
+		Accounts: map[string]config.MCPPolicy{
+			" Personal@Example.com ": {AllowTools: []string{"docs.*"}, AllowWrite: true},
+		},
+	}
+	policy, err := selectMCPPolicy(cfg, "personal@example.com")
+	if err != nil {
+		t.Fatalf("selectMCPPolicy: %v", err)
+	}
+	tools, err := mcpEnabledToolsWithPolicy(McpCmd{}, &RootFlags{}, policy)
+	if err != nil {
+		t.Fatalf("mcpEnabledToolsWithPolicy: %v", err)
+	}
+	if !hasMCPTool(tools, "docs_get") || !hasMCPTool(tools, "docs_write") {
+		t.Fatalf("expected configured Docs tools: %#v", toolNames(tools))
+	}
+	if hasMCPTool(tools, "gmail_search") {
+		t.Fatalf("global policy leaked into account replacement: %#v", toolNames(tools))
+	}
+}
+
+func TestMCPPolicyRuntimeCanOnlyNarrow(t *testing.T) {
+	policy, err := normalizeMCPPolicy(config.MCPPolicy{AllowTools: []string{"docs.*"}, AllowWrite: true})
+	if err != nil {
+		t.Fatalf("normalizeMCPPolicy: %v", err)
+	}
+	tools, err := mcpEnabledToolsWithPolicy(McpCmd{AllowTool: []string{"docs_get"}}, &RootFlags{}, policy)
+	if err != nil {
+		t.Fatalf("mcpEnabledToolsWithPolicy: %v", err)
+	}
+	if got := toolNames(tools); len(got) != 1 || got[0] != "docs_get" {
+		t.Fatalf("runtime narrowed tools = %#v", got)
+	}
+
+	_, err = mcpEnabledToolsWithPolicy(McpCmd{AllowWrite: true}, &RootFlags{}, config.MCPPolicy{AllowTools: []string{"read"}})
+	if err == nil || !strings.Contains(err.Error(), "cannot widen") {
+		t.Fatalf("allow-write widening error = %v", err)
+	}
+}
+
+func TestMCPPolicyReadOnlyRootHidesConfiguredWrites(t *testing.T) {
+	policy, err := normalizeMCPPolicy(config.MCPPolicy{AllowTools: []string{"docs.*"}, AllowWrite: true})
+	if err != nil {
+		t.Fatalf("normalizeMCPPolicy: %v", err)
+	}
+	tools, err := mcpEnabledToolsWithPolicy(McpCmd{}, &RootFlags{ReadOnly: true}, policy)
+	if err != nil {
+		t.Fatalf("mcpEnabledToolsWithPolicy: %v", err)
+	}
+	if !hasMCPTool(tools, "docs_get") || hasMCPTool(tools, "docs_write") {
+		t.Fatalf("readonly tools = %#v", toolNames(tools))
+	}
+}
+
+func TestMCPPolicyRejectsUnsafeOrUnknownConfig(t *testing.T) {
+	for _, policy := range []config.MCPPolicy{
+		{AllowWrite: true},
+		{AllowTools: []string{}},
+		{AllowTools: []string{"not_a_tool"}},
+	} {
+		if _, err := normalizeMCPPolicy(policy); err == nil {
+			t.Fatalf("expected policy error for %#v", policy)
+		}
+	}
+
+	duplicateAccount := " user@example.com "
+	_, err := selectMCPPolicy(config.MCPConfig{Accounts: map[string]config.MCPPolicy{
+		"User@example.com": {},
+		duplicateAccount:   {},
+	}}, "user@example.com")
+	if err == nil || !strings.Contains(err.Error(), "duplicate") {
+		t.Fatalf("duplicate account error = %v", err)
+	}
+
+	_, err = selectMCPPolicy(config.MCPConfig{
+		Accounts: map[string]config.MCPPolicy{
+			"selected@example.com": {AllowTools: []string{"read"}},
+			"other@example.com":    {AllowTools: []string{"not_a_tool"}},
+		},
+	}, "selected@example.com")
+	if err == nil || !strings.Contains(err.Error(), "other@example.com") || !strings.Contains(err.Error(), "matches no tool") {
+		t.Fatalf("unselected account validation error = %v", err)
+	}
+}
+
+func TestMCPPolicyAccountResolutionPinsAliasAndRejectsUnverifiableIdentity(t *testing.T) {
+	store := config.NewConfigStore(config.Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(config.File{AccountAliases: map[string]string{"personal": "Personal@Example.com"}}); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	flags := &RootFlags{
+		Account: "personal",
+		configStoreResolver: func() (*config.ConfigStore, error) {
+			return store, nil
+		},
+	}
+	account, err := resolveMCPPolicyAccount(flags)
+	if err != nil {
+		t.Fatalf("resolveMCPPolicyAccount: %v", err)
+	}
+	if account != "Personal@Example.com" {
+		t.Fatalf("resolved account = %q", account)
+	}
+
+	for _, unverifiable := range []*RootFlags{
+		{AccessToken: "token", Account: "label@example.com"},
+		{authMode: googleapi.AuthModeADC, Account: "label@example.com"},
+	} {
+		account, err := resolveMCPPolicyAccount(unverifiable)
+		if err != nil || account != "" {
+			t.Fatalf("unverifiable identity resolution = %q, %v", account, err)
+		}
 	}
 }
 

--- a/internal/config/account_references.go
+++ b/internal/config/account_references.go
@@ -1,6 +1,13 @@
 package config
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+)
+
+var errMCPPolicyDestinationExists = errors.New("destination MCP policy already exists")
 
 func (s *ConfigStore) MigrateAccountEmailReferences(oldEmail, newEmail string) error {
 	oldEmail, newEmail = strings.ToLower(strings.TrimSpace(oldEmail)), strings.ToLower(strings.TrimSpace(newEmail))
@@ -21,6 +28,50 @@ func (s *ConfigStore) MigrateAccountEmailReferences(oldEmail, newEmail string) e
 			delete(cfg.AccountClients, oldEmail)
 		}
 
+		if cfg.MCP != nil {
+			if err := migrateMCPAccountPolicy(cfg.MCP.Accounts, oldEmail, newEmail); err != nil {
+				return err
+			}
+		}
+
 		return nil
 	})
+}
+
+func migrateMCPAccountPolicy(accounts map[string]MCPPolicy, oldEmail, newEmail string) error {
+	var oldKey, newKey string
+
+	for account := range accounts {
+		normalized := strings.TrimSpace(account)
+
+		if strings.EqualFold(normalized, oldEmail) {
+			oldKey = account
+		}
+
+		if strings.EqualFold(normalized, newEmail) {
+			newKey = account
+		}
+	}
+
+	if oldKey == "" {
+		return nil
+	}
+
+	oldPolicy := accounts[oldKey]
+
+	if newKey != "" {
+		newPolicy := accounts[newKey]
+		if oldPolicy.AllowWrite != newPolicy.AllowWrite || !slices.Equal(oldPolicy.AllowTools, newPolicy.AllowTools) {
+			return fmt.Errorf("migrate MCP policy from %s to %s: %w", oldEmail, newEmail, errMCPPolicyDestinationExists)
+		}
+
+		delete(accounts, oldKey)
+
+		return nil
+	}
+
+	accounts[newEmail] = oldPolicy
+	delete(accounts, oldKey)
+
+	return nil
 }

--- a/internal/config/account_references_test.go
+++ b/internal/config/account_references_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"sync"
 	"testing"
 )
@@ -16,6 +17,9 @@ func TestConfigStoreMigrateAccountEmailReferences(t *testing.T) {
 			"old@example.com":   "work-client",
 			"other@example.com": "default",
 		},
+		MCP: &MCPConfig{Accounts: map[string]MCPPolicy{
+			" Old@Example.com ": {AllowTools: []string{"docs.*"}, AllowWrite: true},
+		}},
 	}); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -39,6 +43,40 @@ func TestConfigStoreMigrateAccountEmailReferences(t *testing.T) {
 
 	if _, ok := cfg.AccountClients["old@example.com"]; ok {
 		t.Fatalf("old account client retained: %#v", cfg.AccountClients)
+	}
+
+	if policy, ok := cfg.MCP.Accounts["new@example.com"]; !ok || !policy.AllowWrite {
+		t.Fatalf("MCP account policies = %#v", cfg.MCP.Accounts)
+	}
+
+	if _, ok := cfg.MCP.Accounts[" Old@Example.com "]; ok {
+		t.Fatalf("old MCP account policy retained: %#v", cfg.MCP.Accounts)
+	}
+}
+
+func TestConfigStoreMigrateAccountEmailReferencesRejectsMCPPolicyCollision(t *testing.T) {
+	store := NewConfigStore(Layout{ConfigDir: t.TempDir()})
+
+	original := File{MCP: &MCPConfig{Accounts: map[string]MCPPolicy{
+		"old@example.com": {AllowTools: []string{"docs.*"}, AllowWrite: true},
+		"new@example.com": {AllowTools: []string{"read"}},
+	}}}
+	if err := store.Write(original); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	err := store.MigrateAccountEmailReferences("old@example.com", "new@example.com")
+	if !errors.Is(err, errMCPPolicyDestinationExists) {
+		t.Fatalf("migration collision error = %v", err)
+	}
+
+	cfg, readErr := store.Read()
+	if readErr != nil {
+		t.Fatalf("Read: %v", readErr)
+	}
+
+	if len(cfg.MCP.Accounts) != 2 || !cfg.MCP.Accounts["old@example.com"].AllowWrite {
+		t.Fatalf("collision changed MCP policies: %#v", cfg.MCP.Accounts)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,17 @@ type File struct {
 	CalendarAliases map[string]string `json:"calendar_aliases,omitempty"`
 	GmailNoSend     bool              `json:"gmail_no_send,omitempty"`
 	NoSendAccounts  map[string]bool   `json:"no_send_accounts,omitempty"`
+	MCP             *MCPConfig        `json:"mcp,omitempty"`
+}
+
+type MCPConfig struct {
+	MCPPolicy
+	Accounts map[string]MCPPolicy `json:"accounts,omitempty"`
+}
+
+type MCPPolicy struct {
+	AllowTools []string `json:"allow_tools"`
+	AllowWrite bool     `json:"allow_write,omitempty"`
 }
 
 var errConfigLockTimeout = errors.New("acquire config lock timeout")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,6 +62,59 @@ func TestReadConfig_JSON5(t *testing.T) {
 	}
 }
 
+func TestReadConfig_MCPPolicy(t *testing.T) {
+	t.Parallel()
+
+	store := NewConfigStore(Layout{ConfigDir: t.TempDir()})
+
+	data := `{
+  mcp: {
+    allow_tools: ["read"],
+    accounts: {
+      "personal@example.com": {
+        allow_tools: ["docs.*"],
+        allow_write: true,
+      },
+    },
+  },
+}`
+	if err := os.WriteFile(store.Path(), []byte(data), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := store.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if cfg.MCP == nil || len(cfg.MCP.AllowTools) != 1 {
+		t.Fatalf("MCP policy = %#v", cfg.MCP)
+	}
+
+	personal := cfg.MCP.Accounts["personal@example.com"]
+	if !personal.AllowWrite || len(personal.AllowTools) != 1 || personal.AllowTools[0] != "docs.*" {
+		t.Fatalf("personal MCP policy = %#v", personal)
+	}
+}
+
+func TestConfigStorePreservesExplicitEmptyMCPAllowTools(t *testing.T) {
+	t.Parallel()
+
+	store := NewConfigStore(Layout{ConfigDir: t.TempDir()})
+	if err := store.Write(File{MCP: &MCPConfig{MCPPolicy: MCPPolicy{AllowTools: []string{}}}}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	cfg, err := store.Read()
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+
+	if cfg.MCP == nil || cfg.MCP.AllowTools == nil || len(cfg.MCP.AllowTools) != 0 {
+		t.Fatalf("explicit empty allow_tools was not preserved: %#v", cfg.MCP)
+	}
+}
+
 func TestConfigStoreWriteAndUpdate(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add an optional persistent MCP capability ceiling to config.json
- support complete per-account policies using the existing MCP selectors
- resolve and pin stored-account identities while keeping direct-token and ADC modes on the global policy
- fail closed on unknown selectors, explicit empty lists, write widening, invalid unselected policies, and account-migration collisions
- preserve legacy runtime flag behavior when no MCP policy is configured

Closes #913.

## Proof

- `make ci`
- `govulncheck ./...` — zero callable vulnerabilities
- `actionlint`
- focused MCP/config/account-migration tests
- source-blind behavior contract: all eight clauses passed, including legacy behavior, global/account selection, persistent narrow writes, runtime narrowing, root read-only, invalid config, and widening rejection
- live authenticated MCP stdio `gmail_search`: typed read result with exit code 0
- autoreview: clean, no accepted/actionable findings

## Notes

- no new dependencies or MCP tools
- no shell or workflow files changed
- full-repo ShellCheck still reports existing findings in untouched live-test scripts
